### PR TITLE
Scroll to article top when collapsing expanded view

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -600,9 +600,17 @@
             key: "Enter",
             description: "Toggle expand",
             category: "Navigation",
-            action: () => {
+            action: async () => {
                 if (selectedIndex >= 0) {
-                    expandedIndex = expandedIndex === selectedIndex ? -1 : selectedIndex;
+                    if (expandedIndex === selectedIndex) {
+                        expandedIndex = -1;
+                        await tick();
+                        scrollToCenter();
+                    } else {
+                        expandedIndex = selectedIndex;
+                        await tick();
+                        scrollToCenter();
+                    }
                 }
             },
             condition: () => auth.isAuthenticated && selectedIndex >= 0,
@@ -878,6 +886,8 @@
                                 onExpand={async () => {
                                     if (expandedIndex === index) {
                                         expandedIndex = -1;
+                                        await tick();
+                                        scrollToCenter();
                                     } else {
                                         expandedIndex = index;
                                         await tick();
@@ -915,6 +925,8 @@
                                 onExpand={async () => {
                                     if (expandedIndex === index) {
                                         expandedIndex = -1;
+                                        await tick();
+                                        scrollToCenter();
                                     } else {
                                         expandedIndex = index;
                                         await tick();
@@ -977,6 +989,8 @@
                             onExpand={async () => {
                                 if (expandedIndex === index) {
                                     expandedIndex = -1;
+                                    await tick();
+                                    scrollToCenter();
                                 } else {
                                     expandedIndex = index;
                                     await tick();
@@ -1049,6 +1063,8 @@
                             onExpand={async () => {
                                 if (expandedIndex === index) {
                                     expandedIndex = -1;
+                                    await tick();
+                                    scrollToCenter();
                                 } else {
                                     expandedIndex = index;
                                     await tick();
@@ -1101,6 +1117,8 @@
                             onExpand={async () => {
                                 if (expandedIndex === index) {
                                     expandedIndex = -1;
+                                    await tick();
+                                    scrollToCenter();
                                 } else {
                                     expandedIndex = index;
                                     await tick();


### PR DESCRIPTION
## Summary
When collapsing a long expanded article, the page now scrolls back to position the article at 1/3 from the top of the viewport. This matches the behavior when expanding articles and provides better visual context.

## Changes
- Added scroll behavior to keyboard shortcut (Enter key)
- Added scroll behavior to all five collapse handlers (across different view modes)
- Uses existing `scrollToCenter()` function to position articles consistently

## Test Plan
- Expand a long article and scroll through its content
- Click "Collapse" or press Enter to collapse
- Verify the article scrolls back into view at comfortable position

🤖 Generated with Claude Code