### PR TITLE
Improve feed processing CPU resilience

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "backend",
 			"version": "0.0.0",
+			"license": "GPL-3.0",
 			"dependencies": {
 				"fast-xml-parser": "^5.2.0"
 			},


### PR DESCRIPTION
## Summary
Reduce cpuExceeded errors by optimizing RSS feed parsing and processing. Pre-compile HTML entity regex patterns, limit items parsed per feed, process feeds sequentially, and skip oversized feeds.

## Changes
- Pre-compile regex patterns to eliminate ~2800 regex creations per feed
- Limit items parsed to 100 to cap CPU usage on large feeds  
- Reduce batch size from 3 to 1 to prevent concurrent CPU spikes
- Skip feeds >2MB to prevent memory/CPU exhaustion

## Test plan
- Trigger feed refresh cycle to verify completion without cpuExceeded errors
- Check FeedRefresher logs for skipped feeds and error tracking
- Verify feeds still parse correctly (spot check subscriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)