### PR TITLE
Fix unordered/ordered list rendering

### DIFF
--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -1078,8 +1078,8 @@
   .article-body :global(ul),
   .article-body :global(ol) {
     margin: 0.75rem 0;
-    padding-left: 0.5rem;
-    list-style-position: inside;
+    padding-left: 1.5rem;
+    list-style-position: outside;
   }
 
   .article-body :global(li ul),

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -870,11 +870,13 @@
   .reader-body :global(ul),
   .reader-body :global(ol) {
     margin: 1rem 0;
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .reader-body :global(li) {
     margin: 0.25rem 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   .reader-body :global(mark.highlight) {


### PR DESCRIPTION
## Summary
- Fix list bullet/number and text appearing on different lines for long content
- Switch ArticleCard from `list-style-position: inside` to `outside` with proper `padding-left: 1.5rem`
- Increase SavedReader list `padding-left` to `2rem` and add `word-wrap: break-word` on `li` elements
- Ensures wrapped text aligns with first line of text (hanging indent), not under the bullet

## Test plan
- [ ] Open an article with unordered/ordered lists in the feed card view — bullets should be inline with text
- [ ] Open the same article in the full reader view — same behavior
- [ ] Test on narrow mobile viewport to confirm wrapping works correctly
- [ ] Verify nested lists still indent properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)