### PR TITLE
Add login_hint parameter to OAuth authorization requests

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -109,6 +109,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
           state,
           code_challenge: codeChallenge,
           code_challenge_method: 'S256',
+          login_hint: did,
         }),
       });
 
@@ -129,6 +130,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
         state,
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
+        login_hint: did,
       });
       authUrl = `${authMeta.authorization_endpoint}?${params}`;
     }


### PR DESCRIPTION
## Summary

Pass the resolved DID as `login_hint` to OAuth authorization requests to restrict authentication to the user's intended account. This fixes the DID mismatch errors users were experiencing when logging in with multiple Bluesky accounts.

## Changes

- Added `login_hint` parameter to PAR (Pushed Authorization Request) flow
- Added `login_hint` parameter to direct authorization request flow

## Why

Without `login_hint`, the auth server allows users to authenticate with any account they have access to. When a user enters one handle but the auth server authenticates them as a different account, the DID validation check rejects it with a mismatch error. Per the AT Protocol OAuth spec, `login_hint` should be passed when the auth flow starts with an account identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)