### PR TITLE
Configure deployment for skyreader.app custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build
         working-directory: frontend
         env:
-          VITE_API_URL: https://skyreader-api.tim-54a.workers.dev
+          VITE_API_URL: https://api.skyreader.app
         run: npm run build
 
       - name: Deploy to Cloudflare Pages

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -31,7 +31,7 @@ database_id = "94dbfd9e-3e55-4551-a812-75ce4bc8339f"
 
 # Environment variables
 [vars]
-FRONTEND_URL = "https://skyreader.pages.dev"
+FRONTEND_URL = "https://skyreader.app"
 
 # Cron Triggers - run every minute for Jetstream polling
 [triggers]


### PR DESCRIPTION
## Summary

Update frontend and backend configuration to deploy to custom domain skyreader.app:
- Frontend: https://skyreader.pages.dev → https://skyreader.app
- Backend API: https://skyreader-api.tim-54a.workers.dev → https://api.skyreader.app

## Prerequisites

Before merging, ensure custom domains are configured in Cloudflare:
1. Add skyreader.app as custom domain to Pages project
2. Add api.skyreader.app as custom domain to Workers

Once domains are configured, GitHub Actions will deploy both frontend and backend to the new URLs.

🤖 Generated with Claude Code