### PR TITLE
Add saved inbox count badge to sidebar

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -12,6 +12,7 @@
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { fetchSingleFeed } from '$lib/services/feedFetcher';
   import { onMount, onDestroy } from 'svelte';
   import AddFeedModal from './AddFeedModal.svelte';
@@ -427,6 +428,9 @@
     >
       <span class="nav-icon"><Icon name="bookmark" /></span>
       <span class="nav-label">Saved</span>
+      {#if itemLabelsStore.inboxCount > 0}
+        <span class="nav-count">{itemLabelsStore.inboxCount}</span>
+      {/if}
     </button>
 
     <button

--- a/src/lib/stores/itemLabels.svelte.ts
+++ b/src/lib/stores/itemLabels.svelte.ts
@@ -530,6 +530,16 @@ function createItemLabelsStore() {
   // Saved count: purely from saves
   let savedCount = $derived(savesStore.articles.length);
 
+  // Inbox count: saved but not archived
+  let inboxCount = $derived.by(() => {
+    let count = 0;
+    for (const bm of savesStore.articles) {
+      const key = bm.uri || bm.itemGuid || '';
+      if (key && !hasLabel(key, 'archived')) count++;
+    }
+    return count;
+  });
+
   // Archived count (saved + archived)
   let archivedCount = $derived.by(() => {
     let count = 0;
@@ -1321,6 +1331,9 @@ function createItemLabelsStore() {
     },
     get archivedCount() {
       return archivedCount;
+    },
+    get inboxCount() {
+      return inboxCount;
     },
     // Tags
     get allTags() {


### PR DESCRIPTION
## Summary
- Adds `inboxCount` derived to `itemLabelsStore` that counts saved items excluding archived ones
- Displays the count as a badge next to the "Saved" nav item in the sidebar
- Badge is hidden when count is 0, matching existing badge behavior for All/Shared/Activity

## Test plan
- [ ] Save some items and verify the count appears next to "Saved" in the sidebar
- [ ] Archive a saved item and verify the count decreases
- [ ] Unsave all items and verify the badge disappears (count = 0)
- [ ] Verify existing badges (All unread, Shared, Activity) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)