### PR TITLE
Fix: archive in saved list causes item to reappear

### DIFF
--- a/src/lib/components/feed/SavedListView.svelte
+++ b/src/lib/components/feed/SavedListView.svelte
@@ -48,6 +48,11 @@
 
   function handleArchive(item: FeedDisplayItem) {
     itemLabelsStore.toggleArchive(item.key, getItemType(item));
+    // For saved items where itemGuid differs from key, also toggle archive by itemGuid
+    // to ensure consistent archive state regardless of which key is used for lookup
+    if (item.type === 'saved' && item.item.itemGuid && item.item.itemGuid !== item.key) {
+      itemLabelsStore.toggleArchive(item.item.itemGuid, 'saved');
+    }
     if (readerItem?.key === item.key) {
       closeReader();
     }

--- a/src/lib/stores/feedView.svelte.ts
+++ b/src/lib/stores/feedView.svelte.ts
@@ -494,21 +494,29 @@ function createFeedViewStore() {
         }));
 
       // Add bookmarks — exclude bookmarks already shown via articles/shares/documents
-      const articleGuids = new Set(displayedArticles.map((a) => a.guid));
+      // Use ALL saved article guids for dedup (not just displayed ones) to prevent
+      // archived feed-source bookmarks from reappearing as 'saved' type items
+      const allSavedArticleGuids = new Set(
+        articlesStore.allArticles.filter((a) => itemLabelsStore.isSaved(a.guid)).map((a) => a.guid)
+      );
       const shareRecordUris = new Set(starredShareItems.map((s) => s.key));
       const documentRecordUris = new Set(starredDocumentItems.map((d) => d.key));
       const bookmarkItems: FeedDisplayItem[] = savesStore.articles
         .filter((bm) => {
-          // Skip feed-source bookmarks whose guid matches a displayed article
-          if (bm.source === 'feed' && bm.itemGuid && articleGuids.has(bm.itemGuid)) return false;
+          // Skip feed-source bookmarks whose guid matches a saved article in the articles store
+          if (bm.source === 'feed' && bm.itemGuid && allSavedArticleGuids.has(bm.itemGuid))
+            return false;
           // Skip share-source bookmarks whose itemGuid matches a displayed share
           if (bm.source === 'share' && bm.itemGuid && shareRecordUris.has(bm.itemGuid))
             return false;
           // Skip document-source bookmarks whose itemGuid matches a displayed document
           if (bm.source === 'document' && bm.itemGuid && documentRecordUris.has(bm.itemGuid))
             return false;
-          if (isArchiveView) return itemLabelsStore.isArchived(bm.uri || bm.itemGuid || '');
-          return !itemLabelsStore.isArchived(bm.uri || bm.itemGuid || '');
+          // Use itemGuid (article guid) for archive checks when available, since archive
+          // labels are stored against the article guid, not the AT Protocol URI
+          const archiveKey = bm.itemGuid || bm.uri || '';
+          if (isArchiveView) return itemLabelsStore.isArchived(archiveKey);
+          return !itemLabelsStore.isArchived(archiveKey);
         })
         .map((bm) => ({
           type: 'saved' as const,


### PR DESCRIPTION
## Summary
- Fix dedup logic to use all saved article GUIDs (not just displayed), preventing archived feed-source bookmarks from reappearing as 'saved' type items
- Prefer itemGuid over AT Protocol URI for archive key lookups on bookmarks
- Dual-key archive toggle in SavedListView for items with mismatched keys

## Test plan
- [ ] Archive a feed-source saved item in inbox — it should disappear from inbox
- [ ] Archived item should appear only in archive view, not both views
- [ ] Content should not be replaced with description after archiving
- [ ] Unarchiving should return the item to inbox correctly
- [ ] URL-saved items can still be archived/unarchived correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)