### PR TITLE
Add safe Dexie write wrappers for Svelte 5 proxy safety

### DIFF
--- a/src/lib/services/liveDb.svelte.ts
+++ b/src/lib/services/liveDb.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from './db';
+import { safeAdd, safeUpdate, safeBulkAdd } from './safeDb.svelte';
 import type { Subscription, Article, FeedItem } from '$lib/types';
 
 const MAX_ARTICLES_PER_FEED = 100;
@@ -69,7 +70,7 @@ class LiveDatabase {
    * Add a new subscription to both IndexedDB and memory
    */
   async addSubscription(subscription: Omit<Subscription, 'id'>): Promise<number> {
-    const id = await db.subscriptions.add(subscription);
+    const id = await safeAdd(db.subscriptions, subscription);
     this._subscriptions = [...this._subscriptions, { ...subscription, id }];
     this.subscriptionsVersion++;
     return id;
@@ -79,7 +80,7 @@ class LiveDatabase {
    * Update an existing subscription
    */
   async updateSubscription(id: number, updates: Partial<Subscription>): Promise<void> {
-    await db.subscriptions.update(id, updates);
+    await safeUpdate(db.subscriptions, id, updates);
     this._subscriptions = this._subscriptions.map((s) => (s.id === id ? { ...s, ...updates } : s));
     this.subscriptionsVersion++;
   }
@@ -92,7 +93,7 @@ class LiveDatabase {
     id: number,
     updates: { customTitle?: string; customIconUrl?: string }
   ): Promise<void> {
-    await db.subscriptions.update(id, updates);
+    await safeUpdate(db.subscriptions, id, updates);
     this._subscriptions = this._subscriptions.map((s) => (s.id === id ? { ...s, ...updates } : s));
     this.subscriptionsVersion++;
   }
@@ -127,7 +128,7 @@ class LiveDatabase {
   async replaceSubscriptions(subscriptions: Subscription[]): Promise<void> {
     await db.subscriptions.clear();
     if (subscriptions.length > 0) {
-      await db.subscriptions.bulkAdd(subscriptions);
+      await safeBulkAdd(db.subscriptions, subscriptions);
     }
     this._subscriptions = subscriptions;
     this._subscriptionsLoaded = true;
@@ -174,7 +175,7 @@ class LiveDatabase {
     }));
 
     // Add to IndexedDB
-    await db.articles.bulkAdd(newArticles);
+    await safeBulkAdd(db.articles, newArticles);
 
     // Update in-memory state
     this._articles = [...this._articles, ...newArticles].sort(

--- a/src/lib/services/safeDb.svelte.ts
+++ b/src/lib/services/safeDb.svelte.ts
@@ -1,0 +1,34 @@
+import { type Table, type UpdateSpec } from 'dexie';
+
+/**
+ * Safe Dexie write wrappers that automatically call $state.snapshot()
+ * before passing values to IndexedDB. This prevents Svelte 5 reactive
+ * proxies from being serialized by Dexie, which causes silent data
+ * corruption or write failures.
+ *
+ * Use these instead of direct db.<table>.put/add/bulkPut/bulkAdd/update calls.
+ */
+
+export function safePut<T, TKey>(table: Table<T, TKey>, value: T): Promise<TKey> {
+  return table.put($state.snapshot(value) as T);
+}
+
+export function safeAdd<T, TKey>(table: Table<T, TKey>, value: T): Promise<TKey> {
+  return table.add($state.snapshot(value) as T);
+}
+
+export function safeBulkPut<T, TKey>(table: Table<T, TKey>, values: T[]): Promise<TKey> {
+  return table.bulkPut($state.snapshot(values) as T[]);
+}
+
+export function safeBulkAdd<T, TKey>(table: Table<T, TKey>, values: T[]): Promise<TKey> {
+  return table.bulkAdd($state.snapshot(values) as T[]);
+}
+
+export function safeUpdate<T, TKey>(
+  table: Table<T, TKey>,
+  key: TKey,
+  changes: UpdateSpec<T>
+): Promise<number> {
+  return table.update(key, $state.snapshot(changes) as UpdateSpec<T>);
+}

--- a/src/lib/stores/filteredViews.svelte.ts
+++ b/src/lib/stores/filteredViews.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safeAdd, safeUpdate } from '$lib/services/safeDb.svelte';
 import type { FilteredView } from '$lib/types';
 
 function createFilteredViewsStore() {
@@ -20,7 +21,7 @@ function createFilteredViewsStore() {
       updatedAt: now,
       position: maxPosition + 1,
     };
-    const id = await db.filteredViews.add(newView);
+    const id = await safeAdd(db.filteredViews, newView);
     newView.id = id as number;
     views = [...views, newView];
     return id as number;
@@ -30,7 +31,7 @@ function createFilteredViewsStore() {
     const updated = { ...changes, updatedAt: Date.now() };
     // Update in-memory first for immediate reactivity, then persist
     views = views.map((v) => (v.id === id ? { ...v, ...updated } : v));
-    await db.filteredViews.update(id, updated);
+    await safeUpdate(db.filteredViews, id, updated);
   }
 
   async function remove(id: number) {

--- a/src/lib/stores/itemLabels.svelte.ts
+++ b/src/lib/stores/itemLabels.svelte.ts
@@ -1,5 +1,6 @@
 import { api } from '$lib/services/api';
 import { db } from '$lib/services/db';
+import { safePut, safeAdd, safeBulkPut } from '$lib/services/safeDb.svelte';
 import {
   syncQueue,
   type ReadingPayload,
@@ -89,7 +90,7 @@ function createItemLabelsStore() {
 
   async function putLabel(lbl: ItemLabel) {
     addToState(lbl);
-    await db.itemLabels.put($state.snapshot(lbl));
+    await safePut(db.itemLabels, lbl);
   }
 
   async function deleteLabel(itemKey: string, label: string) {
@@ -239,7 +240,7 @@ function createItemLabelsStore() {
         await db.itemLabels.where('[itemKey+label]').equals([itemKey, label]).delete();
       }
       if (dbOps.length > 0) {
-        await db.itemLabels.bulkPut(dbOps);
+        await safeBulkPut(db.itemLabels, dbOps);
       }
     } catch (e) {
       console.error('Failed to sync read positions to cache:', e);
@@ -309,12 +310,12 @@ function createItemLabelsStore() {
         await db.itemLabels.where('[itemKey+label]').equals([l.itemKey, l.label]).delete();
       }
       if (dbOps.length > 0) {
-        await db.itemLabels.bulkPut(dbOps);
+        await safeBulkPut(db.itemLabels, dbOps);
       }
       // Also sync socialReadPositions table for backward compat
       await db.socialReadPositions.clear();
       for (const p of newSocialPositions.values()) {
-        await db.socialReadPositions.add(p);
+        await safeAdd(db.socialReadPositions, p);
       }
     } catch (e) {
       console.error('Failed to sync social read positions to cache:', e);
@@ -361,7 +362,7 @@ function createItemLabelsStore() {
         await db.itemLabels.where('[itemKey+label]').equals([l.itemKey, 'tagged']).delete();
       }
       if (dbOps.length > 0) {
-        await db.itemLabels.bulkPut(dbOps);
+        await safeBulkPut(db.itemLabels, dbOps);
       }
     } catch (e) {
       console.error('Failed to sync tags to cache:', e);
@@ -406,7 +407,7 @@ function createItemLabelsStore() {
         await db.itemLabels.where('[itemKey+label]').equals([l.itemKey, 'archived']).delete();
       }
       if (dbOps.length > 0) {
-        await db.itemLabels.bulkPut(dbOps);
+        await safeBulkPut(db.itemLabels, dbOps);
       }
     } catch (e) {
       console.error('Failed to sync archived labels to cache:', e);
@@ -451,7 +452,7 @@ function createItemLabelsStore() {
         await db.itemLabels.where('[itemKey+label]').equals([l.itemKey, 'readProgress']).delete();
       }
       if (dbOps.length > 0) {
-        await db.itemLabels.bulkPut(dbOps);
+        await safeBulkPut(db.itemLabels, dbOps);
       }
     } catch (e) {
       console.error('Failed to sync read progress to cache:', e);
@@ -580,7 +581,7 @@ function createItemLabelsStore() {
 
     addToState(readLabel);
     triggerReactivity();
-    db.itemLabels.put($state.snapshot(readLabel));
+    safePut(db.itemLabels, readLabel);
 
     pendingMarkRead.push({ articleGuid, articleUrl, articleTitle });
     if (debounceTimer) clearTimeout(debounceTimer);
@@ -616,7 +617,7 @@ function createItemLabelsStore() {
     triggerReactivity();
 
     if (dbOps.length > 0) {
-      await db.itemLabels.bulkPut(dbOps);
+      await safeBulkPut(db.itemLabels, dbOps);
     }
 
     if (syncStore.isOnline) {
@@ -809,7 +810,7 @@ function createItemLabelsStore() {
         updatedAt: now,
       };
       addToState(label);
-      await db.itemLabels.put($state.snapshot(label));
+      await safePut(db.itemLabels, label);
     }
     triggerReactivity();
 
@@ -829,7 +830,7 @@ function createItemLabelsStore() {
     };
     addToState(label);
     triggerReactivity();
-    await db.itemLabels.put($state.snapshot(label));
+    await safePut(db.itemLabels, label);
 
     await syncArchiveToBackend(itemKey, true, itemType);
   }
@@ -902,7 +903,7 @@ function createItemLabelsStore() {
     };
     addToState(label);
     triggerReactivity();
-    await db.itemLabels.put($state.snapshot(label));
+    await safePut(db.itemLabels, label);
 
     await syncTaggedLabel(itemKey, label.itemType as ItemLabelType, newTags);
   }
@@ -931,7 +932,7 @@ function createItemLabelsStore() {
       };
       addToState(label);
       triggerReactivity();
-      await db.itemLabels.put($state.snapshot(label));
+      await safePut(db.itemLabels, label);
     }
 
     await syncTaggedLabel(itemKey, existing.itemType as ItemLabelType, newTags);
@@ -972,7 +973,7 @@ function createItemLabelsStore() {
       } else {
         const updated: ItemLabel = { ...lbl, props: { tags: newTags }, updatedAt: now };
         addToState(updated);
-        await db.itemLabels.put($state.snapshot(updated));
+        await safePut(db.itemLabels, updated);
       }
 
       await syncTaggedLabel(itemKey, lbl.itemType as ItemLabelType, newTags);
@@ -1018,7 +1019,7 @@ function createItemLabelsStore() {
 
     addToState(readLabel);
     triggerReactivity();
-    await db.itemLabels.put($state.snapshot(readLabel));
+    await safePut(db.itemLabels, readLabel);
 
     // Also update socialPositions for backward compat
     const position: SocialReadPosition = {
@@ -1032,7 +1033,7 @@ function createItemLabelsStore() {
     };
     socialPositions.set(itemUri, position);
     socialPositions = new Map(socialPositions);
-    await db.socialReadPositions.add(position);
+    await safeAdd(db.socialReadPositions, position);
 
     const payload: SocialReadingPayload = {
       type,
@@ -1121,7 +1122,7 @@ function createItemLabelsStore() {
     socialPositions = new Map(socialPositions);
 
     if (dbOps.length > 0) {
-      await db.itemLabels.bulkPut(dbOps);
+      await safeBulkPut(db.itemLabels, dbOps);
     }
 
     // Build API payloads
@@ -1311,7 +1312,7 @@ function createItemLabelsStore() {
     };
     addToState(label);
     triggerReactivity();
-    await db.itemLabels.put($state.snapshot(label));
+    await safePut(db.itemLabels, label);
   }
 
   async function removeHighlight(itemKey: string, highlightId: string) {
@@ -1338,7 +1339,7 @@ function createItemLabelsStore() {
       };
       addToState(label);
       triggerReactivity();
-      await db.itemLabels.put($state.snapshot(label));
+      await safePut(db.itemLabels, label);
     }
   }
 

--- a/src/lib/stores/saves.svelte.ts
+++ b/src/lib/stores/saves.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safePut, safeBulkPut } from '$lib/services/safeDb.svelte';
 import { api, UrlSaveLimitError } from '$lib/services/api';
 import { generateTid } from '$lib/utils/tid';
 import { syncQueue, type SavedPayload } from '$lib/services/sync-queue';
@@ -45,7 +46,7 @@ function createSavesStore() {
       // Update local cache
       await db.saved.clear();
       if (response.articles.length > 0) {
-        await db.saved.bulkPut(response.articles);
+        await safeBulkPut(db.saved, response.articles);
       }
     } catch (err) {
       console.error('Failed to load saved items:', err);
@@ -83,7 +84,7 @@ function createSavesStore() {
       // Add to local state and cache
       articles = [savedItem, ...articles];
       rebuildMaps();
-      await db.saved.put(savedItem);
+      await safePut(db.saved, savedItem);
 
       return savedItem;
     } catch (err) {
@@ -131,7 +132,7 @@ function createSavesStore() {
 
       articles = [savedItem, ...articles];
       rebuildMaps();
-      await db.saved.put(savedItem);
+      await safePut(db.saved, savedItem);
 
       if (syncStore.isOnline) {
         try {
@@ -153,7 +154,7 @@ function createSavesStore() {
           };
           articles = articles.map((a) => (a.rkey === rkey ? updated : a));
           rebuildMaps();
-          await db.saved.put(updated);
+          await safePut(db.saved, updated);
 
           return updated;
         } catch (err) {
@@ -231,7 +232,7 @@ function createSavesStore() {
 
       articles = [savedItem, ...articles];
       rebuildMaps();
-      await db.saved.put(savedItem);
+      await safePut(db.saved, savedItem);
 
       if (syncStore.isOnline) {
         try {
@@ -252,7 +253,7 @@ function createSavesStore() {
           };
           articles = articles.map((a) => (a.rkey === rkey ? updated : a));
           rebuildMaps();
-          await db.saved.put(updated);
+          await safePut(db.saved, updated);
           return updated;
         } catch (err) {
           console.error('Failed to save share to backend, queueing:', err);
@@ -325,7 +326,7 @@ function createSavesStore() {
 
       articles = [savedItem, ...articles];
       rebuildMaps();
-      await db.saved.put(savedItem);
+      await safePut(db.saved, savedItem);
 
       if (syncStore.isOnline) {
         try {
@@ -344,7 +345,7 @@ function createSavesStore() {
           };
           articles = articles.map((a) => (a.rkey === rkey ? updated : a));
           rebuildMaps();
-          await db.saved.put(updated);
+          await safePut(db.saved, updated);
           return updated;
         } catch (err) {
           console.error('Failed to save document to backend, queueing:', err);

--- a/src/lib/stores/shareReading.svelte.ts
+++ b/src/lib/stores/shareReading.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safeAdd } from '$lib/services/safeDb.svelte';
 import { api } from '$lib/services/api';
 import { syncQueue, type ShareReadingPayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
@@ -46,7 +47,7 @@ function createShareReadingStore() {
           itemTitle: p.itemTitle || undefined,
           readAt: p.readAt,
         };
-        const id = await db.shareReadPositions.add(position);
+        const id = await safeAdd(db.shareReadPositions, position);
         newPositions.set(p.shareUri, { ...position, id });
       }
 
@@ -88,7 +89,7 @@ function createShareReadingStore() {
     shareReadPositions.set(shareUri, { ...position });
     shareReadPositions = new Map(shareReadPositions);
 
-    const id = await db.shareReadPositions.add(position);
+    const id = await safeAdd(db.shareReadPositions, position);
     shareReadPositions.set(shareUri, { ...position, id });
     shareReadPositions = new Map(shareReadPositions);
 

--- a/src/lib/stores/shares.svelte.ts
+++ b/src/lib/stores/shares.svelte.ts
@@ -1,5 +1,6 @@
 import { api } from '$lib/services/api';
 import { db } from '$lib/services/db';
+import { safeAdd, safeBulkPut } from '$lib/services/safeDb.svelte';
 import { syncQueue, type SharePayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
 import type { UserShare } from '$lib/types';
@@ -76,7 +77,7 @@ function createSharesStore() {
       try {
         await db.userShares.clear();
         if (sharesForDb.length > 0) {
-          await db.userShares.bulkPut(sharesForDb);
+          await safeBulkPut(db.userShares, sharesForDb);
         }
       } catch (cacheError) {
         console.error('Failed to sync shares cache:', cacheError);
@@ -136,7 +137,7 @@ function createSharesStore() {
     userShares.set(articleGuid, { ...shareData });
     userShares = new Map(userShares);
 
-    const id = await db.userShares.add(shareData);
+    const id = await safeAdd(db.userShares, shareData);
     userShares.set(articleGuid, { ...shareData, id });
     userShares = new Map(userShares);
 
@@ -268,7 +269,7 @@ function createSharesStore() {
     userShares.set(effectiveGuid, { ...shareData });
     userShares = new Map(userShares);
 
-    const id = await db.userShares.add(shareData);
+    const id = await safeAdd(db.userShares, shareData);
     userShares.set(effectiveGuid, { ...shareData, id });
     userShares = new Map(userShares);
 

--- a/src/lib/stores/social.svelte.ts
+++ b/src/lib/stores/social.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safeBulkAdd } from '$lib/services/safeDb.svelte';
 import { api } from '$lib/services/api';
 import { profileService } from '$lib/services/profiles';
 import { syncQueue, type FollowPayload } from '$lib/services/sync-queue';
@@ -68,17 +69,17 @@ function createSocialStore() {
         documents = result.documents || [];
         // Cache in IndexedDB
         await db.socialShares.clear();
-        await db.socialShares.bulkAdd(result.shares);
+        await safeBulkAdd(db.socialShares, result.shares);
         await db.socialDocuments.clear();
         if (result.documents && result.documents.length > 0) {
-          await db.socialDocuments.bulkAdd(result.documents);
+          await safeBulkAdd(db.socialDocuments, result.documents);
         }
       } else {
         shares = [...shares, ...result.shares];
         documents = [...documents, ...(result.documents || [])];
-        await db.socialShares.bulkAdd(result.shares);
+        await safeBulkAdd(db.socialShares, result.shares);
         if (result.documents && result.documents.length > 0) {
-          await db.socialDocuments.bulkAdd(result.documents);
+          await safeBulkAdd(db.socialDocuments, result.documents);
         }
       }
 

--- a/src/lib/stores/socialReading.svelte.ts
+++ b/src/lib/stores/socialReading.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safeAdd } from '$lib/services/safeDb.svelte';
 import { api } from '$lib/services/api';
 import { syncQueue, type SocialReadingPayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
@@ -49,7 +50,7 @@ function createSocialReadingStore() {
           itemTitle: p.itemTitle || undefined,
           readAt: p.readAt,
         };
-        const id = await db.socialReadPositions.add(position);
+        const id = await safeAdd(db.socialReadPositions, position);
         newPositions.set(p.itemUri, { ...position, id });
       }
 
@@ -93,7 +94,7 @@ function createSocialReadingStore() {
     positions.set(itemUri, { ...position });
     positions = new Map(positions);
 
-    const id = await db.socialReadPositions.add(position);
+    const id = await safeAdd(db.socialReadPositions, position);
     positions.set(itemUri, { ...position, id });
     positions = new Map(positions);
 
@@ -174,7 +175,7 @@ function createSocialReadingStore() {
         itemTitle: item.itemTitle,
         readAt: now,
       };
-      const id = await db.socialReadPositions.add(position);
+      const id = await safeAdd(db.socialReadPositions, position);
       positions.set(item.itemUri, { ...position, id });
     }
     positions = new Map(positions);

--- a/src/lib/stores/tags.svelte.ts
+++ b/src/lib/stores/tags.svelte.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/services/db';
+import { safePut } from '$lib/services/safeDb.svelte';
 import type { ItemTags } from '$lib/types';
 
 function createTagsStore() {
@@ -46,11 +47,11 @@ function createTagsStore() {
       const newTags = [...existing.tags, trimmed];
       const updated = { ...existing, tags: newTags };
       tagsByItem = new Map(tagsByItem).set(itemKey, updated);
-      await db.itemTags.put(updated);
+      await safePut(db.itemTags, updated);
     } else {
       const entry: ItemTags = { itemKey, itemType, tags: [trimmed] };
       tagsByItem = new Map(tagsByItem).set(itemKey, entry);
-      await db.itemTags.put(entry);
+      await safePut(db.itemTags, entry);
     }
   }
 
@@ -67,7 +68,7 @@ function createTagsStore() {
     } else {
       const updated = { ...existing, tags: newTags };
       tagsByItem = new Map(tagsByItem).set(itemKey, updated);
-      await db.itemTags.put(updated);
+      await safePut(db.itemTags, updated);
     }
   }
 
@@ -101,7 +102,7 @@ function createTagsStore() {
 
     tagsByItem = updated;
     await Promise.all([
-      ...toUpdate.map((e) => db.itemTags.put(e)),
+      ...toUpdate.map((e) => safePut(db.itemTags, e)),
       ...toDelete.map((k) => db.itemTags.delete(k)),
     ]);
   }


### PR DESCRIPTION
## Summary

- New `safeDb.svelte.ts` module with wrapper functions (`safePut`, `safeAdd`, `safeBulkPut`, `safeBulkAdd`, `safeUpdate`) that automatically call `$state.snapshot()` before Dexie writes
- Migrated all 9 store/service files to use safe wrappers instead of direct Dexie write calls
- Eliminates silent data corruption from Svelte 5 reactive proxies being serialized by IndexedDB

## Files changed

| File | Change |
|---|---|
| `src/lib/services/safeDb.svelte.ts` | **New** — safe Dexie write wrappers |
| `src/lib/stores/saves.svelte.ts` | 7 `put`/`bulkPut` → `safePut`/`safeBulkPut` |
| `src/lib/stores/filteredViews.svelte.ts` | `add`/`update` → `safeAdd`/`safeUpdate` |
| `src/lib/stores/socialReading.svelte.ts` | 3 `add` → `safeAdd` |
| `src/lib/stores/shareReading.svelte.ts` | 2 `add` → `safeAdd` |
| `src/lib/stores/shares.svelte.ts` | `bulkPut`/2 `add` → `safeBulkPut`/`safeAdd` |
| `src/lib/stores/social.svelte.ts` | 4 `bulkAdd` → `safeBulkAdd` |
| `src/lib/stores/itemLabels.svelte.ts` | Replaced manual `$state.snapshot()` + `put`/`bulkPut` with `safePut`/`safeBulkPut`/`safeAdd` |
| `src/lib/stores/tags.svelte.ts` | 4 `put` → `safePut` |
| `src/lib/services/liveDb.svelte.ts` | `add`/`update`/`bulkAdd` → safe wrappers |

## Test plan

- [ ] TypeScript compilation passes (verified: `svelte-check` reports 0 errors)
- [ ] Verify subscriptions, articles, saved items, tags, shares, and read positions persist correctly
- [ ] Verify offline sync queue operations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)