### PR TITLE
feat: make view delete accessible on mobile

### DIFF
--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -189,6 +189,14 @@
   // Whether we're editing an existing saved view
   let isEditingView = $derived(!!feedViewStore.viewFilter);
 
+  async function handleDeleteView() {
+    if (!feedViewStore.viewFilter) return;
+    if (!confirm('Are you sure you want to delete this view?')) return;
+    const id = parseInt(feedViewStore.viewFilter);
+    await filteredViewsStore.remove(id);
+    goto('/');
+  }
+
   async function handleSave() {
     if (isEditingView) {
       // Update existing view
@@ -571,6 +579,11 @@
         <Icon name="save" size={16} />
         <span class="filter-label">{isEditingView ? 'Update' : 'Save'}</span>
       </button>
+      {#if isEditingView}
+        <button class="filter-btn delete-btn" onclick={handleDeleteView} title="Delete view">
+          <Icon name="trash" size={16} />
+        </button>
+      {/if}
     {/if}
   </div>
 </div>
@@ -817,6 +830,15 @@
   .save-btn:not(:disabled):not(.has-changes):hover {
     color: var(--color-text);
     background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  .delete-btn {
+    color: var(--color-text-secondary);
+  }
+
+  .delete-btn:hover {
+    color: #dc2626;
+    background: rgba(220, 38, 38, 0.08);
   }
 
   .save-name-input {

--- a/frontend/src/lib/components/sidebar/ViewItem.svelte
+++ b/frontend/src/lib/components/sidebar/ViewItem.svelte
@@ -185,6 +185,12 @@
     opacity: 1;
   }
 
+  @media (max-width: 1000px) {
+    .more-btn {
+      opacity: 1;
+    }
+  }
+
   .more-btn:hover {
     color: var(--color-text);
     background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.1));


### PR DESCRIPTION
## Summary
- Show the three-dot more button (rename/delete) on custom views in the sidebar on mobile viewports (≤1000px) instead of requiring hover
- Add a delete (trash) button to the FilterToolbar when editing a saved view, so users can delete the active view directly from the toolbar

## Test plan
- [ ] On mobile viewport (≤1000px), verify the three-dot more button is visible on custom views in the sidebar without hovering
- [ ] Tap the more button and verify the context menu with Rename and Delete options appears
- [ ] On desktop, verify the more button still only appears on hover (unchanged behavior)
- [ ] Navigate to a saved custom view and verify the trash icon appears in the FilterToolbar next to the Update button
- [ ] Click the trash icon, confirm the deletion dialog, and verify the view is deleted and you're navigated to the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)