### PR TITLE
Add client-side tagging for feed items

### DIFF
--- a/src/lib/components/ArticleCard.svelte
+++ b/src/lib/components/ArticleCard.svelte
@@ -21,6 +21,10 @@
   import { sharesStore } from '$lib/stores/shares.svelte';
   import { auth } from '$lib/stores/auth.svelte';
   import Icon from './Icon.svelte';
+  import TagMenu from '$lib/components/feed/TagMenu.svelte';
+  import { tagsStore } from '$lib/stores/tags.svelte';
+  import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import type { ItemTags } from '$lib/types';
   import logo from '$lib/assets/logo.svg';
 
   let {
@@ -325,6 +329,30 @@
       isTruncated = bodyEl.scrollHeight > bodyEl.clientHeight;
     }
   });
+
+  // Tag menu state
+  let tagMenuOpenLocal = $state(false);
+  let tagBtnRef = $state<HTMLButtonElement | null>(null);
+
+  // Tag menu can be opened via button click or keyboard shortcut (via feedViewStore)
+  let tagMenuOpen = $derived(tagMenuOpenLocal || feedViewStore.tagMenuItemKey === itemGuid);
+
+  let itemTagType = $derived.by((): ItemTags['itemType'] => {
+    if (isShareMode) return 'share';
+    if (isDocumentMode) return 'document';
+    return 'article';
+  });
+
+  let itemTagCount = $derived(tagsStore.getTagsForItem(itemGuid).length);
+
+  function handleTagClick(e: MouseEvent) {
+    e.stopPropagation();
+    tagMenuOpenLocal = !tagMenuOpenLocal;
+    // Clear store-level tag menu if we're toggling
+    if (feedViewStore.tagMenuItemKey === itemGuid) {
+      feedViewStore.closeTagMenu();
+    }
+  }
 </script>
 
 <article
@@ -510,6 +538,16 @@
             >
           </button>
         {/if}
