### PR TITLE
Hide feed controls on scroll down, show on scroll up

### DIFF
--- a/src/lib/components/feed/FeedPageHeader.svelte
+++ b/src/lib/components/feed/FeedPageHeader.svelte
@@ -43,6 +43,22 @@
   let tick = $state(0);
   let intervalId: ReturnType<typeof setInterval> | null = null;
 
+  // Scroll-hide state
+  let controlsVisible = $state(true);
+  let lastScrollY = $state(0);
+
+  function handleScroll() {
+    const currentY = window.scrollY;
+    if (currentY > lastScrollY && currentY > 60) {
+      controlsVisible = false;
+      styleToolbarOpen = false;
+      feedViewStore.setFilterToolbarOpen(false);
+    } else {
+      controlsVisible = true;
+    }
+    lastScrollY = currentY;
+  }
+
   // Debounce refresh button
   let lastRefreshClick = 0;
   const DEBOUNCE_MS = 2000;
@@ -60,11 +76,13 @@
       tick++;
     }, 60000);
     document.addEventListener('click', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, { passive: true });
   });
 
   onDestroy(() => {
     if (intervalId) clearInterval(intervalId);
     document.removeEventListener('click', handleClickOutside);
+    window.removeEventListener('scroll', handleScroll);
   });
 
   // Use tick to force re-evaluation (void to suppress unused warning)
@@ -120,7 +138,7 @@
   });
 </script>
 
-<div class="feed-header-fixed" bind:this={headerRef}>
+<div class="feed-header-fixed" class:hidden={!controlsVisible} bind:this={headerRef}>
   <div class="feed-header-controls">
     <div class="control-left feed-title-group" class:dropdown-open={dropdownOpen}>
       <NavigationDropdown currentTitle={title} />
@@ -269,6 +287,15 @@
     pointer-events: none;
     z-index: 10;
     padding: 0 1rem;
+    transition:
+      transform 0.3s ease,
+      opacity 0.3s ease;
+  }
+
+  .feed-header-fixed.hidden {
+    transform: translateY(-100%);
+    opacity: 0;
+    pointer-events: none !important;
   }
 
   .feed-header-controls {


### PR DESCRIPTION
## Summary

- Add scroll-based header hiding to FeedPageHeader, replicating the pattern already used in SavedReader
- Controls hide when scrolling down past 60px threshold, reappear when scrolling up
- Open style/filter toolbars auto-close when controls hide
- Smooth CSS transition (transform + opacity) matching SavedReader behavior

## Test plan

- [ ] Scroll down in feed view — controls should hide after 60px
- [ ] Scroll up — controls should reappear
- [ ] Open style/filter toolbar, scroll down — toolbar should close and controls hide
- [ ] At top of page (scrollY near 0) — controls stay visible
- [ ] Verify scroll-mark-as-read still works
- [ ] Test on mobile viewport
- [ ] Verify SavedReader scroll-hide is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)