### PR TITLE
Add click-to-position for paragraph read tracking

### DIFF
--- a/src/lib/hooks/useParagraphTracking.svelte.ts
+++ b/src/lib/hooks/useParagraphTracking.svelte.ts
@@ -22,6 +22,8 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
   let hasRestored = false;
   let highlightEl: HTMLDivElement | null = null;
   let scrollHandler: (() => void) | null = null;
+  let clickHandler: ((e: Event) => void) | null = null;
+  let clickTarget: HTMLElement | null = null;
   let scrollTarget: EventTarget | null = null;
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let lastScrollTop = 0;
@@ -149,6 +151,17 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     }, SAVE_DEBOUNCE_MS);
   }
 
+  function goToParagraph(index: number) {
+    if (index < 0 || index >= paragraphs.length) return;
+    currentParagraphIndex = index;
+    if (index > furthestParagraphIndex) {
+      furthestParagraphIndex = index;
+    }
+    updateHighlight();
+    debouncedSave();
+    scrollToParagraph(index);
+  }
+
   function setupObserver() {
     cleanup();
     if (!params.enabled()) return;
@@ -176,6 +189,20 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     };
 
     scrollTarget.addEventListener('scroll', scrollHandler, { passive: true });
+
+    // Click handler for paragraph navigation
+    clickTarget = contentEl;
+    clickHandler = (e: Event) => {
+      const target = (e.target as HTMLElement).closest('[data-para-index]');
+      if (!target) return;
+      // Don't interfere with link clicks
+      if ((e.target as HTMLElement).closest('a')) return;
+      const index = parseInt((target as HTMLElement).dataset.paraIndex!, 10);
+      if (!isNaN(index)) {
+        goToParagraph(index);
+      }
+    };
+    clickTarget.addEventListener('click', clickHandler);
 
     // Initial position check
     updateCurrentParagraph();
@@ -218,6 +245,11 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
       scrollHandler = null;
       scrollTarget = null;
     }
+    if (clickHandler && clickTarget) {
+      clickTarget.removeEventListener('click', clickHandler);
+      clickHandler = null;
+      clickTarget = null;
+    }
     if (saveTimer) {
       clearTimeout(saveTimer);
       saveTimer = null;
@@ -241,6 +273,7 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
       return totalParagraphs;
     },
     setupObserver,
+    goToParagraph,
     scrollToParagraph,
     nextParagraph,
     prevParagraph,


### PR DESCRIPTION
## Summary
- Add click/tap on paragraphs to move read position marker to that paragraph
- Uses event delegation on content element, detecting `data-para-index` attributes
- Excludes link clicks so normal navigation is preserved

## Test plan
- [ ] Click a paragraph in an expanded article — highlight moves to it and progress persists
- [ ] Click a paragraph in SavedReader (full-screen bookmarks) — same behavior
- [ ] Click a link inside a paragraph — link navigates normally, read position does not change
- [ ] Scroll-based tracking continues to work alongside click tracking
- [ ] `furthestParagraphIndex` advances when clicking a paragraph beyond the current furthest

🤖 Generated with [Claude Code](https://claude.com/claude-code)