### PR TITLE
Fix overscroll in SavedReader overlay

### DIFF
--- a/src/lib/components/feed/SavedReader.svelte
+++ b/src/lib/components/feed/SavedReader.svelte
@@ -403,6 +403,7 @@
     z-index: 100;
     background: var(--color-bg, #ffffff);
     overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .reader-container {


### PR DESCRIPTION
## Summary
- Add `overscroll-behavior: contain` to `.reader-overlay` in SavedReader.svelte to prevent elastic/bounce scroll from revealing bookmark list content underneath on iOS/macOS

## Test plan
- [ ] Open a bookmarked article in the full-screen SavedReader
- [ ] Overscroll at the top and bottom — content underneath should not be visible
- [ ] Normal scrolling within the reader still works
- [ ] Header hide/show, style controls, and navigation are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)