### PR TITLE
Rename AT-RSS to Skyreader with app.skyreader namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# AT-RSS Development Guide
+# Skyreader Development Guide
 
 ## Project Overview
 
-AT-RSS is a decentralized RSS reader using the AT Protocol (Bluesky's underlying protocol) for data storage. Users authenticate with their Bluesky account and their data is stored in their Personal Data Server (PDS).
+Skyreader is a decentralized RSS reader using the AT Protocol (Bluesky's underlying protocol) for data storage. Users authenticate with their Bluesky account and their data is stored in their Personal Data Server (PDS).
 
 ## Key Concepts
 
@@ -12,7 +12,7 @@ AT-RSS is a decentralized RSS reader using the AT Protocol (Bluesky's underlying
 - **Handle**: Human-readable username (e.g., `user.bsky.social`)
 - **PDS**: Personal Data Server - where user data is stored
 - **Lexicon**: Schema definition language for record types (like JSON Schema)
-- **NSID**: Namespaced identifier for schemas (e.g., `com.at-rss.feed.subscription`)
+- **NSID**: Namespaced identifier for schemas (e.g., `app.skyreader.feed.subscription`)
 
 ### OAuth Requirements
 
@@ -77,7 +77,7 @@ See [backend/ARCHITECTURE.md](backend/ARCHITECTURE.md) for detailed backend docu
 
 ### Lexicon Schemas
 
-Located in `lexicons/com/at-rss/`:
+Located in `lexicons/app/skyreader/`:
 
 ```
 feed/subscription.json  - RSS feed subscription
@@ -104,7 +104,7 @@ social/share.json       - Shared article
 
 ### Adding a New Lexicon Field
 
-1. Update schema in `lexicons/com/at-rss/...`
+1. Update schema in `lexicons/app/skyreader/...`
 2. Update TypeScript types in `frontend/src/lib/types/index.ts`
 3. Update Dexie schema version in `frontend/src/lib/services/db.ts`
 4. Update relevant store and components
@@ -133,10 +133,10 @@ social/share.json       - Shared article
 
 ## Deployment Checklist
 
-1. Create D1 database: `npx wrangler d1 create at-rss`
+1. Create D1 database: `npx wrangler d1 create skyreader`
 2. Create KV namespaces: `npx wrangler kv namespace create FEED_CACHE` (and SESSION_CACHE)
 3. Update `wrangler.toml` with resource IDs
-4. Run migration: `npx wrangler d1 execute at-rss --remote --file=migrations/0001_initial.sql`
+4. Run migration: `npx wrangler d1 execute skyreader --remote --file=migrations/0001_initial.sql`
 5. Deploy backend: `npx wrangler deploy`
 6. Update frontend `.env` with backend URL
 7. Build frontend: `npm run build`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AT-RSS
+# Skyreader
 
 A decentralized RSS reader built on the [AT Protocol](https://atproto.com). Your subscriptions, reading progress, and shares are stored in your Personal Data Server (PDS), giving you full ownership and portability of your data.
 
@@ -32,7 +32,7 @@ A decentralized RSS reader built on the [AT Protocol](https://atproto.com). Your
 ## Project Structure
 
 ```
-at-rss/
+skyreader/
 ├── frontend/           # Svelte 5 PWA
 │   ├── src/
 │   │   ├── lib/
@@ -51,7 +51,7 @@ at-rss/
 │   │   └── durable-objects/  # Jetstream consumer
 │   └── migrations/           # D1 SQL migrations
 └── lexicons/           # AT Protocol schemas
-    └── com/at-rss/
+    └── app/skyreader/
         ├── feed/             # subscription, readPosition
         └── social/           # share
 ```
@@ -74,7 +74,7 @@ at-rss/
 
 2. Create Cloudflare resources:
    ```bash
-   npx wrangler d1 create at-rss
+   npx wrangler d1 create skyreader
    npx wrangler kv namespace create FEED_CACHE
    npx wrangler kv namespace create SESSION_CACHE
    ```
@@ -83,7 +83,7 @@ at-rss/
 
 4. Run the database migration:
    ```bash
-   npx wrangler d1 execute at-rss --remote --file=migrations/0001_initial.sql
+   npx wrangler d1 execute skyreader --remote --file=migrations/0001_initial.sql
    ```
 
 5. Deploy:
@@ -101,7 +101,7 @@ at-rss/
 
 2. Create `.env` with your backend URL:
    ```
-   VITE_API_URL=https://at-rss-api.YOUR_SUBDOMAIN.workers.dev
+   VITE_API_URL=https://skyreader-api.YOUR_SUBDOMAIN.workers.dev
    ```
 
 3. Run development server:
@@ -115,11 +115,11 @@ at-rss/
 
 ### Lexicon Schemas
 
-The app defines three custom record types under the `com.at-rss` namespace:
+The app defines three custom record types under the `app.skyreader` namespace:
 
-- **`com.at-rss.feed.subscription`**: RSS feed subscriptions
-- **`com.at-rss.feed.readPosition`**: Read/starred state for articles
-- **`com.at-rss.social.share`**: Shared articles with optional notes
+- **`app.skyreader.feed.subscription`**: RSS feed subscriptions
+- **`app.skyreader.feed.readPosition`**: Read/starred state for articles
+- **`app.skyreader.social.share`**: Shared articles with optional notes
 
 ### OAuth Flow
 
@@ -154,7 +154,7 @@ cd backend
 npx wrangler dev          # Local dev (limited - no real OAuth)
 npx wrangler deploy       # Deploy to Cloudflare
 npx wrangler tail         # Stream live logs
-npx wrangler d1 execute at-rss --remote --command "SELECT * FROM users"
+npx wrangler d1 execute skyreader --remote --command "SELECT * FROM users"
 
 # Frontend
 cd frontend
@@ -178,10 +178,10 @@ Durable Objects (like `JetstreamConsumer`) persist across deploys. WebSocket han
 **Debug endpoints**:
 ```bash
 # Check DO status (instanceId, codeVersion, connection state)
-curl https://at-rss-api.YOUR_SUBDOMAIN.workers.dev/api/jetstream/status
+curl https://skyreader-api.YOUR_SUBDOMAIN.workers.dev/api/jetstream/status
 
 # Force reconnect
-curl https://at-rss-api.YOUR_SUBDOMAIN.workers.dev/api/jetstream/reconnect
+curl https://skyreader-api.YOUR_SUBDOMAIN.workers.dev/api/jetstream/reconnect
 ```
 
 ## License

--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# AT-RSS Backend Architecture
+# Skyreader Backend Architecture
 
 ## Overview
 
-The AT-RSS backend is a Cloudflare Worker that serves as an API gateway between the frontend and the AT Protocol ecosystem. It handles authentication, RSS feed fetching/parsing, social features, and real-time updates.
+The Skyreader backend is a Cloudflare Worker that serves as an API gateway between the frontend and the AT Protocol ecosystem. It handles authentication, RSS feed fetching/parsing, social features, and real-time updates.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
@@ -168,9 +168,9 @@ Return parsed feed JSON
 | `/api/records/list` | GET | Bearer | List all records of a collection |
 
 **Supported collections:**
-- `com.at-rss.feed.subscription` - RSS feed subscriptions
-- `com.at-rss.feed.readPosition` - Read/starred state
-- `com.at-rss.social.share` - Shared articles
+- `app.skyreader.feed.subscription` - RSS feed subscriptions
+- `app.skyreader.feed.readPosition` - Read/starred state
+- `app.skyreader.social.share` - Shared articles
 
 ### Realtime (`/api/realtime`)
 
@@ -236,7 +236,7 @@ Read cursor from D1 (sync_state.jetstream_cursor)
        ↓
 Connect to wss://jetstream2.us-east.bsky.network/subscribe
        ↓
-Subscribe to com.at-rss.social.share collection
+Subscribe to app.skyreader.social.share collection
        ↓
 Resume from cursor (with 5-second buffer)
        ↓

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -35,7 +35,7 @@ export function handleClientMetadata(request: Request, env: Env): Response {
   const metadata = {
     client_id: `${baseUrl}/.well-known/client-metadata`,
     application_type: 'web',
-    client_name: 'AT-RSS Reader',
+    client_name: 'Skyreader',
     client_uri: baseUrl,
     redirect_uris: [`${baseUrl}/api/auth/callback`],
     grant_types: ['authorization_code', 'refresh_token'],

--- a/backend/src/routes/feeds.ts
+++ b/backend/src/routes/feeds.ts
@@ -188,7 +188,7 @@ export async function fetchAndCacheFeed(env: Env, feedUrl: string): Promise<void
 
   const response = await fetch(feedUrl, {
     headers: {
-      'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+      'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
       Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
     },
   });
@@ -389,7 +389,7 @@ export async function handleFeedFetch(request: Request, env: Env): Promise<Respo
 
   try {
     const headers: HeadersInit = {
-      'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+      'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
       Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
     };
 
@@ -587,7 +587,7 @@ export async function handleArticleFetch(request: Request, env: Env): Promise<Re
     // Fetch the feed
     const response = await fetch(feedUrl, {
       headers: {
-        'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+        'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
         Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
       },
     });

--- a/backend/src/routes/records.ts
+++ b/backend/src/routes/records.ts
@@ -4,11 +4,11 @@ import { fetchArticleContent } from '../services/jetstream-poller';
 import { fetchAndCacheFeed } from './feeds';
 
 const ALLOWED_COLLECTIONS = [
-  'com.at-rss.feed.subscription',
-  'com.at-rss.feed.readPosition',
-  'com.at-rss.social.share',
-  'com.at-rss.social.follow',
-  'com.at-rss.social.shareReadPosition',
+  'app.skyreader.feed.subscription',
+  'app.skyreader.feed.readPosition',
+  'app.skyreader.social.share',
+  'app.skyreader.social.follow',
+  'app.skyreader.social.shareReadPosition',
 ];
 
 interface ProfileInfo {
@@ -212,7 +212,7 @@ async function hydrateReadPositionsCacheFromPds(
     do {
       const params: Record<string, string> = {
         repo: session.did,
-        collection: 'com.at-rss.feed.readPosition',
+        collection: 'app.skyreader.feed.readPosition',
         limit: '100',
       };
       if (cursor) {
@@ -275,7 +275,7 @@ async function handleReadPositionSync(
   rkey: string,
   record?: Record<string, unknown>
 ): Promise<Response> {
-  const collection = 'com.at-rss.feed.readPosition';
+  const collection = 'app.skyreader.feed.readPosition';
 
   // Ensure cache is hydrated from PDS before checking
   await hydrateReadPositionsCacheFromPds(env, session);
@@ -409,7 +409,7 @@ async function handleShareReadPositionSync(
   rkey: string,
   record?: Record<string, unknown>
 ): Promise<Response> {
-  const collection = 'com.at-rss.social.shareReadPosition';
+  const collection = 'app.skyreader.social.shareReadPosition';
 
   if (operation === 'delete') {
     // For delete, remove from cache and PDS
@@ -586,12 +586,12 @@ export async function handleRecordSync(request: Request, env: Env): Promise<Resp
 
   try {
     // Handle read positions with cache-first deduplication
-    if (collection === 'com.at-rss.feed.readPosition') {
+    if (collection === 'app.skyreader.feed.readPosition') {
       return await handleReadPositionSync(env, session, operation, rkey, record);
     }
 
     // Handle share read positions with cache-first deduplication
-    if (collection === 'com.at-rss.social.shareReadPosition') {
+    if (collection === 'app.skyreader.social.shareReadPosition') {
       return await handleShareReadPositionSync(env, session, operation, rkey, record);
     }
 
@@ -629,7 +629,7 @@ export async function handleRecordSync(request: Request, env: Env): Promise<Resp
     }
 
     // Cache subscription for scheduled feed fetching
-    if (collection === 'com.at-rss.feed.subscription') {
+    if (collection === 'app.skyreader.feed.subscription') {
       const feedRecord = record as { feedUrl: string; title?: string };
       try {
         if (operation === 'create' || operation === 'update') {
@@ -667,7 +667,7 @@ export async function handleRecordSync(request: Request, env: Env): Promise<Resp
     }
 
     // Index shares for social feed
-    if (collection === 'com.at-rss.social.share') {
+    if (collection === 'app.skyreader.social.share') {
       try {
         const recordUri = result.data.uri || `at://${session.did}/${collection}/${rkey}`;
         if (operation === 'create' || operation === 'update') {
@@ -780,7 +780,7 @@ export async function handleRecordSync(request: Request, env: Env): Promise<Resp
     }
 
     // Index in-app follows
-    if (collection === 'com.at-rss.social.follow') {
+    if (collection === 'app.skyreader.social.follow') {
       try {
         const followRecord = record as { subject: string; createdAt: string };
         const recordUri = result.data.uri || `at://${session.did}/${collection}/${rkey}`;
@@ -968,7 +968,7 @@ export async function handleBulkRecordSync(request: Request, env: Env): Promise<
     const applyResult = result.data as unknown as ApplyWritesResponse;
 
     // Cache subscriptions for scheduled feed fetching
-    const subscriptionOps = operations.filter(op => op.collection === 'com.at-rss.feed.subscription');
+    const subscriptionOps = operations.filter(op => op.collection === 'app.skyreader.feed.subscription');
     const feedsToFetch: string[] = [];
 
     for (let i = 0; i < subscriptionOps.length; i++) {

--- a/backend/src/services/feed-parser.ts
+++ b/backend/src/services/feed-parser.ts
@@ -308,7 +308,7 @@ function decodeHtmlEntities(text: string): string {
 export async function discoverFeeds(url: string): Promise<string[]> {
   const response = await fetch(url, {
     headers: {
-      'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+      'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
     },
   });
 
@@ -352,7 +352,7 @@ export async function discoverFeeds(url: string): Promise<string[]> {
         const feedUrl = new URL(path, baseUrl).toString();
         const feedResponse = await fetch(feedUrl, {
           method: 'HEAD',
-          headers: { 'User-Agent': 'AT-RSS/1.0' },
+          headers: { 'User-Agent': 'Skyreader/1.0' },
         });
         if (feedResponse.ok) {
           const ct = feedResponse.headers.get('Content-Type') || '';

--- a/backend/src/services/jetstream-inapp-follows-poller.ts
+++ b/backend/src/services/jetstream-inapp-follows-poller.ts
@@ -68,7 +68,7 @@ const IDLE_TIMEOUT_MS = 2000; // 2 seconds without events = caught up
 
 async function processInappFollowEvent(env: Env, event: JetstreamInappFollowEvent): Promise<void> {
   const { did: followerDid, commit } = event;
-  if (!commit || commit.collection !== 'com.at-rss.social.follow') return;
+  if (!commit || commit.collection !== 'app.skyreader.social.follow') return;
 
   const { operation, rkey, record } = commit;
 
@@ -79,7 +79,7 @@ async function processInappFollowEvent(env: Env, event: JetstreamInappFollowEven
     await env.DB.prepare(`
       INSERT OR REPLACE INTO inapp_follows (follower_did, following_did, rkey, record_uri, created_at)
       VALUES (?, ?, ?, ?, unixepoch())
-    `).bind(followerDid, followingDid, rkey, `at://${followerDid}/com.at-rss.social.follow/${rkey}`).run();
+    `).bind(followerDid, followingDid, rkey, `at://${followerDid}/app.skyreader.social.follow/${rkey}`).run();
 
     // Fetch profile info for the followed user
     const profile = await fetchProfileInfo(followingDid);
@@ -123,7 +123,7 @@ export async function pollJetstreamInappFollows(env: Env): Promise<InappFollowsP
   ).bind('jetstream_inapp_follows_cursor').first<{ value: string }>();
 
   const wsUrl = new URL('wss://jetstream2.us-east.bsky.network/subscribe');
-  wsUrl.searchParams.append('wantedCollections', 'com.at-rss.social.follow');
+  wsUrl.searchParams.append('wantedCollections', 'app.skyreader.social.follow');
 
   // Use existing cursor if available, otherwise establish baseline
   let lastCursor: string;
@@ -211,7 +211,7 @@ export async function pollJetstreamInappFollows(env: Env): Promise<InappFollowsP
           }
 
           // Process the event
-          if (data.kind === 'commit' && data.commit?.collection === 'com.at-rss.social.follow') {
+          if (data.kind === 'commit' && data.commit?.collection === 'app.skyreader.social.follow') {
             await processInappFollowEvent(env, data);
             processed++;
           }

--- a/backend/src/services/jetstream-poller.ts
+++ b/backend/src/services/jetstream-poller.ts
@@ -78,7 +78,7 @@ export async function fetchArticleContent(env: Env, feedUrl: string, itemGuid: s
     // Not in cache or cache stale, fetch from source
     const response = await fetch(feedUrl, {
       headers: {
-        'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+        'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
         Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
       },
     });
@@ -141,7 +141,7 @@ async function processShareEvent(env: Env, event: JetstreamEvent): Promise<void>
 
   const { operation, collection, rkey, record, cid } = commit;
 
-  if (collection !== 'com.at-rss.social.share') return;
+  if (collection !== 'app.skyreader.social.share') return;
 
   const recordUri = `at://${did}/${collection}/${rkey}`;
 
@@ -215,7 +215,7 @@ export async function pollJetstream(env: Env): Promise<PollResult> {
   ).bind('jetstream_cursor').first<{ value: string }>();
 
   const wsUrl = new URL('wss://jetstream2.us-east.bsky.network/subscribe');
-  wsUrl.searchParams.append('wantedCollections', 'com.at-rss.social.share');
+  wsUrl.searchParams.append('wantedCollections', 'app.skyreader.social.share');
 
   // Use existing cursor if available, otherwise establish baseline
   let lastCursor: string;
@@ -299,7 +299,7 @@ export async function pollJetstream(env: Env): Promise<PollResult> {
           }
 
           // Process the event
-          if (data.kind === 'commit' && data.commit?.collection === 'com.at-rss.social.share') {
+          if (data.kind === 'commit' && data.commit?.collection === 'app.skyreader.social.share') {
             await processShareEvent(env, data);
             processed++;
           }

--- a/backend/src/services/scheduled-feeds.ts
+++ b/backend/src/services/scheduled-feeds.ts
@@ -119,7 +119,7 @@ async function fetchAndCacheFeed(
   timings.metaQuery = Date.now() - startTime;
 
   const headers: HeadersInit = {
-    'User-Agent': 'AT-RSS/1.0 (+https://at-rss.example.com)',
+    'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
     Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
   };
 

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -1,4 +1,4 @@
-name = "at-rss-api"
+name = "skyreader-api"
 main = "src/index.ts"
 compatibility_date = "2025-09-27"
 
@@ -26,7 +26,7 @@ deleted_classes = ["JetstreamConsumer"]
 # D1 Database
 [[d1_databases]]
 binding = "DB"
-database_name = "at-rss"
+database_name = "skyreader"
 database_id = "9ee50bac-d79c-4df7-8c09-6adb9d8940d2"
 
 # Environment variables

--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -1,7 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import type { Subscription, Article, ReadPosition, ShareReadPosition, SocialShare, UserShare, SyncQueueItem } from '$lib/types';
 
-class ATRSSDatabase extends Dexie {
+class SkyreaderDatabase extends Dexie {
   subscriptions!: Table<Subscription>;
   articles!: Table<Article>;
   readPositions!: Table<ReadPosition>;
@@ -11,7 +11,7 @@ class ATRSSDatabase extends Dexie {
   syncQueue!: Table<SyncQueueItem>;
 
   constructor() {
-    super('at-rss');
+    super('skyreader');
 
     this.version(1).stores({
       subscriptions: '++id, atUri, rkey, feedUrl, category, syncStatus, localUpdatedAt',
@@ -48,7 +48,7 @@ class ATRSSDatabase extends Dexie {
   }
 }
 
-export const db = new ATRSSDatabase();
+export const db = new SkyreaderDatabase();
 
 // Helper to check if article is read
 export async function isArticleRead(articleGuid: string): Promise<boolean> {

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -165,25 +165,25 @@ class SyncQueueService {
   }
 
   private async updateLocalRecord(collection: string, rkey: string, atUri: string) {
-    if (collection === 'com.at-rss.feed.subscription') {
+    if (collection === 'app.skyreader.feed.subscription') {
       const sub = await db.subscriptions.where('rkey').equals(rkey).first();
       if (sub?.id) {
         await db.subscriptions.update(sub.id, { atUri, syncStatus: 'synced' });
         this.notifySyncComplete(collection, rkey);
       }
-    } else if (collection === 'com.at-rss.feed.readPosition') {
+    } else if (collection === 'app.skyreader.feed.readPosition') {
       const pos = await db.readPositions.where('rkey').equals(rkey).first();
       if (pos?.id) {
         await db.readPositions.update(pos.id, { atUri, syncStatus: 'synced' });
         this.notifySyncComplete(collection, rkey);
       }
-    } else if (collection === 'com.at-rss.social.share') {
+    } else if (collection === 'app.skyreader.social.share') {
       const share = await db.userShares.where('rkey').equals(rkey).first();
       if (share?.id) {
         await db.userShares.update(share.id, { atUri, syncStatus: 'synced' });
         this.notifySyncComplete(collection, rkey);
       }
-    } else if (collection === 'com.at-rss.social.shareReadPosition') {
+    } else if (collection === 'app.skyreader.social.shareReadPosition') {
       const pos = await db.shareReadPositions.where('rkey').equals(rkey).first();
       if (pos?.id) {
         await db.shareReadPositions.update(pos.id, { atUri, syncStatus: 'synced' });

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -26,7 +26,7 @@ function createAuthStore() {
     api.setSession(null);
 
     if (browser) {
-      localStorage.removeItem('at-rss-auth');
+      localStorage.removeItem('skyreader-auth');
       // Redirect to login
       window.location.href = '/auth/login';
     }
@@ -34,7 +34,7 @@ function createAuthStore() {
 
   // Restore session from localStorage on init
   if (browser) {
-    const stored = localStorage.getItem('at-rss-auth');
+    const stored = localStorage.getItem('skyreader-auth');
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
@@ -42,7 +42,7 @@ function createAuthStore() {
         state.sessionId = parsed.sessionId;
         api.setSession(parsed.sessionId);
       } catch {
-        localStorage.removeItem('at-rss-auth');
+        localStorage.removeItem('skyreader-auth');
       }
     }
     state.isLoading = false;
@@ -58,7 +58,7 @@ function createAuthStore() {
     api.setSession(sessionId);
 
     if (browser) {
-      localStorage.setItem('at-rss-auth', JSON.stringify({ user, sessionId }));
+      localStorage.setItem('skyreader-auth', JSON.stringify({ user, sessionId }));
     }
   }
 
@@ -74,7 +74,7 @@ function createAuthStore() {
     api.setSession(null);
 
     if (browser) {
-      localStorage.removeItem('at-rss-auth');
+      localStorage.removeItem('skyreader-auth');
       await clearAllData();
     }
   }

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -6,7 +6,7 @@ interface PreferencesState {
   articleFont: ArticleFont;
 }
 
-const STORAGE_KEY = 'at-rss-preferences';
+const STORAGE_KEY = 'skyreader-preferences';
 
 function createPreferencesStore() {
   let state = $state<PreferencesState>({

--- a/frontend/src/lib/stores/reading.svelte.ts
+++ b/frontend/src/lib/stores/reading.svelte.ts
@@ -33,7 +33,7 @@ function createReadingStore() {
     for (const { rkey, record } of toEnqueue) {
       await syncQueue.enqueue({
         operation: 'create',
-        collection: 'com.at-rss.feed.readPosition',
+        collection: 'app.skyreader.feed.readPosition',
         rkey,
         record,
       });
@@ -137,7 +137,7 @@ function createReadingStore() {
     if (position.syncStatus === 'synced' && position.rkey) {
       await syncQueue.enqueue({
         operation: 'delete',
-        collection: 'com.at-rss.feed.readPosition',
+        collection: 'app.skyreader.feed.readPosition',
         rkey: position.rkey,
       });
     }
@@ -176,7 +176,7 @@ function createReadingStore() {
 
       await syncQueue.enqueue({
         operation: 'update',
-        collection: 'com.at-rss.feed.readPosition',
+        collection: 'app.skyreader.feed.readPosition',
         rkey: position.rkey,
         record,
       });

--- a/frontend/src/lib/stores/shareReading.svelte.ts
+++ b/frontend/src/lib/stores/shareReading.svelte.ts
@@ -73,7 +73,7 @@ function createShareReadingStore() {
 
     await syncQueue.enqueue({
       operation: 'create',
-      collection: 'com.at-rss.social.shareReadPosition',
+      collection: 'app.skyreader.social.shareReadPosition',
       rkey,
       record,
     });
@@ -94,7 +94,7 @@ function createShareReadingStore() {
     if (position.syncStatus === 'synced' && position.rkey) {
       await syncQueue.enqueue({
         operation: 'delete',
-        collection: 'com.at-rss.social.shareReadPosition',
+        collection: 'app.skyreader.social.shareReadPosition',
         rkey: position.rkey,
       });
     }

--- a/frontend/src/lib/stores/shares.svelte.ts
+++ b/frontend/src/lib/stores/shares.svelte.ts
@@ -103,7 +103,7 @@ function createSharesStore() {
 
     await syncQueue.enqueue({
       operation: 'create',
-      collection: 'com.at-rss.social.share',
+      collection: 'app.skyreader.social.share',
       rkey,
       record,
     });
@@ -126,7 +126,7 @@ function createSharesStore() {
     if (existingShare.syncStatus === 'synced' && existingShare.rkey) {
       await syncQueue.enqueue({
         operation: 'delete',
-        collection: 'com.at-rss.social.share',
+        collection: 'app.skyreader.social.share',
         rkey: existingShare.rkey,
       });
     }

--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -36,7 +36,7 @@ function createSidebarStore() {
 
   // Restore from localStorage on init
   if (browser) {
-    const stored = localStorage.getItem('at-rss-sidebar');
+    const stored = localStorage.getItem('skyreader-sidebar');
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
@@ -52,7 +52,7 @@ function createSidebarStore() {
   function persist() {
     if (browser) {
       localStorage.setItem(
-        'at-rss-sidebar',
+        'skyreader-sidebar',
         JSON.stringify({
           isCollapsed: state.isCollapsed,
           expandedSections: state.expandedSections,

--- a/frontend/src/lib/stores/social.svelte.ts
+++ b/frontend/src/lib/stores/social.svelte.ts
@@ -177,7 +177,7 @@ function createSocialStore() {
 
       await api.syncRecord({
         operation: 'create',
-        collection: 'com.at-rss.social.follow',
+        collection: 'app.skyreader.social.follow',
         rkey,
         record,
       });
@@ -196,7 +196,7 @@ function createSocialStore() {
   async function unfollowInApp(did: string): Promise<boolean> {
     try {
       // Find the user's in-app follow record
-      const records = await api.listRecords<{ subject: string }>('com.at-rss.social.follow');
+      const records = await api.listRecords<{ subject: string }>('app.skyreader.social.follow');
       const followRecord = records.records.find(r => r.value.subject === did);
 
       if (!followRecord) {
@@ -212,7 +212,7 @@ function createSocialStore() {
 
       await api.syncRecord({
         operation: 'delete',
-        collection: 'com.at-rss.social.follow',
+        collection: 'app.skyreader.social.follow',
         rkey,
       });
 

--- a/frontend/src/lib/stores/subscriptions.svelte.ts
+++ b/frontend/src/lib/stores/subscriptions.svelte.ts
@@ -21,7 +21,7 @@ function createSubscriptionsStore() {
 
   // Listen for sync completions and update local state
   syncQueue.onSyncComplete(async (collection, rkey) => {
-    if (collection === 'com.at-rss.feed.subscription') {
+    if (collection === 'app.skyreader.feed.subscription') {
       const sub = await db.subscriptions.where('rkey').equals(rkey).first();
       if (sub) {
         subscriptions = subscriptions.map((s) =>
@@ -95,7 +95,7 @@ function createSubscriptionsStore() {
 
     await syncQueue.enqueue({
       operation: 'create',
-      collection: 'com.at-rss.feed.subscription',
+      collection: 'app.skyreader.feed.subscription',
       rkey,
       record: {
         feedUrl,
@@ -177,7 +177,7 @@ function createSubscriptionsStore() {
       try {
         const operations = localRecords.map(({ rkey, feed }) => ({
           operation: 'create' as const,
-          collection: 'com.at-rss.feed.subscription',
+          collection: 'app.skyreader.feed.subscription',
           rkey,
           record: {
             feedUrl: feed.feedUrl,
@@ -212,7 +212,7 @@ function createSubscriptionsStore() {
         for (const { rkey, feed } of localRecords) {
           await syncQueue.enqueue({
             operation: 'create',
-            collection: 'com.at-rss.feed.subscription',
+            collection: 'app.skyreader.feed.subscription',
             rkey,
             record: {
               feedUrl: feed.feedUrl,
@@ -264,7 +264,7 @@ function createSubscriptionsStore() {
     const pendingCreateItems = await db.syncQueue
       .where('rkey')
       .equals(sub.rkey)
-      .filter((item) => item.operation === 'create' && item.collection === 'com.at-rss.feed.subscription')
+      .filter((item) => item.operation === 'create' && item.collection === 'app.skyreader.feed.subscription')
       .toArray();
 
     if (pendingCreateItems.length > 0) {
@@ -284,7 +284,7 @@ function createSubscriptionsStore() {
       // Enqueue an update operation to ensure PDS gets the latest data
       await syncQueue.enqueue({
         operation: 'update',
-        collection: 'com.at-rss.feed.subscription',
+        collection: 'app.skyreader.feed.subscription',
         rkey: sub.rkey,
         record: updatedRecord,
       });
@@ -303,7 +303,7 @@ function createSubscriptionsStore() {
     if (sub.syncStatus === 'synced') {
       await syncQueue.enqueue({
         operation: 'delete',
-        collection: 'com.at-rss.feed.subscription',
+        collection: 'app.skyreader.feed.subscription',
         rkey: sub.rkey,
       });
     }
@@ -474,7 +474,7 @@ function createSubscriptionsStore() {
         tags?: string[];
         createdAt: string;
         updatedAt?: string;
-      }>('com.at-rss.feed.subscription');
+      }>('app.skyreader.feed.subscription');
 
       // Get existing local subscriptions
       const localSubs = await db.subscriptions.toArray();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -193,7 +193,7 @@
 <svelte:window onkeydown={keyboardStore.handleKeydown} />
 
 <svelte:head>
-  <title>AT-RSS</title>
+  <title>Skyreader</title>
   <meta name="description" content="A decentralized RSS reader built on AT Protocol" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#0066cc" />
@@ -216,7 +216,7 @@
     {:else}
       <header class="header-full">
         <div class="header-content">
-          <a href="/" class="logo">AT-RSS</a>
+          <a href="/" class="logo">Skyreader</a>
           <a href="/auth/login" class="login-btn">Login</a>
         </div>
       </header>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -637,7 +637,7 @@
 
 {#if !auth.isAuthenticated}
   <div class="welcome">
-    <h1>Welcome to AT-RSS</h1>
+    <h1>Welcome to Skyreader</h1>
     <p>A decentralized RSS reader built on the AT Protocol.</p>
     <ul class="features">
       <li>Store your subscriptions in your own data server</li>

--- a/frontend/src/routes/auth/callback/+page.svelte
+++ b/frontend/src/routes/auth/callback/+page.svelte
@@ -16,7 +16,7 @@
     }
 
     // Check if we already have a valid session
-    const stored = localStorage.getItem('at-rss-auth');
+    const stored = localStorage.getItem('skyreader-auth');
     if (stored) {
       goto(returnUrl);
       return;

--- a/frontend/src/routes/auth/login/+page.svelte
+++ b/frontend/src/routes/auth/login/+page.svelte
@@ -27,7 +27,7 @@
 
 <div class="login-page">
   <div class="login-card card">
-    <h1>Login to AT-RSS</h1>
+    <h1>Login to Skyreader</h1>
     <p>Sign in with your Bluesky account</p>
 
     <form onsubmit={handleSubmit}>
@@ -53,7 +53,7 @@
     </form>
 
     <p class="info">
-      You'll be redirected to your Bluesky server to authorize AT-RSS.
+      You'll be redirected to your Bluesky server to authorize Skyreader.
     </p>
   </div>
 </div>

--- a/frontend/src/routes/discover/+page.svelte
+++ b/frontend/src/routes/discover/+page.svelte
@@ -42,7 +42,7 @@
   <div class="page-header">
     <div class="header-content">
       <h1>Discover</h1>
-      <p class="subtitle">Find active AT-RSS users to follow</p>
+      <p class="subtitle">Find active Skyreader users to follow</p>
     </div>
     <button class="btn btn-secondary" onclick={shuffle} disabled={socialStore.isDiscoverLoading}>
       {socialStore.isDiscoverLoading ? 'Loading...' : 'Shuffle'}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -192,7 +192,7 @@
 
   <section class="card">
     <h2>About</h2>
-    <p>AT-RSS is a decentralized RSS reader built on the AT Protocol.</p>
+    <p>Skyreader is a decentralized RSS reader built on the AT Protocol.</p>
     <p>Your data is stored in your Personal Data Server (PDS), giving you full ownership and portability.</p>
   </section>
 

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -5,7 +5,7 @@ import { build, files, version } from '$service-worker';
 
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_NAME = `at-rss-${version}`;
+const CACHE_NAME = `skyreader-${version}`;
 const STATIC_ASSETS = [...build, ...files];
 
 // API routes to cache with network-first strategy

--- a/frontend/static/manifest.json
+++ b/frontend/static/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "AT-RSS Reader",
-  "short_name": "AT-RSS",
+  "name": "Skyreader",
+  "short_name": "Skyreader",
   "description": "A decentralized RSS reader built on AT Protocol",
   "start_url": "/",
   "display": "standalone",

--- a/lexicons/app/skyreader/feed/readPosition.json
+++ b/lexicons/app/skyreader/feed/readPosition.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "com.at-rss.feed.readPosition",
+  "id": "app.skyreader.feed.readPosition",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/app/skyreader/feed/subscription.json
+++ b/lexicons/app/skyreader/feed/subscription.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "com.at-rss.feed.subscription",
+  "id": "app.skyreader.feed.subscription",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/app/skyreader/social/follow.json
+++ b/lexicons/app/skyreader/social/follow.json
@@ -1,10 +1,10 @@
 {
   "lexicon": 1,
-  "id": "com.at-rss.social.follow",
+  "id": "app.skyreader.social.follow",
   "defs": {
     "main": {
       "type": "record",
-      "description": "An in-app follow relationship to another AT-RSS user",
+      "description": "An in-app follow relationship to another Skyreader user",
       "key": "tid",
       "record": {
         "type": "object",

--- a/lexicons/app/skyreader/social/share.json
+++ b/lexicons/app/skyreader/social/share.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "com.at-rss.social.share",
+  "id": "app.skyreader.social.share",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/app/skyreader/social/shareReadPosition.json
+++ b/lexicons/app/skyreader/social/shareReadPosition.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "com.at-rss.social.shareReadPosition",
+  "id": "app.skyreader.social.shareReadPosition",
   "defs": {
     "main": {
       "type": "record",


### PR DESCRIPTION
## Summary

Rename project from AT-RSS to Skyreader. Updates lexicon namespace from `com.at-rss.*` to `app.skyreader.*`, all configuration and branding throughout frontend and backend, and migrates lexicon definitions to the new namespace directory structure.

## Changes

- Lexicon namespace: `com.at-rss.*` → `app.skyreader.*`
- Lexicon directory: `lexicons/com/at-rss/` → `lexicons/app/skyreader/`
- Database/worker name: `at-rss` → `skyreader`
- localStorage keys: `at-rss-*` → `skyreader-*`
- UI branding: "AT-RSS" → "Skyreader"
- User-Agent headers: Updated to reference skyreader.app

## Test plan

- [x] All lexicon JSON files validate
- [x] No remaining references to `at-rss` or `com.at-rss` in codebase
- [x] Lexicon IDs correctly updated to `app.skyreader.*`
- [ ] Start both backend and frontend dev servers
- [ ] Verify app displays "Skyreader" branding
- [ ] Verify localStorage uses new `skyreader-auth` key
- [ ] Verify collection references work with new `app.skyreader.*` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)