+        <button
+          class="action-btn"
+          class:tagged={itemTagCount > 0}
+          onclick={handleTagClick}
+          bind:this={tagBtnRef}
+        >
+          <span class="action-icon"><Icon name="tag" size={16} /></span><span class="action-label"
+            >Tag{#if itemTagCount > 0}<span class="tag-count">({itemTagCount})</span>{/if}</span
+          >
+        </button>
         <span class="action-separator"></span>
         {#if expanded}
           <button class="action-btn show-less-btn" onclick={handleExpandClick}
@@ -529,6 +567,26 @@
         {/if}
       </div>
     </div>
+
+    {#if tagMenuOpen}
+      <TagMenu
+        itemKey={itemGuid}
+        itemType={itemTagType}
+        anchorEl={tagBtnRef}
+        onClose={() => {
+          tagMenuOpenLocal = false;
+          feedViewStore.closeTagMenu();
+        }}
+      />
+    {/if}
+
+    {#if itemTagCount > 0}
+      <div class="tag-chips">
+        {#each tagsStore.getTagsForItem(itemGuid) as tag}
+          <span class="tag-chip">{tag}</span>
+        {/each}
+      </div>
+    {/if}
   {/if}
 </article>
 
@@ -889,6 +947,33 @@
   .action-btn.show-more-btn,
   .action-btn.show-less-btn {
     color: var(--color-primary, #0066cc);
+  }
+
+  .action-btn.tagged {
+    color: var(--color-primary, #0066cc);
+  }
+
+  .tag-count {
+    font-size: 0.75rem;
+    margin-left: 0.125rem;
+  }
+
+  .tag-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0 0 0.5rem;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--color-primary, #2563eb);
+    border-radius: 999px;
   }
 
   .action-btn.disabled {

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -34,7 +34,9 @@
     | 'type'
     | 'minus'
     | 'a-large-small'
-    | 'share-2';
+    | 'share-2'
+    | 'tag'
+    | 'x';
 
   interface Props {
     name: IconName;
@@ -193,6 +195,14 @@
     <circle cx="18" cy="19" r="3" />
     <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
     <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  {:else if name === 'tag'}
+    <path
+      d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
+    />
+    <circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
+  {:else if name === 'x'}
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
   {/if}
 </svg>
 

--- a/src/lib/components/feed/FilterToolbar.svelte
+++ b/src/lib/components/feed/FilterToolbar.svelte
@@ -7,6 +7,7 @@
   import { socialStore } from '$lib/stores/social.svelte';
   import { profileService } from '$lib/services/profiles';
   import { getFaviconUrl } from '$lib/utils/favicon';
+  import { tagsStore } from '$lib/stores/tags.svelte';
   import { goto } from '$app/navigation';
   import {
     rssSourceKey,
@@ -107,6 +108,35 @@
       : socialStore.inAppFollows
   );
 
+  // Tag filter state
+  let tagPopoverOpen = $state(false);
+  let tagPopoverRef = $state<HTMLDivElement | null>(null);
+  let allTags = $derived(tagsStore.allTags);
+  let activeTagFilter = $derived(feedViewStore.toolbarTagFilter);
+  let activeTagSet = $derived(new Set(activeTagFilter));
+
+  let tagFilterLabel = $derived.by(() => {
+    if (activeTagFilter.length === 0) return 'Tags';
+    return `Tags (${activeTagFilter.length})`;
+  });
+
+  function toggleTagFilter(tag: string) {
+    const newTags = activeTagSet.has(tag)
+      ? activeTagFilter.filter((t) => t !== tag)
+      : [...activeTagFilter, tag];
+    feedViewStore.setToolbarTagFilter(newTags);
+  }
+
+  function clearTagFilter() {
+    feedViewStore.setToolbarTagFilter([]);
+  }
+
+  function handleTagClickOutside(e: MouseEvent) {
+    if (tagPopoverOpen && tagPopoverRef && !tagPopoverRef.contains(e.target as Node)) {
+      tagPopoverOpen = false;
+    }
+  }
+
   function setSourceMode(mode: 'all' | 'include') {
     feedViewStore.setToolbarSourceFilter(mode, mode === 'all' ? [] : [...ef.sourceKeys]);
   }
@@ -165,11 +195,13 @@
     if (sourcePopoverOpen && sourcePopoverRef && !sourcePopoverRef.contains(e.target as Node)) {
       feedViewStore.setSourcePopoverOpen(false);
     }
+    handleTagClickOutside(e);
   }
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
       feedViewStore.setSourcePopoverOpen(false);
+      tagPopoverOpen = false;
     }
   }
 
@@ -222,6 +254,7 @@
         sourceKeys: [...ef.sourceKeys],
         readFilter: feedViewStore.showOnlyUnread ? 'unread' : 'all',
         sortOrder: feedViewStore.currentSortOrder,
+        tagFilter: activeTagFilter.length > 0 ? [...activeTagFilter] : undefined,
       });
       showNameInput = false;
       newViewName = '';
@@ -485,6 +518,52 @@
                 {/if}
               {/if}
             {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  {#if allTags.length > 0}
+    <span class="toolbar-divider group-divider"></span>
+
+    <!-- Group 3: Tags dropdown -->
+    <div class="filter-group">
+      <div class="dropdown-wrapper" bind:this={tagPopoverRef}>
+        <button
+          class="filter-btn"
+          class:has-filter={activeTagFilter.length > 0}
+          onclick={(e) => {
+            e.stopPropagation();
+            tagPopoverOpen = !tagPopoverOpen;
+          }}
+        >
+          <Icon name="tag" size={16} />
+          <span class="filter-label">{tagFilterLabel}</span>
+          <Icon name="chevron-down" size={12} />
+        </button>
+
+        {#if tagPopoverOpen}
+          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+          <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+            <div class="popover-group-header">
+              <span>Tags</span>
+              {#if activeTagFilter.length > 0}
+                <button class="select-all-btn" onclick={clearTagFilter}>Clear</button>
+              {/if}
+            </div>
+            <div class="popover-list">
+              {#each allTags as tag}
+                <label class="check-label">
+                  <input
+                    type="checkbox"
+                    checked={activeTagSet.has(tag)}
+                    onchange={() => toggleTagFilter(tag)}
+                  />
+                  <span class="check-text">{tag}</span>
+                </label>
+              {/each}
+            </div>
           </div>
         {/if}
       </div>

--- a/src/lib/components/feed/TagMenu.svelte
+++ b/src/lib/components/feed/TagMenu.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { tagsStore } from '$lib/stores/tags.svelte';
+  import type { ItemTags } from '$lib/types';
+
+  interface Props {
+    itemKey: string;
+    itemType: ItemTags['itemType'];
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+  }
+
+  let { itemKey, itemType, anchorEl, onClose }: Props = $props();
+
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let newTagInput = $state('');
+  let showNewTagInput = $state(false);
+  let inputRef = $state<HTMLInputElement | null>(null);
+
+  let allTags = $derived(tagsStore.allTags);
+  let itemTags = $derived(tagsStore.getTagsForItem(itemKey));
+
+  // Show up to 9 existing tags
+  let displayTags = $derived(allTags.slice(0, 9));
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+      return;
+    }
+
+    // If the new tag input is focused, don't handle number keys
+    if (showNewTagInput && document.activeElement === inputRef) return;
+
+    const num = parseInt(e.key);
+    if (isNaN(num)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (num === 0) {
+      showNewTagInput = true;
+      requestAnimationFrame(() => inputRef?.focus());
+      return;
+    }
+
+    const tagIndex = num - 1;
+    if (tagIndex < displayTags.length) {
+      tagsStore.toggleTag(itemKey, itemType, displayTags[tagIndex]);
+    }
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (menuEl && !menuEl.contains(e.target as Node)) {
+      onClose();
+    }
+  }
+
+  async function handleNewTagSubmit() {
+    const tag = newTagInput.trim();
+    if (!tag) return;
+    await tagsStore.addTag(itemKey, itemType, tag);
+    newTagInput = '';
+    showNewTagInput = false;
+  }
+
+  function handleNewTagKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleNewTagSubmit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      showNewTagInput = false;
+      newTagInput = '';
+    }
+    e.stopPropagation();
+  }
+
+  onMount(() => {
+    document.addEventListener('keydown', handleKeydown, true);
+    document.addEventListener('click', handleClickOutside, true);
+    // Reposition on scroll so the menu stays anchored to the button
+    document.addEventListener('scroll', positionMenu, true);
+    window.addEventListener('resize', positionMenu);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('keydown', handleKeydown, true);
+    document.removeEventListener('click', handleClickOutside, true);
+    document.removeEventListener('scroll', positionMenu, true);
+    window.removeEventListener('resize', positionMenu);
+  });
+
+  // Position the menu relative to anchor, adjusting for viewport edges
+  function positionMenu() {
+    if (!anchorEl || !menuEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    const menuRect = menuEl.getBoundingClientRect();
+    const gap = 4;
+
+    // Vertical: prefer below, flip above if it would overflow bottom
+    let top: number;
+    if (rect.bottom + gap + menuRect.height > window.innerHeight) {
+      top = Math.max(gap, rect.top - gap - menuRect.height);
+    } else {
+      top = rect.bottom + gap;
+    }
+
+    // Horizontal: prefer left-aligned with anchor, shift left if overflowing right
+    let left = Math.min(rect.left, window.innerWidth - menuRect.width - gap);
+    left = Math.max(gap, left);
+
+    menuEl.style.top = `${top}px`;
+    menuEl.style.left = `${left}px`;
+  }
+
+  $effect(() => {
+    if (!anchorEl || !menuEl) return;
+    // Re-position when tags or input state changes (menu height may change)
+    void displayTags.length;
+    void showNewTagInput;
+    // Wait a tick for DOM to update before measuring
+    requestAnimationFrame(positionMenu);
+  });
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+<div
+  class="tag-menu"
+  style="position: fixed; z-index: 200;"
+  bind:this={menuEl}
+  onclick={(e) => e.stopPropagation()}
+>
+  {#if displayTags.length > 0}
+    <div class="tag-list">
+      {#each displayTags as tag, i}
+        {@const isActive = itemTags.includes(tag)}
+        <button
+          class="tag-item"
+          class:active={isActive}
+          onclick={() => tagsStore.toggleTag(itemKey, itemType, tag)}
+        >
+          <span class="tag-number">{i + 1}</span>
+          <span class="tag-name">{tag}</span>
+          {#if isActive}
+            <span class="tag-check"><Icon name="check" size={14} /></span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+    <div class="tag-divider"></div>
+  {/if}
+
+  {#if showNewTagInput}
+    <div class="new-tag-row">
+      <input
+        type="text"
+        bind:this={inputRef}
+        bind:value={newTagInput}
+        placeholder="Tag name..."
+        onkeydown={handleNewTagKeydown}
+        maxlength={64}
+        class="new-tag-input"
+      />
+      <button class="new-tag-confirm" onclick={handleNewTagSubmit} disabled={!newTagInput.trim()}>
+        <Icon name="check" size={14} />
+      </button>
+    </div>
+  {:else}
+    <button
+      class="tag-item add-tag"
+      onclick={() => {
+        showNewTagInput = true;
+        requestAnimationFrame(() => inputRef?.focus());
+      }}
+    >
+      <span class="tag-number">0</span>
+      <span class="tag-name">add new tag</span>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .tag-menu {
+    min-width: 180px;
+    max-width: 240px;
+    background: var(--color-bg, #fff);
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+    padding: 0.25rem 0;
+  }
+
+  .tag-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tag-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    width: 100%;
+    text-align: left;
+  }
+
+  .tag-item:hover {
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  .tag-item.active {
+    color: var(--color-primary, #2563eb);
+  }
+
+  .tag-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border: 1.5px solid var(--color-border, #d1d5db);
+    border-radius: 3px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+  }
+
+  .tag-item.active .tag-number {
+    border-color: var(--color-primary, #2563eb);
+    color: var(--color-primary, #2563eb);
+  }
+
+  .tag-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tag-check {
+    display: inline-flex;
+    color: var(--color-primary, #2563eb);
+    flex-shrink: 0;
+  }
+
+  .tag-divider {
+    height: 1px;
+    background: var(--color-border, #e5e7eb);
+    margin: 0.25rem 0;
+  }
+
+  .add-tag {
+    color: var(--color-text-secondary);
+  }
+
+  .add-tag .tag-number {
+    border-style: dashed;
+  }
+
+  .new-tag-row {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .new-tag-input {
+    flex: 1;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    background: var(--color-bg, #fff);
+    color: var(--color-text);
+    outline: none;
+  }
+
+  .new-tag-input:focus {
+    border-color: var(--color-primary, #2563eb);
+  }
+
+  .new-tag-confirm {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    padding: 0.25rem;
+    cursor: pointer;
+    color: var(--color-primary, #2563eb);
+  }
+
+  .new-tag-confirm:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .tag-menu {
+      background: var(--color-bg, #1a1a1a);
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    }
+
+    .tag-item:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .new-tag-input {
+      background: var(--color-bg, #1a1a1a);
+    }
+  }
+</style>

--- a/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
+++ b/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
@@ -289,6 +289,24 @@ export function useFeedKeyboardShortcuts(params: KeyboardShortcutsParams) {
       condition: hasSelected,
     });
 
+    keyboardStore.register({
+      key: 't',
+      description: 'Tag item',
+      category: 'Article',
+      action: () => {
+        const idx = feedViewStore.selectedIndex;
+        if (idx < 0) return;
+        const item = feedViewStore.currentItems[idx];
+        if (!item) return;
+        if (feedViewStore.tagMenuItemKey === item.key) {
+          feedViewStore.closeTagMenu();
+        } else {
+          feedViewStore.openTagMenu(item.key);
+        }
+      },
+      condition: hasSelected,
+    });
+
     // Other shortcuts
     keyboardStore.register({
       key: 'u',
@@ -317,6 +335,7 @@ export function useFeedKeyboardShortcuts(params: KeyboardShortcutsParams) {
     keyboardStore.unregister('s');
     keyboardStore.unregister('S', true);
     keyboardStore.unregister('m');
+    keyboardStore.unregister('t');
     keyboardStore.unregister('u');
     keyboardStore.unregister('A', true);
   }

--- a/src/lib/services/db.ts
+++ b/src/lib/services/db.ts
@@ -8,6 +8,7 @@ import type {
   SocialShare,
   UserShare,
   FilteredView,
+  ItemTags,
 } from '$lib/types';
 
 // Local cache for read positions (backend is source of truth)
@@ -49,6 +50,7 @@ class SkyreaderDatabase extends Dexie {
   syncQueue!: Table<SyncQueueEntry>;
   metadata!: Table<MetadataEntry>;
   filteredViews!: Table<FilteredView>;
+  itemTags!: Table<ItemTags>;
 
   constructor() {
     super('skyreader');
@@ -158,6 +160,11 @@ class SkyreaderDatabase extends Dexie {
     this.version(16).stores({
       filteredViews: '++id, name, position',
     });
+
+    // Add itemTags table for client-side tagging of feed items
+    this.version(17).stores({
+      itemTags: 'itemKey, *tags',
+    });
   }
 }
 
@@ -177,6 +184,7 @@ export async function clearAllData(): Promise<void> {
     db.syncQueue.clear(),
     db.metadata.clear(),
     db.filteredViews.clear(),
+    db.itemTags.clear(),
   ]);
 }
 

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -5,6 +5,7 @@ import { socialReadingStore } from './socialReading.svelte';
 import { sharesStore } from './shares.svelte';
 import { socialStore } from './social.svelte';
 import { filteredViewsStore } from './filteredViews.svelte';
+import { tagsStore } from './tags.svelte';
 import { feedStatusStore } from './feedStatus.svelte';
 import { articlesStore } from './articles.svelte';
 import { syncStore } from './sync.svelte';
@@ -65,6 +66,7 @@ function createAppManager() {
         socialReadingStore.load(),
         sharesStore.load(),
         filteredViewsStore.load(),
+        tagsStore.load(),
       ]);
 
       // Initialize feed statuses for existing subscriptions

--- a/src/lib/stores/feedView.svelte.ts
+++ b/src/lib/stores/feedView.svelte.ts
@@ -7,6 +7,7 @@ import { sharesStore } from './shares.svelte';
 import { socialStore } from './social.svelte';
 import { preferences } from './preferences.svelte';
 import { filteredViewsStore } from './filteredViews.svelte';
+import { tagsStore } from './tags.svelte';
 import type { Article, SocialShare, SocialDocument, CombinedFeedItem, UserShare } from '$lib/types';
 import {
   isRssSource,
@@ -81,6 +82,9 @@ function createFeedViewStore() {
   let expandedIndex = $state(-1);
   let loadedArticleCount = $state(DEFAULT_PAGE_SIZE);
 
+  // Tag menu state (which item key should show the tag menu, null = closed)
+  let tagMenuItemKey = $state<string | null>(null);
+
   // Toolbar filter state (unified source model)
   let filterToolbarOpen = $state(false);
   let sourcePopoverOpen = $state(false);
@@ -88,6 +92,8 @@ function createFeedViewStore() {
   let toolbarSourceKeys = $state<string[]>([]);
   // View-local sort order override (null = use global preferences.sortOrder)
   let toolbarSortOrder = $state<'newest' | 'oldest' | null>(null);
+  // Tag filter (empty = no tag filter)
+  let toolbarTagFilter = $state<string[]>([]);
 
   // URL filters (set by component from $page store)
   let feedFilter = $state<string | null>(null);
@@ -416,9 +422,10 @@ function createFeedViewStore() {
   // Derived: unified current items for the active view mode
   let currentItems = $derived.by((): FeedDisplayItem[] => {
     const mode = viewMode;
+    let items: FeedDisplayItem[];
 
     if (mode === 'combined') {
-      return displayedCombined.map((item) => {
+      items = displayedCombined.map((item) => {
         if (item.type === 'article') {
           return { type: 'article' as const, item: item.item, key: item.item.guid };
         } else if (item.type === 'share') {
@@ -427,13 +434,11 @@ function createFeedViewStore() {
           return { type: 'document' as const, item: item.item, key: item.item.recordUri };
         }
       });
-    }
-
-    if (mode === 'shares') {
+    } else if (mode === 'shares') {
       // Combine shares and documents, sorted by date
       const sortOrder = preferences.sortOrder;
       type ItemWithDate = FeedDisplayItem & { date: number };
-      const items: ItemWithDate[] = [
+      const rawItems: ItemWithDate[] = [
         ...displayedShares.map((item) => ({
           type: 'share' as const,
           item,
@@ -448,16 +453,14 @@ function createFeedViewStore() {
         })),
       ];
 
-      items.sort((a, b) => {
+      rawItems.sort((a, b) => {
         const diff = b.date - a.date;
         return sortOrder === 'newest' ? diff : -diff;
       });
 
-      return items.map(({ type, item, key }) => ({ type, item, key }) as FeedDisplayItem);
-    }
-
-    if (mode === 'userShares') {
-      return displayedUserShares.map((share) => {
+      items = rawItems.map(({ type, item, key }) => ({ type, item, key }) as FeedDisplayItem);
+    } else if (mode === 'userShares') {
+      items = displayedUserShares.map((share) => {
         const localArticle = articlesByGuid.get(share.articleGuid);
         const article: Article = localArticle || {
           guid: share.articleGuid,
@@ -478,14 +481,23 @@ function createFeedViewStore() {
           key: share.articleGuid,
         };
       });
+    } else {
+      // articles mode
+      items = displayedArticles.map((item) => ({
+        type: 'article' as const,
+        item,
+        key: item.guid,
+      }));
     }
 
-    // articles mode
-    return displayedArticles.map((item) => ({
-      type: 'article' as const,
-      item,
-      key: item.guid,
-    }));
+    // Apply tag filter
+    if (toolbarTagFilter.length > 0) {
+      // Access tagsByItem for reactivity
+      const _tags = tagsStore.tagsByItem;
+      items = items.filter((item) => tagsStore.itemHasAnyTag(item.key, toolbarTagFilter));
+    }
+
+    return items;
   });
 
   // Derived: unified pagination state
@@ -636,6 +648,7 @@ function createFeedViewStore() {
       sourceKeys: [...toolbarSourceKeys],
       readFilter: showOnlyUnread ? 'unread' : 'all',
       sortOrder: toolbarSortOrder ?? preferences.sortOrder,
+      tagFilter: toolbarTagFilter.length > 0 ? [...toolbarTagFilter] : undefined,
     });
   }
 
@@ -643,6 +656,7 @@ function createFeedViewStore() {
     toolbarSourceMode = 'all';
     toolbarSourceKeys = [];
     toolbarSortOrder = null;
+    toolbarTagFilter = [];
   }
 
   function toggleUnreadFilter() {
@@ -755,8 +769,14 @@ function createFeedViewStore() {
     get hasUnsavedChanges() {
       return hasUnsavedChanges;
     },
+    get toolbarTagFilter() {
+      return toolbarTagFilter;
+    },
     get currentSortOrder() {
       return toolbarSortOrder ?? preferences.sortOrder;
+    },
+    get tagMenuItemKey() {
+      return tagMenuItemKey;
     },
 
     // All filtered items (not paginated) — for bulk operations like mark-all-as-read
@@ -793,6 +813,9 @@ function createFeedViewStore() {
     setSourcePopoverOpen(open: boolean) {
       sourcePopoverOpen = open;
     },
+    setToolbarTagFilter(tags: string[]) {
+      toolbarTagFilter = tags;
+    },
     setToolbarSourceFilter(mode: 'all' | 'include', keys: string[]) {
       toolbarSourceMode = mode;
       toolbarSourceKeys = keys;
@@ -807,6 +830,12 @@ function createFeedViewStore() {
     },
     resetToolbarFilters,
     syncToolbarToSavedView,
+    openTagMenu(itemKey: string) {
+      tagMenuItemKey = itemKey;
+    },
+    closeTagMenu() {
+      tagMenuItemKey = null;
+    },
     setFilters(filters: {
       feed: string | null;
       starred: string | null;
@@ -855,6 +884,7 @@ function createFeedViewStore() {
           }
           showOnlyUnread = fv.readFilter === 'unread';
           toolbarSortOrder = fv.sortOrder;
+          toolbarTagFilter = fv.tagFilter ? [...fv.tagFilter] : [];
           // Fire-and-forget legacy migration write-back
           if (fv.sourceMode == null && fv.id != null) {
             filteredViewsStore.update(fv.id, {

--- a/src/lib/stores/tags.svelte.ts
+++ b/src/lib/stores/tags.svelte.ts
@@ -1,0 +1,132 @@
+import { db } from '$lib/services/db';
+import type { ItemTags } from '$lib/types';
+
+function createTagsStore() {
+  let tagsByItem = $state<Map<string, ItemTags>>(new Map());
+
+  let allTags = $derived.by((): string[] => {
+    const tagSet = new Set<string>();
+    for (const entry of tagsByItem.values()) {
+      if (!Array.isArray(entry.tags)) continue;
+      for (const tag of entry.tags) {
+        tagSet.add(tag);
+      }
+    }
+    return [...tagSet].sort();
+  });
+
+  async function load() {
+    const all = await db.itemTags.toArray();
+    const map = new Map<string, ItemTags>();
+    for (const entry of all) {
+      if (!Array.isArray(entry.tags)) {
+        entry.tags = [];
+      }
+      map.set(entry.itemKey, entry);
+    }
+    tagsByItem = map;
+  }
+
+  function getTagsForItem(itemKey: string): string[] {
+    return tagsByItem.get(itemKey)?.tags ?? [];
+  }
+
+  function hasTag(itemKey: string, tag: string): boolean {
+    return getTagsForItem(itemKey).includes(tag);
+  }
+
+  async function addTag(itemKey: string, itemType: ItemTags['itemType'], tag: string) {
+    const trimmed = tag.trim().slice(0, 64);
+    if (!trimmed) return;
+
+    const existing = tagsByItem.get(itemKey);
+    if (existing) {
+      if (existing.tags.includes(trimmed)) return;
+      if (existing.tags.length >= 10) return;
+      const newTags = [...existing.tags, trimmed];
+      const updated = { ...existing, tags: newTags };
+      tagsByItem = new Map(tagsByItem).set(itemKey, updated);
+      await db.itemTags.put(updated);
+    } else {
+      const entry: ItemTags = { itemKey, itemType, tags: [trimmed] };
+      tagsByItem = new Map(tagsByItem).set(itemKey, entry);
+      await db.itemTags.put(entry);
+    }
+  }
+
+  async function removeTag(itemKey: string, tag: string) {
+    const existing = tagsByItem.get(itemKey);
+    if (!existing) return;
+
+    const newTags = existing.tags.filter((t) => t !== tag);
+    if (newTags.length === 0) {
+      const updated = new Map(tagsByItem);
+      updated.delete(itemKey);
+      tagsByItem = updated;
+      await db.itemTags.delete(itemKey);
+    } else {
+      const updated = { ...existing, tags: newTags };
+      tagsByItem = new Map(tagsByItem).set(itemKey, updated);
+      await db.itemTags.put(updated);
+    }
+  }
+
+  async function toggleTag(itemKey: string, itemType: ItemTags['itemType'], tag: string) {
+    if (hasTag(itemKey, tag)) {
+      await removeTag(itemKey, tag);
+    } else {
+      await addTag(itemKey, itemType, tag);
+    }
+  }
+
+  async function deleteTag(tag: string) {
+    const updated = new Map<string, ItemTags>();
+    const toUpdate: ItemTags[] = [];
+    const toDelete: string[] = [];
+
+    for (const [key, entry] of tagsByItem) {
+      if (entry.tags.includes(tag)) {
+        const newTags = entry.tags.filter((t) => t !== tag);
+        if (newTags.length === 0) {
+          toDelete.push(key);
+        } else {
+          const newEntry = { ...entry, tags: newTags };
+          updated.set(key, newEntry);
+          toUpdate.push(newEntry);
+        }
+      } else {
+        updated.set(key, entry);
+      }
+    }
+
+    tagsByItem = updated;
+    await Promise.all([
+      ...toUpdate.map((e) => db.itemTags.put(e)),
+      ...toDelete.map((k) => db.itemTags.delete(k)),
+    ]);
+  }
+
+  function itemHasAnyTag(itemKey: string, tags: string[]): boolean {
+    const itemTags = getTagsForItem(itemKey);
+    return tags.some((t) => itemTags.includes(t));
+  }
+
+  return {
+    get allTags() {
+      return allTags;
+    },
+    get tagsByItem() {
+      return tagsByItem;
+    },
+    load,
+    getTagsForItem,
+    hasTag,
+    addTag,
+    removeTag,
+    toggleTag,
+    deleteTag,
+    itemHasAnyTag,
+  };
+}
+
+export const tagsStore = createTagsStore();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -662,9 +662,16 @@ export interface FilteredView {
   accountDids?: string[];
   readFilter: 'all' | 'unread' | 'read';
   sortOrder: 'newest' | 'oldest';
+  tagFilter?: string[];
   createdAt: number;
   updatedAt: number;
   position: number;
+}
+
+export interface ItemTags {
+  itemKey: string;
+  tags: string[];
+  itemType: 'article' | 'share' | 'document' | 'userShare';
 }
 
 export interface DiscoverUser {


### PR DESCRIPTION
## Summary

- Adds item-level tagging stored in IndexedDB (new `itemTags` Dexie table v17)
- Tag popup menu with numbered shortcuts [0]-[9] and boxed number badges
- Tag button in ArticleCard action bar for all item types (articles, shares, documents)
- `t` keyboard shortcut to open tag menu on selected item
- Tag filter dropdown in FilterToolbar for filtering by one or more tags
- Tag filter persistence in saved filtered views
- No backend API calls (client-only)

## Test plan

- [ ] Create tags via the tag menu (click Tag button or press `t`)
- [ ] Verify numbered shortcuts [1]-[9] toggle tags, [0] creates new tag
- [ ] Verify tags appear as chips below article content
- [ ] Verify tag count badge appears on Tag button
- [ ] Verify tags persist across page refresh (IndexedDB)
- [ ] Verify tag filter appears in FilterToolbar when tags exist
- [ ] Verify filtering by tags works in the feed view
- [ ] Verify tag filter can be saved in filtered views
- [ ] Verify Escape closes the tag menu
- [ ] Verify existing data is not disrupted (clean Dexie v17 migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)