### PR TITLE
Fix feed articles not appearing on app open

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -415,8 +415,8 @@
             // Load existing articles from IndexedDB first (instant display of cached data)
             allArticles = await subscriptionsStore.getAllArticles();
 
-            // If we have subscriptions but no articles, fetch from backend
-            if (subscriptionsStore.subscriptions.length > 0 && allArticles.length === 0) {
+            // Fetch latest articles from backend (store handles deduplication)
+            if (subscriptionsStore.subscriptions.length > 0) {
                 // Check which feeds are ready on the backend
                 const feedUrls = subscriptionsStore.subscriptions.map((s) => s.feedUrl);
                 await subscriptionsStore.checkFeedStatuses(feedUrls);


### PR DESCRIPTION
## Problem
New articles from subscribed feeds only appear after logout/login, not when simply reopening the app.

## Solution
Remove the empty cache condition that prevented article fetches on app load. Articles now refresh from the backend on every app mount when subscriptions exist. Store-level deduplication prevents duplicates.

## Testing
Open the app with existing subscriptions and verify articles load without requiring logout/login.