### PR TITLE
Remove redundant feed_cache.content to free ~175MB

### DIFF
--- a/backend/migrations/0018_feed_cache_cleanup.sql
+++ b/backend/migrations/0018_feed_cache_cleanup.sql
@@ -1,0 +1,3 @@
+-- Clear existing bloated content (one-time cleanup)
+-- The content column stored redundant JSON blobs that now exist in feed_items
+UPDATE feed_cache SET content = '{}';


### PR DESCRIPTION
## Summary
The `feed_cache.content` column stored full parsed feed JSON that's already available in the `feed_items` table. This was redundant and caused 175MB of storage bloat. Refactored article content lookup to query `feed_items` directly. All future cache writes now use empty JSON, and a migration clears existing bloated content.

## Changes
- `article-content.ts`: Query `feed_items` instead of parsing JSON from `feed_cache`
- `feeds.ts` (3 locations): Write `{}` instead of full feed JSON
- `feed-refresher.ts`: Write `{}` to cache for TTL tracking only
- Remove now-unused `MAX_CONTENT_SIZE` constants and truncation logic

## Testing
- TypeScript type checking passes
- Article content lookup still works by querying stored items

🤖 Generated with [Claude Code](https://claude.com/claude-code)