### PR TITLE
Reduce cron frequency to hourly (production) and every 12 hours (staging)

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -33,9 +33,9 @@ database_id = "YOUR_D1_DATABASE_ID"
 [vars]
 FRONTEND_URL = "https://skyreader.app"
 
-# Cron Triggers - run every 5 minutes for feed refresh
+# Cron Triggers - run every hour
 [triggers]
-crons = ["*/5 * * * *"]
+crons = ["0 * * * *"]
 
 # Development environment
 [env.dev]
@@ -57,6 +57,6 @@ binding = "DB"
 database_name = "skyreader-staging"
 database_id = "YOUR_STAGING_D1_DATABASE_ID"
 
-# Cron Triggers - run every 30 minutes in staging
+# Cron Triggers - run every 12 hours in staging
 [env.staging.triggers]
-crons = ["*/30 * * * *"]
+crons = ["0 */12 * * *"]


### PR DESCRIPTION
## Summary

Reduce backend cron frequency and simplify scheduling logic. Production now runs hourly at minute 0, staging every 12 hours. Removes redundant time-modulo checks since all operations execute on each cron invocation.

## Changes

- Update cron expressions in wrangler.toml (production: `0 * * * *`, staging: `0 */12 * * *`)
- Remove minute-based conditional checks (feed refresh, PDS sync, cleanup)
- Simplify scheduled handler by eliminating throttling logic

🤖 Generated with Claude Code