### PR TITLE
Remove refresh metadata and sync status sections

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "frontend",
 			"version": "0.0.1",
+			"license": "GPL-3.0",
 			"dependencies": {
 				"@atproto/api": "^0.18.13",
 				"@sveltejs/adapter-static": "^3.0.10",

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { auth } from '$lib/stores/auth.svelte';
-  import { syncStore } from '$lib/stores/sync.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { preferences, type ArticleFont, type ArticleFontSize } from '$lib/stores/preferences.svelte';
   import ImportOPMLModal from '$lib/components/ImportOPMLModal.svelte';
@@ -22,9 +21,6 @@
   ];
 
   let showImportModal = $state(false);
-  let isRefreshingMetadata = $state(false);
-  let refreshProgress = $state({ current: 0, total: 0 });
-  let refreshResult = $state<{ updated: number; failed: number } | null>(null);
 
   onMount(async () => {
     if (!auth.isAuthenticated) {
@@ -42,41 +38,6 @@
       await auth.logout();
       goto('/');
     }
-  }
-
-  async function handleRefreshMetadata() {
-    if (isRefreshingMetadata) return;
-
-    isRefreshingMetadata = true;
-    refreshResult = null;
-    const subs = subscriptionsStore.subscriptions;
-    refreshProgress = { current: 0, total: subs.length };
-
-    let updated = 0;
-    let failed = 0;
-
-    for (const sub of subs) {
-      if (!sub.id) continue;
-
-      try {
-        const feed = await subscriptionsStore.fetchFeed(sub.id, true);
-        if (feed && (feed.title !== sub.title || feed.siteUrl !== sub.siteUrl)) {
-          await subscriptionsStore.update(sub.id, {
-            title: feed.title,
-            siteUrl: feed.siteUrl,
-          });
-          updated++;
-        }
-      } catch (e) {
-        console.error(`Failed to refresh metadata for ${sub.feedUrl}:`, e);
-        failed++;
-      }
-
-      refreshProgress = { current: refreshProgress.current + 1, total: subs.length };
-    }
-
-    refreshResult = { updated, failed };
-    isRefreshingMetadata = false;
   }
 
   let isUnsubscribingAll = $state(false);
@@ -128,27 +89,6 @@
   {/if}
 
   <section class="card">
-    <h2>Sync Status</h2>
-    <dl class="status-list">
-      <dt>Connection</dt>
-      <dd>
-        <span class="status-badge" class:online={syncStore.isOnline} class:offline={!syncStore.isOnline}>
-          {syncStore.isOnline ? 'Online' : 'Offline'}
-        </span>
-      </dd>
-      <dt>Pending Changes</dt>
-      <dd>{syncStore.pendingCount}</dd>
-      {#if syncStore.lastSyncedAt}
-        <dt>Last Sync</dt>
-        <dd>{new Date(syncStore.lastSyncedAt).toLocaleTimeString()}</dd>
-      {/if}
-    </dl>
-    <button class="btn btn-secondary" onclick={() => syncStore.triggerSync()} disabled={!syncStore.isOnline}>
-      Sync Now
-    </button>
-  </section>
-
-  <section class="card">
     <h2>Appearance</h2>
     <div class="setting-row">
       <label for="article-font">Article Font</label>
@@ -195,29 +135,6 @@
     <p class="setting-description">
       Automatically mark articles as read when you scroll past them in the feed.
     </p>
-  </section>
-
-  <section class="card">
-    <h2>Feeds</h2>
-    <p>Refresh feed titles and icons from their sources. This will update your PDS with the correct metadata.</p>
-    <div class="refresh-section">
-      <button
-        class="btn btn-secondary"
-        onclick={handleRefreshMetadata}
-        disabled={isRefreshingMetadata || subscriptionsStore.subscriptions.length === 0}
-      >
-        {#if isRefreshingMetadata}
-          Refreshing... ({refreshProgress.current}/{refreshProgress.total})
-        {:else}
-          Refresh All Metadata
-        {/if}
-      </button>
-      {#if refreshResult}
-        <p class="refresh-result">
-          Updated {refreshResult.updated} feed{refreshResult.updated !== 1 ? 's' : ''}{#if refreshResult.failed > 0}, {refreshResult.failed} failed{/if}
-        </p>
-      {/if}
-    </div>
   </section>
 
   <section class="card">
@@ -298,47 +215,6 @@
     font-size: 0.75rem;
     color: var(--color-text-secondary);
     word-break: break-all;
-  }
-
-  .status-list {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 0.5rem 1rem;
-    margin-bottom: 1rem;
-  }
-
-  .status-list dt {
-    font-weight: 500;
-  }
-
-  .status-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.75rem;
-  }
-
-  .status-badge.online {
-    background: var(--color-success);
-    color: white;
-  }
-
-  .status-badge.offline {
-    background: var(--color-error);
-    color: white;
-  }
-
-  .refresh-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: flex-start;
-  }
-
-  .refresh-result {
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    margin: 0;
   }
 
   .debug-section {


### PR DESCRIPTION
## Summary
Removes the "Refresh All Metadata" button and "Sync Status" section from the settings page, simplifying the UI.

## Changes
- Removed refresh metadata state and function logic
- Removed sync status section UI
- Removed associated CSS styles and store imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)