### PR TITLE
Fix D1 SQL variable limit error in feed sync

### DIFF
--- a/backend/src/routes/feeds.ts
+++ b/backend/src/routes/feeds.ts
@@ -3,7 +3,7 @@ import { parseFeed, discoverFeeds } from '../services/feed-parser';
 
 const MAX_ITEM_CONTENT_SIZE = 100000; // 100KB per item
 const MAX_INITIAL_ITEMS = 50; // Limit items on initial feed import
-const MAX_SQL_PARAMS = 900; // Leave buffer below SQLite's 999 limit
+const MAX_SQL_PARAMS = 90; // Conservative limit for D1 (empirically lower than SQLite's 999)
 const BATCH_INSERT_SIZE = 90; // 90 items × 10 params = 900, under 999 limit
 
 function chunkArray<T>(array: T[], chunkSize: number): T[][] {


### PR DESCRIPTION
## Summary
Reduces MAX_SQL_PARAMS from 900 to 90 to respect D1's empirically lower parameter limit. The SELECT query building GUIDs IN clauses was exceeding D1's limit, causing cron jobs to fail with "too many SQL variables" errors.

## Test plan
- Deploy to staging and monitor cron jobs via `npx wrangler tail`
- Verify feeds are fetched successfully without D1 SQL parameter errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)