### PR TITLE
Fix OAuth login_hint to show handle instead of DID

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -114,7 +114,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
           state,
           code_challenge: codeChallenge,
           code_challenge_method: 'S256',
-          login_hint: did,
+          login_hint: handle,
         }),
       });
 
@@ -135,7 +135,7 @@ export async function handleAuthLogin(request: Request, env: Env): Promise<Respo
         state,
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
-        login_hint: did,
+        login_hint: handle,
       });
       authUrl = `${authMeta.authorization_endpoint}?${params}`;
     }


### PR DESCRIPTION
Per AT Protocol OAuth spec, login_hint should be the account identifier the user entered (handle) to ensure recognition on the auth screen. Previously we were passing the DID, which users wouldn't recognize. The security benefit is preserved as Bluesky's auth server still restricts authentication to the resolved account.

🤖 Generated with Claude Code