### PR TITLE
fix mark as read when scrolling

### DIFF
--- a/src/lib/stores/feedView.svelte.ts
+++ b/src/lib/stores/feedView.svelte.ts
@@ -347,6 +347,17 @@ function createFeedViewStore() {
 		showOnlyUnread = !showOnlyUnread;
 	}
 
+	// Track an item as "seen this session" so it stays visible after being marked read
+	function trackSeenThisSession(item: FeedDisplayItem) {
+		if (item.type === 'article') {
+			readArticleGuidsThisSession.add(item.item.guid);
+			readArticleGuidsThisSession = new Set(readArticleGuidsThisSession);
+		} else if (item.type === 'share') {
+			readShareUrisThisSession.add(item.item.recordUri);
+			readShareUrisThisSession = new Set(readShareUrisThisSession);
+		}
+	}
+
 	function getArticleForShare(share: SocialShare): Article | undefined {
 		if (!share.itemGuid) return undefined;
 		return articlesByGuid.get(share.itemGuid);
@@ -419,6 +430,7 @@ function createFeedViewStore() {
 		collapse,
 		resetSelection,
 		toggleUnreadFilter,
+		trackSeenThisSession,
 		setShowOnlyUnread(value: boolean) {
 			showOnlyUnread = value;
 		},

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,11 +64,14 @@
 		return 'All';
 	});
 
-	// Mark an item as read by its index
-	function markItemAsReadByIndex(index: number) {
+	// Mark an item as read by its stable key
+	function markItemAsReadByKey(key: string) {
 		const items = feedViewStore.currentItems;
-		const item = items[index];
+		const item = items.find((i) => i.key === key);
 		if (!item) return;
+
+		// Track the item so it stays visible in unread filter until view changes
+		feedViewStore.trackSeenThisSession(item);
 
 		if (item.type === 'article') {
 			const article = item.item;
@@ -95,8 +98,9 @@
 	// Initialize scroll-to-mark-as-read hook
 	const scrollMarkAsRead = useScrollMarkAsRead({
 		getArticleElements,
+		getItemKey: (index) => feedViewStore.currentItems[index]?.key,
 		enabled: preferences.scrollToMarkAsRead,
-		onMarkAsRead: markItemAsReadByIndex,
+		onMarkAsRead: markItemAsReadByKey,
 	});
 
 	// Setup/teardown scroll-to-mark-as-read observer when content changes


### PR DESCRIPTION
When mark as read while scrolling was enabled items inserted while feeds were loading would be unintentionally marked as read.