### PR TITLE
Fix handle resolution for usernames without domain suffix

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -64,11 +64,8 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
   }
 
   try {
-    // Normalize handle (remove @ if present)
-    const normalizedHandle = handle.startsWith('@') ? handle.substring(1) : handle;
-
-    // Resolve handle to DID
-    const did = await resolveHandle(normalizedHandle);
+    // Resolve handle to DID (resolveHandle handles normalization)
+    const did = await resolveHandle(handle);
 
     // Get PDS URL from DID
     const pdsUrl = await getPdsFromDid(did);
@@ -82,11 +79,11 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
     // Generate state
     const state = generateRandomString(32);
 
-    // Store state in KV
+    // Store state in KV (handle will be updated from profile in callback)
     await storeOAuthState(env, state, {
       codeVerifier,
       did,
-      handle: normalizedHandle,
+      handle,
       pdsUrl,
       authServer: authMeta.issuer,
       returnUrl,

--- a/frontend/src/routes/auth/login/+page.svelte
+++ b/frontend/src/routes/auth/login/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { api } from '$lib/services/api';
   import Logo from '$lib/assets/logo.svg';
@@ -7,6 +6,22 @@
   let handle = $state('');
   let isLoading = $state(false);
   let error = $state<string | null>(null);
+
+  // Compute the normalized handle for display hint
+  const normalizedHandle = $derived.by(() => {
+    const trimmed = handle.trim().toLowerCase();
+    if (!trimmed) return '';
+    const withoutAt = trimmed.startsWith('@') ? trimmed.substring(1) : trimmed;
+    return withoutAt.includes('.') ? withoutAt : `${withoutAt}.bsky.social`;
+  });
+
+  // Show hint when user enters a handle without a dot
+  const showNormalizationHint = $derived.by(() => {
+    const trimmed = handle.trim();
+    if (!trimmed) return false;
+    const withoutAt = trimmed.startsWith('@') ? trimmed.substring(1) : trimmed;
+    return !withoutAt.includes('.') && withoutAt.length > 0;
+  });
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
@@ -41,10 +56,16 @@
           type="text"
           id="handle"
           class="input"
-          placeholder="yourname.bsky.social"
+          placeholder="yourname or yourname.bsky.social"
           bind:value={handle}
           disabled={isLoading}
+          autocapitalize="none"
+          autocorrect="off"
+          spellcheck="false"
         />
+        {#if showNormalizationHint}
+          <p class="hint">Will sign in as <strong>{normalizedHandle}</strong></p>
+        {/if}
       </div>
 
       {#if error}
@@ -116,5 +137,16 @@
     color: var(--color-text-secondary);
     margin-top: 1rem;
     text-align: center;
+  }
+
+  .hint {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    margin-top: 0.25rem;
+    margin-bottom: 0;
+  }
+
+  .hint strong {
+    color: var(--color-text-primary);
   }
 </style>


### PR DESCRIPTION
## Summary
- Adds handle normalization that auto-appends `.bsky.social` when user enters a username without a domain
- Uses Bluesky public API (`com.atproto.identity.resolveHandle`) as the primary resolver
- Maintains DNS TXT and HTTP well-known fallbacks for custom domain handles
- Improves login page UX with a hint showing the normalized handle

## Test plan
- [ ] Test login with username only (e.g., "alice")
- [ ] Test login with full handle (e.g., "alice.bsky.social")
- [ ] Test login with @ prefix (e.g., "@alice")
- [ ] Test login with custom domain handle
- [ ] Verify error message is clear for non-existent users

🤖 Generated with [Claude Code](https://claude.com/claude-code)