### PR TITLE
Fix bookmarks sort to use saved date

### DIFF
--- a/src/lib/stores/feedView.svelte.ts
+++ b/src/lib/stores/feedView.svelte.ts
@@ -95,6 +95,17 @@ function getItemDate(item: FeedDisplayItem): number {
   }
 }
 
+function getSavedDate(item: FeedDisplayItem): number {
+  if (item.type === 'saved') {
+    return new Date(item.item.savedAt).getTime();
+  }
+  const savedItem = savesStore.getByGuid(item.key);
+  if (savedItem) {
+    return new Date(savedItem.savedAt).getTime();
+  }
+  return getItemDate(item);
+}
+
 function createFeedViewStore() {
   // UI state
   let showOnlyUnread = $state(true);
@@ -526,10 +537,10 @@ function createFeedViewStore() {
 
       items = [...articleItems, ...starredShareItems, ...starredDocumentItems, ...bookmarkItems];
 
-      // Sort by date
+      // Sort by saved date (when the item was bookmarked, not published)
       items.sort((a, b) => {
-        const dateA = getItemDate(a);
-        const dateB = getItemDate(b);
+        const dateA = getSavedDate(a);
+        const dateB = getSavedDate(b);
         return sortOrder === 'newest' ? dateB - dateA : dateA - dateB;
       });
 


### PR DESCRIPTION
## Summary
- Bookmarks list now sorts by the date items were saved (savedAt), not by their original publish date
- Added `getSavedDate()` helper that looks up savedAt from the saves store for all item types
- Falls back to publish date if savedAt is unavailable (shouldn't happen in practice)
- Only affects the bookmarks/saved view — main feed continues sorting by publish date

## Test plan
- [ ] Save several articles at different times — verify they appear sorted by when they were saved, not when they were published
- [ ] Toggle sort order (newest/oldest) — verify it still works correctly
- [ ] Check that standalone bookmarks (URL-saved) continue to sort by savedAt
- [ ] Verify main feed view sorting is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)