### PR TITLE
Clean up UX for custom views

### DIFF
--- a/src/lib/components/NavigationDropdown.svelte
+++ b/src/lib/components/NavigationDropdown.svelte
@@ -125,6 +125,20 @@
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' },
     ];
 
+    const customViews: NavItem[] = filteredViewsStore.views.map((v) => ({
+      type: 'filteredView' as const,
+      id: v.id!,
+      label: v.name,
+      icon: 'filter' as const,
+    }));
+
+    const addViewAction: NavItem = {
+      type: 'action',
+      id: 'add-view',
+      label: 'New view',
+      icon: 'plus',
+    };
+
     const userItems: NavItem[] = followedUsers.map((u) => {
       const profile = userProfiles.get(u.did);
       return {
@@ -162,22 +176,10 @@
 
     const sections: SectionData[] = [];
 
-    const filteredViews = views.filter(filterItem);
-    if (filteredViews.length > 0) {
-      sections.push({ section: '', items: filteredViews });
-    }
-
-    const customViews: NavItem[] = [
-      ...filteredViewsStore.views.map((v) => ({
-        type: 'filteredView' as const,
-        id: v.id!,
-        label: v.name,
-        icon: 'filter' as const,
-      })),
-    ];
-    const filteredCustomViews = customViews.filter(filterItem);
-    if (filteredCustomViews.length > 0 || filterSection('Views')) {
-      sections.push({ section: 'Views', icon: 'layers', items: filteredCustomViews });
+    // System views + custom views + add action in one flat section
+    const allViews = [...views, ...customViews, addViewAction].filter(filterItem);
+    if (allViews.length > 0) {
+      sections.push({ section: '', items: allViews });
     }
 
     const filteredUsers = userItems.filter(filterItem);

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -474,17 +474,31 @@
 
     <div class="nav-separator"></div>
 
-    <!-- Views section -->
-    <NavSection
-      title="Views"
-      icon="layers"
-      isExpanded={sidebarStore.expandedSections.views}
-      showOnlyUnread={false}
-      isActive={false}
-      onToggle={() => sidebarStore.toggleSection('views')}
-      onLabelClick={() => sidebarStore.toggleSection('views')}
-      onUnreadToggle={() => {}}
-      onAdd={async () => {
+    <!-- Custom views -->
+    {#each filteredViewsStore.views as view (view.id)}
+      <ViewItem
+        {view}
+        isActive={currentFilter().type === 'view' && currentFilter().id === view.id}
+        isRenaming={renamingViewId === view.id}
+        onSelect={() => selectFilter('view', view.id)}
+        onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+        onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+        onTouchEnd={handleViewTouchEnd}
+        onTouchMove={handleViewTouchMove}
+        onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+        onRename={async (name) => {
+          if (view.id != null) {
+            await filteredViewsStore.update(view.id, { name });
+          }
+          renamingViewId = null;
+        }}
+        onRenameCancel={() => (renamingViewId = null)}
+      />
+    {/each}
+
+    <button
+      class="nav-item new-view-btn"
+      onclick={async () => {
         const id = await filteredViewsStore.create({
           name: 'new view',
           sourceMode: 'include',
@@ -497,28 +511,11 @@
         feedViewStore.setSourcePopoverOpen(true);
       }}
     >
-      {@const filter = currentFilter()}
-      {#each filteredViewsStore.views as view (view.id)}
-        <ViewItem
-          {view}
-          isActive={filter.type === 'view' && filter.id === view.id}
-          isRenaming={renamingViewId === view.id}
-          onSelect={() => selectFilter('view', view.id)}
-          onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-          onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-          onTouchEnd={handleViewTouchEnd}
-          onTouchMove={handleViewTouchMove}
-          onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-          onRename={async (name) => {
-            if (view.id != null) {
-              await filteredViewsStore.update(view.id, { name });
-            }
-            renamingViewId = null;
-          }}
-          onRenameCancel={() => (renamingViewId = null)}
-        />
-      {/each}
-    </NavSection>
+      <span class="nav-icon"><Icon name="plus" size={16} /></span>
+      <span class="nav-label">New view</span>
+    </button>
+
+    <div class="nav-separator"></div>
 
     <!-- Following section -->
     <NavSection
@@ -813,6 +810,14 @@
     font-size: 0.8125rem;
     color: var(--color-text-secondary);
     font-style: italic;
+  }
+
+  .new-view-btn {
+    color: var(--color-text-secondary);
+  }
+
+  .new-view-btn:hover {
+    color: var(--color-text);
   }
 
   .nav-separator {

--- a/src/lib/components/sidebar/ViewItem.svelte
+++ b/src/lib/components/sidebar/ViewItem.svelte
@@ -55,7 +55,7 @@
 </script>
 
 <button
-  class="nav-item sub-item view-item"
+  class="nav-item view-item"
   class:active={isActive}
   onclick={isRenaming ? undefined : onSelect}
   oncontextmenu={onContextMenu}
@@ -130,10 +130,6 @@
   .nav-item.active {
     background-color: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
     color: var(--color-primary);
-  }
-
-  .nav-item.sub-item {
-    padding-left: 0.75rem;
   }
 
   .view-icon {

--- a/src/lib/stores/sidebar.svelte.ts
+++ b/src/lib/stores/sidebar.svelte.ts
@@ -9,7 +9,6 @@ interface SidebarState {
   expandedSections: {
     shared: boolean;
     feeds: boolean;
-    views: boolean;
   };
   showOnlyUnread: {
     shared: boolean;
@@ -32,7 +31,6 @@ function createSidebarStore() {
     expandedSections: {
       shared: false,
       feeds: true,
-      views: true,
     },
     showOnlyUnread: {
       shared: false,
@@ -52,7 +50,6 @@ function createSidebarStore() {
         state.expandedSections = {
           shared: false,
           feeds: true,
-          views: true,
           ...parsed.expandedSections,
         };
         state.showOnlyUnread = parsed.showOnlyUnread ?? { shared: false, feeds: false };
@@ -84,7 +81,7 @@ function createSidebarStore() {
     state.isOpen = false;
   }
 
-  function toggleSection(section: 'shared' | 'feeds' | 'views') {
+  function toggleSection(section: 'shared' | 'feeds') {
     state.expandedSections[section] = !state.expandedSections[section];
     persist();
   }


### PR DESCRIPTION
## Summary

- Remove the collapsible "Views" NavSection wrapper from the sidebar
- Render custom views as individual top-level nav items between Feedback and Following/Feeds
- Add a "+ New view" button after the last custom view
- Flatten the quick switch dropdown so custom views appear inline with system views (All, Saved, Shared, etc.) instead of under a "Views" section header
- Remove `views` from `expandedSections` in sidebar store (no longer needed)
- Clean up `sub-item` class from ViewItem (now top-level)

## Test plan

- [ ] Custom views appear as individual nav items in sidebar (not inside collapsible section)
- [ ] Views appear between Feedback and Following/Feeds with separators
- [ ] "+ New view" button works and opens filter toolbar
- [ ] Context menu (rename, delete) still works on views
- [ ] Inline rename still works
- [ ] Quick switch shows custom views inline with system views
- [ ] Following and Feeds sections unchanged
- [ ] Mobile layout works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)