### PR TITLE
Narrow OAuth scopes to granular permissions

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -19,6 +19,19 @@ import {
 import { syncFollowsForUser } from './social';
 import { syncReadPositionsForUser } from '../services/pds-sync';
 
+// Granular OAuth scopes - only request permissions we actually need
+// See: https://atproto.com/specs/permission
+const OAUTH_SCOPES = [
+  'atproto',
+  'repo:app.skyreader.feed.subscription',
+  'repo:app.skyreader.feed.readPosition',
+  'repo:app.skyreader.social.share',
+  'repo:app.skyreader.social.follow',
+  'repo:app.skyreader.social.shareReadPosition',
+  'rpc:app.bsky.graph.getFollows?aud=*',
+  'rpc:app.bsky.actor.getProfile?aud=*',
+].join(' ');
+
 // RFC 8252 requires loopback IP instead of localhost for OAuth
 function getBaseUrl(url: URL): string {
   let host = url.host;
@@ -41,7 +54,7 @@ export function handleClientMetadata(request: Request, env: Env): Response {
     redirect_uris: [`${baseUrl}/api/auth/callback`],
     grant_types: ['authorization_code', 'refresh_token'],
     response_types: ['code'],
-    scope: 'atproto transition:generic',
+    scope: OAUTH_SCOPES,
     token_endpoint_auth_method: 'none',
     dpop_bound_access_tokens: true,
   };
@@ -105,7 +118,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
           client_id: clientId,
           redirect_uri: redirectUri,
           response_type: 'code',
-          scope: 'atproto transition:generic',
+          scope: OAUTH_SCOPES,
           state,
           code_challenge: codeChallenge,
           code_challenge_method: 'S256',
@@ -126,7 +139,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
         client_id: clientId,
         redirect_uri: redirectUri,
         response_type: 'code',
-        scope: 'atproto transition:generic',
+        scope: OAUTH_SCOPES,
         state,
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',


### PR DESCRIPTION
## Summary
Replace broad `transition:generic` OAuth scope with granular permissions that only grant access to Skyreader collections and the specific Bluesky RPC endpoints we use. This minimizes the app's privilege level per OAuth security best practices.

## Changes
- Added `OAUTH_SCOPES` constant with 8 specific permissions
- Request access only to Skyreader's 5 collections (subscriptions, read positions, shares, follows, share read positions)
- Request access only to `app.bsky.graph.getFollows` and `app.bsky.actor.getProfile` RPC endpoints
- Previously the app had broad permissions to read/write ANY of the user's AT Protocol records

## Testing
- Verified TypeScript compilation passes
- Test on staging: login flow should work normally but consent screen shows specific permissions instead of broad access