### PR TITLE
Add 100 feed limit per user

### DIFF
--- a/frontend/src/lib/components/AddFeedModal.svelte
+++ b/frontend/src/lib/components/AddFeedModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { subscriptionsStore } from "$lib/stores/subscriptions.svelte";
+    import { subscriptionsStore, MAX_SUBSCRIPTIONS } from "$lib/stores/subscriptions.svelte";
     import FeedDiscoveryForm from "$lib/components/FeedDiscoveryForm.svelte";
     import Modal from "$lib/components/common/Modal.svelte";
 
@@ -10,33 +10,67 @@
 
     let { open, onclose }: Props = $props();
     let feedFormRef: { reset: () => void } | undefined = $state();
+    let error = $state<string | null>(null);
+
+    const isAtLimit = $derived(subscriptionsStore.subscriptions.length >= MAX_SUBSCRIPTIONS);
 
     function handleClose() {
         feedFormRef?.reset();
+        error = null;
         onclose();
     }
 
     async function handleFeedSelected(url: string) {
-        // Add subscription with URL as temporary title
-        const tempTitle = new URL(url).hostname;
-        const id = await subscriptionsStore.add(url, tempTitle, {});
+        error = null;
 
-        // Close modal immediately
-        handleClose();
+        try {
+            // Add subscription with URL as temporary title
+            const tempTitle = new URL(url).hostname;
+            const id = await subscriptionsStore.add(url, tempTitle, {});
 
-        // Fetch feed in background (updates title and loads articles)
-        subscriptionsStore.fetchFeed(id, true).then(async (feed) => {
-            if (feed) {
-                // Update subscription with actual title and siteUrl
-                await subscriptionsStore.update(id, {
-                    title: feed.title,
-                    siteUrl: feed.siteUrl,
-                });
-            }
-        });
+            // Close modal immediately
+            handleClose();
+
+            // Fetch feed in background (updates title and loads articles)
+            subscriptionsStore.fetchFeed(id, true).then(async (feed) => {
+                if (feed) {
+                    // Update subscription with actual title and siteUrl
+                    await subscriptionsStore.update(id, {
+                        title: feed.title,
+                        siteUrl: feed.siteUrl,
+                    });
+                }
+            });
+        } catch (e) {
+            error = e instanceof Error ? e.message : "Failed to add feed";
+        }
     }
 </script>
 
 <Modal {open} onclose={handleClose} title="Add Feed">
-    <FeedDiscoveryForm bind:this={feedFormRef} onFeedSelected={handleFeedSelected} />
+    {#if isAtLimit}
+        <p class="limit-message">
+            You've reached the maximum of {MAX_SUBSCRIPTIONS} feeds.
+            Remove some feeds to add new ones.
+        </p>
+    {:else}
+        <FeedDiscoveryForm bind:this={feedFormRef} onFeedSelected={handleFeedSelected} />
+        {#if error}
+            <p class="error-message">{error}</p>
+        {/if}
+    {/if}
 </Modal>
+
+<style>
+    .limit-message {
+        color: var(--color-text-secondary);
+        text-align: center;
+        padding: 1rem;
+    }
+
+    .error-message {
+        color: var(--color-error);
+        font-size: 0.875rem;
+        margin-top: 0.5rem;
+    }
+</style>


### PR DESCRIPTION
## Summary
Enforce a maximum of 100 subscriptions per user to prevent excessive feed storage and processing. The limit is enforced server-side by querying user's PDS before accepting new subscriptions, with client-side checks for immediate feedback.

## Changes
- Backend: Add `countUserSubscriptions()` helper and limit checks in `handleRecordSync()` and `handleBulkRecordSync()`
- Frontend store: Export `MAX_SUBSCRIPTIONS` constant, validate before add/addBulk, truncate bulk imports to available slots
- UI: Show "limit reached" message in AddFeedModal, display capacity warning and truncation count in ImportOPMLModal

## Testing
- Backend type-checks with no errors
- Frontend builds successfully with warnings from existing code only
- Add and bulk import flows properly respect the limit