### PR TITLE
Fix Cloudflare subrequest limit errors

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "backend",
 			"version": "0.0.0",
+			"license": "GPL-3.0",
 			"dependencies": {
 				"fast-xml-parser": "^5.2.0"
 			},


### PR DESCRIPTION
## Summary

Fix "Too many subrequests" errors by batching database and PDS operations. Reduces individual D1 INSERT/UPDATE calls and uses `com.atproto.repo.applyWrites` for batched PDS syncs instead of individual calls, cutting subrequests from 100+ down to ~3 for typical operations.

## Changes

- Replace individual D1 operations with `env.DB.batch()` in reading.ts and records.ts
- Use batched `applyWrites` for PDS sync in pds-sync.ts
- Reduce BATCH_SIZE from 50 to 25 for safety margin
- Chunk cache hydration into 50-record batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)