### PR TITLE
Channels and folders

### DIFF
--- a/backend/migrations/0049_channels.sql
+++ b/backend/migrations/0049_channels.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS channels (
+    uuid TEXT NOT NULL,
+    user_did TEXT NOT NULL,
+    name TEXT NOT NULL,
+    config TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    deleted_at INTEGER,
+    PRIMARY KEY (user_did, uuid)
+);
+CREATE INDEX IF NOT EXISTS idx_channels_user_position ON channels(user_did, position);

--- a/backend/migrations/0050_subscription_category.sql
+++ b/backend/migrations/0050_subscription_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions_cache ADD COLUMN category TEXT DEFAULT NULL;

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -529,16 +529,19 @@ export class JetstreamPoller implements DurableObject {
     const recordUri = `at://${did}/app.skyreader.feed.subscription/${rkey}`;
 
     if ((operation === 'create' || operation === 'update') && record) {
-      // Extract sourceType and subjectDid from the record (cast to access AT Proto fields)
+      // Extract fields from the record (cast to access AT Proto fields)
       const recAny = record as Record<string, unknown>;
       const sourceType = (recAny.sourceType as string) || null;
       const subjectDid = (recAny.subjectDid as string) || null;
+      const customTitle = (recAny.customTitle as string) || null;
+      const customIconUrl = (recAny.customIconUrl as string) || null;
+      const category = (recAny.category as string) || null;
 
       try {
         await this.env.DB.prepare(
           `
-					INSERT OR REPLACE INTO subscriptions_cache (user_did, record_uri, feed_url, title, created_at, source_type, subject_did)
-					VALUES (?, ?, ?, ?, ?, ?, ?)
+					INSERT OR REPLACE INTO subscriptions_cache (user_did, record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url, category)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				`
         )
           .bind(
@@ -550,7 +553,10 @@ export class JetstreamPoller implements DurableObject {
               ? Math.floor(new Date(record.createdAt).getTime() / 1000)
               : Math.floor(Date.now() / 1000),
             sourceType,
-            subjectDid
+            subjectDid,
+            customTitle,
+            customIconUrl,
+            category
           )
           .run();
       } catch (dbError) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import {
   handleUpdateSubscription,
   handleBulkCreateSubscriptions,
   handleBulkDeleteSubscriptions,
+  handleBulkUpdateSubscriptions,
 } from './routes/subscriptions';
 import {
   handleGetSocialReadPositions,
@@ -247,6 +248,10 @@ export default {
         case url.pathname === '/api/subscriptions/bulk':
           if (!session) return unauthorizedResponse(headers);
           response = await handleBulkCreateSubscriptions(request, env, ctx);
+          break;
+        case url.pathname === '/api/subscriptions/bulk-update':
+          if (!session) return unauthorizedResponse(headers);
+          response = await handleBulkUpdateSubscriptions(request, env, ctx);
           break;
         case url.pathname === '/api/subscriptions/bulk-delete':
           if (!session) return unauthorizedResponse(headers);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -62,6 +62,12 @@ import {
   handleListMarginCollections,
 } from './routes/integrations';
 import { handleFullSync, handleSyncSubscriptions, handleSyncStatus } from './routes/sync';
+import {
+  handleGetChannels,
+  handleSyncChannels,
+  handleUpsertChannel,
+  handleDeleteChannel,
+} from './routes/channels';
 import { getSessionFromRequest, updateUserActivity } from './services/oauth';
 import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './services/rate-limit';
 
@@ -374,6 +380,36 @@ export default {
           if (!session) return unauthorizedResponse(headers);
           response = await handleListMarginCollections(request, env);
           break;
+
+        // Channels routes
+        case url.pathname === '/api/channels':
+          if (!session) return unauthorizedResponse(headers);
+          if (request.method === 'GET') {
+            response = await handleGetChannels(request, env);
+          } else if (request.method === 'PUT') {
+            response = await handleSyncChannels(request, env);
+          } else {
+            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+              status: 405,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          break;
+        case url.pathname.startsWith('/api/channels/'): {
+          if (!session) return unauthorizedResponse(headers);
+          const channelUuid = url.pathname.split('/').pop()!;
+          if (request.method === 'PUT') {
+            response = await handleUpsertChannel(request, env, channelUuid);
+          } else if (request.method === 'DELETE') {
+            response = await handleDeleteChannel(request, env, channelUuid);
+          } else {
+            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+              status: 405,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          break;
+        }
 
         // Sync routes
         case url.pathname === '/api/sync/full':

--- a/backend/src/routes/channels.ts
+++ b/backend/src/routes/channels.ts
@@ -1,0 +1,246 @@
+import type { Env } from '../types';
+import { getSessionFromRequest } from '../services/oauth';
+
+interface ChannelRow {
+  uuid: string;
+  name: string;
+  config: string;
+  position: number;
+  created_at: number;
+  updated_at: number;
+}
+
+interface ChannelBody {
+  name: string;
+  config: string;
+  position: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface SyncChannelsBody {
+  channels: Array<{
+    uuid: string;
+    name: string;
+    config: string;
+    position: number;
+    createdAt: number;
+    updatedAt: number;
+  }>;
+}
+
+// GET /api/channels - Get all channels for the current user
+export async function handleGetChannels(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const result = await env.DB.prepare(
+      `SELECT uuid, name, config, position, created_at, updated_at
+       FROM channels WHERE user_did = ? AND deleted_at IS NULL ORDER BY position`
+    )
+      .bind(session.did)
+      .all<ChannelRow>();
+
+    const channels = result.results.map((row) => ({
+      uuid: row.uuid,
+      name: row.name,
+      config: row.config,
+      position: row.position,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+
+    // Also return UUIDs of recently deleted channels so other devices can remove them
+    const deletedResult = await env.DB.prepare(
+      `SELECT uuid FROM channels WHERE user_did = ? AND deleted_at IS NOT NULL`
+    )
+      .bind(session.did)
+      .all<{ uuid: string }>();
+
+    const deletedUuids = deletedResult.results.map((row) => row.uuid);
+
+    return new Response(JSON.stringify({ channels, deletedUuids }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to get channels:', error);
+    return new Response(JSON.stringify({ error: 'Failed to get channels' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// PUT /api/channels - Sync all channels (bulk upsert)
+export async function handleSyncChannels(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: SyncChannelsBody;
+  try {
+    body = (await request.json()) as SyncChannelsBody;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!Array.isArray(body.channels)) {
+    return new Response(JSON.stringify({ error: 'Missing channels array' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const statements = body.channels.map((channel) =>
+      env.DB.prepare(
+        `INSERT INTO channels (uuid, user_did, name, config, position, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (user_did, uuid) DO UPDATE SET
+           name = excluded.name,
+           config = excluded.config,
+           position = excluded.position,
+           updated_at = excluded.updated_at
+         WHERE deleted_at IS NULL`
+      ).bind(
+        channel.uuid,
+        session.did,
+        channel.name,
+        channel.config,
+        channel.position,
+        channel.createdAt,
+        channel.updatedAt
+      )
+    );
+
+    if (statements.length > 0) {
+      await env.DB.batch(statements);
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to sync channels:', error);
+    return new Response(JSON.stringify({ error: 'Failed to sync channels' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// PUT /api/channels/:uuid - Upsert a single channel
+export async function handleUpsertChannel(
+  request: Request,
+  env: Env,
+  uuid: string
+): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: ChannelBody;
+  try {
+    body = (await request.json()) as ChannelBody;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    await env.DB.prepare(
+      `INSERT INTO channels (uuid, user_did, name, config, position, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (user_did, uuid) DO UPDATE SET
+         name = excluded.name,
+         config = excluded.config,
+         position = excluded.position,
+         updated_at = excluded.updated_at
+       WHERE deleted_at IS NULL`
+    )
+      .bind(
+        uuid,
+        session.did,
+        body.name,
+        body.config,
+        body.position,
+        body.createdAt,
+        body.updatedAt
+      )
+      .run();
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to upsert channel:', error);
+    return new Response(JSON.stringify({ error: 'Failed to upsert channel' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// DELETE /api/channels/:uuid - Soft delete a channel
+export async function handleDeleteChannel(
+  request: Request,
+  env: Env,
+  uuid: string
+): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const now = Date.now();
+    // Two-step soft-delete: update if exists, insert tombstone if not.
+    const updateResult = await env.DB.prepare(
+      `UPDATE channels SET deleted_at = ? WHERE user_did = ? AND uuid = ?`
+    )
+      .bind(now, session.did, uuid)
+      .run();
+
+    if (updateResult.meta.changes === 0) {
+      // Row didn't exist — insert a tombstone so other devices see the deletion
+      await env.DB.prepare(
+        `INSERT INTO channels (uuid, user_did, name, config, position, created_at, updated_at, deleted_at)
+         VALUES (?, ?, '', '{}', 0, ?, ?, ?)`
+      )
+        .bind(uuid, session.did, now, now, now)
+        .run();
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to delete channel:', error);
+    return new Response(JSON.stringify({ error: 'Failed to delete channel' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/backend/src/routes/channels.ts
+++ b/backend/src/routes/channels.ts
@@ -1,6 +1,10 @@
 import type { Env } from '../types';
 import { getSessionFromRequest } from '../services/oauth';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_NAME_LENGTH = 200;
+const MAX_CONFIG_LENGTH = 50_000; // 50 KB serialized config limit
+
 interface ChannelRow {
   uuid: string;
   name: string;
@@ -27,6 +31,37 @@ interface SyncChannelsBody {
     createdAt: number;
     updatedAt: number;
   }>;
+}
+
+function validateUuid(uuid: string): string | null {
+  if (typeof uuid !== 'string' || !UUID_RE.test(uuid)) return 'Invalid UUID format';
+  return null;
+}
+
+function validateChannelBody(body: ChannelBody, uuid?: string): string | null {
+  if (uuid != null) {
+    const uuidErr = validateUuid(uuid);
+    if (uuidErr) return uuidErr;
+  }
+  if (typeof body.name !== 'string' || body.name.length === 0) return 'Name is required';
+  if (body.name.length > MAX_NAME_LENGTH)
+    return `Name must be ${MAX_NAME_LENGTH} characters or less`;
+  if (typeof body.config !== 'string') return 'Config must be a string';
+  if (body.config.length > MAX_CONFIG_LENGTH) return 'Config is too large';
+  if (typeof body.position !== 'number' || !Number.isFinite(body.position) || body.position < 0)
+    return 'Position must be a non-negative number';
+  if (typeof body.createdAt !== 'number' || !Number.isFinite(body.createdAt))
+    return 'createdAt must be a number';
+  if (typeof body.updatedAt !== 'number' || !Number.isFinite(body.updatedAt))
+    return 'updatedAt must be a number';
+  return null;
+}
+
+function validationError(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 // GET /api/channels - Get all channels for the current user
@@ -98,10 +133,12 @@ export async function handleSyncChannels(request: Request, env: Env): Promise<Re
   }
 
   if (!Array.isArray(body.channels)) {
-    return new Response(JSON.stringify({ error: 'Missing channels array' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return validationError('Missing channels array');
+  }
+
+  for (const channel of body.channels) {
+    const err = validateChannelBody(channel, channel.uuid);
+    if (err) return validationError(err);
   }
 
   try {
@@ -156,6 +193,9 @@ export async function handleUpsertChannel(
     });
   }
 
+  const uuidErr = validateUuid(uuid);
+  if (uuidErr) return validationError(uuidErr);
+
   let body: ChannelBody;
   try {
     body = (await request.json()) as ChannelBody;
@@ -165,6 +205,9 @@ export async function handleUpsertChannel(
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  const bodyErr = validateChannelBody(body);
+  if (bodyErr) return validationError(bodyErr);
 
   try {
     await env.DB.prepare(
@@ -206,6 +249,9 @@ export async function handleDeleteChannel(
   env: Env,
   uuid: string
 ): Promise<Response> {
+  const uuidErr = validateUuid(uuid);
+  if (uuidErr) return validationError(uuidErr);
+
   const session = await getSessionFromRequest(request, env);
   if (!session) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {

--- a/backend/src/routes/channels.ts
+++ b/backend/src/routes/channels.ts
@@ -48,6 +48,11 @@ function validateChannelBody(body: ChannelBody, uuid?: string): string | null {
     return `Name must be ${MAX_NAME_LENGTH} characters or less`;
   if (typeof body.config !== 'string') return 'Config must be a string';
   if (body.config.length > MAX_CONFIG_LENGTH) return 'Config is too large';
+  try {
+    JSON.parse(body.config);
+  } catch {
+    return 'Config must be valid JSON';
+  }
   if (typeof body.position !== 'number' || !Number.isFinite(body.position) || body.position < 0)
     return 'Position must be a non-negative number';
   if (typeof body.createdAt !== 'number' || !Number.isFinite(body.createdAt))
@@ -262,22 +267,14 @@ export async function handleDeleteChannel(
 
   try {
     const now = Date.now();
-    // Two-step soft-delete: update if exists, insert tombstone if not.
-    const updateResult = await env.DB.prepare(
-      `UPDATE channels SET deleted_at = ? WHERE user_did = ? AND uuid = ?`
+    // Atomic soft-delete: upsert a tombstone whether the row exists or not.
+    await env.DB.prepare(
+      `INSERT INTO channels (uuid, user_did, name, config, position, created_at, updated_at, deleted_at)
+       VALUES (?, ?, '', '{}', 0, ?, ?, ?)
+       ON CONFLICT (user_did, uuid) DO UPDATE SET deleted_at = excluded.deleted_at, updated_at = excluded.updated_at`
     )
-      .bind(now, session.did, uuid)
+      .bind(uuid, session.did, now, now, now)
       .run();
-
-    if (updateResult.meta.changes === 0) {
-      // Row didn't exist — insert a tombstone so other devices see the deletion
-      await env.DB.prepare(
-        `INSERT INTO channels (uuid, user_did, name, config, position, created_at, updated_at, deleted_at)
-         VALUES (?, ?, '', '{}', 0, ?, ?, ?)`
-      )
-        .bind(uuid, session.did, now, now, now)
-        .run();
-    }
 
     return new Response(JSON.stringify({ success: true }), {
       headers: { 'Content-Type': 'application/json' },

--- a/backend/src/routes/records.ts
+++ b/backend/src/routes/records.ts
@@ -12,6 +12,7 @@ interface SubscriptionRow {
   subject_did: string | null;
   custom_title: string | null;
   custom_icon_url: string | null;
+  category: string | null;
 }
 
 interface ShareRow {
@@ -54,7 +55,7 @@ export async function handleRecordsList(request: Request, env: Env): Promise<Res
 
     if (collection === 'app.skyreader.feed.subscription') {
       const result = await env.DB.prepare(
-        'SELECT record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url FROM subscriptions_cache WHERE user_did = ?'
+        'SELECT record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url, category FROM subscriptions_cache WHERE user_did = ?'
       )
         .bind(session.did)
         .all<SubscriptionRow>();
@@ -76,6 +77,7 @@ export async function handleRecordsList(request: Request, env: Env): Promise<Res
             subjectDid: row.subject_did || undefined,
             customTitle: row.custom_title || undefined,
             customIconUrl: row.custom_icon_url || undefined,
+            category: row.category || undefined,
           },
         };
       });

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -23,7 +23,8 @@ async function maybePushToPds(
   subjectDid?: string,
   collectionNsid?: string,
   customTitle?: string,
-  customIconUrl?: string
+  customIconUrl?: string,
+  category?: string
 ): Promise<void> {
   console.log('[PDS Sync] maybePushToPds called:', {
     pdsSyncEnabled,
@@ -54,7 +55,8 @@ async function maybePushToPds(
       subjectDid,
       collectionNsid,
       customTitle,
-      customIconUrl
+      customIconUrl,
+      category
     );
     if (result.success) {
       console.log('[PDS Sync] Successfully pushed subscription to PDS');
@@ -490,8 +492,8 @@ export async function handleCreateSubscription(
     await env.DB.prepare(
       `
 			INSERT OR REPLACE INTO subscriptions_cache
-			(user_did, record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url)
-			VALUES (?, ?, ?, ?, unixepoch(), ?, ?, ?, ?)
+			(user_did, record_uri, feed_url, title, category, created_at, source_type, subject_did, custom_title, custom_icon_url)
+			VALUES (?, ?, ?, ?, ?, unixepoch(), ?, ?, ?, ?)
 			`
     )
       .bind(
@@ -499,6 +501,7 @@ export async function handleCreateSubscription(
         recordUri,
         feedUrl || '',
         title || null,
+        category || null,
         sourceType || null,
         subjectDid || null,
         customTitle || null,
@@ -540,7 +543,8 @@ export async function handleCreateSubscription(
         subjectDid,
         collectionNsid,
         customTitle,
-        customIconUrl
+        customIconUrl,
+        category
       )
     );
 
@@ -656,7 +660,11 @@ export async function handleUpdateSubscription(
     return invalidRkeyResponse();
   }
 
-  let body: { customTitle?: string | null; customIconUrl?: string | null };
+  let body: {
+    customTitle?: string | null;
+    customIconUrl?: string | null;
+    category?: string | null;
+  };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -669,7 +677,7 @@ export async function handleUpdateSubscription(
   try {
     // Read existing row to get full record for PDS push
     const existing = await env.DB.prepare(
-      `SELECT feed_url, title, source_type, subject_did, custom_title, custom_icon_url
+      `SELECT feed_url, title, source_type, subject_did, custom_title, custom_icon_url, category
        FROM subscriptions_cache
        WHERE user_did = ? AND record_uri LIKE ?`
     )
@@ -681,6 +689,7 @@ export async function handleUpdateSubscription(
         subject_did: string | null;
         custom_title: string | null;
         custom_icon_url: string | null;
+        category: string | null;
       }>();
 
     if (!existing) {
@@ -695,12 +704,13 @@ export async function handleUpdateSubscription(
       body.customTitle === null ? null : (body.customTitle ?? existing.custom_title);
     const newCustomIconUrl =
       body.customIconUrl === null ? null : (body.customIconUrl ?? existing.custom_icon_url);
+    const newCategory = body.category === null ? null : (body.category ?? existing.category);
 
     await env.DB.prepare(
-      `UPDATE subscriptions_cache SET custom_title = ?, custom_icon_url = ?
+      `UPDATE subscriptions_cache SET custom_title = ?, custom_icon_url = ?, category = ?
        WHERE user_did = ? AND record_uri LIKE ?`
     )
-      .bind(newCustomTitle, newCustomIconUrl, session.did, `%/${rkey}`)
+      .bind(newCustomTitle, newCustomIconUrl, newCategory, session.did, `%/${rkey}`)
       .run();
 
     // Push full record to PDS in background
@@ -717,7 +727,8 @@ export async function handleUpdateSubscription(
         existing.subject_did || undefined,
         undefined,
         newCustomTitle || undefined,
-        newCustomIconUrl || undefined
+        newCustomIconUrl || undefined,
+        newCategory || undefined
       )
     );
 
@@ -845,10 +856,10 @@ export async function handleBulkCreateSubscriptions(
         env.DB.prepare(
           `
 					INSERT OR REPLACE INTO subscriptions_cache
-					(user_did, record_uri, feed_url, title, created_at)
-					VALUES (?, ?, ?, ?, unixepoch())
+					(user_did, record_uri, feed_url, title, category, created_at)
+					VALUES (?, ?, ?, ?, ?, unixepoch())
 					`
-        ).bind(session.did, recordUri, sub.feedUrl, sub.title || null)
+        ).bind(session.did, recordUri, sub.feedUrl, sub.title || null, sub.category || null)
       );
 
       feedsToFetch.push(sub.feedUrl);
@@ -893,6 +904,157 @@ export async function handleBulkCreateSubscriptions(
     console.error('Bulk create subscriptions error:', error);
     const errorMessage =
       error instanceof Error ? `${error.name}: ${error.message}` : 'Failed to create subscriptions';
+    return new Response(JSON.stringify({ error: errorMessage }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// POST /api/subscriptions/bulk-update - Bulk update subscription fields
+export async function handleBulkUpdateSubscriptions(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: {
+    rkeys: string[];
+    updates: {
+      customTitle?: string | null;
+      customIconUrl?: string | null;
+      category?: string | null;
+    };
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { rkeys, updates } = body;
+
+  if (!Array.isArray(rkeys) || rkeys.length === 0) {
+    return new Response(JSON.stringify({ error: 'rkeys array is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!updates || typeof updates !== 'object') {
+    return new Response(JSON.stringify({ error: 'updates object is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  for (const rkey of rkeys) {
+    if (!isValidRkey(rkey)) {
+      return new Response(JSON.stringify({ error: `Invalid rkey format: ${rkey}` }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  try {
+    // Build SET clause from provided updates
+    const setClauses: string[] = [];
+    const setValues: (string | null)[] = [];
+
+    if (updates.customTitle !== undefined) {
+      setClauses.push('custom_title = ?');
+      setValues.push(updates.customTitle);
+    }
+    if (updates.customIconUrl !== undefined) {
+      setClauses.push('custom_icon_url = ?');
+      setValues.push(updates.customIconUrl);
+    }
+    if (updates.category !== undefined) {
+      setClauses.push('category = ?');
+      setValues.push(updates.category);
+    }
+
+    if (setClauses.length === 0) {
+      return new Response(JSON.stringify({ success: true, updated: 0 }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const batchStatements = rkeys.map((rkey) =>
+      env.DB.prepare(
+        `UPDATE subscriptions_cache SET ${setClauses.join(', ')}
+         WHERE user_did = ? AND record_uri LIKE ?`
+      ).bind(...setValues, session.did, `%/${rkey}`)
+    );
+
+    await env.DB.batch(batchStatements);
+
+    // Push updated records to PDS in background
+    const settings = await getUserSettings(env, session.did);
+    if (settings.pdsSyncEnabled) {
+      const rows = await env.DB.prepare(
+        `SELECT record_uri, feed_url, title, source_type, subject_did, custom_title, custom_icon_url, category
+         FROM subscriptions_cache
+         WHERE user_did = ? AND (${rkeys.map(() => 'record_uri LIKE ?').join(' OR ')})`
+      )
+        .bind(session.did, ...rkeys.map((rk) => `%/${rk}`))
+        .all<{
+          record_uri: string;
+          feed_url: string;
+          title: string | null;
+          source_type: string | null;
+          subject_did: string | null;
+          custom_title: string | null;
+          custom_icon_url: string | null;
+          category: string | null;
+        }>();
+
+      for (const row of rows.results) {
+        const rkey = row.record_uri.split('/').pop()!;
+        ctx.waitUntil(
+          maybePushToPds(
+            session,
+            true,
+            rkey,
+            row.feed_url,
+            row.title || undefined,
+            undefined,
+            row.source_type || undefined,
+            row.subject_did || undefined,
+            undefined,
+            row.custom_title || undefined,
+            row.custom_icon_url || undefined,
+            row.category || undefined
+          )
+        );
+      }
+    }
+
+    return new Response(JSON.stringify({ success: true, updated: rkeys.length }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Bulk update subscriptions error:', error);
+    const errorMessage =
+      error instanceof Error ? `${error.name}: ${error.message}` : 'Failed to update subscriptions';
     return new Response(JSON.stringify({ error: errorMessage }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/backend/src/services/subscription-sync.ts
+++ b/backend/src/services/subscription-sync.ts
@@ -197,6 +197,7 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
       subjectDid: string | null;
       customTitle: string | null;
       customIconUrl: string | null;
+      category: string | null;
     }> = [];
 
     for (const pdsRecord of sortedPdsRecords) {
@@ -227,6 +228,7 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
           subjectDid: pdsRecord.value.subjectDid || null,
           customTitle: pdsRecord.value.customTitle || null,
           customIconUrl: pdsRecord.value.customIconUrl || null,
+          category: pdsRecord.value.category || null,
         });
       }
     }
@@ -243,8 +245,8 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
         const recordUri = buildRecordUri(session.did, COLLECTION, sub.rkey);
         return env.DB.prepare(
           `INSERT OR IGNORE INTO subscriptions_cache
-					 (user_did, record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					 (user_did, record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url, category)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).bind(
           session.did,
           recordUri,
@@ -254,7 +256,8 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
           sub.sourceType,
           sub.subjectDid,
           sub.customTitle,
-          sub.customIconUrl
+          sub.customIconUrl,
+          sub.category
         );
       });
 
@@ -432,7 +435,8 @@ export async function pushSubscriptionToPds(
   subjectDid?: string,
   collectionNsid?: string,
   customTitle?: string,
-  customIconUrl?: string
+  customIconUrl?: string,
+  category?: string
 ): Promise<PDSResult<void>> {
   const pdsClient = createPDSClient(session);
 
@@ -441,6 +445,7 @@ export async function pushSubscriptionToPds(
     feedUrl: feedUrl || undefined,
     title,
     siteUrl,
+    category,
     createdAt: new Date().toISOString(),
     sourceType,
     subjectDid,

--- a/e2e/channels.spec.ts
+++ b/e2e/channels.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+
+/** Create a channel via the sidebar + button and modal form. */
+async function createChannel(page: Page, name: string) {
+  const channelsSection = page.locator('.section-header', { hasText: 'Channels' });
+  await expect(channelsSection).toBeVisible({ timeout: 15_000 });
+  await channelsSection.locator('.add-btn').click();
+
+  // Fill the channel name in the modal
+  const nameInput = page.locator('#view-name');
+  await expect(nameInput).toBeVisible({ timeout: 5_000 });
+  await nameInput.fill(name);
+
+  // Click the Create button
+  await page.locator('button.btn-primary', { hasText: 'Create' }).click();
+
+  // Wait for the channel to appear in the sidebar
+  const channel = page.locator('.view-item .nav-label', { hasText: name });
+  await expect(channel).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('Channels', () => {
+  test('sidebar shows Channels section', async ({ authedPage }) => {
+    await expect(authedPage.locator('text=Channels')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('create a new channel via + button', async ({ authedPage }) => {
+    await createChannel(authedPage, 'Test Channel');
+
+    // URL should include view= parameter
+    await expect(authedPage).toHaveURL(/view=/);
+  });
+
+  test('rename a channel via context menu', async ({ authedPage }) => {
+    await createChannel(authedPage, 'Rename Me');
+
+    // Click the more (three dot) button to open context menu
+    const viewItem = authedPage.locator('.view-item', { hasText: 'Rename Me' });
+    const moreBtn = viewItem.locator('.more-btn');
+    // Force click since the more-btn may be hidden until hover
+    await moreBtn.click({ force: true });
+
+    // Click Rename in the context menu
+    const renameItem = authedPage.locator('.context-menu-item', { hasText: 'Rename' });
+    await expect(renameItem).toBeVisible({ timeout: 5_000 });
+    await renameItem.click();
+
+    // An input should appear with the current name
+    const renameInput = viewItem.locator('.rename-input');
+    await expect(renameInput).toBeVisible({ timeout: 5_000 });
+
+    // Clear and type a new name
+    await renameInput.fill('My Tech Channel');
+    await renameInput.press('Enter');
+
+    // The channel should now display the new name
+    await expect(
+      authedPage.locator('.view-item .nav-label', { hasText: 'My Tech Channel' })
+    ).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test('delete a channel via context menu', async ({ authedPage }) => {
+    await createChannel(authedPage, 'Delete Me');
+
+    // Open context menu
+    const viewItem = authedPage.locator('.view-item', { hasText: 'Delete Me' });
+    await viewItem.locator('.more-btn').click({ force: true });
+
+    // Handle the confirmation dialog
+    authedPage.on('dialog', (dialog) => dialog.accept());
+
+    // Click Delete
+    const deleteItem = authedPage.locator('.context-menu-item.danger', { hasText: 'Delete' });
+    await expect(deleteItem).toBeVisible({ timeout: 5_000 });
+    await deleteItem.click();
+
+    // Channel should be gone — wait for it to disappear
+    const channel = authedPage.locator('.view-item .nav-label', { hasText: 'Delete Me' });
+    await expect(channel).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test('clicking a channel navigates to its view', async ({ authedPage }) => {
+    await createChannel(authedPage, 'Nav Channel');
+
+    const viewItem = authedPage.locator('.view-item', { hasText: 'Nav Channel' });
+
+    // Navigate away first
+    await authedPage.locator('.nav-label', { hasText: 'Everything' }).click();
+    await expect(authedPage).toHaveURL(/\/$/);
+
+    // Click the channel to navigate to it
+    await viewItem.click();
+    await expect(authedPage).toHaveURL(/view=/);
+
+    // The channel should be active (highlighted)
+    await expect(viewItem).toHaveClass(/active/);
+  });
+
+  test('Manage Sources link navigates to /sources', async ({ authedPage }) => {
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await expect(authedPage).toHaveURL(/\/sources/);
+  });
+});

--- a/e2e/channels.spec.ts
+++ b/e2e/channels.spec.ts
@@ -1,11 +1,14 @@
 import { test, expect } from './fixtures';
 import type { Page } from '@playwright/test';
 
-/** Create a channel via the sidebar + button and modal form. */
+/** Create a source channel via the Everything row's + button and modal form. */
 async function createChannel(page: Page, name: string) {
-  const channelsSection = page.locator('.section-header', { hasText: 'Channels' });
-  await expect(channelsSection).toBeVisible({ timeout: 15_000 });
-  await channelsSection.locator('.add-btn').click();
+  // Channels live under the Everything nav row. Click the + add button on that row.
+  const everythingRow = page.locator('.nav-row', {
+    has: page.locator('.nav-label', { hasText: 'Everything' }),
+  });
+  await expect(everythingRow).toBeVisible({ timeout: 15_000 });
+  await everythingRow.locator('.row-add-btn').click({ force: true });
 
   // Fill the channel name in the modal
   const nameInput = page.locator('#view-name');
@@ -21,8 +24,10 @@ async function createChannel(page: Page, name: string) {
 }
 
 test.describe('Channels', () => {
-  test('sidebar shows Channels section', async ({ authedPage }) => {
-    await expect(authedPage.locator('text=Channels')).toBeVisible({ timeout: 15_000 });
+  test('sidebar shows Everything section', async ({ authedPage }) => {
+    await expect(authedPage.locator('.nav-label', { hasText: 'Everything' })).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test('create a new channel via + button', async ({ authedPage }) => {
@@ -35,19 +40,18 @@ test.describe('Channels', () => {
   test('rename a channel via context menu', async ({ authedPage }) => {
     await createChannel(authedPage, 'Rename Me');
 
-    // Click the more (three dot) button to open context menu
+    // Right-click the view item to open the context menu
     const viewItem = authedPage.locator('.view-item', { hasText: 'Rename Me' });
-    const moreBtn = viewItem.locator('.more-btn');
-    // Force click since the more-btn may be hidden until hover
-    await moreBtn.click({ force: true });
+    await viewItem.click({ button: 'right' });
 
     // Click Rename in the context menu
     const renameItem = authedPage.locator('.context-menu-item', { hasText: 'Rename' });
     await expect(renameItem).toBeVisible({ timeout: 5_000 });
     await renameItem.click();
 
-    // An input should appear with the current name
-    const renameInput = viewItem.locator('.rename-input');
+    // An input should appear — when the view enters rename mode the nav-label
+    // is replaced with an input, so we can't filter by the old name's text.
+    const renameInput = authedPage.locator('.view-item .rename-input');
     await expect(renameInput).toBeVisible({ timeout: 5_000 });
 
     // Clear and type a new name

--- a/e2e/custom-fields.spec.ts
+++ b/e2e/custom-fields.spec.ts
@@ -1,28 +1,37 @@
 import { test, expect } from './fixtures';
 import { seedSubscription } from './seed';
+import type { Page, Locator } from '@playwright/test';
+
+/** Locate the SourceRow for a given title on the /sources page. */
+function sourceRowByTitle(page: Page, title: string): Locator {
+  return page.locator('.source-row', {
+    has: page.locator('.source-title', { hasText: title }),
+  });
+}
+
+/** Open the edit modal for a source row via its popover menu. */
+async function openEditModal(page: Page, row: Locator) {
+  await row.locator('button.menu-trigger').click({ force: true });
+  const editItem = page.locator('.menu-item', { hasText: 'Edit' });
+  await expect(editItem).toBeVisible({ timeout: 5_000 });
+  await editItem.click();
+}
 
 test.describe('Custom Fields', () => {
   const FEED_URL = 'https://example.com/feed.xml';
   const FEED_TITLE = 'Example Feed';
 
-  test('edit custom title via sidebar context menu', async ({ authedPage, testUser }) => {
-    // Seed a subscription so it shows up in the sidebar
+  test('edit custom title via sources page', async ({ authedPage, testUser }) => {
     seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
 
-    // Reload to pick up the seeded subscription from the backend
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
 
-    // Wait for the feed to appear in the sidebar
-    const feedItem = authedPage.locator('.nav-label', { hasText: FEED_TITLE });
-    await expect(feedItem).toBeVisible({ timeout: 15_000 });
+    const row = sourceRowByTitle(authedPage, FEED_TITLE);
+    await expect(row).toBeVisible({ timeout: 15_000 });
 
-    // Right-click to open context menu
-    await feedItem.click({ button: 'right' });
-
-    // Click "Edit" in the context menu
-    const editButton = authedPage.locator('.context-menu-item', { hasText: 'Edit' });
-    await expect(editButton).toBeVisible();
-    await editButton.click();
+    await openEditModal(authedPage, row);
 
     // The EditFeedModal should be open
     const titleInput = authedPage.locator('#feed-title');
@@ -42,23 +51,28 @@ test.describe('Custom Fields', () => {
     // Wait for modal to close
     await expect(authedPage.locator('#feed-title')).not.toBeVisible({ timeout: 5_000 });
 
-    // Verify the sidebar now shows the custom title
-    const customFeedItem = authedPage.locator('.nav-label', { hasText: customTitle });
-    await expect(customFeedItem).toBeVisible({ timeout: 10_000 });
+    // Verify the sources page now shows the custom title
+    await expect(
+      sourceRowByTitle(authedPage, customTitle)
+    ).toBeVisible({ timeout: 10_000 });
 
     // Wait for the PATCH to actually complete so D1 is updated
     const patchResp = await patchPromise;
     expect(patchResp.status()).toBe(200);
 
-    // Reload and verify persistence (round-trips through D1 → backend → IndexedDB)
+    // Reload and verify persistence (round-trips through D1 → backend → IndexedDB).
+    // Reload lands on /sources which doesn't initialize the store — bounce through
+    // '/' to trigger appManager.initialize() and re-sync subscriptions from backend.
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Everything' }).click();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
     await expect(
-      authedPage.locator('.nav-label', { hasText: customTitle })
+      sourceRowByTitle(authedPage, customTitle)
     ).toBeVisible({ timeout: 15_000 });
   });
 
   test('clear custom title resets to original', async ({ authedPage, testUser }) => {
-    // Seed a subscription with a custom title already set
     seedSubscription(testUser, {
       feedUrl: FEED_URL,
       title: FEED_TITLE,
@@ -66,14 +80,13 @@ test.describe('Custom Fields', () => {
     });
 
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
 
-    // Wait for the feed to appear with the custom title
-    const feedItem = authedPage.locator('.nav-label', { hasText: 'Old Custom Title' });
-    await expect(feedItem).toBeVisible({ timeout: 15_000 });
+    const row = sourceRowByTitle(authedPage, 'Old Custom Title');
+    await expect(row).toBeVisible({ timeout: 15_000 });
 
-    // Right-click → Edit
-    await feedItem.click({ button: 'right' });
-    await authedPage.locator('.context-menu-item', { hasText: 'Edit' }).click();
+    await openEditModal(authedPage, row);
 
     // The custom title input should have the current custom title
     const titleInput = authedPage.locator('#feed-title');
@@ -88,9 +101,9 @@ test.describe('Custom Fields', () => {
     // Save
     await authedPage.locator('button[type="submit"]').click();
 
-    // Sidebar should show the original title now
+    // Sources page should show the original title now
     await expect(
-      authedPage.locator('.nav-label', { hasText: FEED_TITLE })
+      sourceRowByTitle(authedPage, FEED_TITLE)
     ).toBeVisible({ timeout: 5_000 });
   });
 
@@ -98,13 +111,13 @@ test.describe('Custom Fields', () => {
     seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
 
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
 
-    const feedItem = authedPage.locator('.nav-label', { hasText: FEED_TITLE });
-    await expect(feedItem).toBeVisible({ timeout: 15_000 });
+    const row = sourceRowByTitle(authedPage, FEED_TITLE);
+    await expect(row).toBeVisible({ timeout: 15_000 });
 
-    // Right-click → Edit
-    await feedItem.click({ button: 'right' });
-    await authedPage.locator('.context-menu-item', { hasText: 'Edit' }).click();
+    await openEditModal(authedPage, row);
 
     // Fill the custom icon URL
     const iconInput = authedPage.locator('#feed-icon');

--- a/e2e/feed-management.spec.ts
+++ b/e2e/feed-management.spec.ts
@@ -2,65 +2,75 @@ import { test, expect } from './fixtures';
 import { seedSubscription } from './seed';
 
 test.describe('Feed Management', () => {
-  test('add feed by URL via sidebar input', async ({ authedPage }) => {
-    const addFeedInput = authedPage.getByPlaceholder('Add feed, URL, or @handle...');
+  test('add feed by URL via sidebar add trigger', async ({ authedPage }) => {
+    // Open the AddSourceInput popover from the sidebar
+    await authedPage.locator('button.add-trigger[aria-label="Add source"]').click();
+
+    const addFeedInput = authedPage.getByPlaceholder('Paste URL or @handle...');
     await expect(addFeedInput).toBeVisible({ timeout: 15_000 });
 
     await addFeedInput.fill('https://xkcd.com/atom.xml');
     await addFeedInput.press('Enter');
 
-    // Wait for the feed to appear in the sidebar (discovery + add)
-    await expect(authedPage.locator('.nav-label', { hasText: 'xkcd' })).toBeVisible({
-      timeout: 30_000,
-    });
+    // AddFeedModal opens with the URL prefilled — click Add to submit
+    const modalInput = authedPage.locator('.modal-content input.search-input');
+    await expect(modalInput).toBeVisible({ timeout: 5_000 });
+    await authedPage.locator('.modal-content button.add-btn', { hasText: 'Add' }).click();
+
+    // Navigate to the sources page via SPA navigation (preserves store state)
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
+    await expect(
+      authedPage.locator('.source-title', { hasText: 'xkcd' })
+    ).toBeVisible({ timeout: 30_000 });
   });
 
-  test('remove feed via context menu', async ({ authedPage, testUser }) => {
+  test('remove feed via sources page menu', async ({ authedPage, testUser }) => {
     seedSubscription(testUser, {
       feedUrl: 'https://example.com/delete-test.xml',
       title: 'Delete Test Feed',
     });
 
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
 
-    const feedItem = authedPage.locator('.nav-label', { hasText: 'Delete Test Feed' });
-    await expect(feedItem).toBeVisible({ timeout: 15_000 });
+    const sourceRow = authedPage.locator('.source-row', {
+      has: authedPage.locator('.source-title', { hasText: 'Delete Test Feed' }),
+    });
+    await expect(sourceRow).toBeVisible({ timeout: 15_000 });
 
-    // Accept the confirm dialog
+    // Accept the confirm dialog that pops up on Remove
     authedPage.on('dialog', (dialog) => dialog.accept());
 
-    // Right-click to open context menu
-    await feedItem.click({ button: 'right' });
+    // Open the row's popover menu and click Remove
+    await sourceRow.locator('button.menu-trigger').click({ force: true });
+    await authedPage.locator('.menu-item.danger', { hasText: 'Remove' }).click();
 
-    const deleteButton = authedPage.locator('.context-menu-item', { hasText: 'Delete' });
-    await expect(deleteButton).toBeVisible();
-    await deleteButton.click();
-
-    // Feed should disappear from sidebar
-    await expect(feedItem).not.toBeVisible({ timeout: 10_000 });
+    // Row should disappear
+    await expect(sourceRow).not.toBeVisible({ timeout: 10_000 });
   });
 
   test('articles load after adding feed', async ({ authedPage }) => {
-    const addFeedInput = authedPage.getByPlaceholder('Add feed, URL, or @handle...');
+    await authedPage.locator('button.add-trigger[aria-label="Add source"]').click();
+
+    const addFeedInput = authedPage.getByPlaceholder('Paste URL or @handle...');
     await expect(addFeedInput).toBeVisible({ timeout: 15_000 });
 
     await addFeedInput.fill('https://xkcd.com/atom.xml');
     await addFeedInput.press('Enter');
 
-    // Wait for feed to appear
-    const feedItem = authedPage.locator('.nav-label', { hasText: 'xkcd' });
-    await expect(feedItem).toBeVisible({ timeout: 30_000 });
+    const modalInput = authedPage.locator('.modal-content input.search-input');
+    await expect(modalInput).toBeVisible({ timeout: 5_000 });
+    await authedPage.locator('.modal-content button.add-btn', { hasText: 'Add' }).click();
 
-    // Click the feed to view its articles
-    await feedItem.click();
-
-    // Articles should load
+    // Already on the main feed — articles should load as the feed is fetched
     await expect(authedPage.locator('article.article-item').first()).toBeVisible({
-      timeout: 15_000,
+      timeout: 30_000,
     });
   });
 
-  test('multiple feeds show in sidebar', async ({ authedPage, testUser }) => {
+  test('multiple feeds show on sources page', async ({ authedPage, testUser }) => {
     seedSubscription(testUser, {
       feedUrl: 'https://example.com/feed1.xml',
       title: 'Multi Feed One',
@@ -75,15 +85,17 @@ test.describe('Feed Management', () => {
     });
 
     await authedPage.reload();
+    await authedPage.locator('.nav-label', { hasText: 'Manage Sources' }).click();
+    await authedPage.locator('button.tab', { hasText: 'Websites' }).click();
 
     await expect(
-      authedPage.locator('.nav-label', { hasText: 'Multi Feed One' })
+      authedPage.locator('.source-title', { hasText: 'Multi Feed One' })
     ).toBeVisible({ timeout: 15_000 });
     await expect(
-      authedPage.locator('.nav-label', { hasText: 'Multi Feed Two' })
+      authedPage.locator('.source-title', { hasText: 'Multi Feed Two' })
     ).toBeVisible();
     await expect(
-      authedPage.locator('.nav-label', { hasText: 'Multi Feed Three' })
+      authedPage.locator('.source-title', { hasText: 'Multi Feed Three' })
     ).toBeVisible();
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,16 +1,16 @@
 import { test, expect } from './fixtures';
-import { seedSubscription } from './seed';
 
 test.describe('Navigation', () => {
   test('sidebar shows all nav items', async ({ authedPage }) => {
-    await expect(authedPage.locator('.nav-label', { hasText: 'All' })).toBeVisible({
+    await expect(authedPage.locator('.nav-label', { hasText: 'Everything' })).toBeVisible({
       timeout: 15_000,
     });
     await expect(authedPage.locator('.nav-label', { hasText: 'Saved' })).toBeVisible();
     await expect(authedPage.locator('.nav-label', { hasText: 'Shared' })).toBeVisible();
+    await expect(authedPage.locator('.nav-label', { hasText: 'Manage Sources' })).toBeVisible();
     await expect(authedPage.locator('.nav-label', { hasText: 'Activity' })).toBeVisible();
     await expect(authedPage.locator('.nav-label', { hasText: 'Settings' })).toBeVisible();
-    await expect(authedPage.locator('.nav-label', { hasText: 'Feedback' })).toBeVisible();
+    await expect(authedPage.locator('text=Channels')).toBeVisible();
   });
 
   test('clicking Saved sets filter', async ({ authedPage }) => {
@@ -34,20 +34,5 @@ test.describe('Navigation', () => {
   test('Activity link navigates to /activity', async ({ authedPage }) => {
     await authedPage.locator('.nav-label', { hasText: 'Activity' }).click();
     await expect(authedPage).toHaveURL(/\/activity/);
-  });
-
-  test('clicking a feed sets feed filter', async ({ authedPage, testUser }) => {
-    seedSubscription(testUser, {
-      feedUrl: 'https://example.com/feed.xml',
-      title: 'Nav Test Feed',
-    });
-
-    await authedPage.reload();
-
-    const feedItem = authedPage.locator('.nav-label', { hasText: 'Nav Test Feed' });
-    await expect(feedItem).toBeVisible({ timeout: 15_000 });
-
-    await feedItem.click();
-    await expect(authedPage).toHaveURL(/feed=/);
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -10,7 +10,6 @@ test.describe('Navigation', () => {
     await expect(authedPage.locator('.nav-label', { hasText: 'Manage Sources' })).toBeVisible();
     await expect(authedPage.locator('.nav-label', { hasText: 'Activity' })).toBeVisible();
     await expect(authedPage.locator('.nav-label', { hasText: 'Settings' })).toBeVisible();
-    await expect(authedPage.locator('text=Channels')).toBeVisible();
   });
 
   test('clicking Saved sets filter', async ({ authedPage }) => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "svelte": "^5.45.6",
         "svelte-check": "^4.3.4",
         "typescript": "^5.9.3",
-        "vite": "^7.2.6"
+        "vite": "^7.2.6",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@atproto/api": {
@@ -1020,10 +1021,28 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/dompurify": {
@@ -1048,6 +1067,119 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
@@ -1080,6 +1212,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/await-lock": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
@@ -1101,6 +1243,16 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -1135,6 +1287,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -1302,6 +1461,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -1356,6 +1522,26 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1580,6 +1766,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1729,6 +1922,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -1751,6 +1951,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.47.1",
@@ -1812,6 +2026,23 @@
         "node": ">=18.13.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1826,6 +2057,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tlds": {
@@ -1989,6 +2230,105 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
     "check:types": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^7.0.0",
@@ -25,7 +27,8 @@
     "svelte": "^5.45.6",
     "svelte-check": "^4.3.4",
     "typescript": "^5.9.3",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.1.2"
   },
   "dependencies": {
     "@atproto/api": "^0.18.13",

--- a/frontend/src/lib/components/AddFeedModal.svelte
+++ b/frontend/src/lib/components/AddFeedModal.svelte
@@ -13,9 +13,10 @@
   interface Props {
     open: boolean;
     onclose: () => void;
+    initialValue?: string;
   }
 
-  let { open, onclose }: Props = $props();
+  let { open, onclose, initialValue = '' }: Props = $props();
   let error = $state<string | null>(null);
 
   let inputValue = $state('');
@@ -26,6 +27,13 @@
   const isAtLimit = $derived(
     subscriptionsStore.subscriptions.length >= subscriptionsStore.maxSubscriptions
   );
+
+  // Pre-fill input when modal opens with an initial value
+  $effect(() => {
+    if (open && initialValue) {
+      inputValue = initialValue;
+    }
+  });
 
   function resetAll() {
     inputValue = '';

--- a/frontend/src/lib/components/AddHandleModal.svelte
+++ b/frontend/src/lib/components/AddHandleModal.svelte
@@ -23,9 +23,10 @@
   interface Props {
     open: boolean;
     onclose: () => void;
+    initialValue?: string;
   }
 
-  let { open, onclose }: Props = $props();
+  let { open, onclose, initialValue = '' }: Props = $props();
   let error = $state<string | null>(null);
 
   // Search state
@@ -99,6 +100,13 @@
   let selectedCount = $derived(
     selectedPublications.size + (sharesSelected ? 1 : 0) + (freestandingDocsSelected ? 1 : 0)
   );
+
+  // Pre-fill input when modal opens with an initial value
+  $effect(() => {
+    if (open && initialValue) {
+      inputValue = initialValue;
+    }
+  });
 
   function resetAll() {
     inputValue = '';

--- a/frontend/src/lib/components/AddSourceInput.svelte
+++ b/frontend/src/lib/components/AddSourceInput.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { sidebarStore } from '$lib/stores/sidebar.svelte';
+
+  let isOpen = $state(false);
+  let inputValue = $state('');
+  let inputRef: HTMLInputElement | null = $state(null);
+  let buttonRef: HTMLButtonElement | null = $state(null);
+  let menuRef: HTMLDivElement | null = $state(null);
+  let menuPosition = $state<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  // Detect what the user is typing
+  let inputType = $derived.by((): 'handle' | 'url' | 'unknown' => {
+    const v = inputValue.trim();
+    if (!v) return 'unknown';
+    if (v.startsWith('@')) return 'handle';
+    if (v.startsWith('http://') || v.startsWith('https://')) return 'url';
+    if (!v.includes('/') && /^[\w.-]+\.\w+$/.test(v)) return 'handle';
+    return 'unknown';
+  });
+
+  function updateMenuPosition() {
+    if (!buttonRef) return;
+    const rect = buttonRef.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const menuWidth = 260;
+
+    let top = rect.bottom + 4;
+    let left = rect.left;
+
+    if (left + menuWidth > viewportWidth - 8) {
+      left = rect.right - menuWidth;
+    }
+    if (left < 8) left = 8;
+
+    menuPosition = { top, left };
+  }
+
+  function toggle(e: MouseEvent) {
+    e.stopPropagation();
+    isOpen = !isOpen;
+    if (isOpen) {
+      inputValue = '';
+      requestAnimationFrame(() => {
+        updateMenuPosition();
+        inputRef?.focus();
+      });
+    }
+  }
+
+  function close() {
+    isOpen = false;
+    inputValue = '';
+  }
+
+  function handleSubmit() {
+    const v = inputValue.trim();
+    if (!v) return;
+
+    close();
+
+    if (inputType === 'handle') {
+      const handle = v.startsWith('@') ? v.slice(1) : v;
+      sidebarStore.setAddSourceInitialValue(handle);
+      sidebarStore.openAddHandleModal();
+    } else {
+      sidebarStore.setAddSourceInitialValue(v);
+      sidebarStore.openAddFeedModal();
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  }
+
+  function handleAction(action: () => void, e: MouseEvent) {
+    e.stopPropagation();
+    close();
+    sidebarStore.closeNavigationDropdown();
+    action();
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (
+      isOpen &&
+      menuRef &&
+      buttonRef &&
+      !menuRef.contains(e.target as Node) &&
+      !buttonRef.contains(e.target as Node)
+    ) {
+      close();
+    }
+  }
+
+  function handleEscape(e: KeyboardEvent) {
+    if (isOpen && e.key === 'Escape') {
+      close();
+      buttonRef?.focus();
+    }
+  }
+
+  // Portal action to move element to body (escapes overflow:hidden ancestors)
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
+
+  onMount(() => {
+    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('click', handleClickOutside);
+    document.removeEventListener('keydown', handleEscape);
+  });
+</script>
+
+<div class="add-source">
+  <button
+    bind:this={buttonRef}
+    class="add-trigger"
+    onclick={toggle}
+    aria-haspopup="true"
+    aria-expanded={isOpen}
+    aria-label="Add source"
+  >
+    <Icon name="plus" size={16} />
+  </button>
+
+  {#if isOpen}
+    <div use:portal>
+      <div
+        bind:this={menuRef}
+        class="add-menu"
+        style="top: {menuPosition.top}px; left: {menuPosition.left}px;"
+      >
+        <div class="menu-input-row">
+          <span class="input-icon">
+            {#if inputType === 'handle'}
+              <Icon name="at-sign" size={14} />
+            {:else if inputType === 'url'}
+              <Icon name="link" size={14} />
+            {:else}
+              <Icon name="search" size={14} />
+            {/if}
+          </span>
+          <input
+            bind:this={inputRef}
+            bind:value={inputValue}
+            placeholder="Paste URL or @handle..."
+            class="menu-input"
+            onkeydown={handleKeydown}
+          />
+          {#if inputValue.trim()}
+            <button class="go-btn" onclick={handleSubmit}>
+              <Icon name="arrow-right" size={14} />
+            </button>
+          {/if}
+        </div>
+        <div class="menu-divider"></div>
+        <button
+          class="menu-item"
+          onclick={(e) => handleAction(() => sidebarStore.openAddFeedModal(), e)}
+        >
+          <span class="item-icon"><Icon name="rss" size={16} /></span>
+          Add RSS Feed
+        </button>
+        <button
+          class="menu-item"
+          onclick={(e) => handleAction(() => sidebarStore.openAddHandleModal(), e)}
+        >
+          <span class="item-icon"><Icon name="users" size={16} /></span>
+          Follow @handle
+        </button>
+        <button
+          class="menu-item"
+          onclick={(e) => handleAction(() => sidebarStore.openSaveArticleModal(), e)}
+        >
+          <span class="item-icon"><Icon name="bookmark" size={16} /></span>
+          Save article by URL
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .add-source {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .add-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.375rem;
+    border: none;
+    background: transparent;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      background-color 0.2s,
+      color 0.2s;
+  }
+
+  .add-trigger:hover {
+    background: var(--color-bg-secondary);
+    color: var(--color-text);
+  }
+
+  /* Menu is portaled to body, so styles must be global */
+  :global(.add-menu) {
+    position: fixed;
+    width: 260px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    z-index: 9999;
+    overflow: hidden;
+  }
+
+  :global(.add-menu .menu-input-row) {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 0.625rem;
+  }
+
+  :global(.add-menu .input-icon) {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    color: var(--color-text-secondary);
+  }
+
+  :global(.add-menu .menu-input) {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    outline: none;
+    padding: 0.125rem 0;
+  }
+
+  :global(.add-menu .menu-input::placeholder) {
+    color: var(--color-text-secondary);
+  }
+
+  :global(.add-menu .go-btn) {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.125rem;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-primary);
+    border-radius: 4px;
+  }
+
+  :global(.add-menu .go-btn:hover) {
+    background: rgba(0, 102, 204, 0.1);
+  }
+
+  :global(.add-menu .menu-divider) {
+    height: 1px;
+    background: var(--color-border);
+  }
+
+  :global(.add-menu .menu-item) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    font-size: 0.8125rem;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.15s;
+  }
+
+  :global(.add-menu .menu-item:hover) {
+    background: var(--color-bg-secondary);
+  }
+
+  :global(.add-menu .item-icon) {
+    display: flex;
+    align-items: center;
+    color: var(--color-text-secondary);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(.add-menu) {
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -26,6 +26,7 @@
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
+  import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { useParagraphTracking } from '$lib/hooks/useParagraphTracking.svelte';
   import { useLinkInterception } from '$lib/hooks/useLinkInterception.svelte';
   import { useHighlights } from '$lib/hooks/useHighlights.svelte';
@@ -96,6 +97,31 @@
   let isShareMode = $derived(Boolean(share && !article && !document));
   // Determine if we're in document mode (showing someone's published document)
   let isDocumentMode = $derived(Boolean(document && !article && !share));
+
+  // Can the user follow this source? (not already subscribed)
+  let canFollowSource = $derived.by(() => {
+    if (!auth.user) return false;
+    // For shares/documents from another person, check if we follow that person's shares
+    if (isShareMode && share?.authorDid && share.authorDid !== auth.user.did) {
+      return !subscriptionsStore.subscriptions.some(
+        (s) => s.sourceType === 'atproto.shares' && s.subjectDid === share!.authorDid
+      );
+    }
+    if (isDocumentMode && document?.authorDid && document.authorDid !== auth.user.did) {
+      return !subscriptionsStore.subscriptions.some(
+        (s) => s.sourceType === 'atproto.documents' && s.subjectDid === document!.authorDid
+      );
+    }
+    return false;
+  });
+
+  function handleFollowSource() {
+    overflowMenuOpen = false;
+    if ((isShareMode && share?.authorDid) || (isDocumentMode && document?.authorDid)) {
+      const did = share?.authorDid || document?.authorDid || '';
+      sidebarStore.openAddFeedModalForDid(did);
+    }
+  }
 
   // Normalize data for article, share, and document modes
   let itemUrl = $derived(
@@ -824,6 +850,12 @@
                 <button class="overflow-menu-item" onclick={handleOverflowMargin}>
                   <Icon name="margin" size={16} />
                   <span>Save to Margin</span>
+                </button>
+              {/if}
+              {#if canFollowSource}
+                <button class="overflow-menu-item" onclick={handleFollowSource}>
+                  <Icon name="plus" size={16} />
+                  <span>Follow source</span>
                 </button>
               {/if}
             </div>

--- a/frontend/src/lib/components/DomainPatternInput.svelte
+++ b/frontend/src/lib/components/DomainPatternInput.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  interface Props {
+    patterns: string[];
+    availableDomains: string[];
+    onchange: (patterns: string[]) => void;
+    hint?: string;
+  }
+
+  let { patterns, availableDomains, onchange, hint = 'Press Enter to add. Matches against feed URL hostnames.' }: Props = $props();
+
+  let domainInput = $state('');
+  let suggestionsOpen = $state(false);
+  let highlightIndex = $state(-1);
+
+  let suggestions = $derived.by(() => {
+    const q = domainInput.trim().toLowerCase();
+    const existing = new Set(patterns);
+    return availableDomains.filter((d) => (!q || d.includes(q)) && !existing.has(d));
+  });
+
+  function addPattern(value?: string) {
+    const v = (value ?? domainInput).trim();
+    if (v && !patterns.includes(v)) {
+      onchange([...patterns, v]);
+    }
+    domainInput = '';
+    suggestionsOpen = false;
+    highlightIndex = -1;
+  }
+
+  function removePattern(pattern: string) {
+    onchange(patterns.filter((p) => p !== pattern));
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (suggestionsOpen && suggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        highlightIndex = (highlightIndex + 1) % suggestions.length;
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        highlightIndex = highlightIndex <= 0 ? suggestions.length - 1 : highlightIndex - 1;
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+          addPattern(suggestions[highlightIndex]);
+        } else {
+          addPattern();
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        suggestionsOpen = false;
+        highlightIndex = -1;
+        return;
+      }
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addPattern();
+    } else if (e.key === 'Backspace' && !domainInput && patterns.length > 0) {
+      onchange(patterns.slice(0, -1));
+    }
+  }
+
+  function handleInput() {
+    suggestionsOpen = true;
+    highlightIndex = -1;
+  }
+
+  function handleBlur() {
+    setTimeout(() => {
+      suggestionsOpen = false;
+      addPattern();
+    }, 150);
+  }
+</script>
+
+<div class="chip-input-wrapper">
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div
+    class="chip-input"
+    onclick={(e) => {
+      const input = (e.currentTarget as HTMLElement).querySelector('input');
+      input?.focus();
+    }}
+  >
+    {#each patterns as pattern}
+      <span class="chip">
+        {pattern}
+        <button
+          type="button"
+          class="chip-remove"
+          onclick={() => removePattern(pattern)}
+          aria-label="Remove {pattern}"
+        >
+          &times;
+        </button>
+      </span>
+    {/each}
+    <input
+      type="text"
+      bind:value={domainInput}
+      onkeydown={handleKeydown}
+      oninput={handleInput}
+      onblur={handleBlur}
+      onfocus={() => (suggestionsOpen = true)}
+      placeholder={patterns.length === 0 ? 'Type a domain and press Enter' : ''}
+      class="chip-text-input"
+      role="combobox"
+      aria-expanded={suggestionsOpen && suggestions.length > 0}
+      aria-autocomplete="list"
+      autocomplete="off"
+    />
+  </div>
+  {#if suggestionsOpen && suggestions.length > 0}
+    <ul class="chip-suggestions" role="listbox">
+      {#each suggestions as suggestion, i (suggestion)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <li
+          class="chip-suggestion"
+          class:highlighted={i === highlightIndex}
+          role="option"
+          aria-selected={i === highlightIndex}
+          onmousedown={(e) => {
+            e.preventDefault();
+            addPattern(suggestion);
+          }}
+          onmouseenter={() => (highlightIndex = i)}
+        >
+          {suggestion}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+{#if hint}
+  <span class="form-hint">{hint}</span>
+{/if}
+
+<style>
+  .chip-input-wrapper {
+    position: relative;
+  }
+
+  .chip-input {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    cursor: text;
+    min-height: 2.25rem;
+  }
+
+  .chip-input:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.25rem 0.125rem 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    line-height: 1.4;
+  }
+
+  .chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.125rem;
+    height: 1.125rem;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    line-height: 1;
+    border-radius: 3px;
+  }
+
+  .chip-remove:hover {
+    background: rgba(0, 0, 0, 0.1);
+    color: var(--color-text);
+  }
+
+  .chip-text-input {
+    flex: 1;
+    min-width: 8rem;
+    border: none;
+    background: none;
+    outline: none;
+    font: inherit;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    padding: 0.125rem 0;
+  }
+
+  .chip-text-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .chip-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: 0.25rem 0 0;
+    padding: 0.25rem;
+    list-style: none;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    z-index: 10;
+    max-height: 160px;
+    overflow-y: auto;
+  }
+
+  .chip-suggestion {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8125rem;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .chip-suggestion.highlighted {
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+  }
+
+  .form-hint {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    margin-top: 0.25rem;
+  }
+</style>

--- a/frontend/src/lib/components/DomainPatternInput.svelte
+++ b/frontend/src/lib/components/DomainPatternInput.svelte
@@ -6,7 +6,12 @@
     hint?: string;
   }
 
-  let { patterns, availableDomains, onchange, hint = 'Press Enter to add. Matches against feed URL hostnames.' }: Props = $props();
+  let {
+    patterns,
+    availableDomains,
+    onchange,
+    hint = 'Press Enter to add. Matches against feed URL hostnames.',
+  }: Props = $props();
 
   let domainInput = $state('');
   let suggestionsOpen = $state(false);

--- a/frontend/src/lib/components/EditFeedModal.svelte
+++ b/frontend/src/lib/components/EditFeedModal.svelte
@@ -74,10 +74,11 @@
     saving = true;
 
     try {
-      // Local-only update - no backend sync
+      // Local-only update - no backend sync. Pass empty strings through (not
+      // converted to undefined) so clearing a custom field actually takes effect.
       await subscriptionsStore.updateLocal(subscription.id, {
-        customTitle: customTitle.trim() || undefined,
-        customIconUrl: iconUrl.trim() || undefined,
+        customTitle: customTitle.trim(),
+        customIconUrl: iconUrl.trim(),
       });
       handleClose();
     } catch (e) {

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -29,12 +29,20 @@
   interface Props {
     open: boolean;
     editingViewId: number | null;
+    initialChannelType?: 'feed' | 'saved' | null;
     onclose: () => void;
     oncreated?: (uuid: string) => void;
     ondeleted?: () => void;
   }
 
-  let { open, editingViewId, onclose, oncreated, ondeleted }: Props = $props();
+  let {
+    open,
+    editingViewId,
+    initialChannelType = null,
+    onclose,
+    oncreated,
+    ondeleted,
+  }: Props = $props();
 
   // Form state
   let name = $state('');
@@ -229,7 +237,7 @@
       }
       // New channel defaults
       name = '';
-      channelType = 'feed';
+      channelType = initialChannelType ?? 'feed';
       channelMode = 'manual';
       autoRuleType = 'frequency:high';
       recentWithinDays = 14;
@@ -797,7 +805,6 @@
     border-color: var(--color-primary);
     box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
   }
-
 
   .visually-hidden {
     position: absolute;

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
+  import { articlesStore } from '$lib/stores/articles.svelte';
   import Modal from '$lib/components/common/Modal.svelte';
-  import type { SubscriptionSourceType } from '$lib/types';
-  import { subscriptionSourceKey, migrateLegacyView } from '$lib/utils/sourceKeys';
+  import type { SubscriptionSourceType, ChannelAutoRule } from '$lib/types';
+  import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
   import { getFaviconUrl } from '$lib/utils/favicon';
+  import { computeSourceKeys } from '$lib/utils/channelLogic';
 
   const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
     { value: 'rss', label: 'RSS Feeds' },
@@ -12,16 +14,91 @@
     { value: 'atproto.documents', label: 'Standard.site Documents' },
   ];
 
+  type AutoRuleOption =
+    | 'frequency:high'
+    | 'frequency:low'
+    | 'longReads'
+    | 'recent'
+    | 'category'
+    | 'subscriptionTag'
+    | 'domain'
+    | 'people';
+
+  const AUTO_RULE_OPTIONS: { value: AutoRuleOption; label: string; description: string }[] = [
+    {
+      value: 'frequency:high',
+      label: 'Daily Digest',
+      description: 'High-volume feeds that publish 2+ times per day',
+    },
+    {
+      value: 'frequency:low',
+      label: "Don't Miss",
+      description: 'Infrequent feeds where every post counts',
+    },
+    {
+      value: 'longReads',
+      label: 'Long Reads',
+      description: 'Feeds with in-depth, long-form articles',
+    },
+    {
+      value: 'recent',
+      label: 'Recently Added',
+      description: 'Sources you added recently',
+    },
+    {
+      value: 'category',
+      label: 'Category',
+      description: 'All sources in a specific folder',
+    },
+    {
+      value: 'subscriptionTag',
+      label: 'Tag',
+      description: 'All sources with a specific tag',
+    },
+    {
+      value: 'domain',
+      label: 'Domain',
+      description: 'Sources matching URL patterns',
+    },
+    {
+      value: 'people',
+      label: 'People',
+      description: 'Everyone you follow on AT Protocol',
+    },
+  ];
+
+  const DEFAULT_NAMES: Record<AutoRuleOption, string> = {
+    'frequency:high': 'Daily Digest',
+    'frequency:low': "Don't Miss",
+    longReads: 'Long Reads',
+    recent: 'New Sources',
+    category: '',
+    subscriptionTag: '',
+    domain: '',
+    people: 'People I Follow',
+  };
+
   interface Props {
     open: boolean;
     editingViewId: number | null;
     onclose: () => void;
+    oncreated?: (id: number) => void;
+    ondeleted?: () => void;
   }
 
-  let { open, editingViewId, onclose }: Props = $props();
+  let { open, editingViewId, onclose, oncreated, ondeleted }: Props = $props();
 
   // Form state
   let name = $state('');
+  let channelMode = $state<'manual' | 'smart'>('manual');
+  let autoRuleType = $state<AutoRuleOption>('frequency:high');
+  let recentWithinDays = $state(14);
+  let categoryValue = $state('');
+  let tagValue = $state('');
+  let domainPatterns = $state<string[]>([]);
+  let domainInput = $state('');
+  let domainSuggestionsOpen = $state(false);
+  let domainHighlightIndex = $state(-1);
   let sourceMode = $state<'all' | 'include'>('all');
   let sourceKeys = $state<Set<string>>(new Set());
   let readFilter = $state<'all' | 'unread' | 'read'>('all');
@@ -29,9 +106,111 @@
   let typeFilter = $state<Set<SubscriptionSourceType>>(new Set());
   let saving = $state(false);
   let error = $state<string | null>(null);
+  let showAdvanced = $state(false);
 
   // Search state for filtering source lists
   let feedSearch = $state('');
+
+  // Track whether user has manually edited the name
+  let nameManuallyEdited = $state(false);
+
+  // Available categories and tags from subscriptions (for dropdowns)
+  let availableCategories = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .map((s) => s.category?.trim())
+          .filter((c): c is string => !!c)
+      ),
+    ].sort()
+  );
+
+  let availableTags = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .flatMap((s) => s.tags.map((t) => t.trim().toLowerCase()))
+          .filter(Boolean)
+      ),
+    ].sort()
+  );
+
+  // Unique hostnames from RSS subscriptions for domain autocomplete
+  let availableDomains = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .filter((s) => !s.sourceType || s.sourceType === 'rss')
+          .flatMap((s) => {
+            const urls = [s.feedUrl, s.siteUrl].filter(Boolean);
+            return urls
+              .map((u) => {
+                try {
+                  return new URL(u!).hostname;
+                } catch {
+                  return null;
+                }
+              })
+              .filter((h): h is string => !!h);
+          })
+      ),
+    ].sort()
+  );
+
+  let domainSuggestions = $derived.by(() => {
+    const q = domainInput.trim().toLowerCase();
+    const existing = new Set(domainPatterns);
+    return availableDomains.filter((d) => (!q || d.includes(q)) && !existing.has(d));
+  });
+
+  // Build the auto-rule from current selections
+  let currentAutoRule = $derived.by((): ChannelAutoRule | undefined => {
+    if (channelMode !== 'smart') return undefined;
+    switch (autoRuleType) {
+      case 'frequency:high':
+        return { type: 'frequency', threshold: 'high' };
+      case 'frequency:low':
+        return { type: 'frequency', threshold: 'low' };
+      case 'longReads':
+        return { type: 'longReads', minLength: 5000 };
+      case 'recent':
+        return { type: 'recent', withinDays: recentWithinDays };
+      case 'category':
+        return categoryValue.trim() ? { type: 'category', value: categoryValue.trim() } : undefined;
+      case 'subscriptionTag':
+        return tagValue.trim() ? { type: 'subscriptionTag', value: tagValue.trim() } : undefined;
+      case 'domain':
+        return domainPatterns.length > 0 ? { type: 'domain', patterns: domainPatterns } : undefined;
+      case 'people':
+        return { type: 'people' };
+    }
+  });
+
+  // Preview matched sources for smart mode
+  let matchedSourceKeys = $derived.by(() => {
+    if (!currentAutoRule) return [];
+    return computeSourceKeys(
+      currentAutoRule,
+      subscriptionsStore.subscriptions,
+      articlesStore.allArticles
+    );
+  });
+
+  // Auto-fill name when switching rule type (only if not manually edited)
+  $effect(() => {
+    if (channelMode === 'smart' && !nameManuallyEdited) {
+      if (autoRuleType === 'category' && categoryValue.trim()) {
+        name = categoryValue.trim();
+      } else if (autoRuleType === 'subscriptionTag' && tagValue.trim()) {
+        const t = tagValue.trim();
+        name = t.charAt(0).toUpperCase() + t.slice(1);
+      } else if (autoRuleType === 'domain' && domainPatterns.length > 0) {
+        name = domainPatterns[0];
+      } else {
+        name = DEFAULT_NAMES[autoRuleType];
+      }
+    }
+  });
 
   // Filtered subscriptions based on search
   let filteredSubscriptions = $derived(
@@ -56,15 +235,24 @@
     typeFilter = next;
   }
 
-  // Helper to get all account DIDs for legacy migration
-  function getAllFollowDids(): string[] {
-    const dids = new Set<string>();
-    for (const sub of subscriptionsStore.subscriptions) {
-      if (sub.sourceType?.startsWith('atproto.') && sub.subjectDid) {
-        dids.add(sub.subjectDid);
-      }
+  /** Map a stored autoRule back to an AutoRuleOption. */
+  function autoRuleToOption(rule: ChannelAutoRule): AutoRuleOption {
+    switch (rule.type) {
+      case 'frequency':
+        return rule.threshold === 'high' ? 'frequency:high' : 'frequency:low';
+      case 'longReads':
+        return 'longReads';
+      case 'recent':
+        return 'recent';
+      case 'category':
+        return 'category';
+      case 'subscriptionTag':
+        return 'subscriptionTag';
+      case 'domain':
+        return 'domain';
+      case 'people':
+        return 'people';
     }
-    return [...dids];
   }
 
   // Reset form when modal opens or editingViewId changes
@@ -77,45 +265,57 @@
           readFilter = view.readFilter;
           sortOrder = view.sortOrder;
           typeFilter = new Set(view.typeFilter ?? []);
+          nameManuallyEdited = true; // Preserve existing name when editing
 
-          if (view.sourceMode != null) {
-            // New format (coerce any stale 'exclude' to 'include')
-            sourceMode = view.sourceMode === 'all' ? 'all' : 'include';
-            sourceKeys = sourceMode === 'all' ? new Set() : new Set(view.sourceKeys ?? []);
+          // Detect auto-rule
+          const isSmartChannel = !!view.autoRule;
+          if (isSmartChannel) {
+            channelMode = 'smart';
+            autoRuleType = autoRuleToOption(view.autoRule!);
+            if (view.autoRule!.type === 'recent') {
+              recentWithinDays = view.autoRule!.withinDays;
+            } else if (view.autoRule!.type === 'category') {
+              categoryValue = view.autoRule!.value;
+            } else if (view.autoRule!.type === 'subscriptionTag') {
+              tagValue = view.autoRule!.value;
+            } else if (view.autoRule!.type === 'domain') {
+              domainPatterns = [...view.autoRule!.patterns];
+            }
           } else {
-            // Legacy format — migrate
-            const allSubIds = subscriptionsStore.subscriptions
-              .map((s) => s.id)
-              .filter((id): id is number => id != null);
-            const allDids = getAllFollowDids();
-            const migrated = migrateLegacyView(
-              {
-                showArticles: view.showArticles,
-                showShares: view.showShares,
-                showDocuments: view.showDocuments,
-                feedMode: view.feedMode,
-                feedIds: view.feedIds,
-                accountMode: view.accountMode,
-                accountDids: view.accountDids,
-              },
-              allSubIds,
-              allDids
-            );
-            sourceMode = migrated.sourceMode;
-            sourceKeys = new Set(migrated.sourceKeys);
+            channelMode = 'manual';
+          }
+
+          // Load source mode/keys for manual mode
+          if (!isSmartChannel) {
+            const mode = view.sourceMode === 'include' ? 'include' : 'all';
+            sourceMode = mode;
+            sourceKeys = mode === 'all' ? new Set() : new Set(view.sourceKeys ?? []);
           }
           feedSearch = '';
+          // Auto-open advanced if non-default values (read from view, not $state, to avoid re-triggering this effect)
+          showAdvanced =
+            (view.typeFilter ?? []).length > 0 ||
+            view.readFilter !== 'unread' ||
+            view.sortOrder !== 'newest';
           return;
         }
       }
-      // New view defaults
+      // New channel defaults
       name = '';
+      channelMode = 'manual';
+      autoRuleType = 'frequency:high';
+      recentWithinDays = 14;
+      categoryValue = '';
+      tagValue = '';
+      domainPatterns = [];
+      nameManuallyEdited = false;
       sourceMode = 'all';
       sourceKeys = new Set();
       readFilter = 'all';
       sortOrder = 'newest';
       typeFilter = new Set();
       feedSearch = '';
+      showAdvanced = false;
     }
   });
 
@@ -123,6 +323,70 @@
     error = null;
     saving = false;
     onclose();
+  }
+
+  function addDomainPattern(value?: string) {
+    const v = (value ?? domainInput).trim();
+    if (v && !domainPatterns.includes(v)) {
+      domainPatterns = [...domainPatterns, v];
+    }
+    domainInput = '';
+    domainSuggestionsOpen = false;
+    domainHighlightIndex = -1;
+  }
+
+  function removeDomainPattern(pattern: string) {
+    domainPatterns = domainPatterns.filter((p) => p !== pattern);
+  }
+
+  function handleDomainKeydown(e: KeyboardEvent) {
+    if (domainSuggestionsOpen && domainSuggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        domainHighlightIndex = (domainHighlightIndex + 1) % domainSuggestions.length;
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        domainHighlightIndex =
+          domainHighlightIndex <= 0 ? domainSuggestions.length - 1 : domainHighlightIndex - 1;
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (domainHighlightIndex >= 0 && domainHighlightIndex < domainSuggestions.length) {
+          addDomainPattern(domainSuggestions[domainHighlightIndex]);
+        } else {
+          addDomainPattern();
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        domainSuggestionsOpen = false;
+        domainHighlightIndex = -1;
+        return;
+      }
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addDomainPattern();
+    } else if (e.key === 'Backspace' && !domainInput && domainPatterns.length > 0) {
+      domainPatterns = domainPatterns.slice(0, -1);
+    }
+  }
+
+  function handleDomainInput() {
+    domainSuggestionsOpen = true;
+    domainHighlightIndex = -1;
+  }
+
+  function handleDomainBlur() {
+    // Delay to allow click on suggestion to fire first
+    setTimeout(() => {
+      domainSuggestionsOpen = false;
+      addDomainPattern();
+    }, 150);
   }
 
   function toggleSourceKey(key: string) {
@@ -135,6 +399,14 @@
     sourceKeys = next;
   }
 
+  async function handleDelete() {
+    if (editingViewId == null) return;
+    if (!confirm('Delete this channel?')) return;
+    await filteredViewsStore.remove(editingViewId);
+    ondeleted?.();
+    handleClose();
+  }
+
   async function handleSave() {
     if (!name.trim()) {
       error = 'Name is required';
@@ -145,10 +417,13 @@
     saving = true;
 
     try {
+      const isSmartMode = channelMode === 'smart' && currentAutoRule;
+
       const viewData = {
         name: name.trim(),
-        sourceMode,
-        sourceKeys: Array.from(sourceKeys),
+        sourceMode: isSmartMode ? ('include' as const) : sourceMode,
+        sourceKeys: isSmartMode ? matchedSourceKeys : Array.from(sourceKeys),
+        autoRule: isSmartMode ? currentAutoRule : undefined,
         readFilter,
         sortOrder,
         typeFilter: typeFilter.size > 0 ? Array.from(typeFilter) : undefined,
@@ -157,7 +432,8 @@
       if (editingViewId != null) {
         await filteredViewsStore.update(editingViewId, viewData);
       } else {
-        await filteredViewsStore.create(viewData);
+        const id = await filteredViewsStore.create(viewData);
+        oncreated?.(id);
       }
 
       handleClose();
@@ -169,7 +445,11 @@
   }
 </script>
 
-<Modal {open} onclose={handleClose} title={editingViewId != null ? 'Edit View' : 'Create View'}>
+<Modal
+  {open}
+  onclose={handleClose}
+  title={editingViewId != null ? 'Edit Channel' : 'Create Channel'}
+>
   <form
     class="form"
     onsubmit={(e) => {
@@ -180,117 +460,303 @@
     <!-- Name -->
     <div class="form-group">
       <label for="view-name">Name</label>
-      <input id="view-name" type="text" bind:value={name} placeholder="My view" required />
+      <input
+        id="view-name"
+        type="text"
+        bind:value={name}
+        oninput={() => (nameManuallyEdited = true)}
+        placeholder="My channel"
+        required
+      />
     </div>
 
-    <!-- Sources -->
+    <!-- Channel Mode -->
     <div class="form-group">
-      <span class="form-label">Sources</span>
-      <div class="radio-group">
-        <label class="radio-label">
-          <input type="radio" bind:group={sourceMode} value="all" />
-          All sources
+      <span class="form-label">Source Selection</span>
+      <div class="mode-options">
+        <label class="mode-option" class:selected={channelMode === 'manual'}>
+          <input type="radio" bind:group={channelMode} value="manual" class="visually-hidden" />
+          <span class="mode-title">Manual</span>
+          <span class="mode-desc">Pick sources individually</span>
         </label>
-        <label class="radio-label">
-          <input type="radio" bind:group={sourceMode} value="include" />
-          Include only
+        <label class="mode-option" class:selected={channelMode === 'smart'}>
+          <input
+            type="radio"
+            bind:group={channelMode}
+            value="smart"
+            class="visually-hidden"
+            onchange={() => {
+              if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
+            }}
+          />
+          <span class="mode-title">Smart</span>
+          <span class="mode-desc">Auto-updates based on a rule</span>
         </label>
       </div>
+    </div>
 
-      {#if sourceMode === 'include'}
-        <!-- Subscriptions -->
-        {#if subscriptionsStore.subscriptions.length > 0}
-          <div class="source-group-header">Subscriptions</div>
+    {#if channelMode === 'smart'}
+      <!-- Smart rule type -->
+      <div class="form-group">
+        <span class="form-label">Rule</span>
+        <div class="rule-cards">
+          {#each AUTO_RULE_OPTIONS as opt (opt.value)}
+            <button
+              type="button"
+              class="rule-card"
+              class:selected={autoRuleType === opt.value}
+              onclick={() => {
+                autoRuleType = opt.value;
+                if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
+              }}
+            >
+              <span class="rule-card-label">{opt.label}</span>
+              <span class="rule-card-desc">{opt.description}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      {#if autoRuleType === 'recent'}
+        <div class="form-group">
+          <label for="recent-days" class="form-label">Within the last</label>
+          <div class="inline-input">
+            <input
+              id="recent-days"
+              type="number"
+              bind:value={recentWithinDays}
+              min="1"
+              max="90"
+              class="days-input"
+            />
+            <span class="input-suffix">days</span>
+          </div>
+        </div>
+      {:else if autoRuleType === 'category'}
+        <div class="form-group">
+          <label for="category-value" class="form-label">Category</label>
           <input
+            id="category-value"
             type="text"
-            placeholder="Search subscriptions..."
-            bind:value={feedSearch}
-            class="search-input"
+            list="category-options"
+            bind:value={categoryValue}
+            placeholder="e.g. Technology"
           />
-          <div class="checklist">
-            {#each filteredSubscriptions as sub (sub.id)}
-              {@const key = subscriptionSourceKey(sub)}
-              {#if key}
-                {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
-                {@const iconUrl =
-                  sub.customIconUrl ||
-                  (isAtProto
-                    ? sub.siteUrl
-                      ? getFaviconUrl(sub.siteUrl)
-                      : '/icons/icon-192.svg'
-                    : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
-                <label class="checklist-item">
-                  <input
-                    type="checkbox"
-                    checked={sourceKeys.has(key)}
-                    onchange={() => toggleSourceKey(key)}
-                  />
-                  {#if iconUrl}
-                    <img src={iconUrl} alt="" class="checklist-icon" />
-                  {/if}
-                  <span class="checklist-label">{sub.customTitle || sub.title}</span>
-                </label>
-              {/if}
+          <datalist id="category-options">
+            {#each availableCategories as cat}
+              <option value={cat} />
             {/each}
-            {#if feedSearch && filteredSubscriptions.length === 0}
-              <div class="no-results">No subscriptions match</div>
+          </datalist>
+        </div>
+      {:else if autoRuleType === 'subscriptionTag'}
+        <div class="form-group">
+          <label for="tag-value" class="form-label">Tag</label>
+          <input
+            id="tag-value"
+            type="text"
+            list="tag-options"
+            bind:value={tagValue}
+            placeholder="e.g. news"
+          />
+          <datalist id="tag-options">
+            {#each availableTags as tag}
+              <option value={tag} />
+            {/each}
+          </datalist>
+        </div>
+      {:else if autoRuleType === 'domain'}
+        <div class="form-group">
+          <span class="form-label">Domain patterns</span>
+          <div class="chip-input-wrapper">
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div
+              class="chip-input"
+              onclick={(e) => {
+                const input = (e.currentTarget as HTMLElement).querySelector('input');
+                input?.focus();
+              }}
+            >
+              {#each domainPatterns as pattern}
+                <span class="chip">
+                  {pattern}
+                  <button
+                    type="button"
+                    class="chip-remove"
+                    onclick={() => removeDomainPattern(pattern)}
+                    aria-label="Remove {pattern}"
+                  >
+                    &times;
+                  </button>
+                </span>
+              {/each}
+              <input
+                type="text"
+                bind:value={domainInput}
+                onkeydown={handleDomainKeydown}
+                oninput={handleDomainInput}
+                onblur={handleDomainBlur}
+                onfocus={() => (domainSuggestionsOpen = true)}
+                placeholder={domainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
+                class="chip-text-input"
+                role="combobox"
+                aria-expanded={domainSuggestionsOpen && domainSuggestions.length > 0}
+                aria-autocomplete="list"
+                autocomplete="off"
+              />
+            </div>
+            {#if domainSuggestionsOpen && domainSuggestions.length > 0}
+              <ul class="chip-suggestions" role="listbox">
+                {#each domainSuggestions as suggestion, i (suggestion)}
+                  <!-- svelte-ignore a11y_click_events_have_key_events -->
+                  <li
+                    class="chip-suggestion"
+                    class:highlighted={i === domainHighlightIndex}
+                    role="option"
+                    aria-selected={i === domainHighlightIndex}
+                    onmousedown={(e) => {
+                      e.preventDefault();
+                      addDomainPattern(suggestion);
+                    }}
+                    onmouseenter={() => (domainHighlightIndex = i)}
+                  >
+                    {suggestion}
+                  </li>
+                {/each}
+              </ul>
             {/if}
           </div>
-        {/if}
+          <span class="form-hint">Press Enter to add. Matches against feed URL hostnames.</span>
+        </div>
       {/if}
-    </div>
 
-    <!-- Type Filter -->
-    <div class="form-group">
-      <span class="form-label">Content Types</span>
-      <div class="checklist type-checklist">
-        {#each TYPE_OPTIONS as opt}
-          <label class="checklist-item">
-            <input
-              type="checkbox"
-              checked={typeFilter.has(opt.value)}
-              onchange={() => toggleTypeFilter(opt.value)}
-            />
-            <span class="checklist-label">{opt.label}</span>
+      <!-- Matched sources preview -->
+      <div class="match-preview" class:empty={matchedSourceKeys.length === 0}>
+        {#if matchedSourceKeys.length > 0}
+          Matches <strong>{matchedSourceKeys.length}</strong>
+          {matchedSourceKeys.length === 1 ? 'source' : 'sources'}
+        {:else}
+          No sources match this rule yet
+        {/if}
+      </div>
+    {:else}
+      <!-- Manual source picker -->
+      <div class="form-group">
+        <span class="form-label">Sources</span>
+        <div class="radio-group">
+          <label class="radio-label">
+            <input type="radio" bind:group={sourceMode} value="all" />
+            All sources
           </label>
-        {/each}
-      </div>
-      <span class="form-hint">Leave all unchecked to show all types</span>
-    </div>
+          <label class="radio-label">
+            <input type="radio" bind:group={sourceMode} value="include" />
+            Include only
+          </label>
+        </div>
 
-    <!-- Read State -->
-    <div class="form-group">
-      <span class="form-label">Read State</span>
-      <div class="radio-group">
-        <label class="radio-label">
-          <input type="radio" bind:group={readFilter} value="all" />
-          All
-        </label>
-        <label class="radio-label">
-          <input type="radio" bind:group={readFilter} value="unread" />
-          Unread only
-        </label>
-        <label class="radio-label">
-          <input type="radio" bind:group={readFilter} value="read" />
-          Read only
-        </label>
+        {#if sourceMode === 'include'}
+          {#if subscriptionsStore.subscriptions.length > 0}
+            <div class="source-group-header">Subscriptions</div>
+            <input
+              type="text"
+              placeholder="Search subscriptions..."
+              bind:value={feedSearch}
+              class="search-input"
+            />
+            <div class="checklist">
+              {#each filteredSubscriptions as sub (sub.id)}
+                {@const key = subscriptionSourceKey(sub)}
+                {#if key}
+                  {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
+                  {@const iconUrl =
+                    sub.customIconUrl ||
+                    (isAtProto
+                      ? sub.siteUrl
+                        ? getFaviconUrl(sub.siteUrl)
+                        : '/icons/icon-192.svg'
+                      : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
+                  <label class="checklist-item">
+                    <input
+                      type="checkbox"
+                      checked={sourceKeys.has(key)}
+                      onchange={() => toggleSourceKey(key)}
+                    />
+                    {#if iconUrl}
+                      <img src={iconUrl} alt="" class="checklist-icon" />
+                    {/if}
+                    <span class="checklist-label">{sub.customTitle || sub.title}</span>
+                  </label>
+                {/if}
+              {/each}
+              {#if feedSearch && filteredSubscriptions.length === 0}
+                <div class="no-results">No subscriptions match</div>
+              {/if}
+            </div>
+          {/if}
+        {/if}
       </div>
-    </div>
+    {/if}
 
-    <!-- Sort Order -->
-    <div class="form-group">
-      <span class="form-label">Sort Order</span>
-      <div class="radio-group">
-        <label class="radio-label">
-          <input type="radio" bind:group={sortOrder} value="newest" />
-          Newest first
-        </label>
-        <label class="radio-label">
-          <input type="radio" bind:group={sortOrder} value="oldest" />
-          Oldest first
-        </label>
+    <!-- Advanced options (collapsed by default) -->
+    <button type="button" class="advanced-toggle" onclick={() => (showAdvanced = !showAdvanced)}>
+      <span class="advanced-arrow" class:open={showAdvanced}>&#9656;</span>
+      More options
+    </button>
+
+    {#if showAdvanced}
+      <div class="advanced-section">
+        <!-- Type Filter -->
+        <div class="form-group">
+          <span class="form-label">Content Types</span>
+          <div class="checklist type-checklist">
+            {#each TYPE_OPTIONS as opt}
+              <label class="checklist-item">
+                <input
+                  type="checkbox"
+                  checked={typeFilter.has(opt.value)}
+                  onchange={() => toggleTypeFilter(opt.value)}
+                />
+                <span class="checklist-label">{opt.label}</span>
+              </label>
+            {/each}
+          </div>
+          <span class="form-hint">Leave all unchecked to show all types</span>
+        </div>
+
+        <!-- Read State -->
+        <div class="form-group">
+          <span class="form-label">Read State</span>
+          <div class="radio-group">
+            <label class="radio-label">
+              <input type="radio" bind:group={readFilter} value="all" />
+              All
+            </label>
+            <label class="radio-label">
+              <input type="radio" bind:group={readFilter} value="unread" />
+              Unread only
+            </label>
+            <label class="radio-label">
+              <input type="radio" bind:group={readFilter} value="read" />
+              Read only
+            </label>
+          </div>
+        </div>
+
+        <!-- Sort Order -->
+        <div class="form-group">
+          <span class="form-label">Sort Order</span>
+          <div class="radio-group">
+            <label class="radio-label">
+              <input type="radio" bind:group={sortOrder} value="newest" />
+              Newest first
+            </label>
+            <label class="radio-label">
+              <input type="radio" bind:group={sortOrder} value="oldest" />
+              Oldest first
+            </label>
+          </div>
+        </div>
       </div>
-    </div>
+    {/if}
 
     {#if error}
       <p class="error-message">{error}</p>
@@ -310,6 +776,12 @@
         {/if}
       </button>
     </div>
+
+    {#if editingViewId != null}
+      <button type="button" class="delete-btn" onclick={handleDelete} disabled={saving}>
+        Delete channel
+      </button>
+    {/if}
   </form>
 </Modal>
 
@@ -346,6 +818,274 @@
     outline: none;
     border-color: var(--color-primary);
     box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+  }
+
+  .chip-input {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    cursor: text;
+    min-height: 2.25rem;
+  }
+
+  .chip-input:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.25rem 0.125rem 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    line-height: 1.4;
+  }
+
+  .chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.125rem;
+    height: 1.125rem;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    line-height: 1;
+    border-radius: 3px;
+  }
+
+  .chip-remove:hover {
+    background: rgba(0, 0, 0, 0.1);
+    color: var(--color-text);
+  }
+
+  .chip-text-input {
+    flex: 1;
+    min-width: 8rem;
+    border: none;
+    background: none;
+    outline: none;
+    font: inherit;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    padding: 0.125rem 0;
+  }
+
+  .chip-text-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .chip-input-wrapper {
+    position: relative;
+  }
+
+  .chip-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: 0.25rem 0 0;
+    padding: 0.25rem;
+    list-style: none;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    z-index: 10;
+    max-height: 160px;
+    overflow-y: auto;
+  }
+
+  .chip-suggestion {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8125rem;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .chip-suggestion.highlighted {
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+
+  .mode-options {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .mode-option {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.625rem 0.75rem;
+    border: 1.5px solid var(--color-border);
+    border-radius: 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .mode-option:hover {
+    border-color: var(--color-text-secondary);
+  }
+
+  .mode-option.selected {
+    border-color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.04);
+  }
+
+  .mode-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .mode-desc {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .rule-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .rule-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.5rem 0.625rem;
+    border: 1.5px solid var(--color-border);
+    border-radius: 8px;
+    cursor: pointer;
+    background: var(--color-bg);
+    text-align: left;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .rule-card:hover {
+    border-color: var(--color-text-secondary);
+  }
+
+  .rule-card.selected {
+    border-color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.04);
+  }
+
+  .rule-card-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .rule-card-desc {
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.3;
+  }
+
+  .advanced-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    transition: color 0.15s;
+  }
+
+  .advanced-toggle:hover {
+    color: var(--color-text);
+  }
+
+  .advanced-arrow {
+    display: inline-block;
+    transition: transform 0.15s;
+    font-size: 0.75rem;
+  }
+
+  .advanced-arrow.open {
+    transform: rotate(90deg);
+  }
+
+  .advanced-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .inline-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .days-input {
+    width: 4rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-size: 0.875rem;
+    background: var(--color-bg);
+    color: var(--color-text);
+    text-align: center;
+  }
+
+  .days-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+  }
+
+  .input-suffix {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+  }
+
+  .match-preview {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    background: rgba(0, 102, 204, 0.04);
+    border: 1px solid rgba(0, 102, 204, 0.1);
+  }
+
+  .match-preview.empty {
+    background: rgba(0, 0, 0, 0.02);
+    border-color: var(--color-border);
+    font-style: italic;
   }
 
   .radio-group {
@@ -498,6 +1238,27 @@
   }
 
   .btn-secondary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .delete-btn {
+    width: 100%;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: 0.8125rem;
+    cursor: pointer;
+    transition: color 0.15s;
+  }
+
+  .delete-btn:hover:not(:disabled) {
+    color: var(--color-error, #dc2626);
+  }
+
+  .delete-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
   }

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -98,7 +98,7 @@
     open: boolean;
     editingViewId: number | null;
     onclose: () => void;
-    oncreated?: (id: number) => void;
+    oncreated?: (uuid: string) => void;
     ondeleted?: () => void;
   }
 

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -128,7 +128,6 @@
   let typeFilter = $state<Set<SubscriptionSourceType>>(new Set());
   let saving = $state(false);
   let error = $state<string | null>(null);
-  let showAdvanced = $state(false);
 
   // Search state for filtering source lists
   let feedSearch = $state('');
@@ -322,11 +321,6 @@
             sourceKeys = mode === 'all' ? new Set() : new Set(view.sourceKeys ?? []);
           }
           feedSearch = '';
-          // Auto-open advanced if non-default values (read from view, not $state, to avoid re-triggering this effect)
-          showAdvanced =
-            (view.typeFilter ?? []).length > 0 ||
-            view.readFilter !== 'unread' ||
-            view.sortOrder !== 'newest';
           return;
         }
       }
@@ -351,7 +345,6 @@
       sortOrder = 'newest';
       typeFilter = new Set();
       feedSearch = '';
-      showAdvanced = false;
     }
   });
 
@@ -889,82 +882,74 @@
       {/if}
     {/if}
 
-    <!-- Advanced options (collapsed by default) -->
-    <button type="button" class="advanced-toggle" onclick={() => (showAdvanced = !showAdvanced)}>
-      <span class="advanced-arrow" class:open={showAdvanced}>&#9656;</span>
-      More options
-    </button>
-
-    {#if showAdvanced}
-      <div class="advanced-section">
-        {#if channelType === 'feed'}
-          <!-- Type Filter (feed channels only) -->
-          <div class="form-group">
-            <span class="form-label">Content Types</span>
-            <div class="checklist type-checklist">
-              {#each TYPE_OPTIONS as opt}
-                <label class="checklist-item">
-                  <input
-                    type="checkbox"
-                    checked={typeFilter.has(opt.value)}
-                    onchange={() => toggleTypeFilter(opt.value)}
-                  />
-                  <span class="checklist-label">{opt.label}</span>
-                </label>
-              {/each}
-            </div>
-            <span class="form-hint">Leave all unchecked to show all types</span>
-          </div>
-        {/if}
-
-        <!-- Read State -->
+    <div class="advanced-section">
+      {#if channelType === 'feed'}
+        <!-- Type Filter (feed channels only) -->
         <div class="form-group">
-          <span class="form-label">{channelType === 'saved' ? 'Status' : 'Read State'}</span>
-          <div class="radio-group">
-            <label class="radio-label">
-              <input type="radio" bind:group={readFilter} value="all" />
-              All
-            </label>
-            <label class="radio-label">
-              <input type="radio" bind:group={readFilter} value="unread" />
-              {channelType === 'saved' ? 'Inbox only' : 'Unread only'}
-            </label>
-            <label class="radio-label">
-              <input type="radio" bind:group={readFilter} value="read" />
-              {channelType === 'saved' ? 'Archived only' : 'Read only'}
-            </label>
+          <span class="form-label">Content Types</span>
+          <div class="checklist type-checklist">
+            {#each TYPE_OPTIONS as opt}
+              <label class="checklist-item">
+                <input
+                  type="checkbox"
+                  checked={typeFilter.has(opt.value)}
+                  onchange={() => toggleTypeFilter(opt.value)}
+                />
+                <span class="checklist-label">{opt.label}</span>
+              </label>
+            {/each}
           </div>
+          <span class="form-hint">Leave all unchecked to show all types</span>
         </div>
+      {/if}
 
-        <!-- Sort Order -->
-        <div class="form-group">
-          <span class="form-label">Sort Order</span>
-          {#if channelType === 'saved'}
-            <select class="form-select" bind:value={sortOrder}>
-              <option value="newest">Date saved (newest)</option>
-              <option value="oldest">Date saved (oldest)</option>
-              <option value="published-newest">Published date (newest)</option>
-              <option value="published-oldest">Published date (oldest)</option>
-              <option value="shortest">Reading time (shortest)</option>
-              <option value="longest">Reading time (longest)</option>
-              <option value="domain-asc">Domain (A–Z)</option>
-              <option value="domain-desc">Domain (Z–A)</option>
-            </select>
-          {:else}
-            <div class="radio-group">
-              <label class="radio-label">
-                <input type="radio" bind:group={sortOrder} value="newest" />
-                Newest first
-              </label>
-              <label class="radio-label">
-                <input type="radio" bind:group={sortOrder} value="oldest" />
-                Oldest first
-              </label>
-            </div>
-          {/if}
+      <!-- Read State -->
+      <div class="form-group">
+        <span class="form-label">{channelType === 'saved' ? 'Status' : 'Read State'}</span>
+        <div class="radio-group">
+          <label class="radio-label">
+            <input type="radio" bind:group={readFilter} value="all" />
+            All
+          </label>
+          <label class="radio-label">
+            <input type="radio" bind:group={readFilter} value="unread" />
+            {channelType === 'saved' ? 'Inbox only' : 'Unread only'}
+          </label>
+          <label class="radio-label">
+            <input type="radio" bind:group={readFilter} value="read" />
+            {channelType === 'saved' ? 'Archived only' : 'Read only'}
+          </label>
         </div>
       </div>
-    {/if}
+
+      <!-- Sort Order -->
+      <div class="form-group">
+        <span class="form-label">Sort Order</span>
+        {#if channelType === 'saved'}
+          <select class="form-select" bind:value={sortOrder}>
+            <option value="newest">Date saved (newest)</option>
+            <option value="oldest">Date saved (oldest)</option>
+            <option value="published-newest">Published date (newest)</option>
+            <option value="published-oldest">Published date (oldest)</option>
+            <option value="shortest">Reading time (shortest)</option>
+            <option value="longest">Reading time (longest)</option>
+            <option value="domain-asc">Domain (A–Z)</option>
+            <option value="domain-desc">Domain (Z–A)</option>
+          </select>
+        {:else}
+          <div class="radio-group">
+            <label class="radio-label">
+              <input type="radio" bind:group={sortOrder} value="newest" />
+              Newest first
+            </label>
+            <label class="radio-label">
+              <input type="radio" bind:group={sortOrder} value="oldest" />
+              Oldest first
+            </label>
+          </div>
+        {/if}
+      </div>
+    </div>
 
     {#if error}
       <p class="error-message">{error}</p>
@@ -1218,33 +1203,6 @@
     font-size: 0.6875rem;
     color: var(--color-text-secondary);
     line-height: 1.3;
-  }
-
-  .advanced-toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    color: var(--color-text-secondary);
-    transition: color 0.15s;
-  }
-
-  .advanced-toggle:hover {
-    color: var(--color-text);
-  }
-
-  .advanced-arrow {
-    display: inline-block;
-    transition: transform 0.15s;
-    font-size: 0.75rem;
-  }
-
-  .advanced-arrow.open {
-    transform: rotate(90deg);
   }
 
   .advanced-section {

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -3,7 +3,16 @@
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import Modal from '$lib/components/common/Modal.svelte';
-  import type { SubscriptionSourceType, ChannelAutoRule } from '$lib/types';
+  import type {
+    SubscriptionSourceType,
+    ChannelAutoRule,
+    SavedSourceType,
+    DateAddedPreset,
+    ReadingLengthFilter,
+    SortOrder,
+  } from '$lib/types';
+  import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { computeSourceKeys } from '$lib/utils/channelLogic';
@@ -12,6 +21,13 @@
     { value: 'rss', label: 'RSS Feeds' },
     { value: 'atproto.shares', label: 'Skyreader Shares' },
     { value: 'atproto.documents', label: 'Standard.site Documents' },
+  ];
+
+  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
+    { value: 'url', label: 'URL Saves' },
+    { value: 'feed', label: 'Feed Articles' },
+    { value: 'share', label: 'Shared Articles' },
+    { value: 'document', label: 'Documents' },
   ];
 
   type AutoRuleOption =
@@ -90,7 +106,9 @@
 
   // Form state
   let name = $state('');
+  let channelType = $state<'feed' | 'saved'>('feed');
   let channelMode = $state<'manual' | 'smart'>('manual');
+  let savedSourceFilter = $state<Set<SavedSourceType>>(new Set());
   let autoRuleType = $state<AutoRuleOption>('frequency:high');
   let recentWithinDays = $state(14);
   let categoryValue = $state('');
@@ -102,7 +120,11 @@
   let sourceMode = $state<'all' | 'include'>('all');
   let sourceKeys = $state<Set<string>>(new Set());
   let readFilter = $state<'all' | 'unread' | 'read'>('all');
-  let sortOrder = $state<'newest' | 'oldest'>('newest');
+  let sortOrder = $state<SortOrder>('newest');
+  let savedDateFilter = $state<DateAddedPreset | ''>('');
+  let savedReadingLength = $state<Set<ReadingLengthFilter>>(new Set());
+  let savedDomainFilter = $state<Set<string>>(new Set());
+  let savedTagFilter = $state<Set<string>>(new Set());
   let typeFilter = $state<Set<SubscriptionSourceType>>(new Set());
   let saving = $state(false);
   let error = $state<string | null>(null);
@@ -267,6 +289,14 @@
           typeFilter = new Set(view.typeFilter ?? []);
           nameManuallyEdited = true; // Preserve existing name when editing
 
+          // Detect saved channel
+          channelType = view.mode === 'saved' ? 'saved' : 'feed';
+          savedSourceFilter = new Set(view.savedSourceFilter ?? []);
+          savedDateFilter = view.savedDateFilter ?? '';
+          savedReadingLength = new Set(view.savedReadingLength ?? []);
+          savedDomainFilter = new Set(view.savedDomainFilter ?? []);
+          savedTagFilter = new Set(view.tagFilter ?? []);
+
           // Detect auto-rule
           const isSmartChannel = !!view.autoRule;
           if (isSmartChannel) {
@@ -302,6 +332,7 @@
       }
       // New channel defaults
       name = '';
+      channelType = 'feed';
       channelMode = 'manual';
       autoRuleType = 'frequency:high';
       recentWithinDays = 14;
@@ -311,6 +342,11 @@
       nameManuallyEdited = false;
       sourceMode = 'all';
       sourceKeys = new Set();
+      savedSourceFilter = new Set();
+      savedDateFilter = '';
+      savedReadingLength = new Set();
+      savedDomainFilter = new Set();
+      savedTagFilter = new Set();
       readFilter = 'all';
       sortOrder = 'newest';
       typeFilter = new Set();
@@ -419,15 +455,32 @@
     try {
       const isSmartMode = channelMode === 'smart' && currentAutoRule;
 
-      const viewData = {
-        name: name.trim(),
-        sourceMode: isSmartMode ? ('include' as const) : sourceMode,
-        sourceKeys: isSmartMode ? matchedSourceKeys : Array.from(sourceKeys),
-        autoRule: isSmartMode ? currentAutoRule : undefined,
-        readFilter,
-        sortOrder,
-        typeFilter: typeFilter.size > 0 ? Array.from(typeFilter) : undefined,
-      };
+      const viewData =
+        channelType === 'saved'
+          ? {
+              name: name.trim(),
+              mode: 'saved' as const,
+              savedSourceFilter:
+                savedSourceFilter.size > 0 ? Array.from(savedSourceFilter) : undefined,
+              savedDateFilter: savedDateFilter || undefined,
+              savedReadingLength:
+                savedReadingLength.size > 0 ? Array.from(savedReadingLength) : undefined,
+              savedDomainFilter:
+                savedDomainFilter.size > 0 ? Array.from(savedDomainFilter) : undefined,
+              tagFilter: savedTagFilter.size > 0 ? Array.from(savedTagFilter) : undefined,
+              readFilter,
+              sortOrder,
+            }
+          : {
+              name: name.trim(),
+              mode: 'feed' as const,
+              sourceMode: isSmartMode ? ('include' as const) : sourceMode,
+              sourceKeys: isSmartMode ? matchedSourceKeys : Array.from(sourceKeys),
+              autoRule: isSmartMode ? currentAutoRule : undefined,
+              readFilter,
+              sortOrder,
+              typeFilter: typeFilter.size > 0 ? Array.from(typeFilter) : undefined,
+            };
 
       if (editingViewId != null) {
         await filteredViewsStore.update(editingViewId, viewData);
@@ -470,230 +523,370 @@
       />
     </div>
 
-    <!-- Channel Mode -->
+    <!-- Channel Type -->
     <div class="form-group">
-      <span class="form-label">Source Selection</span>
+      <span class="form-label">Channel Type</span>
       <div class="mode-options">
-        <label class="mode-option" class:selected={channelMode === 'manual'}>
-          <input type="radio" bind:group={channelMode} value="manual" class="visually-hidden" />
-          <span class="mode-title">Manual</span>
-          <span class="mode-desc">Pick sources individually</span>
+        <label class="mode-option" class:selected={channelType === 'feed'}>
+          <input type="radio" bind:group={channelType} value="feed" class="visually-hidden" />
+          <span class="mode-title">Feed</span>
+          <span class="mode-desc">RSS, shares, and documents</span>
         </label>
-        <label class="mode-option" class:selected={channelMode === 'smart'}>
-          <input
-            type="radio"
-            bind:group={channelMode}
-            value="smart"
-            class="visually-hidden"
-            onchange={() => {
-              if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
-            }}
-          />
-          <span class="mode-title">Smart</span>
-          <span class="mode-desc">Auto-updates based on a rule</span>
+        <label class="mode-option" class:selected={channelType === 'saved'}>
+          <input type="radio" bind:group={channelType} value="saved" class="visually-hidden" />
+          <span class="mode-title">Saved</span>
+          <span class="mode-desc">Your saved/bookmarked items</span>
         </label>
       </div>
     </div>
 
-    {#if channelMode === 'smart'}
-      <!-- Smart rule type -->
+    {#if channelType === 'saved'}
+      <!-- Saved source filter -->
       <div class="form-group">
-        <span class="form-label">Rule</span>
-        <div class="rule-cards">
-          {#each AUTO_RULE_OPTIONS as opt (opt.value)}
-            <button
-              type="button"
-              class="rule-card"
-              class:selected={autoRuleType === opt.value}
-              onclick={() => {
-                autoRuleType = opt.value;
-                if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
-              }}
-            >
-              <span class="rule-card-label">{opt.label}</span>
-              <span class="rule-card-desc">{opt.description}</span>
-            </button>
+        <span class="form-label">Include Sources</span>
+        <p class="form-hint">Leave all unchecked to include everything</p>
+        <div class="checklist type-checklist">
+          {#each SAVED_SOURCE_OPTIONS as opt}
+            <label class="checklist-item">
+              <input
+                type="checkbox"
+                checked={savedSourceFilter.has(opt.value)}
+                onchange={() => {
+                  const next = new Set(savedSourceFilter);
+                  if (next.has(opt.value)) {
+                    next.delete(opt.value);
+                  } else {
+                    next.add(opt.value);
+                  }
+                  savedSourceFilter = next;
+                }}
+              />
+              <span class="checklist-label">{opt.label}</span>
+            </label>
           {/each}
         </div>
       </div>
 
-      {#if autoRuleType === 'recent'}
-        <div class="form-group">
-          <label for="recent-days" class="form-label">Within the last</label>
-          <div class="inline-input">
-            <input
-              id="recent-days"
-              type="number"
-              bind:value={recentWithinDays}
-              min="1"
-              max="90"
-              class="days-input"
-            />
-            <span class="input-suffix">days</span>
-          </div>
-        </div>
-      {:else if autoRuleType === 'category'}
-        <div class="form-group">
-          <label for="category-value" class="form-label">Category</label>
-          <input
-            id="category-value"
-            type="text"
-            list="category-options"
-            bind:value={categoryValue}
-            placeholder="e.g. Technology"
-          />
-          <datalist id="category-options">
-            {#each availableCategories as cat}
-              <option value={cat} />
-            {/each}
-          </datalist>
-        </div>
-      {:else if autoRuleType === 'subscriptionTag'}
-        <div class="form-group">
-          <label for="tag-value" class="form-label">Tag</label>
-          <input
-            id="tag-value"
-            type="text"
-            list="tag-options"
-            bind:value={tagValue}
-            placeholder="e.g. news"
-          />
-          <datalist id="tag-options">
-            {#each availableTags as tag}
-              <option value={tag} />
-            {/each}
-          </datalist>
-        </div>
-      {:else if autoRuleType === 'domain'}
-        <div class="form-group">
-          <span class="form-label">Domain patterns</span>
-          <div class="chip-input-wrapper">
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-            <div
-              class="chip-input"
-              onclick={(e) => {
-                const input = (e.currentTarget as HTMLElement).querySelector('input');
-                input?.focus();
-              }}
-            >
-              {#each domainPatterns as pattern}
-                <span class="chip">
-                  {pattern}
-                  <button
-                    type="button"
-                    class="chip-remove"
-                    onclick={() => removeDomainPattern(pattern)}
-                    aria-label="Remove {pattern}"
-                  >
-                    &times;
-                  </button>
-                </span>
-              {/each}
+      <!-- Date Added -->
+      <div class="form-group">
+        <span class="form-label">Date Added</span>
+        <select class="form-select" bind:value={savedDateFilter}>
+          <option value="">Any time</option>
+          <option value="last-week">Last week</option>
+          <option value="last-month">Last month</option>
+          <option value="last-3-months">Last 3 months</option>
+          <option value="last-year">Last year</option>
+        </select>
+      </div>
+
+      <!-- Reading Length -->
+      <div class="form-group">
+        <span class="form-label">Reading Length</span>
+        <p class="form-hint">Leave all unchecked to include everything</p>
+        <div class="checklist type-checklist">
+          {#each [{ value: 'quick', label: 'Quick (< 5 min)' }, { value: 'medium', label: 'Medium (5–15 min)' }, { value: 'long', label: 'Long (15+ min)' }] as opt}
+            <label class="checklist-item">
               <input
-                type="text"
-                bind:value={domainInput}
-                onkeydown={handleDomainKeydown}
-                oninput={handleDomainInput}
-                onblur={handleDomainBlur}
-                onfocus={() => (domainSuggestionsOpen = true)}
-                placeholder={domainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
-                class="chip-text-input"
-                role="combobox"
-                aria-expanded={domainSuggestionsOpen && domainSuggestions.length > 0}
-                aria-autocomplete="list"
-                autocomplete="off"
+                type="checkbox"
+                checked={savedReadingLength.has(opt.value as ReadingLengthFilter)}
+                onchange={() => {
+                  const next = new Set(savedReadingLength);
+                  const v = opt.value as ReadingLengthFilter;
+                  if (next.has(v)) {
+                    next.delete(v);
+                  } else {
+                    next.add(v);
+                  }
+                  savedReadingLength = next;
+                }}
               />
-            </div>
-            {#if domainSuggestionsOpen && domainSuggestions.length > 0}
-              <ul class="chip-suggestions" role="listbox">
-                {#each domainSuggestions as suggestion, i (suggestion)}
-                  <!-- svelte-ignore a11y_click_events_have_key_events -->
-                  <li
-                    class="chip-suggestion"
-                    class:highlighted={i === domainHighlightIndex}
-                    role="option"
-                    aria-selected={i === domainHighlightIndex}
-                    onmousedown={(e) => {
-                      e.preventDefault();
-                      addDomainPattern(suggestion);
-                    }}
-                    onmouseenter={() => (domainHighlightIndex = i)}
-                  >
-                    {suggestion}
-                  </li>
-                {/each}
-              </ul>
-            {/if}
+              <span class="checklist-label">{opt.label}</span>
+            </label>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Domain Filter -->
+      {#if feedViewStore.availableSavedDomains.length > 0}
+        <div class="form-group">
+          <span class="form-label">Domains</span>
+          <p class="form-hint">Leave all unchecked to include everything</p>
+          <div class="checklist type-checklist domain-checklist">
+            {#each feedViewStore.availableSavedDomains as domain}
+              <label class="checklist-item">
+                <input
+                  type="checkbox"
+                  checked={savedDomainFilter.has(domain)}
+                  onchange={() => {
+                    const next = new Set(savedDomainFilter);
+                    if (next.has(domain)) {
+                      next.delete(domain);
+                    } else {
+                      next.add(domain);
+                    }
+                    savedDomainFilter = next;
+                  }}
+                />
+                <span class="checklist-label">{domain}</span>
+              </label>
+            {/each}
           </div>
-          <span class="form-hint">Press Enter to add. Matches against feed URL hostnames.</span>
         </div>
       {/if}
 
-      <!-- Matched sources preview -->
-      <div class="match-preview" class:empty={matchedSourceKeys.length === 0}>
-        {#if matchedSourceKeys.length > 0}
-          Matches <strong>{matchedSourceKeys.length}</strong>
-          {matchedSourceKeys.length === 1 ? 'source' : 'sources'}
-        {:else}
-          No sources match this rule yet
-        {/if}
-      </div>
+      <!-- Tag Filter -->
+      {#if itemLabelsStore.allTags.length > 0}
+        <div class="form-group">
+          <span class="form-label">Tags</span>
+          <p class="form-hint">Leave all unchecked to include everything</p>
+          <div class="checklist type-checklist">
+            {#each itemLabelsStore.allTags as tag}
+              <label class="checklist-item">
+                <input
+                  type="checkbox"
+                  checked={savedTagFilter.has(tag)}
+                  onchange={() => {
+                    const next = new Set(savedTagFilter);
+                    if (next.has(tag)) {
+                      next.delete(tag);
+                    } else {
+                      next.add(tag);
+                    }
+                    savedTagFilter = next;
+                  }}
+                />
+                <span class="checklist-label">{tag}</span>
+              </label>
+            {/each}
+          </div>
+        </div>
+      {/if}
     {:else}
-      <!-- Manual source picker -->
+      <!-- Channel Mode (feed channels only) -->
       <div class="form-group">
-        <span class="form-label">Sources</span>
-        <div class="radio-group">
-          <label class="radio-label">
-            <input type="radio" bind:group={sourceMode} value="all" />
-            All sources
+        <span class="form-label">Source Selection</span>
+        <div class="mode-options">
+          <label class="mode-option" class:selected={channelMode === 'manual'}>
+            <input type="radio" bind:group={channelMode} value="manual" class="visually-hidden" />
+            <span class="mode-title">Manual</span>
+            <span class="mode-desc">Pick sources individually</span>
           </label>
-          <label class="radio-label">
-            <input type="radio" bind:group={sourceMode} value="include" />
-            Include only
+          <label class="mode-option" class:selected={channelMode === 'smart'}>
+            <input
+              type="radio"
+              bind:group={channelMode}
+              value="smart"
+              class="visually-hidden"
+              onchange={() => {
+                if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
+              }}
+            />
+            <span class="mode-title">Smart</span>
+            <span class="mode-desc">Auto-updates based on a rule</span>
           </label>
         </div>
+      </div>
 
-        {#if sourceMode === 'include'}
-          {#if subscriptionsStore.subscriptions.length > 0}
-            <div class="source-group-header">Subscriptions</div>
+      {#if channelMode === 'smart'}
+        <!-- Smart rule type -->
+        <div class="form-group">
+          <span class="form-label">Rule</span>
+          <div class="rule-cards">
+            {#each AUTO_RULE_OPTIONS as opt (opt.value)}
+              <button
+                type="button"
+                class="rule-card"
+                class:selected={autoRuleType === opt.value}
+                onclick={() => {
+                  autoRuleType = opt.value;
+                  if (!nameManuallyEdited) name = DEFAULT_NAMES[autoRuleType];
+                }}
+              >
+                <span class="rule-card-label">{opt.label}</span>
+                <span class="rule-card-desc">{opt.description}</span>
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        {#if autoRuleType === 'recent'}
+          <div class="form-group">
+            <label for="recent-days" class="form-label">Within the last</label>
+            <div class="inline-input">
+              <input
+                id="recent-days"
+                type="number"
+                bind:value={recentWithinDays}
+                min="1"
+                max="90"
+                class="days-input"
+              />
+              <span class="input-suffix">days</span>
+            </div>
+          </div>
+        {:else if autoRuleType === 'category'}
+          <div class="form-group">
+            <label for="category-value" class="form-label">Category</label>
             <input
+              id="category-value"
               type="text"
-              placeholder="Search subscriptions..."
-              bind:value={feedSearch}
-              class="search-input"
+              list="category-options"
+              bind:value={categoryValue}
+              placeholder="e.g. Technology"
             />
-            <div class="checklist">
-              {#each filteredSubscriptions as sub (sub.id)}
-                {@const key = subscriptionSourceKey(sub)}
-                {#if key}
-                  {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
-                  {@const iconUrl =
-                    sub.customIconUrl ||
-                    (isAtProto
-                      ? sub.siteUrl
-                        ? getFaviconUrl(sub.siteUrl)
-                        : '/icons/icon-192.svg'
-                      : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
-                  <label class="checklist-item">
-                    <input
-                      type="checkbox"
-                      checked={sourceKeys.has(key)}
-                      onchange={() => toggleSourceKey(key)}
-                    />
-                    {#if iconUrl}
-                      <img src={iconUrl} alt="" class="checklist-icon" />
-                    {/if}
-                    <span class="checklist-label">{sub.customTitle || sub.title}</span>
-                  </label>
-                {/if}
+            <datalist id="category-options">
+              {#each availableCategories as cat}
+                <option value={cat} />
               {/each}
-              {#if feedSearch && filteredSubscriptions.length === 0}
-                <div class="no-results">No subscriptions match</div>
+            </datalist>
+          </div>
+        {:else if autoRuleType === 'subscriptionTag'}
+          <div class="form-group">
+            <label for="tag-value" class="form-label">Tag</label>
+            <input
+              id="tag-value"
+              type="text"
+              list="tag-options"
+              bind:value={tagValue}
+              placeholder="e.g. news"
+            />
+            <datalist id="tag-options">
+              {#each availableTags as tag}
+                <option value={tag} />
+              {/each}
+            </datalist>
+          </div>
+        {:else if autoRuleType === 'domain'}
+          <div class="form-group">
+            <span class="form-label">Domain patterns</span>
+            <div class="chip-input-wrapper">
+              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+              <div
+                class="chip-input"
+                onclick={(e) => {
+                  const input = (e.currentTarget as HTMLElement).querySelector('input');
+                  input?.focus();
+                }}
+              >
+                {#each domainPatterns as pattern}
+                  <span class="chip">
+                    {pattern}
+                    <button
+                      type="button"
+                      class="chip-remove"
+                      onclick={() => removeDomainPattern(pattern)}
+                      aria-label="Remove {pattern}"
+                    >
+                      &times;
+                    </button>
+                  </span>
+                {/each}
+                <input
+                  type="text"
+                  bind:value={domainInput}
+                  onkeydown={handleDomainKeydown}
+                  oninput={handleDomainInput}
+                  onblur={handleDomainBlur}
+                  onfocus={() => (domainSuggestionsOpen = true)}
+                  placeholder={domainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
+                  class="chip-text-input"
+                  role="combobox"
+                  aria-expanded={domainSuggestionsOpen && domainSuggestions.length > 0}
+                  aria-autocomplete="list"
+                  autocomplete="off"
+                />
+              </div>
+              {#if domainSuggestionsOpen && domainSuggestions.length > 0}
+                <ul class="chip-suggestions" role="listbox">
+                  {#each domainSuggestions as suggestion, i (suggestion)}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <li
+                      class="chip-suggestion"
+                      class:highlighted={i === domainHighlightIndex}
+                      role="option"
+                      aria-selected={i === domainHighlightIndex}
+                      onmousedown={(e) => {
+                        e.preventDefault();
+                        addDomainPattern(suggestion);
+                      }}
+                      onmouseenter={() => (domainHighlightIndex = i)}
+                    >
+                      {suggestion}
+                    </li>
+                  {/each}
+                </ul>
               {/if}
             </div>
-          {/if}
+            <span class="form-hint">Press Enter to add. Matches against feed URL hostnames.</span>
+          </div>
         {/if}
-      </div>
+
+        <!-- Matched sources preview -->
+        <div class="match-preview" class:empty={matchedSourceKeys.length === 0}>
+          {#if matchedSourceKeys.length > 0}
+            Matches <strong>{matchedSourceKeys.length}</strong>
+            {matchedSourceKeys.length === 1 ? 'source' : 'sources'}
+          {:else}
+            No sources match this rule yet
+          {/if}
+        </div>
+      {:else}
+        <!-- Manual source picker -->
+        <div class="form-group">
+          <span class="form-label">Sources</span>
+          <div class="radio-group">
+            <label class="radio-label">
+              <input type="radio" bind:group={sourceMode} value="all" />
+              All sources
+            </label>
+            <label class="radio-label">
+              <input type="radio" bind:group={sourceMode} value="include" />
+              Include only
+            </label>
+          </div>
+
+          {#if sourceMode === 'include'}
+            {#if subscriptionsStore.subscriptions.length > 0}
+              <div class="source-group-header">Subscriptions</div>
+              <input
+                type="text"
+                placeholder="Search subscriptions..."
+                bind:value={feedSearch}
+                class="search-input"
+              />
+              <div class="checklist">
+                {#each filteredSubscriptions as sub (sub.id)}
+                  {@const key = subscriptionSourceKey(sub)}
+                  {#if key}
+                    {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
+                    {@const iconUrl =
+                      sub.customIconUrl ||
+                      (isAtProto
+                        ? sub.siteUrl
+                          ? getFaviconUrl(sub.siteUrl)
+                          : '/icons/icon-192.svg'
+                        : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
+                    <label class="checklist-item">
+                      <input
+                        type="checkbox"
+                        checked={sourceKeys.has(key)}
+                        onchange={() => toggleSourceKey(key)}
+                      />
+                      {#if iconUrl}
+                        <img src={iconUrl} alt="" class="checklist-icon" />
+                      {/if}
+                      <span class="checklist-label">{sub.customTitle || sub.title}</span>
+                    </label>
+                  {/if}
+                {/each}
+                {#if feedSearch && filteredSubscriptions.length === 0}
+                  <div class="no-results">No subscriptions match</div>
+                {/if}
+              </div>
+            {/if}
+          {/if}
+        </div>
+      {/if}
     {/if}
 
     <!-- Advanced options (collapsed by default) -->
@@ -704,27 +897,29 @@
 
     {#if showAdvanced}
       <div class="advanced-section">
-        <!-- Type Filter -->
-        <div class="form-group">
-          <span class="form-label">Content Types</span>
-          <div class="checklist type-checklist">
-            {#each TYPE_OPTIONS as opt}
-              <label class="checklist-item">
-                <input
-                  type="checkbox"
-                  checked={typeFilter.has(opt.value)}
-                  onchange={() => toggleTypeFilter(opt.value)}
-                />
-                <span class="checklist-label">{opt.label}</span>
-              </label>
-            {/each}
+        {#if channelType === 'feed'}
+          <!-- Type Filter (feed channels only) -->
+          <div class="form-group">
+            <span class="form-label">Content Types</span>
+            <div class="checklist type-checklist">
+              {#each TYPE_OPTIONS as opt}
+                <label class="checklist-item">
+                  <input
+                    type="checkbox"
+                    checked={typeFilter.has(opt.value)}
+                    onchange={() => toggleTypeFilter(opt.value)}
+                  />
+                  <span class="checklist-label">{opt.label}</span>
+                </label>
+              {/each}
+            </div>
+            <span class="form-hint">Leave all unchecked to show all types</span>
           </div>
-          <span class="form-hint">Leave all unchecked to show all types</span>
-        </div>
+        {/if}
 
         <!-- Read State -->
         <div class="form-group">
-          <span class="form-label">Read State</span>
+          <span class="form-label">{channelType === 'saved' ? 'Status' : 'Read State'}</span>
           <div class="radio-group">
             <label class="radio-label">
               <input type="radio" bind:group={readFilter} value="all" />
@@ -732,11 +927,11 @@
             </label>
             <label class="radio-label">
               <input type="radio" bind:group={readFilter} value="unread" />
-              Unread only
+              {channelType === 'saved' ? 'Inbox only' : 'Unread only'}
             </label>
             <label class="radio-label">
               <input type="radio" bind:group={readFilter} value="read" />
-              Read only
+              {channelType === 'saved' ? 'Archived only' : 'Read only'}
             </label>
           </div>
         </div>
@@ -744,16 +939,29 @@
         <!-- Sort Order -->
         <div class="form-group">
           <span class="form-label">Sort Order</span>
-          <div class="radio-group">
-            <label class="radio-label">
-              <input type="radio" bind:group={sortOrder} value="newest" />
-              Newest first
-            </label>
-            <label class="radio-label">
-              <input type="radio" bind:group={sortOrder} value="oldest" />
-              Oldest first
-            </label>
-          </div>
+          {#if channelType === 'saved'}
+            <select class="form-select" bind:value={sortOrder}>
+              <option value="newest">Date saved (newest)</option>
+              <option value="oldest">Date saved (oldest)</option>
+              <option value="published-newest">Published date (newest)</option>
+              <option value="published-oldest">Published date (oldest)</option>
+              <option value="shortest">Reading time (shortest)</option>
+              <option value="longest">Reading time (longest)</option>
+              <option value="domain-asc">Domain (A–Z)</option>
+              <option value="domain-desc">Domain (Z–A)</option>
+            </select>
+          {:else}
+            <div class="radio-group">
+              <label class="radio-label">
+                <input type="radio" bind:group={sortOrder} value="newest" />
+                Newest first
+              </label>
+              <label class="radio-label">
+                <input type="radio" bind:group={sortOrder} value="oldest" />
+                Oldest first
+              </label>
+            </div>
+          {/if}
         </div>
       </div>
     {/if}
@@ -1155,6 +1363,21 @@
 
   .type-checklist {
     max-height: none;
+  }
+
+  .domain-checklist {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .form-select {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-secondary, #333);
+    border-radius: 0.5rem;
+    background: var(--surface-primary, #1a1a1a);
+    color: var(--text-primary, #e0e0e0);
+    font-size: 0.875rem;
   }
 
   .form-hint {

--- a/frontend/src/lib/components/FilteredViewModal.svelte
+++ b/frontend/src/lib/components/FilteredViewModal.svelte
@@ -16,83 +16,15 @@
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { computeSourceKeys } from '$lib/utils/channelLogic';
-
-  const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
-    { value: 'rss', label: 'RSS Feeds' },
-    { value: 'atproto.shares', label: 'Skyreader Shares' },
-    { value: 'atproto.documents', label: 'Standard.site Documents' },
-  ];
-
-  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
-    { value: 'url', label: 'URL Saves' },
-    { value: 'feed', label: 'Feed Articles' },
-    { value: 'share', label: 'Shared Articles' },
-    { value: 'document', label: 'Documents' },
-  ];
-
-  type AutoRuleOption =
-    | 'frequency:high'
-    | 'frequency:low'
-    | 'longReads'
-    | 'recent'
-    | 'category'
-    | 'subscriptionTag'
-    | 'domain'
-    | 'people';
-
-  const AUTO_RULE_OPTIONS: { value: AutoRuleOption; label: string; description: string }[] = [
-    {
-      value: 'frequency:high',
-      label: 'Daily Digest',
-      description: 'High-volume feeds that publish 2+ times per day',
-    },
-    {
-      value: 'frequency:low',
-      label: "Don't Miss",
-      description: 'Infrequent feeds where every post counts',
-    },
-    {
-      value: 'longReads',
-      label: 'Long Reads',
-      description: 'Feeds with in-depth, long-form articles',
-    },
-    {
-      value: 'recent',
-      label: 'Recently Added',
-      description: 'Sources you added recently',
-    },
-    {
-      value: 'category',
-      label: 'Category',
-      description: 'All sources in a specific folder',
-    },
-    {
-      value: 'subscriptionTag',
-      label: 'Tag',
-      description: 'All sources with a specific tag',
-    },
-    {
-      value: 'domain',
-      label: 'Domain',
-      description: 'Sources matching URL patterns',
-    },
-    {
-      value: 'people',
-      label: 'People',
-      description: 'Everyone you follow on AT Protocol',
-    },
-  ];
-
-  const DEFAULT_NAMES: Record<AutoRuleOption, string> = {
-    'frequency:high': 'Daily Digest',
-    'frequency:low': "Don't Miss",
-    longReads: 'Long Reads',
-    recent: 'New Sources',
-    category: '',
-    subscriptionTag: '',
-    domain: '',
-    people: 'People I Follow',
-  };
+  import DomainPatternInput from '$lib/components/DomainPatternInput.svelte';
+  import {
+    TYPE_OPTIONS,
+    SAVED_SOURCE_OPTIONS,
+    AUTO_RULE_OPTIONS,
+    AUTO_RULE_DEFAULT_NAMES as DEFAULT_NAMES,
+    autoRuleToOption,
+    type AutoRuleOption,
+  } from '$lib/constants/channelOptions';
 
   interface Props {
     open: boolean;
@@ -114,9 +46,6 @@
   let categoryValue = $state('');
   let tagValue = $state('');
   let domainPatterns = $state<string[]>([]);
-  let domainInput = $state('');
-  let domainSuggestionsOpen = $state(false);
-  let domainHighlightIndex = $state(-1);
   let sourceMode = $state<'all' | 'include'>('all');
   let sourceKeys = $state<Set<string>>(new Set());
   let readFilter = $state<'all' | 'unread' | 'read'>('all');
@@ -177,12 +106,6 @@
       ),
     ].sort()
   );
-
-  let domainSuggestions = $derived.by(() => {
-    const q = domainInput.trim().toLowerCase();
-    const existing = new Set(domainPatterns);
-    return availableDomains.filter((d) => (!q || d.includes(q)) && !existing.has(d));
-  });
 
   // Build the auto-rule from current selections
   let currentAutoRule = $derived.by((): ChannelAutoRule | undefined => {
@@ -254,26 +177,6 @@
       next.add(type);
     }
     typeFilter = next;
-  }
-
-  /** Map a stored autoRule back to an AutoRuleOption. */
-  function autoRuleToOption(rule: ChannelAutoRule): AutoRuleOption {
-    switch (rule.type) {
-      case 'frequency':
-        return rule.threshold === 'high' ? 'frequency:high' : 'frequency:low';
-      case 'longReads':
-        return 'longReads';
-      case 'recent':
-        return 'recent';
-      case 'category':
-        return 'category';
-      case 'subscriptionTag':
-        return 'subscriptionTag';
-      case 'domain':
-        return 'domain';
-      case 'people':
-        return 'people';
-    }
   }
 
   // Reset form when modal opens or editingViewId changes
@@ -352,70 +255,6 @@
     error = null;
     saving = false;
     onclose();
-  }
-
-  function addDomainPattern(value?: string) {
-    const v = (value ?? domainInput).trim();
-    if (v && !domainPatterns.includes(v)) {
-      domainPatterns = [...domainPatterns, v];
-    }
-    domainInput = '';
-    domainSuggestionsOpen = false;
-    domainHighlightIndex = -1;
-  }
-
-  function removeDomainPattern(pattern: string) {
-    domainPatterns = domainPatterns.filter((p) => p !== pattern);
-  }
-
-  function handleDomainKeydown(e: KeyboardEvent) {
-    if (domainSuggestionsOpen && domainSuggestions.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        domainHighlightIndex = (domainHighlightIndex + 1) % domainSuggestions.length;
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        domainHighlightIndex =
-          domainHighlightIndex <= 0 ? domainSuggestions.length - 1 : domainHighlightIndex - 1;
-        return;
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        if (domainHighlightIndex >= 0 && domainHighlightIndex < domainSuggestions.length) {
-          addDomainPattern(domainSuggestions[domainHighlightIndex]);
-        } else {
-          addDomainPattern();
-        }
-        return;
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        domainSuggestionsOpen = false;
-        domainHighlightIndex = -1;
-        return;
-      }
-    }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      addDomainPattern();
-    } else if (e.key === 'Backspace' && !domainInput && domainPatterns.length > 0) {
-      domainPatterns = domainPatterns.slice(0, -1);
-    }
-  }
-
-  function handleDomainInput() {
-    domainSuggestionsOpen = true;
-    domainHighlightIndex = -1;
-  }
-
-  function handleDomainBlur() {
-    // Delay to allow click on suggestion to fire first
-    setTimeout(() => {
-      domainSuggestionsOpen = false;
-      addDomainPattern();
-    }, 150);
   }
 
   function toggleSourceKey(key: string) {
@@ -752,65 +591,11 @@
         {:else if autoRuleType === 'domain'}
           <div class="form-group">
             <span class="form-label">Domain patterns</span>
-            <div class="chip-input-wrapper">
-              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-              <div
-                class="chip-input"
-                onclick={(e) => {
-                  const input = (e.currentTarget as HTMLElement).querySelector('input');
-                  input?.focus();
-                }}
-              >
-                {#each domainPatterns as pattern}
-                  <span class="chip">
-                    {pattern}
-                    <button
-                      type="button"
-                      class="chip-remove"
-                      onclick={() => removeDomainPattern(pattern)}
-                      aria-label="Remove {pattern}"
-                    >
-                      &times;
-                    </button>
-                  </span>
-                {/each}
-                <input
-                  type="text"
-                  bind:value={domainInput}
-                  onkeydown={handleDomainKeydown}
-                  oninput={handleDomainInput}
-                  onblur={handleDomainBlur}
-                  onfocus={() => (domainSuggestionsOpen = true)}
-                  placeholder={domainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
-                  class="chip-text-input"
-                  role="combobox"
-                  aria-expanded={domainSuggestionsOpen && domainSuggestions.length > 0}
-                  aria-autocomplete="list"
-                  autocomplete="off"
-                />
-              </div>
-              {#if domainSuggestionsOpen && domainSuggestions.length > 0}
-                <ul class="chip-suggestions" role="listbox">
-                  {#each domainSuggestions as suggestion, i (suggestion)}
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <li
-                      class="chip-suggestion"
-                      class:highlighted={i === domainHighlightIndex}
-                      role="option"
-                      aria-selected={i === domainHighlightIndex}
-                      onmousedown={(e) => {
-                        e.preventDefault();
-                        addDomainPattern(suggestion);
-                      }}
-                      onmouseenter={() => (domainHighlightIndex = i)}
-                    >
-                      {suggestion}
-                    </li>
-                  {/each}
-                </ul>
-              {/if}
-            </div>
-            <span class="form-hint">Press Enter to add. Matches against feed URL hostnames.</span>
+            <DomainPatternInput
+              patterns={domainPatterns}
+              {availableDomains}
+              onchange={(p) => (domainPatterns = p)}
+            />
           </div>
         {/if}
 
@@ -1013,105 +798,6 @@
     box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
   }
 
-  .chip-input {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg);
-    cursor: text;
-    min-height: 2.25rem;
-  }
-
-  .chip-input:focus-within {
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
-  }
-
-  .chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.125rem 0.25rem 0.125rem 0.5rem;
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
-    border-radius: 4px;
-    font-size: 0.8125rem;
-    color: var(--color-text);
-    line-height: 1.4;
-  }
-
-  .chip-remove {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.125rem;
-    height: 1.125rem;
-    padding: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: var(--color-text-secondary);
-    font-size: 0.875rem;
-    line-height: 1;
-    border-radius: 3px;
-  }
-
-  .chip-remove:hover {
-    background: rgba(0, 0, 0, 0.1);
-    color: var(--color-text);
-  }
-
-  .chip-text-input {
-    flex: 1;
-    min-width: 8rem;
-    border: none;
-    background: none;
-    outline: none;
-    font: inherit;
-    font-size: 0.8125rem;
-    color: var(--color-text);
-    padding: 0.125rem 0;
-  }
-
-  .chip-text-input::placeholder {
-    color: var(--color-text-secondary);
-  }
-
-  .chip-input-wrapper {
-    position: relative;
-  }
-
-  .chip-suggestions {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin: 0.25rem 0 0;
-    padding: 0.25rem;
-    list-style: none;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-    z-index: 10;
-    max-height: 160px;
-    overflow-y: auto;
-  }
-
-  .chip-suggestion {
-    padding: 0.375rem 0.5rem;
-    font-size: 0.8125rem;
-    border-radius: 4px;
-    cursor: pointer;
-    color: var(--color-text);
-  }
-
-  .chip-suggestion.highlighted {
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
-  }
 
   .visually-hidden {
     position: absolute;

--- a/frontend/src/lib/components/Icon.svelte
+++ b/frontend/src/lib/components/Icon.svelte
@@ -51,7 +51,9 @@
     | 'link'
     | 'globe'
     | 'alert-triangle'
-    | 'user';
+    | 'user'
+    | 'folder'
+    | 'folder-plus';
 
   interface Props {
     name: IconName;
@@ -298,6 +300,16 @@
   {:else if name === 'user'}
     <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
     <circle cx="12" cy="7" r="4" />
+  {:else if name === 'folder'}
+    <path
+      d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
+    />
+  {:else if name === 'folder-plus'}
+    <path d="M12 10v6" />
+    <path d="M9 13h6" />
+    <path
+      d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
+    />
   {/if}
 </svg>
 

--- a/frontend/src/lib/components/Icon.svelte
+++ b/frontend/src/lib/components/Icon.svelte
@@ -45,7 +45,13 @@
     | 'highlighter'
     | 'send'
     | 'semble'
-    | 'margin';
+    | 'margin'
+    | 'arrow-right'
+    | 'at-sign'
+    | 'link'
+    | 'globe'
+    | 'alert-triangle'
+    | 'user';
 
   interface Props {
     name: IconName;
@@ -268,6 +274,30 @@
         stroke="none"
       />
     </g>
+  {:else if name === 'arrow-right'}
+    <line x1="5" y1="12" x2="19" y2="12" />
+    <polyline points="12 5 19 12 12 19" />
+  {:else if name === 'at-sign'}
+    <circle cx="12" cy="12" r="4" />
+    <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94" />
+  {:else if name === 'link'}
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  {:else if name === 'globe'}
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path
+      d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+    />
+  {:else if name === 'alert-triangle'}
+    <path
+      d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+    />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  {:else if name === 'user'}
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
   {/if}
 </svg>
 

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -113,7 +113,7 @@
 
   async function deleteView(viewId: number) {
     closeViewMenu();
-    if (!confirm('Are you sure you want to delete this view?')) return;
+    if (!confirm('Are you sure you want to delete this channel?')) return;
     await filteredViewsStore.remove(viewId);
     // If we're currently viewing the deleted view, navigate away
     const currentView = $page.url.searchParams.get('view');
@@ -178,6 +178,7 @@
       { type: 'view', id: 'saved', label: 'Saved', count: savedCount, icon: 'bookmark' },
       { type: 'view', id: 'shared', label: 'Shared', count: sharedCount, icon: 'share' },
       { type: 'utility', id: 'activity', label: 'Activity', count: activityCount, icon: 'bell' },
+      { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' },
     ];
 
@@ -190,8 +191,8 @@
 
     const addViewAction: NavItem = {
       type: 'action',
-      id: 'add-view',
-      label: 'New view',
+      id: 'add-channel',
+      label: 'New channel',
       icon: 'plus',
     };
 
@@ -255,6 +256,7 @@
 
     // Utility pages (separate routes)
     if (pathname === '/activity') return { type: 'icon', name: 'bell' };
+    if (pathname === '/sources') return { type: 'icon', name: 'rss' };
     if (pathname === '/settings') return { type: 'icon', name: 'settings' };
 
     // Feed page filters (query params on /)
@@ -353,10 +355,10 @@
   function selectItem(item: NavItem) {
     if (item.type === 'action') {
       close();
-      if (item.id === 'add-view') {
+      if (item.id === 'add-channel') {
         filteredViewsStore
           .create({
-            name: 'new view',
+            name: 'new channel',
             sourceMode: 'include',
             sourceKeys: [],
             readFilter: 'unread',

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -158,11 +158,25 @@
 
   // Navigation item type
   type NavItem =
-    | { type: 'view'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'feed'; id: number; label: string; count: number; iconUrl: string | null }
-    | { type: 'utility'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'action'; id: string; label: string; icon: IconName }
-    | { type: 'filteredView'; id: string; label: string; icon: IconName };
+    | { type: 'view'; id: string; label: string; count?: number; icon: IconName; indent?: boolean }
+    | {
+        type: 'feed';
+        id: number;
+        label: string;
+        count: number;
+        iconUrl: string | null;
+        indent?: boolean;
+      }
+    | {
+        type: 'utility';
+        id: string;
+        label: string;
+        count?: number;
+        icon: IconName;
+        indent?: boolean;
+      }
+    | { type: 'action'; id: string; label: string; icon: IconName; indent?: boolean }
+    | { type: 'filteredView'; id: string; label: string; icon: IconName; indent?: boolean };
 
   // Section type with optional icon and click handler for styled section headers
   type SectionData = {
@@ -176,21 +190,46 @@
   let filteredItems = $derived.by((): SectionData[] => {
     const query = searchQuery.toLowerCase().trim();
 
-    const views: NavItem[] = [
-      { type: 'view', id: 'all', label: 'All', count: totalUnread, icon: 'inbox' },
-      { type: 'view', id: 'saved', label: 'Saved', count: savedCount, icon: 'bookmark' },
+    const everythingItem: NavItem = {
+      type: 'view',
+      id: 'all',
+      label: 'Everything',
+      count: totalUnread,
+      icon: 'inbox',
+    };
+    const savedItem: NavItem = {
+      type: 'view',
+      id: 'saved',
+      label: 'Saved',
+      count: savedCount,
+      icon: 'bookmark',
+    };
+    const otherViews: NavItem[] = [
       { type: 'view', id: 'shared', label: 'Shared', count: sharedCount, icon: 'share' },
       { type: 'utility', id: 'activity', label: 'Activity', count: activityCount, icon: 'bell' },
       { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' },
     ];
 
-    const customViews: NavItem[] = filteredViewsStore.views.map((v) => ({
-      type: 'filteredView' as const,
-      id: v.uuid,
-      label: v.name,
-      icon: 'filter' as const,
-    }));
+    const sourceChannelItems: NavItem[] = filteredViewsStore.views
+      .filter((v) => v.mode !== 'saved')
+      .map((v) => ({
+        type: 'filteredView' as const,
+        id: v.uuid,
+        label: v.name,
+        icon: 'filter' as const,
+        indent: true,
+      }));
+
+    const savedChannelItems: NavItem[] = filteredViewsStore.views
+      .filter((v) => v.mode === 'saved')
+      .map((v) => ({
+        type: 'filteredView' as const,
+        id: v.uuid,
+        label: v.name,
+        icon: 'bookmark' as const,
+        indent: true,
+      }));
 
     const addViewAction: NavItem = {
       type: 'action',
@@ -241,10 +280,22 @@
 
     const sections: SectionData[] = [];
 
-    // System views + custom views + add action in one flat section
-    const allViews = [...views, ...customViews, addViewAction].filter(filterItem);
-    if (allViews.length > 0) {
-      sections.push({ section: '', items: allViews });
+    // Everything group: Everything + nested source channels
+    const everythingGroup = [everythingItem, ...sourceChannelItems].filter(filterItem);
+    if (everythingGroup.length > 0) {
+      sections.push({ section: '', items: everythingGroup });
+    }
+
+    // Saved group: Saved + nested saved channels
+    const savedGroup = [savedItem, ...savedChannelItems].filter(filterItem);
+    if (savedGroup.length > 0) {
+      sections.push({ section: '', items: savedGroup });
+    }
+
+    // Other views + add action
+    const otherGroup = [...otherViews, addViewAction].filter(filterItem);
+    if (otherGroup.length > 0) {
+      sections.push({ section: '', items: otherGroup });
     }
 
     // Categorized feeds - one section per folder
@@ -588,7 +639,7 @@
               filteredItems.slice(0, sectionIndex).reduce((acc, s) => acc + s.items.length, 0) +
               itemIndex}
             {#if item.type === 'filteredView' && renamingViewUuid === item.id}
-              <div class="nav-item rename-row" class:section-child={!!section}>
+              <div class="nav-item rename-row" class:section-child={item.indent || !!section}>
                 <span class="item-icon"><Icon name={item.icon} size={16} /></span>
                 <!-- svelte-ignore a11y_autofocus -->
                 <input
@@ -611,7 +662,7 @@
             {:else}
               <button
                 class="nav-item"
-                class:section-child={!!section}
+                class:section-child={item.indent || !!section}
                 class:active={isItemActive(item)}
                 class:highlighted={flatIndex === highlightedIndex}
                 role="option"
@@ -739,7 +790,7 @@
               filteredItems.slice(0, sectionIndex).reduce((acc, s) => acc + s.items.length, 0) +
               itemIndex}
             {#if item.type === 'filteredView' && renamingViewUuid === item.id}
-              <div class="nav-item rename-row" class:section-child={!!section}>
+              <div class="nav-item rename-row" class:section-child={item.indent || !!section}>
                 <span class="item-icon"><Icon name={item.icon} size={16} /></span>
                 <!-- svelte-ignore a11y_autofocus -->
                 <input
@@ -762,7 +813,7 @@
             {:else}
               <button
                 class="nav-item"
-                class:section-child={!!section}
+                class:section-child={item.indent || !!section}
                 class:active={isItemActive(item)}
                 class:highlighted={flatIndex === highlightedIndex}
                 role="option"

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -37,23 +37,23 @@
   let mobilePanelEl = $state<HTMLDivElement | null>(null);
   let isMobile = $state(false);
 
-  // View context menu state
-  let viewMenuId = $state<number | null>(null);
+  // View context menu state (uses uuid for identification)
+  let viewMenuUuid = $state<string | null>(null);
   let viewMenuX = $state(0);
   let viewMenuY = $state(0);
   let viewMenuRef = $state<HTMLDivElement | null>(null);
   let adjustedMenuX = $state(0);
   let adjustedMenuY = $state(0);
-  let renamingViewId = $state<number | null>(null);
+  let renamingViewUuid = $state<string | null>(null);
   let renameValue = $state('');
   let renameInputRef = $state<HTMLInputElement | null>(null);
 
-  function openViewMenu(e: MouseEvent, viewId: number) {
+  function openViewMenu(e: MouseEvent, viewUuid: string) {
     e.stopPropagation();
     e.preventDefault();
     viewMenuX = e.clientX;
     viewMenuY = e.clientY;
-    viewMenuId = viewId;
+    viewMenuUuid = viewUuid;
   }
 
   $effect(() => {
@@ -79,14 +79,14 @@
   });
 
   function closeViewMenu() {
-    viewMenuId = null;
+    viewMenuUuid = null;
   }
 
-  function startRenameView(viewId: number) {
-    const view = filteredViewsStore.getById(viewId);
+  function startRenameView(viewUuid: string) {
+    const view = filteredViewsStore.getByUuid(viewUuid);
     if (!view) return;
     closeViewMenu();
-    renamingViewId = viewId;
+    renamingViewUuid = viewUuid;
     renameValue = view.name;
     tick().then(() => {
       renameInputRef?.focus();
@@ -96,28 +96,30 @@
 
   function commitRenameView() {
     const trimmed = renameValue.trim();
-    if (renamingViewId !== null && trimmed) {
-      const view = filteredViewsStore.getById(renamingViewId);
-      if (view && trimmed !== view.name) {
-        filteredViewsStore.update(renamingViewId, { name: trimmed });
+    if (renamingViewUuid !== null && trimmed) {
+      const view = filteredViewsStore.getByUuid(renamingViewUuid);
+      if (view && view.id != null && trimmed !== view.name) {
+        filteredViewsStore.update(view.id, { name: trimmed });
       }
     }
-    renamingViewId = null;
+    renamingViewUuid = null;
     renameValue = '';
   }
 
   function cancelRenameView() {
-    renamingViewId = null;
+    renamingViewUuid = null;
     renameValue = '';
   }
 
-  async function deleteView(viewId: number) {
+  async function deleteView(viewUuid: string) {
     closeViewMenu();
     if (!confirm('Are you sure you want to delete this channel?')) return;
-    await filteredViewsStore.remove(viewId);
+    const view = filteredViewsStore.getByUuid(viewUuid);
+    if (!view || view.id == null) return;
+    await filteredViewsStore.remove(view.id);
     // If we're currently viewing the deleted view, navigate away
     const currentView = $page.url.searchParams.get('view');
-    if (currentView && parseInt(currentView) === viewId) {
+    if (currentView === viewUuid) {
       goto('/');
     }
   }
@@ -159,7 +161,7 @@
     | { type: 'feed'; id: number; label: string; count: number; iconUrl: string | null }
     | { type: 'utility'; id: string; label: string; count?: number; icon: IconName }
     | { type: 'action'; id: string; label: string; icon: IconName }
-    | { type: 'filteredView'; id: number; label: string; icon: IconName };
+    | { type: 'filteredView'; id: string; label: string; icon: IconName };
 
   // Section type with optional icon and click handler for styled section headers
   type SectionData = {
@@ -184,7 +186,7 @@
 
     const customViews: NavItem[] = filteredViewsStore.views.map((v) => ({
       type: 'filteredView' as const,
-      id: v.id!,
+      id: v.uuid,
       label: v.name,
       icon: 'filter' as const,
     }));
@@ -295,7 +297,7 @@
     const saved = url.searchParams.get('saved');
     const shared = url.searchParams.get('shared');
     const view = url.searchParams.get('view');
-    if (view) return { type: 'filteredView', id: parseInt(view) };
+    if (view) return { type: 'filteredView', id: view };
     if (feed) return { type: 'feed', id: parseInt(feed) };
     if (saved) return { type: 'saved' };
     if (shared) return { type: 'shared' };
@@ -555,7 +557,7 @@
             {@const flatIndex =
               filteredItems.slice(0, sectionIndex).reduce((acc, s) => acc + s.items.length, 0) +
               itemIndex}
-            {#if item.type === 'filteredView' && renamingViewId === item.id}
+            {#if item.type === 'filteredView' && renamingViewUuid === item.id}
               <div class="nav-item rename-row" class:section-child={!!section}>
                 <span class="item-icon"><Icon name={item.icon} size={16} /></span>
                 <!-- svelte-ignore a11y_autofocus -->
@@ -630,7 +632,7 @@
   {/if}
 </div>
 
-{#if viewMenuId !== null}
+{#if viewMenuUuid !== null}
   <!-- View context menu (portaled to body to escape backdrop-filter containing block) -->
   <div class="view-menu-portal" use:portal>
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -641,11 +643,11 @@
       style="left: {adjustedMenuX}px; top: {adjustedMenuY}px;"
       role="menu"
     >
-      <button class="view-menu-item" onclick={() => startRenameView(viewMenuId!)} role="menuitem">
+      <button class="view-menu-item" onclick={() => startRenameView(viewMenuUuid!)} role="menuitem">
         <span class="view-menu-icon"><Icon name="edit" size={16} /></span>
         Rename
       </button>
-      <button class="view-menu-item danger" onclick={() => deleteView(viewMenuId!)} role="menuitem">
+      <button class="view-menu-item danger" onclick={() => deleteView(viewMenuUuid!)} role="menuitem">
         <span class="view-menu-icon"><Icon name="trash" size={16} /></span>
         Delete
       </button>
@@ -702,7 +704,7 @@
             {@const flatIndex =
               filteredItems.slice(0, sectionIndex).reduce((acc, s) => acc + s.items.length, 0) +
               itemIndex}
-            {#if item.type === 'filteredView' && renamingViewId === item.id}
+            {#if item.type === 'filteredView' && renamingViewUuid === item.id}
               <div class="nav-item rename-row" class:section-child={!!section}>
                 <span class="item-icon"><Icon name={item.icon} size={16} /></span>
                 <!-- svelte-ignore a11y_autofocus -->

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -153,7 +153,8 @@
     | 'newspaper'
     | 'plus'
     | 'filter'
-    | 'layers';
+    | 'layers'
+    | 'folder';
 
   // Navigation item type
   type NavItem =
@@ -198,19 +199,34 @@
       icon: 'plus',
     };
 
-    const feedItems: NavItem[] = subscriptions.map((s) => ({
-      type: 'feed' as const,
-      id: s.id!,
-      label: s.customTitle || s.title,
-      count: feedUnreadCounts.get(s.id!) || 0,
-      iconUrl:
-        s.customIconUrl ||
-        (s.sourceType?.startsWith('atproto.')
-          ? s.siteUrl
-            ? getFaviconUrl(s.siteUrl)
-            : '/icons/icon-192.svg'
-          : getFaviconUrl(s.siteUrl || s.feedUrl || '')),
-    }));
+    function toFeedItem(s: (typeof subscriptions)[0]): NavItem & { type: 'feed' } {
+      return {
+        type: 'feed' as const,
+        id: s.id!,
+        label: s.customTitle || s.title,
+        count: feedUnreadCounts.get(s.id!) || 0,
+        iconUrl:
+          s.customIconUrl ||
+          (s.sourceType?.startsWith('atproto.')
+            ? s.siteUrl
+              ? getFaviconUrl(s.siteUrl)
+              : '/icons/icon-192.svg'
+            : getFaviconUrl(s.siteUrl || s.feedUrl || '')),
+      };
+    }
+
+    // Group subscriptions by category
+    const byCategory = new Map<string, typeof subscriptions>();
+    const uncategorized: typeof subscriptions = [];
+    for (const s of subscriptions) {
+      if (s.category) {
+        const existing = byCategory.get(s.category) || [];
+        existing.push(s);
+        byCategory.set(s.category, existing);
+      } else {
+        uncategorized.push(s);
+      }
+    }
 
     // Filter by search query
     const filterItem = (item: NavItem) => {
@@ -231,16 +247,30 @@
       sections.push({ section: '', items: allViews });
     }
 
-    const filteredFeeds = feedItems.filter(filterItem);
-    if (filteredFeeds.length > 0 || filterSection('Feeds')) {
+    // Categorized feeds - one section per folder
+    const sortedCategories = [...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b));
+    for (const [category, subs] of sortedCategories) {
+      const items = subs.map(toFeedItem).filter(filterItem);
+      if (items.length > 0 || filterSection(category)) {
+        sections.push({
+          section: category,
+          icon: 'folder' as IconName,
+          items,
+        });
+      }
+    }
+
+    // Uncategorized feeds
+    const uncategorizedItems = uncategorized.map(toFeedItem).filter(filterItem);
+    if (uncategorizedItems.length > 0 || filterSection('Feeds')) {
       sections.push({
-        section: 'Feeds',
+        section: sortedCategories.length > 0 ? 'Uncategorized' : 'Feeds',
         icon: 'rss',
         onSectionClick: () => {
           sidebarStore.toggleSection('feeds');
           close();
         },
-        items: filteredFeeds,
+        items: uncategorizedItems,
       });
     }
 
@@ -647,7 +677,11 @@
         <span class="view-menu-icon"><Icon name="edit" size={16} /></span>
         Rename
       </button>
-      <button class="view-menu-item danger" onclick={() => deleteView(viewMenuUuid!)} role="menuitem">
+      <button
+        class="view-menu-item danger"
+        onclick={() => deleteView(viewMenuUuid!)}
+        role="menuitem"
+      >
         <span class="view-menu-icon"><Icon name="trash" size={16} /></span>
         Delete
       </button>

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -12,6 +12,8 @@
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { channelSuggestions } from '$lib/stores/channelSuggestions.svelte';
+  import { savedChannelSuggestions } from '$lib/stores/savedChannelSuggestions.svelte';
+  import type { SavedChannelSuggestion } from '$lib/stores/savedChannelSuggestions.svelte';
   import { syncAutoRuleChannels } from '$lib/stores/channelAutoUpdate.svelte';
   import { onMount, onDestroy } from 'svelte';
   import AddFeedModal from './AddFeedModal.svelte';
@@ -162,6 +164,20 @@
     selectFilter('view', id);
   }
 
+  async function acceptSavedSuggestion(suggestion: SavedChannelSuggestion) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      mode: 'saved',
+      savedSourceFilter: suggestion.savedSourceFilter,
+      savedDomainFilter: suggestion.savedDomainFilter,
+      savedReadingLength: suggestion.savedReadingLength,
+      savedDateFilter: suggestion.savedDateFilter,
+      readFilter: suggestion.readFilter ?? 'all',
+      sortOrder: suggestion.sortOrder ?? 'newest',
+    });
+    selectFilter('view', id);
+  }
+
   function selectFilter(type: string, id?: string | number) {
     const params = new URLSearchParams();
     if (type === 'view' && id) params.set('view', String(id));
@@ -262,7 +278,7 @@
           onRenameCancel={() => (renamingViewId = null)}
         />
       {:else}
-        {#if channelSuggestions.suggestions.length === 0}
+        {#if channelSuggestions.suggestions.length === 0 && savedChannelSuggestions.suggestions.length === 0}
           <div class="empty-section">No channels yet</div>
         {/if}
       {/each}
@@ -285,7 +301,26 @@
           </button>
         </div>
       {/each}
-      {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0}
+      {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+        <div class="suggestion-item">
+          <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
+            <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+            <span class="suggestion-name">{suggestion.name}</span>
+          </button>
+          <Tooltip text={suggestion.description} />
+          <button
+            class="suggestion-dismiss"
+            onclick={(e) => {
+              e.stopPropagation();
+              savedChannelSuggestions.dismiss(suggestion.id);
+            }}
+            title="Dismiss"
+          >
+            <Icon name="x" size={12} />
+          </button>
+        </div>
+      {/each}
+      {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.hasMore || savedChannelSuggestions.suggestions.length > 0}
         <a
           href="/channels/discover"
           class="more-suggestions-link"

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -24,8 +24,11 @@
   import NavSection from './sidebar/NavSection.svelte';
   import ViewItem from './sidebar/ViewItem.svelte';
   import ContextMenu from './sidebar/ContextMenu.svelte';
+  import FeedItem from './sidebar/FeedItem.svelte';
   import Icon from './Icon.svelte';
   import Tooltip from './Tooltip.svelte';
+  import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
+  import { fetchSingleFeed } from '$lib/services/feedFetcher';
 
   function handleClickOutside(e: MouseEvent) {
     if (viewContextMenu) {
@@ -376,6 +379,51 @@
       <span class="nav-icon"><Icon name="settings" /></span>
       <span class="nav-label">Settings</span>
     </a>
+
+    <!-- Sources section -->
+    <div class="sources-separator"></div>
+    <NavSection
+      title="Sources"
+      icon="rss"
+      isExpanded={sidebarStore.expandedSections.feeds}
+      showOnlyUnread={sidebarStore.showOnlyUnread.feeds}
+      isActive={false}
+      onToggle={() => sidebarStore.toggleSection('feeds')}
+      onLabelClick={() => sidebarStore.toggleSection('feeds')}
+      onUnreadToggle={() => sidebarStore.toggleShowOnlyUnread('feeds')}
+    >
+      {#each subscriptionsStore.subscriptions as sub (sub.rkey)}
+        {@const feedUrl = sub.feedUrl ?? ''}
+        {@const status = feedStatusStore.getStatus(feedUrl)}
+        {@const loadingState = !feedUrl
+          ? 'ready'
+          : status?.status === 'error' || status?.status === 'circuit-open'
+            ? 'error'
+            : status?.status === 'pending'
+              ? 'loading'
+              : 'ready'}
+        {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+        {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
+          <FeedItem
+            subscription={sub}
+            unreadCount={subUnread}
+            isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
+            {loadingState}
+            errorMessage={status?.errorMessage ?? ''}
+            errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
+            onSelect={() => sub.id && selectFilter('feed', sub.id)}
+            onContextMenu={() => {}}
+            onTouchStart={() => {}}
+            onTouchEnd={() => {}}
+            onTouchMove={() => {}}
+            onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+            onMoreClick={() => {}}
+          />
+        {/if}
+      {:else}
+        <div class="empty-section">No sources yet</div>
+      {/each}
+    </NavSection>
   </nav>
 </aside>
 
@@ -564,6 +612,12 @@
 
   .nav-item.active .nav-count {
     color: var(--color-primary);
+  }
+
+  .sources-separator {
+    height: 1px;
+    background: var(--color-border);
+    margin: 0.75rem 0.75rem;
   }
 
   .empty-section {

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -17,6 +17,8 @@
   import { syncAutoRuleChannels } from '$lib/stores/channelAutoUpdate.svelte';
   import { onMount, onDestroy } from 'svelte';
   import AddFeedModal from './AddFeedModal.svelte';
+  import EditFeedModal from './EditFeedModal.svelte';
+  import type { Subscription } from '$lib/types';
   import AddHandleModal from './AddHandleModal.svelte';
   import SaveArticleModal from './SaveArticleModal.svelte';
   import FilteredViewModal from './FilteredViewModal.svelte';
@@ -30,15 +32,43 @@
   import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
   import { fetchSingleFeed } from '$lib/services/feedFetcher';
 
+  function handleFeedContextMenu(e: MouseEvent, feedId: number) {
+    e.preventDefault();
+    feedContextMenu = { x: e.clientX, y: e.clientY, feedId };
+  }
+
+  function closeFeedContextMenu() {
+    feedContextMenu = null;
+  }
+
+  function handleEditFeed(feedId: number) {
+    const sub = subscriptionsStore.subscriptions.find((s) => s.id === feedId);
+    if (sub) editingSubscription = sub;
+  }
+
+  async function handleUnsubscribeFeed(feedId: number) {
+    if (confirm('Are you sure you want to unsubscribe from this feed?')) {
+      await subscriptionsStore.remove(feedId);
+      // If we're currently viewing this feed, navigate away
+      if (currentFilter().type === 'feed' && currentFilter().id === feedId) {
+        selectFilter('all');
+      }
+    }
+  }
+
   function handleClickOutside(e: MouseEvent) {
     if (viewContextMenu) {
       closeViewContextMenu();
     }
+    if (feedContextMenu) {
+      closeFeedContextMenu();
+    }
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (viewContextMenu && e.key === 'Escape') {
-      closeViewContextMenu();
+    if (e.key === 'Escape') {
+      if (viewContextMenu) closeViewContextMenu();
+      if (feedContextMenu) closeFeedContextMenu();
     }
   }
 
@@ -99,6 +129,10 @@
 
   // View context menu state
   let viewContextMenu = $state<{ x: number; y: number; viewId: number } | null>(null);
+
+  // Feed context menu state
+  let feedContextMenu = $state<{ x: number; y: number; feedId: number } | null>(null);
+  let editingSubscription = $state<Subscription | null>(null);
   let viewLongPressTimer: ReturnType<typeof setTimeout> | null = null;
   let viewLongPressTriggered = $state(false);
   let renamingViewId = $state<number | null>(null);
@@ -477,12 +511,12 @@
                       errorMessage={status?.errorMessage ?? ''}
                       errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
                       onSelect={() => sub.id && selectFilter('feed', sub.id)}
-                      onContextMenu={() => {}}
+                      onContextMenu={(e) => sub.id && handleFeedContextMenu(e, sub.id)}
                       onTouchStart={() => {}}
                       onTouchEnd={() => {}}
                       onTouchMove={() => {}}
                       onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-                      onMoreClick={() => {}}
+                      onMoreClick={(e) => sub.id && handleFeedContextMenu(e, sub.id)}
                     />
                   {/if}
                 {/each}
@@ -510,12 +544,12 @@
               errorMessage={status?.errorMessage ?? ''}
               errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
               onSelect={() => sub.id && selectFilter('feed', sub.id)}
-              onContextMenu={() => {}}
+              onContextMenu={(e) => sub.id && handleFeedContextMenu(e, sub.id)}
               onTouchStart={() => {}}
               onTouchEnd={() => {}}
               onTouchMove={() => {}}
               onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-              onMoreClick={() => {}}
+              onMoreClick={(e) => sub.id && handleFeedContextMenu(e, sub.id)}
             />
           {/if}
         {/each}
@@ -562,6 +596,23 @@
     onClose={closeViewContextMenu}
   />
 {/if}
+
+{#if feedContextMenu}
+  <ContextMenu
+    x={feedContextMenu.x}
+    y={feedContextMenu.y}
+    onEdit={() => handleEditFeed(feedContextMenu!.feedId)}
+    onDelete={() => handleUnsubscribeFeed(feedContextMenu!.feedId)}
+    onClose={closeFeedContextMenu}
+    deleteLabel="Unsubscribe"
+  />
+{/if}
+
+<EditFeedModal
+  open={editingSubscription !== null}
+  subscription={editingSubscription}
+  onclose={() => (editingSubscription = null)}
+/>
 
 <style>
   .sidebar-backdrop {

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -141,8 +141,11 @@
   let channelModalOpen = $derived(sidebarStore.channelModalOpen);
   let editingChannelId = $derived(sidebarStore.editingChannelId);
 
-  function openChannelModal(viewId: number | null = null) {
-    sidebarStore.openChannelModal(viewId);
+  function openChannelModal(
+    viewId: number | null = null,
+    initialType: 'feed' | 'saved' | null = null
+  ) {
+    sidebarStore.openChannelModal(viewId, initialType);
   }
 
   function handleViewContextMenu(e: MouseEvent, viewId: number) {
@@ -262,6 +265,10 @@
 
   let uncategorizedSources = $derived(subscriptionsStore.subscriptions.filter((s) => !s.category));
 
+  // Split channels: source channels live under Everything, saved channels under Saved
+  let sourceChannels = $derived(filteredViewsStore.views.filter((v) => v.mode !== 'saved'));
+  let savedChannels = $derived(filteredViewsStore.views.filter((v) => v.mode === 'saved'));
+
   function handleBackdropClick() {
     sidebarStore.closeMobile();
   }
@@ -292,115 +299,189 @@
 
   <!-- Navigation items -->
   <nav class="sidebar-nav">
-    <button
-      class="nav-item"
-      class:active={currentFilter().type === 'all'}
-      onclick={() => selectFilter('all')}
-    >
-      <span class="nav-icon"><Icon name="inbox" /></span>
-      <span class="nav-label">Everything</span>
-      {#if totalUnread > 0}
-        <span class="nav-count">{totalUnread}</span>
-      {/if}
-    </button>
-
-    <button
-      class="nav-item"
-      class:active={currentFilter().type === 'saved'}
-      onclick={() => selectFilter('saved')}
-    >
-      <span class="nav-icon"><Icon name="bookmark" /></span>
-      <span class="nav-label">Saved</span>
-      {#if itemLabelsStore.inboxCount > 0}
-        <span class="nav-count">{itemLabelsStore.inboxCount}</span>
-      {/if}
-    </button>
-
-    <!-- Channels section (formerly Views) -->
-    <NavSection
-      title="Channels"
-      icon="layers"
-      isExpanded={sidebarStore.expandedSections.channels}
-      showOnlyUnread={false}
-      isActive={false}
-      onToggle={() => sidebarStore.toggleSection('channels')}
-      onLabelClick={() => sidebarStore.toggleSection('channels')}
-      onAdd={() => openChannelModal()}
-    >
-      {#each filteredViewsStore.views as view (view.uuid)}
-        <ViewItem
-          {view}
-          isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
-          isRenaming={renamingViewId === view.id}
-          unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-          onSelect={() => selectFilter('view', view.uuid)}
-          onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-          onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-          onTouchEnd={handleViewTouchEnd}
-          onTouchMove={handleViewTouchMove}
-          onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-          onRename={async (name) => {
-            if (view.id != null) {
-              await filteredViewsStore.update(view.id, { name });
-            }
-            renamingViewId = null;
+    <!-- Everything: top-level filter + nested source channels -->
+    <div class="nav-group" class:expanded={sidebarStore.expandedSections.everything}>
+      <div class="nav-row" class:active={currentFilter().type === 'all'}>
+        <button class="nav-row-main" onclick={() => selectFilter('all')}>
+          <span class="nav-icon"><Icon name="inbox" /></span>
+          <span class="nav-label">Everything</span>
+        </button>
+        <button
+          class="row-add-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            openChannelModal(null, 'feed');
           }}
-          onRenameCancel={() => (renamingViewId = null)}
-        />
-      {:else}
-        {#if channelSuggestions.suggestions.length === 0 && savedChannelSuggestions.suggestions.length === 0}
-          <div class="empty-section">No channels yet</div>
-        {/if}
-      {/each}
-      {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
-        <div class="suggestion-item">
-          <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
-            <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-            <span class="suggestion-name">{suggestion.name}</span>
-          </button>
-          <Tooltip text={suggestion.description} />
-          <button
-            class="suggestion-dismiss"
-            onclick={(e) => {
-              e.stopPropagation();
-              channelSuggestions.dismiss(suggestion.id);
-            }}
-            title="Dismiss"
-          >
-            <Icon name="x" size={12} />
-          </button>
-        </div>
-      {/each}
-      {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
-        <div class="suggestion-item">
-          <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
-            <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-            <span class="suggestion-name">{suggestion.name}</span>
-          </button>
-          <Tooltip text={suggestion.description} />
-          <button
-            class="suggestion-dismiss"
-            onclick={(e) => {
-              e.stopPropagation();
-              savedChannelSuggestions.dismiss(suggestion.id);
-            }}
-            title="Dismiss"
-          >
-            <Icon name="x" size={12} />
-          </button>
-        </div>
-      {/each}
-      {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.hasMore || savedChannelSuggestions.suggestions.length > 0}
-        <a
-          href="/channels/discover"
-          class="more-suggestions-link"
-          onclick={() => sidebarStore.closeMobile()}
+          title="New channel"
         >
-          More channel ideas
-          <Icon name="arrow-right" size={12} />
-        </a>
+          <Icon name="plus" size={14} strokeWidth={2} />
+        </button>
+        {#if totalUnread > 0}
+          <span class="nav-count">{totalUnread}</span>
+        {/if}
+        <button
+          class="row-disclosure-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            sidebarStore.toggleSection('everything');
+          }}
+          aria-label="Toggle channels"
+        >
+          <Icon
+            name={sidebarStore.expandedSections.everything ? 'chevron-down' : 'chevron-right'}
+            size={14}
+            strokeWidth={2.5}
+          />
+        </button>
+      </div>
+      {#if sidebarStore.expandedSections.everything}
+        <div class="nav-children">
+          {#each sourceChannels as view (view.uuid)}
+            <ViewItem
+              {view}
+              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+              isRenaming={renamingViewId === view.id}
+              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+              onSelect={() => selectFilter('view', view.uuid)}
+              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+              onTouchEnd={handleViewTouchEnd}
+              onTouchMove={handleViewTouchMove}
+              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onRename={async (name) => {
+                if (view.id != null) {
+                  await filteredViewsStore.update(view.id, { name });
+                }
+                renamingViewId = null;
+              }}
+              onRenameCancel={() => (renamingViewId = null)}
+            />
+          {/each}
+          {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+            <div class="suggestion-item">
+              <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                <span class="suggestion-name">{suggestion.name}</span>
+              </button>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  channelSuggestions.dismiss(suggestion.id);
+                }}
+                title="Dismiss"
+              >
+                <Icon name="x" size={12} />
+              </button>
+            </div>
+          {/each}
+          {#if sourceChannels.length === 0 && channelSuggestions.suggestions.length === 0}
+            <div class="empty-section">No channels yet</div>
+          {/if}
+          <a
+            href="/channels/discover"
+            class="more-suggestions-link"
+            onclick={() => sidebarStore.closeMobile()}
+          >
+            More channel ideas
+            <Icon name="arrow-right" size={12} />
+          </a>
+        </div>
       {/if}
-    </NavSection>
+    </div>
+
+    <!-- Saved: top-level filter + nested saved channels -->
+    <div class="nav-group" class:expanded={sidebarStore.expandedSections.saved}>
+      <div class="nav-row" class:active={currentFilter().type === 'saved'}>
+        <button class="nav-row-main" onclick={() => selectFilter('saved')}>
+          <span class="nav-icon"><Icon name="bookmark" /></span>
+          <span class="nav-label">Saved</span>
+        </button>
+        <button
+          class="row-add-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            openChannelModal(null, 'saved');
+          }}
+          title="New saved channel"
+        >
+          <Icon name="plus" size={14} strokeWidth={2} />
+        </button>
+        {#if itemLabelsStore.inboxCount > 0}
+          <span class="nav-count">{itemLabelsStore.inboxCount}</span>
+        {/if}
+        <button
+          class="row-disclosure-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            sidebarStore.toggleSection('saved');
+          }}
+          aria-label="Toggle saved channels"
+        >
+          <Icon
+            name={sidebarStore.expandedSections.saved ? 'chevron-down' : 'chevron-right'}
+            size={14}
+            strokeWidth={2.5}
+          />
+        </button>
+      </div>
+      {#if sidebarStore.expandedSections.saved}
+        <div class="nav-children">
+          {#each savedChannels as view (view.uuid)}
+            <ViewItem
+              {view}
+              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+              isRenaming={renamingViewId === view.id}
+              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+              onSelect={() => selectFilter('view', view.uuid)}
+              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+              onTouchEnd={handleViewTouchEnd}
+              onTouchMove={handleViewTouchMove}
+              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onRename={async (name) => {
+                if (view.id != null) {
+                  await filteredViewsStore.update(view.id, { name });
+                }
+                renamingViewId = null;
+              }}
+              onRenameCancel={() => (renamingViewId = null)}
+            />
+          {/each}
+          {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+            <div class="suggestion-item">
+              <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
+                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                <span class="suggestion-name">{suggestion.name}</span>
+              </button>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  savedChannelSuggestions.dismiss(suggestion.id);
+                }}
+                title="Dismiss"
+              >
+                <Icon name="x" size={12} />
+              </button>
+            </div>
+          {/each}
+          {#if savedChannels.length === 0 && savedChannelSuggestions.suggestions.length === 0}
+            <div class="empty-section">No saved channels yet</div>
+          {/if}
+          <a
+            href="/channels/discover"
+            class="more-suggestions-link"
+            onclick={() => sidebarStore.closeMobile()}
+          >
+            More channel ideas
+            <Icon name="arrow-right" size={12} />
+          </a>
+        </div>
+      {/if}
+    </div>
 
     <button
       class="nav-item"
@@ -580,6 +661,7 @@
 <FilteredViewModal
   open={channelModalOpen}
   editingViewId={editingChannelId}
+  initialChannelType={sidebarStore.initialChannelType}
   onclose={() => sidebarStore.closeChannelModal()}
   oncreated={(id) => selectFilter('view', id)}
   ondeleted={() => selectFilter('all')}
@@ -723,6 +805,104 @@
     font: inherit;
     color: var(--color-text);
     transition: background-color 0.15s;
+  }
+
+  .nav-group {
+    border-radius: 12px;
+    transition: background-color 0.15s;
+  }
+
+  .nav-group + .nav-group {
+    margin-top: 0.5rem;
+  }
+
+  .nav-group.expanded {
+    background-color: rgba(0, 0, 0, 0.025);
+    padding-bottom: 0.25rem;
+  }
+
+  .nav-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    color: var(--color-text);
+    transition: background-color 0.15s;
+  }
+
+  .nav-row:hover {
+    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  }
+
+  .nav-row.active {
+    background-color: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
+    color: var(--color-primary);
+  }
+
+  .nav-row-main {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    padding: 0;
+  }
+
+  .nav-row.active .nav-count {
+    color: var(--color-primary);
+  }
+
+  .row-add-btn,
+  .row-disclosure-btn {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+  }
+
+  .row-add-btn {
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .nav-row:hover .row-add-btn {
+    opacity: 0.6;
+  }
+
+  .row-add-btn:hover {
+    opacity: 1 !important;
+    color: var(--color-primary);
+  }
+
+  .row-disclosure-btn:hover {
+    color: var(--color-text);
+  }
+
+  .nav-row.active .row-disclosure-btn {
+    color: var(--color-primary);
+  }
+
+  .nav-children {
+    margin-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
   }
 
   .nav-item:hover {
@@ -965,6 +1145,14 @@
   @media (prefers-color-scheme: dark) {
     .nav-item:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
+    }
+
+    .nav-row:hover {
+      background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
+    }
+
+    .nav-group.expanded {
+      background-color: rgba(255, 255, 255, 0.025);
     }
   }
 </style>

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -88,8 +88,10 @@
     const feed = $page.url.searchParams.get('feed');
     const starred = $page.url.searchParams.get('saved');
     const shared = $page.url.searchParams.get('shared');
+    const category = $page.url.searchParams.get('category');
     if (view) return { type: 'view' as const, id: view };
     if (feed) return { type: 'feed' as const, id: parseInt(feed) };
+    if (category) return { type: 'category' as const, name: category };
     if (starred) return { type: 'saved' as const };
     if (shared) return { type: 'shared' as const };
     return { type: 'all' as const };
@@ -185,6 +187,7 @@
     const params = new URLSearchParams();
     if (type === 'view' && id) params.set('view', String(id));
     else if (type === 'feed' && id) params.set('feed', String(id));
+    else if (type === 'category' && id) params.set('category', String(id));
     else if (type === 'saved') params.set('saved', 'true');
     else if (type === 'shared') params.set('shared', 'true');
 
@@ -194,6 +197,36 @@
     // Close mobile sidebar after navigation
     sidebarStore.closeMobile();
   }
+
+  // Group subscriptions by category for the Sources section
+  interface CategoryGroup {
+    name: string;
+    subscriptions: typeof subscriptionsStore.subscriptions;
+    unreadCount: number;
+  }
+
+  let sourceCategories = $derived.by((): CategoryGroup[] => {
+    const byCategory = new Map<string, typeof subscriptionsStore.subscriptions>();
+    for (const sub of subscriptionsStore.subscriptions) {
+      if (sub.category) {
+        const existing = byCategory.get(sub.category) || [];
+        existing.push(sub);
+        byCategory.set(sub.category, existing);
+      }
+    }
+    return [...byCategory.entries()]
+      .map(([name, subs]) => ({
+        name,
+        subscriptions: subs,
+        unreadCount: subs.reduce(
+          (sum, s) => sum + (s.id ? (unreadCounts.feedCounts.get(s.id) ?? 0) : 0),
+          0
+        ),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  let uncategorizedSources = $derived(subscriptionsStore.subscriptions.filter((s) => !s.category));
 
   function handleBackdropClick() {
     sidebarStore.closeMobile();
@@ -392,37 +425,103 @@
       onLabelClick={() => sidebarStore.toggleSection('feeds')}
       onUnreadToggle={() => sidebarStore.toggleShowOnlyUnread('feeds')}
     >
-      {#each subscriptionsStore.subscriptions as sub (sub.rkey)}
-        {@const feedUrl = sub.feedUrl ?? ''}
-        {@const status = feedStatusStore.getStatus(feedUrl)}
-        {@const loadingState = !feedUrl
-          ? 'ready'
-          : status?.status === 'error' || status?.status === 'circuit-open'
-            ? 'error'
-            : status?.status === 'pending'
-              ? 'loading'
-              : 'ready'}
-        {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
-        {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
-          <FeedItem
-            subscription={sub}
-            unreadCount={subUnread}
-            isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
-            {loadingState}
-            errorMessage={status?.errorMessage ?? ''}
-            errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
-            onSelect={() => sub.id && selectFilter('feed', sub.id)}
-            onContextMenu={() => {}}
-            onTouchStart={() => {}}
-            onTouchEnd={() => {}}
-            onTouchMove={() => {}}
-            onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-            onMoreClick={() => {}}
-          />
-        {/if}
+      {#if sourceCategories.length > 0 || uncategorizedSources.length > 0}
+        {#each sourceCategories as cat (cat.name)}
+          <div class="category-group">
+            <div class="category-header">
+              <button
+                class="category-expand-btn"
+                onclick={() => sidebarStore.toggleCategory(cat.name)}
+                aria-label={sidebarStore.isCategoryExpanded(cat.name) ? 'Collapse' : 'Expand'}
+              >
+                <Icon
+                  name={sidebarStore.isCategoryExpanded(cat.name)
+                    ? 'chevron-down'
+                    : 'chevron-right'}
+                  size={12}
+                  strokeWidth={2.5}
+                />
+              </button>
+              <button
+                class="category-name-btn"
+                class:active={currentFilter().type === 'category' &&
+                  currentFilter().name === cat.name}
+                onclick={() => selectFilter('category', cat.name)}
+              >
+                <Icon name="folder" size={14} />
+                <span class="category-label">{cat.name}</span>
+              </button>
+              {#if cat.unreadCount > 0}
+                <span class="category-count">{cat.unreadCount}</span>
+              {/if}
+            </div>
+            {#if sidebarStore.isCategoryExpanded(cat.name)}
+              <div class="category-items">
+                {#each cat.subscriptions as sub (sub.rkey)}
+                  {@const feedUrl = sub.feedUrl ?? ''}
+                  {@const status = feedStatusStore.getStatus(feedUrl)}
+                  {@const loadingState = !feedUrl
+                    ? 'ready'
+                    : status?.status === 'error' || status?.status === 'circuit-open'
+                      ? 'error'
+                      : status?.status === 'pending'
+                        ? 'loading'
+                        : 'ready'}
+                  {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+                  {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
+                    <FeedItem
+                      subscription={sub}
+                      unreadCount={subUnread}
+                      isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
+                      {loadingState}
+                      errorMessage={status?.errorMessage ?? ''}
+                      errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
+                      onSelect={() => sub.id && selectFilter('feed', sub.id)}
+                      onContextMenu={() => {}}
+                      onTouchStart={() => {}}
+                      onTouchEnd={() => {}}
+                      onTouchMove={() => {}}
+                      onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+                      onMoreClick={() => {}}
+                    />
+                  {/if}
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/each}
+        {#each uncategorizedSources as sub (sub.rkey)}
+          {@const feedUrl = sub.feedUrl ?? ''}
+          {@const status = feedStatusStore.getStatus(feedUrl)}
+          {@const loadingState = !feedUrl
+            ? 'ready'
+            : status?.status === 'error' || status?.status === 'circuit-open'
+              ? 'error'
+              : status?.status === 'pending'
+                ? 'loading'
+                : 'ready'}
+          {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+          {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
+            <FeedItem
+              subscription={sub}
+              unreadCount={subUnread}
+              isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
+              {loadingState}
+              errorMessage={status?.errorMessage ?? ''}
+              errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
+              onSelect={() => sub.id && selectFilter('feed', sub.id)}
+              onContextMenu={() => {}}
+              onTouchStart={() => {}}
+              onTouchEnd={() => {}}
+              onTouchMove={() => {}}
+              onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+              onMoreClick={() => {}}
+            />
+          {/if}
+        {/each}
       {:else}
         <div class="empty-section">No sources yet</div>
-      {/each}
+      {/if}
     </NavSection>
   </nav>
 </aside>
@@ -714,6 +813,77 @@
   .suggestion-dismiss:hover {
     opacity: 1 !important;
     color: var(--color-text);
+  }
+
+  .category-group {
+    margin-bottom: 2px;
+  }
+
+  .category-items {
+    padding-left: 1.25rem;
+  }
+
+  .category-header {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 8px;
+  }
+
+  .category-expand-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.125rem;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .category-name-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.125rem 0.25rem;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    transition:
+      color 0.15s,
+      background-color 0.15s;
+  }
+
+  .category-name-btn:hover {
+    color: var(--color-text);
+    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  }
+
+  .category-name-btn.active {
+    color: var(--color-primary);
+    background-color: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
+  }
+
+  .category-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .category-count {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    padding-right: 0.25rem;
   }
 
   .nav-separator {

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -85,7 +85,7 @@
     const feed = $page.url.searchParams.get('feed');
     const starred = $page.url.searchParams.get('saved');
     const shared = $page.url.searchParams.get('shared');
-    if (view) return { type: 'view' as const, id: parseInt(view) };
+    if (view) return { type: 'view' as const, id: view };
     if (feed) return { type: 'feed' as const, id: parseInt(feed) };
     if (starred) return { type: 'saved' as const };
     if (shared) return { type: 'shared' as const };
@@ -257,13 +257,13 @@
       onLabelClick={() => sidebarStore.toggleSection('channels')}
       onAdd={() => openChannelModal()}
     >
-      {#each filteredViewsStore.views as view (view.id)}
+      {#each filteredViewsStore.views as view (view.uuid)}
         <ViewItem
           {view}
-          isActive={currentFilter().type === 'view' && currentFilter().id === view.id}
+          isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
           isRenaming={renamingViewId === view.id}
           unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-          onSelect={() => selectFilter('view', view.id)}
+          onSelect={() => selectFilter('view', view.uuid)}
           onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
           onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
           onTouchEnd={handleViewTouchEnd}

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -5,104 +5,33 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { sharesStore } from '$lib/stores/shares.svelte';
-  import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import { activityStore } from '$lib/stores/activity.svelte';
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
-  import { fetchSingleFeed } from '$lib/services/feedFetcher';
+  import { channelSuggestions } from '$lib/stores/channelSuggestions.svelte';
+  import { syncAutoRuleChannels } from '$lib/stores/channelAutoUpdate.svelte';
   import { onMount, onDestroy } from 'svelte';
   import AddFeedModal from './AddFeedModal.svelte';
   import AddHandleModal from './AddHandleModal.svelte';
   import SaveArticleModal from './SaveArticleModal.svelte';
-  import AddDropdownMenu from './AddDropdownMenu.svelte';
-  import EditFeedModal from './EditFeedModal.svelte';
-  import ContextMenu from './sidebar/ContextMenu.svelte';
+  import FilteredViewModal from './FilteredViewModal.svelte';
+  import AddSourceInput from './AddSourceInput.svelte';
   import NavSection from './sidebar/NavSection.svelte';
-  import FeedItem from './sidebar/FeedItem.svelte';
   import ViewItem from './sidebar/ViewItem.svelte';
-  import SidebarAddFeed from './sidebar/SidebarAddFeed.svelte';
+  import ContextMenu from './sidebar/ContextMenu.svelte';
   import Icon from './Icon.svelte';
-  import type { Subscription } from '$lib/types';
-
-  async function removeFeed(id: number) {
-    if (confirm('Are you sure you want to remove this subscription?')) {
-      await subscriptionsStore.remove(id);
-    }
-  }
-
-  // Context menu state (feeds)
-  let contextMenu = $state<{ x: number; y: number; feedId: number } | null>(null);
-  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-  let longPressTriggered = $state(false);
-
-  // Edit modal state
-  let editingSubscription = $state<Subscription | null>(null);
-  let editModalOpen = $state(false);
-
-  function handleEditFeed(feedId: number) {
-    const sub = subscriptionsStore.getById(feedId);
-    if (sub) {
-      editingSubscription = sub;
-      editModalOpen = true;
-    }
-  }
-
-  function closeEditModal() {
-    editModalOpen = false;
-    editingSubscription = null;
-  }
-
-  function handleContextMenu(e: MouseEvent, feedId: number) {
-    e.preventDefault();
-    contextMenu = { x: e.clientX, y: e.clientY, feedId };
-  }
-
-  function handleTouchStart(e: TouchEvent, feedId: number) {
-    longPressTriggered = false;
-    const touch = e.touches[0];
-    longPressTimer = setTimeout(() => {
-      longPressTriggered = true;
-      contextMenu = { x: touch.clientX, y: touch.clientY, feedId };
-    }, 500);
-  }
-
-  function handleTouchEnd(e: TouchEvent) {
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      longPressTimer = null;
-    }
-    if (longPressTriggered) {
-      e.preventDefault();
-    }
-  }
-
-  function handleTouchMove() {
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      longPressTimer = null;
-    }
-  }
-
-  function closeContextMenu() {
-    contextMenu = null;
-  }
+  import Tooltip from './Tooltip.svelte';
 
   function handleClickOutside(e: MouseEvent) {
-    if (contextMenu) {
-      closeContextMenu();
-    }
     if (viewContextMenu) {
       closeViewContextMenu();
     }
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (contextMenu && e.key === 'Escape') {
-      closeContextMenu();
-    }
     if (viewContextMenu && e.key === 'Escape') {
       closeViewContextMenu();
     }
@@ -121,7 +50,6 @@
   onDestroy(() => {
     document.removeEventListener('click', handleClickOutside);
     document.removeEventListener('keydown', handleKeydown);
-    if (longPressTimer) clearTimeout(longPressTimer);
     if (viewLongPressTimer) clearTimeout(viewLongPressTimer);
     document.body.classList.remove('sidebar-open-mobile');
   });
@@ -136,8 +64,14 @@
     }
   });
 
-  let feedUnreadCounts = $derived(unreadCounts.feedCounts);
-  let totalUnread = $derived(unreadCounts.totalArticles);
+  // Auto-update channels with autoRules when subscriptions change
+  $effect(() => {
+    // Access subscriptions to trigger reactivity
+    subscriptionsStore.subscriptions;
+    syncAutoRuleChannels();
+  });
+
+  let totalUnread = $derived(unreadCounts.totalArticles + unreadCounts.totalSocial);
 
   // Current filter from URL
   let currentFilter = $derived(() => {
@@ -156,31 +90,19 @@
     return { type: 'all' as const };
   });
 
-  // Sort and optionally filter subscriptions by unread count (descending)
-  let sortedSubscriptions = $derived(() => {
-    let subs = [...subscriptionsStore.subscriptions].sort((a, b) => {
-      const countA = feedUnreadCounts.get(a.id!) || 0;
-      const countB = feedUnreadCounts.get(b.id!) || 0;
-      return countB - countA;
-    });
-    if (sidebarStore.showOnlyUnread.feeds) {
-      subs = subs.filter((s) => (feedUnreadCounts.get(s.id!) || 0) > 0);
-    }
-    return subs;
-  });
-
-  // Update sorted IDs in store for keyboard navigation
-  $effect(() => {
-    const sorted = sortedSubscriptions();
-    const ids = sorted.map((s) => s.id!).filter((id) => id !== undefined);
-    sidebarStore.setSortedFeedIds(ids);
-  });
-
   // View context menu state
   let viewContextMenu = $state<{ x: number; y: number; viewId: number } | null>(null);
   let viewLongPressTimer: ReturnType<typeof setTimeout> | null = null;
   let viewLongPressTriggered = $state(false);
   let renamingViewId = $state<number | null>(null);
+
+  // Channel create/edit modal (via sidebarStore)
+  let channelModalOpen = $derived(sidebarStore.channelModalOpen);
+  let editingChannelId = $derived(sidebarStore.editingChannelId);
+
+  function openChannelModal(viewId: number | null = null) {
+    sidebarStore.openChannelModal(viewId);
+  }
 
   function handleViewContextMenu(e: MouseEvent, viewId: number) {
     e.preventDefault();
@@ -222,9 +144,22 @@
   }
 
   async function handleDeleteView(viewId: number) {
-    if (confirm('Are you sure you want to delete this view?')) {
+    if (confirm('Are you sure you want to delete this channel?')) {
       await filteredViewsStore.remove(viewId);
     }
+  }
+
+  async function acceptSuggestion(suggestion: (typeof channelSuggestions.suggestions)[0]) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      sourceMode: suggestion.sourceMode,
+      sourceKeys: suggestion.sourceKeys,
+      typeFilter: suggestion.typeFilter.length > 0 ? suggestion.typeFilter : undefined,
+      autoRule: suggestion.autoRule,
+      readFilter: 'unread',
+      sortOrder: 'newest',
+    });
+    selectFilter('view', id);
   }
 
   function selectFilter(type: string, id?: string | number) {
@@ -266,7 +201,7 @@
         <span class="tier-badge">{auth.user.tier}</span>
       {/if}
     </a>
-    <AddDropdownMenu />
+    <AddSourceInput />
   </div>
 
   <!-- Navigation items -->
@@ -277,7 +212,7 @@
       onclick={() => selectFilter('all')}
     >
       <span class="nav-icon"><Icon name="inbox" /></span>
-      <span class="nav-label">All</span>
+      <span class="nav-label">Everything</span>
       {#if totalUnread > 0}
         <span class="nav-count">{totalUnread}</span>
       {/if}
@@ -295,6 +230,73 @@
       {/if}
     </button>
 
+    <!-- Channels section (formerly Views) -->
+    <NavSection
+      title="Channels"
+      icon="layers"
+      isExpanded={sidebarStore.expandedSections.channels}
+      showOnlyUnread={false}
+      isActive={false}
+      onToggle={() => sidebarStore.toggleSection('channels')}
+      onLabelClick={() => sidebarStore.toggleSection('channels')}
+      onAdd={() => openChannelModal()}
+    >
+      {#each filteredViewsStore.views as view (view.id)}
+        <ViewItem
+          {view}
+          isActive={currentFilter().type === 'view' && currentFilter().id === view.id}
+          isRenaming={renamingViewId === view.id}
+          unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+          onSelect={() => selectFilter('view', view.id)}
+          onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+          onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+          onTouchEnd={handleViewTouchEnd}
+          onTouchMove={handleViewTouchMove}
+          onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+          onRename={async (name) => {
+            if (view.id != null) {
+              await filteredViewsStore.update(view.id, { name });
+            }
+            renamingViewId = null;
+          }}
+          onRenameCancel={() => (renamingViewId = null)}
+        />
+      {:else}
+        {#if channelSuggestions.suggestions.length === 0}
+          <div class="empty-section">No channels yet</div>
+        {/if}
+      {/each}
+      {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+        <div class="suggestion-item">
+          <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+            <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+            <span class="suggestion-name">{suggestion.name}</span>
+          </button>
+          <Tooltip text={suggestion.description} />
+          <button
+            class="suggestion-dismiss"
+            onclick={(e) => {
+              e.stopPropagation();
+              channelSuggestions.dismiss(suggestion.id);
+            }}
+            title="Dismiss"
+          >
+            <Icon name="x" size={12} />
+          </button>
+        </div>
+      {/each}
+      {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0}
+        <a
+          href="/channels/discover"
+          class="more-suggestions-link"
+          onclick={() => sidebarStore.closeMobile()}
+        >
+          More channel ideas
+          <Icon name="arrow-right" size={12} />
+        </a>
+      {/if}
+    </NavSection>
+
     <button
       class="nav-item"
       class:active={currentFilter().type === 'shared'}
@@ -307,6 +309,16 @@
       {/if}
     </button>
 
+    <!-- Bottom nav -->
+    <a
+      href="/sources"
+      class="nav-item nav-link"
+      class:active={$page.url.pathname === '/sources'}
+      onclick={() => sidebarStore.closeMobile()}
+    >
+      <span class="nav-icon"><Icon name="rss" /></span>
+      <span class="nav-label">Manage Sources</span>
+    </a>
     <a
       href="/activity"
       class="nav-item nav-link"
@@ -329,118 +341,19 @@
       <span class="nav-icon"><Icon name="settings" /></span>
       <span class="nav-label">Settings</span>
     </a>
-
-    <a
-      href="https://github.com/disnet/skyreader/issues"
-      class="nav-item nav-link"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <span class="nav-icon"><Icon name="message-circle" /></span>
-      <span class="nav-label">Feedback</span>
-    </a>
-
-    <div class="nav-separator"></div>
-
-    <!-- Custom views -->
-    {#each filteredViewsStore.views as view (view.id)}
-      <ViewItem
-        {view}
-        isActive={currentFilter().type === 'view' && currentFilter().id === view.id}
-        isRenaming={renamingViewId === view.id}
-        onSelect={() => selectFilter('view', view.id)}
-        onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-        onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-        onTouchEnd={handleViewTouchEnd}
-        onTouchMove={handleViewTouchMove}
-        onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-        onRename={async (name) => {
-          if (view.id != null) {
-            await filteredViewsStore.update(view.id, { name });
-          }
-          renamingViewId = null;
-        }}
-        onRenameCancel={() => (renamingViewId = null)}
-      />
-    {/each}
-
-    <button
-      class="nav-item new-view-btn"
-      onclick={async () => {
-        const id = await filteredViewsStore.create({
-          name: 'new view',
-          sourceMode: 'include',
-          sourceKeys: [],
-          readFilter: 'unread',
-          sortOrder: 'newest',
-        });
-        selectFilter('view', id);
-        feedViewStore.setFilterToolbarOpen(true);
-        feedViewStore.setSourcePopoverOpen(true);
-      }}
-    >
-      <span class="nav-icon"><Icon name="plus" size={16} /></span>
-      <span class="nav-label">New view</span>
-    </button>
-
-    <div class="nav-separator"></div>
-
-    <!-- Feeds section -->
-    <NavSection
-      title="Feeds"
-      icon="rss"
-      isExpanded={sidebarStore.expandedSections.feeds}
-      showOnlyUnread={sidebarStore.showOnlyUnread.feeds}
-      isActive={false}
-      onToggle={() => sidebarStore.toggleSection('feeds')}
-      onLabelClick={() => sidebarStore.toggleSection('feeds')}
-      onUnreadToggle={() => sidebarStore.toggleShowOnlyUnread('feeds')}
-      onAdd={() => sidebarStore.openAddFeedModal()}
-    >
-      <SidebarAddFeed />
-      {#each sortedSubscriptions() as sub (sub.id)}
-        {@const count = feedUnreadCounts.get(sub.id!) || 0}
-        {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
-        {@const loadingState =
-          status?.status === 'pending'
-            ? 'loading'
-            : status?.status === 'error' || status?.status === 'circuit-open'
-              ? 'error'
-              : undefined}
-        {@const feedError = sub.feedUrl ? feedStatusStore.getStatusMessage(sub.feedUrl) : undefined}
-        {@const errorDetails = sub.feedUrl
-          ? feedStatusStore.getErrorDetails(sub.feedUrl)
-          : undefined}
-        <FeedItem
-          subscription={sub}
-          unreadCount={count}
-          isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
-          {loadingState}
-          errorMessage={feedError || undefined}
-          {errorDetails}
-          onSelect={() => selectFilter('feed', sub.id)}
-          onContextMenu={(e) => sub.id && handleContextMenu(e, sub.id)}
-          onTouchStart={(e) => sub.id && handleTouchStart(e, sub.id)}
-          onTouchEnd={handleTouchEnd}
-          onTouchMove={handleTouchMove}
-          onRetry={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-          onMoreClick={(e) => sub.id && handleContextMenu(e, sub.id)}
-        />
-      {:else}
-        <div class="empty-section">No subscriptions</div>
-      {/each}
-    </NavSection>
   </nav>
 </aside>
 
 <AddFeedModal
   open={sidebarStore.addFeedModalOpen}
   onclose={() => sidebarStore.closeAddFeedModal()}
+  initialValue={sidebarStore.addSourceInitialValue}
 />
 
 <AddHandleModal
   open={sidebarStore.addHandleModalOpen}
   onclose={() => sidebarStore.closeAddHandleModal()}
+  initialValue={sidebarStore.addSourceInitialValue}
 />
 
 <SaveArticleModal
@@ -448,24 +361,20 @@
   onclose={() => sidebarStore.closeSaveArticleModal()}
 />
 
-{#if contextMenu}
-  {@const feedId = contextMenu.feedId}
-  <ContextMenu
-    x={contextMenu.x}
-    y={contextMenu.y}
-    onEdit={() => handleEditFeed(feedId)}
-    onDelete={() => removeFeed(feedId)}
-    onClose={closeContextMenu}
-  />
-{/if}
-
-<EditFeedModal open={editModalOpen} subscription={editingSubscription} onclose={closeEditModal} />
+<FilteredViewModal
+  open={channelModalOpen}
+  editingViewId={editingChannelId}
+  onclose={() => sidebarStore.closeChannelModal()}
+  oncreated={(id) => selectFilter('view', id)}
+  ondeleted={() => selectFilter('all')}
+/>
 
 {#if viewContextMenu}
   {@const viewId = viewContextMenu.viewId}
   <ContextMenu
     x={viewContextMenu.x}
     y={viewContextMenu.y}
+    onEdit={() => openChannelModal(viewId)}
     onRename={() => handleRenameView(viewId)}
     onDelete={() => handleDeleteView(viewId)}
     onClose={closeViewContextMenu}
@@ -629,11 +538,92 @@
     font-style: italic;
   }
 
-  .new-view-btn {
-    color: var(--color-text-secondary);
+  .suggestion-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
   }
 
-  .new-view-btn:hover {
+  .suggestion-accept {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: 0.875rem;
+    text-align: left;
+    transition: color 0.15s;
+  }
+
+  .suggestion-accept:hover {
+    color: var(--color-primary);
+  }
+
+  .suggestion-icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px dashed currentColor;
+  }
+
+  .suggestion-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+  }
+
+  .more-suggestions-link {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .more-suggestions-link:hover {
+    color: var(--color-primary);
+  }
+
+  .suggestion-dismiss {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    padding: 0;
+    opacity: 0;
+    transition: opacity 0.15s;
+    border-radius: 4px;
+  }
+
+  .suggestion-item:hover .suggestion-dismiss {
+    opacity: 0.6;
+  }
+
+  .suggestion-dismiss:hover {
+    opacity: 1 !important;
     color: var(--color-text);
   }
 

--- a/frontend/src/lib/components/Tooltip.svelte
+++ b/frontend/src/lib/components/Tooltip.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+
+  interface Props {
+    text: string;
+  }
+
+  let { text }: Props = $props();
+
+  let open = $state(false);
+  let btnRef: HTMLButtonElement | null = $state(null);
+  let tooltipRef: HTMLDivElement | null = $state(null);
+  let position = $state<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  function toggle(e: MouseEvent | KeyboardEvent) {
+    e.stopPropagation();
+    open = !open;
+    if (open) {
+      requestAnimationFrame(updatePosition);
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle(e);
+    } else if (e.key === 'Escape' && open) {
+      open = false;
+    }
+  }
+
+  function updatePosition() {
+    if (!btnRef) return;
+    const rect = btnRef.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const tooltipWidth = 200;
+
+    let top = rect.bottom + 4;
+    let left = rect.left + rect.width / 2 - tooltipWidth / 2;
+
+    if (left + tooltipWidth > viewportWidth - 8) {
+      left = viewportWidth - tooltipWidth - 8;
+    }
+    if (left < 8) left = 8;
+
+    position = { top, left };
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (
+      open &&
+      btnRef &&
+      tooltipRef &&
+      !btnRef.contains(e.target as Node) &&
+      !tooltipRef.contains(e.target as Node)
+    ) {
+      open = false;
+    }
+  }
+
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
+
+  onMount(() => {
+    document.addEventListener('click', handleClickOutside);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('click', handleClickOutside);
+  });
+</script>
+
+<button
+  bind:this={btnRef}
+  class="tooltip-trigger"
+  onclick={toggle}
+  onkeydown={handleKeydown}
+  aria-label="Info"
+  aria-expanded={open}
+>
+  ?
+</button>
+
+{#if open}
+  <div use:portal>
+    <div
+      bind:this={tooltipRef}
+      class="tooltip-popup"
+      role="tooltip"
+      style="top: {position.top}px; left: {position.left}px;"
+    >
+      {text}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .tooltip-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 1px solid var(--color-text-secondary);
+    background: none;
+    cursor: pointer;
+    font-size: 0.5625rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    padding: 0;
+    line-height: 1;
+    flex-shrink: 0;
+    opacity: 0.6;
+    transition: opacity 0.15s;
+  }
+
+  .tooltip-trigger:hover {
+    opacity: 1;
+  }
+
+  :global(.tooltip-popup) {
+    position: fixed;
+    width: 200px;
+    padding: 0.5rem 0.625rem;
+    background: var(--color-bg);
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    z-index: 9999;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(.tooltip-popup) {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/feed/FeedPageHeader.svelte
+++ b/frontend/src/lib/components/feed/FeedPageHeader.svelte
@@ -101,7 +101,7 @@
   }
 
   let dropdownOpen = $derived(sidebarStore.navigationDropdownOpen);
-  let isSavedView = $derived(Boolean(feedViewStore.savedFilter));
+  let isSavedView = $derived(Boolean(feedViewStore.savedFilter) || feedViewStore.isSavedChannel);
 
   let menuItems = $derived.by(() => {
     const items: Array<{ label: string; icon: string; onclick: () => void; variant?: 'danger' }> =
@@ -189,19 +189,23 @@
               <Icon name="archive" size={16} />
               <span class="btn-label">Archive</span>
             </button>
-            <span class="toggle-divider"></span>
-            <button
-              onclick={() => feedViewStore.toggleSortOrder()}
-              title={feedViewStore.currentSortOrder === 'newest' ? 'Newest first' : 'Oldest first'}
-            >
-              <Icon
-                name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-                size={16}
-              />
-              <span class="btn-label"
-                >{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
+            {#if !feedViewStore.isSavedChannel}
+              <span class="toggle-divider"></span>
+              <button
+                onclick={() => feedViewStore.toggleSortOrder()}
+                title={feedViewStore.currentSortOrder === 'newest'
+                  ? 'Newest first'
+                  : 'Oldest first'}
               >
-            </button>
+                <Icon
+                  name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+                  size={16}
+                />
+                <span class="btn-label"
+                  >{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
+                >
+              </button>
+            {/if}
             <span class="toggle-divider"></span>
             <button
               onclick={() => sidebarStore.openSaveArticleModal()}
@@ -211,6 +215,17 @@
               <Icon name="plus" size={16} />
               <span class="btn-label">Add</span>
             </button>
+            {#if feedViewStore.isSavedChannel && onEditChannel}
+              <span class="toggle-divider"></span>
+              <button
+                onclick={() => onEditChannel(parseInt(feedViewStore.viewFilter!))}
+                aria-label="Edit channel"
+                title="Edit channel"
+              >
+                <Icon name="edit" size={16} />
+                <span class="btn-label">Edit</span>
+              </button>
+            {/if}
           </div>
         {:else}
           <div class="view-toggle" role="group" aria-label="View controls">
@@ -277,7 +292,7 @@
       <AppearanceToolbar />
     </div>
   {/if}
-  {#if !isSavedView && feedViewStore.filterToolbarOpen}
+  {#if !feedViewStore.isSavedChannel && feedViewStore.filterToolbarOpen}
     <div class="filter-toolbar-row">
       <FilterToolbar {showSourceFilter} {onEditChannel} />
     </div>

--- a/frontend/src/lib/components/feed/FeedPageHeader.svelte
+++ b/frontend/src/lib/components/feed/FeedPageHeader.svelte
@@ -23,6 +23,8 @@
     onEdit?: () => void;
     onDelete?: () => void;
     showSourceFilter?: boolean;
+    hideControls?: boolean;
+    onEditChannel?: (id: number) => void;
   }
 
   let {
@@ -38,6 +40,8 @@
     onEdit,
     onDelete,
     showSourceFilter = true,
+    hideControls = false,
+    onEditChannel,
   }: Props = $props();
 
   // Tick counter to force re-evaluation of relative time
@@ -163,107 +167,109 @@
       {/if}
     </div>
 
-    <div class="control-right">
-      {#if isSavedView}
-        <div class="view-toggle" role="group" aria-label="Saved view">
-          <button
-            class:active={feedViewStore.savedView === 'inbox'}
-            onclick={() => feedViewStore.setSavedView('inbox')}
-            aria-label="Inbox"
-            title="Inbox"
-          >
-            <Icon name="inbox" size={16} />
-            <span class="btn-label">Inbox</span>
-          </button>
-          <button
-            class:active={feedViewStore.savedView === 'archive'}
-            onclick={() => feedViewStore.setSavedView('archive')}
-            aria-label="Archive"
-            title="Archive"
-          >
-            <Icon name="archive" size={16} />
-            <span class="btn-label">Archive</span>
-          </button>
-          <span class="toggle-divider"></span>
-          <button
-            onclick={() => feedViewStore.toggleSortOrder()}
-            title={feedViewStore.currentSortOrder === 'newest' ? 'Newest first' : 'Oldest first'}
-          >
-            <Icon
-              name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-              size={16}
-            />
-            <span class="btn-label"
-              >{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
-            >
-          </button>
-          <span class="toggle-divider"></span>
-          <button
-            onclick={() => sidebarStore.openSaveArticleModal()}
-            aria-label="Save article by URL"
-            title="Save article by URL"
-          >
-            <Icon name="plus" size={16} />
-            <span class="btn-label">Add</span>
-          </button>
-        </div>
-      {:else}
-        <div class="view-toggle" role="group" aria-label="View controls">
-          {#if onToggleExpandAll}
+    {#if !hideControls}
+      <div class="control-right">
+        {#if isSavedView}
+          <div class="view-toggle" role="group" aria-label="Saved view">
             <button
-              class:active={!expandAllItems}
-              onclick={() => onToggleExpandAll(false)}
-              aria-label="List view"
-              title="List view"
+              class:active={feedViewStore.savedView === 'inbox'}
+              onclick={() => feedViewStore.setSavedView('inbox')}
+              aria-label="Inbox"
+              title="Inbox"
             >
-              <Icon name="list" size={16} />
-              <span class="btn-label">List</span>
+              <Icon name="inbox" size={16} />
+              <span class="btn-label">Inbox</span>
             </button>
             <button
-              class:active={expandAllItems}
-              onclick={() => onToggleExpandAll(true)}
-              aria-label="Expanded view"
-              title="Expanded view"
+              class:active={feedViewStore.savedView === 'archive'}
+              onclick={() => feedViewStore.setSavedView('archive')}
+              aria-label="Archive"
+              title="Archive"
             >
-              <Icon name="newspaper" size={16} />
-              <span class="btn-label">Expand</span>
+              <Icon name="archive" size={16} />
+              <span class="btn-label">Archive</span>
             </button>
             <span class="toggle-divider"></span>
-          {/if}
-          <button
-            class:active={styleToolbarOpen}
-            onclick={() => {
-              styleToolbarOpen = !styleToolbarOpen;
-              if (styleToolbarOpen) feedViewStore.setFilterToolbarOpen(false);
-            }}
-            aria-label="Toggle style"
-            title="Style"
-          >
-            <Icon name="type" size={16} />
-            <span class="btn-label">Style</span>
-          </button>
-          <span class="toggle-divider"></span>
-          <button
-            class="filter-toggle-btn"
-            class:active={feedViewStore.filterToolbarOpen}
-            onclick={() => {
-              const opening = !feedViewStore.filterToolbarOpen;
-              feedViewStore.setFilterToolbarOpen(opening);
-              if (opening) {
-                styleToolbarOpen = false;
-              } else {
-                feedViewStore.setSourcePopoverOpen(false);
-              }
-            }}
-            aria-label="Toggle filters"
-            title="Filter"
-          >
-            <Icon name="filter" size={16} />
-            <span class="btn-label">Filter</span>
-          </button>
-        </div>
-      {/if}
-    </div>
+            <button
+              onclick={() => feedViewStore.toggleSortOrder()}
+              title={feedViewStore.currentSortOrder === 'newest' ? 'Newest first' : 'Oldest first'}
+            >
+              <Icon
+                name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+                size={16}
+              />
+              <span class="btn-label"
+                >{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
+              >
+            </button>
+            <span class="toggle-divider"></span>
+            <button
+              onclick={() => sidebarStore.openSaveArticleModal()}
+              aria-label="Save article by URL"
+              title="Save article by URL"
+            >
+              <Icon name="plus" size={16} />
+              <span class="btn-label">Add</span>
+            </button>
+          </div>
+        {:else}
+          <div class="view-toggle" role="group" aria-label="View controls">
+            {#if onToggleExpandAll}
+              <button
+                class:active={!expandAllItems}
+                onclick={() => onToggleExpandAll(false)}
+                aria-label="List view"
+                title="List view"
+              >
+                <Icon name="list" size={16} />
+                <span class="btn-label">List</span>
+              </button>
+              <button
+                class:active={expandAllItems}
+                onclick={() => onToggleExpandAll(true)}
+                aria-label="Expanded view"
+                title="Expanded view"
+              >
+                <Icon name="newspaper" size={16} />
+                <span class="btn-label">Expand</span>
+              </button>
+              <span class="toggle-divider"></span>
+            {/if}
+            <button
+              class:active={styleToolbarOpen}
+              onclick={() => {
+                styleToolbarOpen = !styleToolbarOpen;
+                if (styleToolbarOpen) feedViewStore.setFilterToolbarOpen(false);
+              }}
+              aria-label="Toggle style"
+              title="Style"
+            >
+              <Icon name="type" size={16} />
+              <span class="btn-label">Style</span>
+            </button>
+            <span class="toggle-divider"></span>
+            <button
+              class="filter-toggle-btn"
+              class:active={feedViewStore.filterToolbarOpen}
+              onclick={() => {
+                const opening = !feedViewStore.filterToolbarOpen;
+                feedViewStore.setFilterToolbarOpen(opening);
+                if (opening) {
+                  styleToolbarOpen = false;
+                } else {
+                  feedViewStore.setSourcePopoverOpen(false);
+                }
+              }}
+              aria-label="Toggle filters"
+              title="Filter"
+            >
+              <Icon name="filter" size={16} />
+              <span class="btn-label">Filter</span>
+            </button>
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   {#if !isSavedView && styleToolbarOpen}
@@ -273,7 +279,7 @@
   {/if}
   {#if !isSavedView && feedViewStore.filterToolbarOpen}
     <div class="filter-toolbar-row">
-      <FilterToolbar {showSourceFilter} />
+      <FilterToolbar {showSourceFilter} {onEditChannel} />
     </div>
   {/if}
 </div>

--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -8,12 +8,50 @@
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { goto } from '$app/navigation';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
-  import type { SubscriptionSourceType } from '$lib/types';
+  import type {
+    SubscriptionSourceType,
+    SavedSourceType,
+    DateAddedPreset,
+    ReadingLengthFilter,
+    SortOrder,
+  } from '$lib/types';
+
+  const DATE_PRESET_OPTIONS: { value: DateAddedPreset | ''; label: string }[] = [
+    { value: '', label: 'Any time' },
+    { value: 'last-week', label: 'Last week' },
+    { value: 'last-month', label: 'Last month' },
+    { value: 'last-3-months', label: 'Last 3 months' },
+    { value: 'last-year', label: 'Last year' },
+  ];
+
+  const READING_LENGTH_OPTIONS: { value: ReadingLengthFilter; label: string }[] = [
+    { value: 'quick', label: 'Quick (< 5 min)' },
+    { value: 'medium', label: 'Medium (5–15 min)' },
+    { value: 'long', label: 'Long (15+ min)' },
+  ];
+
+  const SAVED_SORT_OPTIONS: { value: SortOrder; label: string }[] = [
+    { value: 'newest', label: 'Saved (newest)' },
+    { value: 'oldest', label: 'Saved (oldest)' },
+    { value: 'published-newest', label: 'Published (newest)' },
+    { value: 'published-oldest', label: 'Published (oldest)' },
+    { value: 'shortest', label: 'Reading time (short)' },
+    { value: 'longest', label: 'Reading time (long)' },
+    { value: 'domain-asc', label: 'Domain (A–Z)' },
+    { value: 'domain-desc', label: 'Domain (Z–A)' },
+  ];
 
   const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
     { value: 'rss', label: 'RSS Feeds' },
     { value: 'atproto.shares', label: 'Skyreader Shares' },
     { value: 'atproto.documents', label: 'Standard.site Documents' },
+  ];
+
+  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
+    { value: 'url', label: 'URL Saves' },
+    { value: 'feed', label: 'Feed Articles' },
+    { value: 'share', label: 'Shared Articles' },
+    { value: 'document', label: 'Documents' },
   ];
 
   interface Props {
@@ -76,6 +114,97 @@
   function clearTypeFilter() {
     feedViewStore.setToolbarTypeFilter([]);
   }
+
+  // Saved source filter state (for saved-mode channels)
+  let isSavedChannel = $derived(feedViewStore.isSavedChannel);
+  let activeSavedSourceFilter = $derived(feedViewStore.toolbarSavedSourceFilter);
+  let activeSavedSourceSet = $derived(new Set(activeSavedSourceFilter));
+
+  let savedSourceFilterLabel = $derived.by(() => {
+    if (activeSavedSourceFilter.length === 0) return 'Source';
+    return `Source (${activeSavedSourceFilter.length})`;
+  });
+
+  // Date filter state
+  let activeDateFilter = $derived(feedViewStore.toolbarDateFilter);
+  let dateFilterLabel = $derived.by(() => {
+    if (!activeDateFilter) return 'Date';
+    const opt = DATE_PRESET_OPTIONS.find((o) => o.value === activeDateFilter);
+    return opt ? opt.label : 'Date';
+  });
+
+  // Reading length filter state
+  let activeReadingLength = $derived(feedViewStore.toolbarReadingLength);
+  let activeReadingLengthSet = $derived(new Set(activeReadingLength));
+  let readingLengthLabel = $derived.by(() => {
+    if (activeReadingLength.length === 0) return 'Length';
+    return `Length (${activeReadingLength.length})`;
+  });
+
+  // Domain filter state
+  let activeDomainFilter = $derived(feedViewStore.toolbarDomainFilter);
+  let activeDomainSet = $derived(new Set(activeDomainFilter));
+  let domainFilterLabel = $derived.by(() => {
+    if (activeDomainFilter.length === 0) return 'Domain';
+    return `Domain (${activeDomainFilter.length})`;
+  });
+  let availableDomains = $derived(feedViewStore.availableSavedDomains);
+
+  // Sort label for saved channels
+  let savedSortLabel = $derived.by(() => {
+    const current = feedViewStore.currentSortOrder;
+    const opt = SAVED_SORT_OPTIONS.find((o) => o.value === current);
+    return opt ? opt.label : 'Sort';
+  });
+
+  let hasSavedChannelFilters = $derived(
+    activeSavedSourceFilter.length > 0 ||
+      !!activeDateFilter ||
+      activeReadingLength.length > 0 ||
+      activeDomainFilter.length > 0
+  );
+
+  // Popover state for new dropdowns
+  let datePopoverOpen = $state(false);
+  let lengthPopoverOpen = $state(false);
+  let domainPopoverOpen = $state(false);
+  let sortPopoverOpen = $state(false);
+  let datePopoverRef = $state<HTMLElement | null>(null);
+  let lengthPopoverRef = $state<HTMLElement | null>(null);
+  let domainPopoverRef = $state<HTMLElement | null>(null);
+  let sortPopoverRef = $state<HTMLElement | null>(null);
+  let domainSearchText = $state('');
+
+  function toggleSavedSourceFilter(source: SavedSourceType) {
+    const newSources = activeSavedSourceSet.has(source)
+      ? activeSavedSourceFilter.filter((s) => s !== source)
+      : [...activeSavedSourceFilter, source];
+    feedViewStore.setToolbarSavedSourceFilter(newSources);
+  }
+
+  function clearSavedSourceFilter() {
+    feedViewStore.setToolbarSavedSourceFilter([]);
+  }
+
+  function toggleReadingLength(bucket: ReadingLengthFilter) {
+    const newLengths = activeReadingLengthSet.has(bucket)
+      ? activeReadingLength.filter((l) => l !== bucket)
+      : [...activeReadingLength, bucket];
+    feedViewStore.setToolbarReadingLength(newLengths);
+  }
+
+  function toggleDomainFilter(domain: string) {
+    const newDomains = activeDomainSet.has(domain)
+      ? activeDomainFilter.filter((d) => d !== domain)
+      : [...activeDomainFilter, domain];
+    feedViewStore.setToolbarDomainFilter(newDomains);
+  }
+
+  let filteredDomains = $derived.by(() => {
+    if (!domainSearchText) return availableDomains;
+    const q = domainSearchText.toLowerCase();
+    return availableDomains.filter((d) => d.toLowerCase().includes(q));
+  });
 
   function handleTypeClickOutside(e: MouseEvent) {
     if (typePopoverOpen && typePopoverRef && !typePopoverRef.contains(e.target as Node)) {
@@ -156,6 +285,19 @@
     }
     handleTypeClickOutside(e);
     handleTagClickOutside(e);
+    if (datePopoverOpen && datePopoverRef && !datePopoverRef.contains(e.target as Node)) {
+      datePopoverOpen = false;
+    }
+    if (lengthPopoverOpen && lengthPopoverRef && !lengthPopoverRef.contains(e.target as Node)) {
+      lengthPopoverOpen = false;
+    }
+    if (domainPopoverOpen && domainPopoverRef && !domainPopoverRef.contains(e.target as Node)) {
+      domainPopoverOpen = false;
+      domainSearchText = '';
+    }
+    if (sortPopoverOpen && sortPopoverRef && !sortPopoverRef.contains(e.target as Node)) {
+      sortPopoverOpen = false;
+    }
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -163,6 +305,11 @@
       feedViewStore.setSourcePopoverOpen(false);
       typePopoverOpen = false;
       tagPopoverOpen = false;
+      datePopoverOpen = false;
+      lengthPopoverOpen = false;
+      domainPopoverOpen = false;
+      sortPopoverOpen = false;
+      domainSearchText = '';
     }
   }
 
@@ -355,18 +502,56 @@
 <div class="filter-toolbar" role="toolbar" aria-label="Filter controls">
   <!-- Group 1: Sort + Read state -->
   <div class="filter-group">
-    <button
-      class="filter-btn"
-      onclick={() => feedViewStore.toggleSortOrder()}
-      title={feedViewStore.currentSortOrder === 'newest' ? 'Newest first' : 'Oldest first'}
-    >
-      <Icon
-        name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-        size={16}
-      />
-      <span class="filter-label">{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
+    {#if isSavedChannel}
+      <!-- Saved channel: sort dropdown -->
+      <div class="dropdown-wrapper" bind:this={sortPopoverRef}>
+        <button
+          class="filter-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            sortPopoverOpen = !sortPopoverOpen;
+          }}
+          title="Sort order"
+        >
+          <Icon name="arrow-down" size={16} />
+          <span class="filter-label">{savedSortLabel}</span>
+          <Icon name="chevron-down" size={12} />
+        </button>
+        {#if sortPopoverOpen}
+          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+          <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+            <div class="popover-list">
+              {#each SAVED_SORT_OPTIONS as opt}
+                <button
+                  class="popover-option"
+                  class:active={feedViewStore.currentSortOrder === opt.value}
+                  onclick={() => {
+                    feedViewStore.setSortOrder(opt.value);
+                    sortPopoverOpen = false;
+                  }}
+                >
+                  {opt.label}
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      </div>
+    {:else}
+      <button
+        class="filter-btn"
+        onclick={() => feedViewStore.toggleSortOrder()}
+        title={feedViewStore.currentSortOrder === 'newest' ? 'Newest first' : 'Oldest first'}
       >
-    </button>
+        <Icon
+          name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+          size={16}
+        />
+        <span class="filter-label"
+          >{feedViewStore.currentSortOrder === 'newest' ? 'New' : 'Old'}</span
+        >
+      </button>
+    {/if}
 
     <span class="toolbar-divider"></span>
 
@@ -406,7 +591,189 @@
       </button>
     </div>
   {:else}
-    {#if showSourceFilter}
+    {#if isSavedChannel}
+      <span class="toolbar-divider group-divider"></span>
+
+      <!-- Saved source filter (for saved-mode channels) -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={typePopoverRef}>
+          <button
+            class="filter-btn"
+            class:has-filter={activeSavedSourceFilter.length > 0}
+            onclick={(e) => {
+              e.stopPropagation();
+              typePopoverOpen = !typePopoverOpen;
+            }}
+          >
+            <Icon name="layers" size={16} />
+            <span class="filter-label">{savedSourceFilterLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
+
+          {#if typePopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-group-header">
+                <span>Save Sources</span>
+                {#if activeSavedSourceFilter.length > 0}
+                  <button class="select-all-btn" onclick={clearSavedSourceFilter}>Clear</button>
+                {/if}
+              </div>
+              <div class="popover-list">
+                {#each SAVED_SOURCE_OPTIONS as opt}
+                  <label class="check-label">
+                    <input
+                      type="checkbox"
+                      checked={activeSavedSourceSet.has(opt.value)}
+                      onchange={() => toggleSavedSourceFilter(opt.value)}
+                    />
+                    <span class="check-text">{opt.label}</span>
+                  </label>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Date filter -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={datePopoverRef}>
+          <button
+            class="filter-btn"
+            class:has-filter={!!activeDateFilter}
+            onclick={(e) => {
+              e.stopPropagation();
+              datePopoverOpen = !datePopoverOpen;
+            }}
+          >
+            <Icon name="clock" size={16} />
+            <span class="filter-label">{dateFilterLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
+          {#if datePopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-list">
+                {#each DATE_PRESET_OPTIONS as opt}
+                  <button
+                    class="popover-option"
+                    class:active={(activeDateFilter ?? '') === opt.value}
+                    onclick={() => {
+                      feedViewStore.setToolbarDateFilter(opt.value || null);
+                      datePopoverOpen = false;
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Reading length filter -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={lengthPopoverRef}>
+          <button
+            class="filter-btn"
+            class:has-filter={activeReadingLength.length > 0}
+            onclick={(e) => {
+              e.stopPropagation();
+              lengthPopoverOpen = !lengthPopoverOpen;
+            }}
+          >
+            <Icon name="file-text" size={16} />
+            <span class="filter-label">{readingLengthLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
+          {#if lengthPopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-group-header">
+                <span>Reading Length</span>
+                {#if activeReadingLength.length > 0}
+                  <button
+                    class="select-all-btn"
+                    onclick={() => feedViewStore.setToolbarReadingLength([])}>Clear</button
+                  >
+                {/if}
+              </div>
+              <div class="popover-list">
+                {#each READING_LENGTH_OPTIONS as opt}
+                  <label class="check-label">
+                    <input
+                      type="checkbox"
+                      checked={activeReadingLengthSet.has(opt.value)}
+                      onchange={() => toggleReadingLength(opt.value)}
+                    />
+                    <span class="check-text">{opt.label}</span>
+                  </label>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Domain filter -->
+      {#if availableDomains.length > 0}
+        <div class="filter-group">
+          <div class="dropdown-wrapper" bind:this={domainPopoverRef}>
+            <button
+              class="filter-btn"
+              class:has-filter={activeDomainFilter.length > 0}
+              onclick={(e) => {
+                e.stopPropagation();
+                domainPopoverOpen = !domainPopoverOpen;
+              }}
+            >
+              <Icon name="globe" size={16} />
+              <span class="filter-label">{domainFilterLabel}</span>
+              <Icon name="chevron-down" size={12} />
+            </button>
+            {#if domainPopoverOpen}
+              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+              <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+                <div class="popover-group-header">
+                  <span>Domains</span>
+                  {#if activeDomainFilter.length > 0}
+                    <button
+                      class="select-all-btn"
+                      onclick={() => feedViewStore.setToolbarDomainFilter([])}>Clear</button
+                    >
+                  {/if}
+                </div>
+                <div class="popover-search">
+                  <input
+                    type="text"
+                    placeholder="Search domains..."
+                    bind:value={domainSearchText}
+                    class="search-input"
+                  />
+                </div>
+                <div class="popover-list">
+                  {#each filteredDomains as domain}
+                    <label class="check-label">
+                      <input
+                        type="checkbox"
+                        checked={activeDomainSet.has(domain)}
+                        onchange={() => toggleDomainFilter(domain)}
+                      />
+                      <span class="check-text">{domain}</span>
+                    </label>
+                  {/each}
+                  {#if domainSearchText && filteredDomains.length === 0}
+                    <div class="no-results">No domains match</div>
+                  {/if}
+                </div>
+              </div>
+            {/if}
+          </div>
+        </div>
+      {/if}
+    {:else if showSourceFilter}
       <span class="toolbar-divider group-divider"></span>
 
       <!-- Group 2: Sources dropdown -->
@@ -508,49 +875,51 @@
       </div>
     {/if}
 
-    <span class="toolbar-divider group-divider"></span>
+    {#if !isSavedChannel}
+      <span class="toolbar-divider group-divider"></span>
 
-    <!-- Type filter dropdown -->
-    <div class="filter-group">
-      <div class="dropdown-wrapper" bind:this={typePopoverRef}>
-        <button
-          class="filter-btn"
-          class:has-filter={activeTypeFilter.length > 0}
-          onclick={(e) => {
-            e.stopPropagation();
-            typePopoverOpen = !typePopoverOpen;
-          }}
-        >
-          <Icon name="layers" size={16} />
-          <span class="filter-label">{typeFilterLabel}</span>
-          <Icon name="chevron-down" size={12} />
-        </button>
+      <!-- Type filter dropdown -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={typePopoverRef}>
+          <button
+            class="filter-btn"
+            class:has-filter={activeTypeFilter.length > 0}
+            onclick={(e) => {
+              e.stopPropagation();
+              typePopoverOpen = !typePopoverOpen;
+            }}
+          >
+            <Icon name="layers" size={16} />
+            <span class="filter-label">{typeFilterLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
 
-        {#if typePopoverOpen}
-          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-          <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
-            <div class="popover-group-header">
-              <span>Types</span>
-              {#if activeTypeFilter.length > 0}
-                <button class="select-all-btn" onclick={clearTypeFilter}>Clear</button>
-              {/if}
+          {#if typePopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-group-header">
+                <span>Types</span>
+                {#if activeTypeFilter.length > 0}
+                  <button class="select-all-btn" onclick={clearTypeFilter}>Clear</button>
+                {/if}
+              </div>
+              <div class="popover-list">
+                {#each TYPE_OPTIONS as opt}
+                  <label class="check-label">
+                    <input
+                      type="checkbox"
+                      checked={activeTypeSet.has(opt.value)}
+                      onchange={() => toggleTypeFilter(opt.value)}
+                    />
+                    <span class="check-text">{opt.label}</span>
+                  </label>
+                {/each}
+              </div>
             </div>
-            <div class="popover-list">
-              {#each TYPE_OPTIONS as opt}
-                <label class="check-label">
-                  <input
-                    type="checkbox"
-                    checked={activeTypeSet.has(opt.value)}
-                    onchange={() => toggleTypeFilter(opt.value)}
-                  />
-                  <span class="check-text">{opt.label}</span>
-                </label>
-              {/each}
-            </div>
-          </div>
-        {/if}
+          {/if}
+        </div>
       </div>
-    </div>
+    {/if}
 
     {#if allTags.length > 0}
       <span class="toolbar-divider group-divider"></span>
@@ -645,11 +1014,15 @@
           class="filter-btn save-btn"
           class:has-changes={isEditingView
             ? feedViewStore.hasUnsavedChanges
-            : ef.sourceMode !== 'all' || activeTypeFilter.length > 0}
+            : isSavedChannel
+              ? hasSavedChannelFilters
+              : ef.sourceMode !== 'all' || activeTypeFilter.length > 0}
           onclick={handleSave}
           disabled={isEditingView
             ? !feedViewStore.hasUnsavedChanges
-            : ef.sourceMode === 'all' && activeTypeFilter.length === 0}
+            : isSavedChannel
+              ? !hasSavedChannelFilters
+              : ef.sourceMode === 'all' && activeTypeFilter.length === 0}
           title={isEditingView ? 'Update channel' : 'Save as new channel'}
         >
           <Icon name="save" size={16} />
@@ -1016,5 +1389,25 @@
     .name-input {
       background: var(--color-bg, #1a1a1a);
     }
+  }
+
+  .popover-option {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.625rem;
+    border: none;
+    background: none;
+    color: var(--color-text-primary, #e0e0e0);
+    font-size: 0.8125rem;
+    text-align: left;
+    border-radius: 0.25rem;
+    cursor: pointer;
+  }
+  .popover-option:hover {
+    background: var(--color-bg-hover, rgba(255, 255, 255, 0.08));
+  }
+  .popover-option.active {
+    background: var(--color-primary, #6366f1);
+    color: #fff;
   }
 </style>

--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -11,48 +11,15 @@
   import type {
     SubscriptionSourceType,
     SavedSourceType,
-    DateAddedPreset,
     ReadingLengthFilter,
-    SortOrder,
   } from '$lib/types';
-
-  const DATE_PRESET_OPTIONS: { value: DateAddedPreset | ''; label: string }[] = [
-    { value: '', label: 'Any time' },
-    { value: 'last-week', label: 'Last week' },
-    { value: 'last-month', label: 'Last month' },
-    { value: 'last-3-months', label: 'Last 3 months' },
-    { value: 'last-year', label: 'Last year' },
-  ];
-
-  const READING_LENGTH_OPTIONS: { value: ReadingLengthFilter; label: string }[] = [
-    { value: 'quick', label: 'Quick (< 5 min)' },
-    { value: 'medium', label: 'Medium (5–15 min)' },
-    { value: 'long', label: 'Long (15+ min)' },
-  ];
-
-  const SAVED_SORT_OPTIONS: { value: SortOrder; label: string }[] = [
-    { value: 'newest', label: 'Saved (newest)' },
-    { value: 'oldest', label: 'Saved (oldest)' },
-    { value: 'published-newest', label: 'Published (newest)' },
-    { value: 'published-oldest', label: 'Published (oldest)' },
-    { value: 'shortest', label: 'Reading time (short)' },
-    { value: 'longest', label: 'Reading time (long)' },
-    { value: 'domain-asc', label: 'Domain (A–Z)' },
-    { value: 'domain-desc', label: 'Domain (Z–A)' },
-  ];
-
-  const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
-    { value: 'rss', label: 'RSS Feeds' },
-    { value: 'atproto.shares', label: 'Skyreader Shares' },
-    { value: 'atproto.documents', label: 'Standard.site Documents' },
-  ];
-
-  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
-    { value: 'url', label: 'URL Saves' },
-    { value: 'feed', label: 'Feed Articles' },
-    { value: 'share', label: 'Shared Articles' },
-    { value: 'document', label: 'Documents' },
-  ];
+  import {
+    TYPE_OPTIONS,
+    SAVED_SOURCE_OPTIONS,
+    DATE_PRESET_OPTIONS,
+    READING_LENGTH_OPTIONS,
+    SAVED_SORT_OPTIONS,
+  } from '$lib/constants/channelOptions';
 
   interface Props {
     showSourceFilter: boolean;

--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -18,9 +18,10 @@
 
   interface Props {
     showSourceFilter: boolean;
+    onEditChannel?: (id: number) => void;
   }
 
-  let { showSourceFilter }: Props = $props();
+  let { showSourceFilter, onEditChannel }: Props = $props();
 
   let ef = $derived(feedViewStore.effectiveFilters);
 
@@ -233,7 +234,7 @@
 
   async function handleDeleteView() {
     if (!feedViewStore.viewFilter) return;
-    if (!confirm('Are you sure you want to delete this view?')) return;
+    if (!confirm('Are you sure you want to delete this channel?')) return;
     const id = parseInt(feedViewStore.viewFilter);
     await filteredViewsStore.remove(id);
     goto('/');
@@ -244,7 +245,7 @@
       // Update existing view
       feedViewStore.syncToolbarToSavedView();
     } else {
-      // Show name input for new view
+      // Show name input for new channel
       showNameInput = true;
       newViewName = '';
       // Focus the input after it renders
@@ -391,189 +392,158 @@
     </div>
   </div>
 
-  {#if showSourceFilter}
+  {#if isEditingView && onEditChannel}
     <span class="toolbar-divider group-divider"></span>
 
-    <!-- Group 2: Sources dropdown -->
     <div class="filter-group">
-      <div class="dropdown-wrapper" bind:this={sourcePopoverRef}>
-        <button
-          class="filter-btn source-btn"
-          class:has-filter={ef.sourceMode !== 'all'}
-          onclick={(e) => {
-            e.stopPropagation();
-            feedViewStore.setSourcePopoverOpen(!sourcePopoverOpen);
-          }}
-        >
-          <Icon name="filter" size={16} />
-          <span class="filter-label">{sourceFilterLabel}</span>
-          <Icon name="chevron-down" size={12} />
-        </button>
-
-        {#if sourcePopoverOpen}
-          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-          <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
-            <div class="popover-section">
-              <label class="radio-label">
-                <input
-                  type="radio"
-                  name="sourceMode"
-                  value="all"
-                  checked={ef.sourceMode === 'all'}
-                  onchange={() => setSourceMode('all')}
-                />
-                All sources
-              </label>
-              <label class="radio-label">
-                <input
-                  type="radio"
-                  name="sourceMode"
-                  value="include"
-                  checked={ef.sourceMode === 'include'}
-                  onchange={() => setSourceMode('include')}
-                />
-                Include only
-              </label>
-            </div>
-
-            {#if ef.sourceMode === 'include'}
-              <!-- Subscriptions list -->
-              {#if subscriptionsStore.subscriptions.length > 0}
-                <div class="popover-group-header">
-                  <span>Subscriptions</span>
-                  <button
-                    class="select-all-btn"
-                    onclick={allSourcesSelected ? deselectAllSources : selectAllSources}
-                  >
-                    {allSourcesSelected ? 'Deselect all' : 'Select all'}
-                  </button>
-                </div>
-                <div class="popover-search">
-                  <input
-                    type="text"
-                    placeholder="Search subscriptions..."
-                    bind:value={feedSearch}
-                    class="search-input"
-                  />
-                </div>
-                <div class="popover-list">
-                  {#each filteredSubscriptions as sub}
-                    {@const key = subscriptionSourceKey(sub)}
-                    {#if key}
-                      {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
-                      {@const iconUrl =
-                        sub.customIconUrl ||
-                        (isAtProto
-                          ? sub.siteUrl
-                            ? getFaviconUrl(sub.siteUrl)
-                            : '/icons/icon-192.svg'
-                          : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
-                      <label class="check-label">
-                        <input
-                          type="checkbox"
-                          checked={sourceKeySet.has(key)}
-                          onchange={() => toggleSourceKey(key)}
-                        />
-                        {#if iconUrl}
-                          <img src={iconUrl} alt="" class="check-icon" />
-                        {/if}
-                        <span class="check-text">{sub.customTitle || sub.title}</span>
-                      </label>
-                    {/if}
-                  {/each}
-                  {#if feedSearch && filteredSubscriptions.length === 0}
-                    <div class="no-results">No subscriptions match</div>
-                  {/if}
-                </div>
-              {/if}
-            {/if}
-          </div>
-        {/if}
-      </div>
-    </div>
-  {/if}
-
-  <span class="toolbar-divider group-divider"></span>
-
-  <!-- Type filter dropdown -->
-  <div class="filter-group">
-    <div class="dropdown-wrapper" bind:this={typePopoverRef}>
       <button
-        class="filter-btn"
-        class:has-filter={activeTypeFilter.length > 0}
-        onclick={(e) => {
-          e.stopPropagation();
-          typePopoverOpen = !typePopoverOpen;
-        }}
+        class="filter-btn edit-channel-btn"
+        onclick={() => onEditChannel(parseInt(feedViewStore.viewFilter!))}
+        title="Edit channel"
       >
-        <Icon name="layers" size={16} />
-        <span class="filter-label">{typeFilterLabel}</span>
-        <Icon name="chevron-down" size={12} />
+        <Icon name="edit" size={16} />
+        <span class="filter-label">Edit Channel</span>
       </button>
-
-      {#if typePopoverOpen}
-        <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-        <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
-          <div class="popover-group-header">
-            <span>Types</span>
-            {#if activeTypeFilter.length > 0}
-              <button class="select-all-btn" onclick={clearTypeFilter}>Clear</button>
-            {/if}
-          </div>
-          <div class="popover-list">
-            {#each TYPE_OPTIONS as opt}
-              <label class="check-label">
-                <input
-                  type="checkbox"
-                  checked={activeTypeSet.has(opt.value)}
-                  onchange={() => toggleTypeFilter(opt.value)}
-                />
-                <span class="check-text">{opt.label}</span>
-              </label>
-            {/each}
-          </div>
-        </div>
-      {/if}
     </div>
-  </div>
+  {:else}
+    {#if showSourceFilter}
+      <span class="toolbar-divider group-divider"></span>
 
-  {#if allTags.length > 0}
+      <!-- Group 2: Sources dropdown -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={sourcePopoverRef}>
+          <button
+            class="filter-btn source-btn"
+            class:has-filter={ef.sourceMode !== 'all'}
+            onclick={(e) => {
+              e.stopPropagation();
+              feedViewStore.setSourcePopoverOpen(!sourcePopoverOpen);
+            }}
+          >
+            <Icon name="filter" size={16} />
+            <span class="filter-label">{sourceFilterLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
+
+          {#if sourcePopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-section">
+                <label class="radio-label">
+                  <input
+                    type="radio"
+                    name="sourceMode"
+                    value="all"
+                    checked={ef.sourceMode === 'all'}
+                    onchange={() => setSourceMode('all')}
+                  />
+                  All sources
+                </label>
+                <label class="radio-label">
+                  <input
+                    type="radio"
+                    name="sourceMode"
+                    value="include"
+                    checked={ef.sourceMode === 'include'}
+                    onchange={() => setSourceMode('include')}
+                  />
+                  Include only
+                </label>
+              </div>
+
+              {#if ef.sourceMode === 'include'}
+                <!-- Subscriptions list -->
+                {#if subscriptionsStore.subscriptions.length > 0}
+                  <div class="popover-group-header">
+                    <span>Subscriptions</span>
+                    <button
+                      class="select-all-btn"
+                      onclick={allSourcesSelected ? deselectAllSources : selectAllSources}
+                    >
+                      {allSourcesSelected ? 'Deselect all' : 'Select all'}
+                    </button>
+                  </div>
+                  <div class="popover-search">
+                    <input
+                      type="text"
+                      placeholder="Search subscriptions..."
+                      bind:value={feedSearch}
+                      class="search-input"
+                    />
+                  </div>
+                  <div class="popover-list">
+                    {#each filteredSubscriptions as sub}
+                      {@const key = subscriptionSourceKey(sub)}
+                      {#if key}
+                        {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
+                        {@const iconUrl =
+                          sub.customIconUrl ||
+                          (isAtProto
+                            ? sub.siteUrl
+                              ? getFaviconUrl(sub.siteUrl)
+                              : '/icons/icon-192.svg'
+                            : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
+                        <label class="check-label">
+                          <input
+                            type="checkbox"
+                            checked={sourceKeySet.has(key)}
+                            onchange={() => toggleSourceKey(key)}
+                          />
+                          {#if iconUrl}
+                            <img src={iconUrl} alt="" class="check-icon" />
+                          {/if}
+                          <span class="check-text">{sub.customTitle || sub.title}</span>
+                        </label>
+                      {/if}
+                    {/each}
+                    {#if feedSearch && filteredSubscriptions.length === 0}
+                      <div class="no-results">No subscriptions match</div>
+                    {/if}
+                  </div>
+                {/if}
+              {/if}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
     <span class="toolbar-divider group-divider"></span>
 
-    <!-- Tags dropdown -->
+    <!-- Type filter dropdown -->
     <div class="filter-group">
-      <div class="dropdown-wrapper" bind:this={tagPopoverRef}>
+      <div class="dropdown-wrapper" bind:this={typePopoverRef}>
         <button
           class="filter-btn"
-          class:has-filter={activeTagFilter.length > 0}
+          class:has-filter={activeTypeFilter.length > 0}
           onclick={(e) => {
             e.stopPropagation();
-            tagPopoverOpen = !tagPopoverOpen;
+            typePopoverOpen = !typePopoverOpen;
           }}
         >
-          <Icon name="tag" size={16} />
-          <span class="filter-label">{tagFilterLabel}</span>
+          <Icon name="layers" size={16} />
+          <span class="filter-label">{typeFilterLabel}</span>
           <Icon name="chevron-down" size={12} />
         </button>
 
-        {#if tagPopoverOpen}
+        {#if typePopoverOpen}
           <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
           <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
             <div class="popover-group-header">
-              <span>Tags</span>
-              {#if activeTagFilter.length > 0}
-                <button class="select-all-btn" onclick={clearTagFilter}>Clear</button>
+              <span>Types</span>
+              {#if activeTypeFilter.length > 0}
+                <button class="select-all-btn" onclick={clearTypeFilter}>Clear</button>
               {/if}
             </div>
             <div class="popover-list">
-              {#each allTags as tag}
+              {#each TYPE_OPTIONS as opt}
                 <label class="check-label">
                   <input
                     type="checkbox"
-                    checked={activeTagSet.has(tag)}
-                    onchange={() => toggleTagFilter(tag)}
+                    checked={activeTypeSet.has(opt.value)}
+                    onchange={() => toggleTypeFilter(opt.value)}
                   />
-                  <span class="check-text">{tag}</span>
+                  <span class="check-text">{opt.label}</span>
                 </label>
               {/each}
             </div>
@@ -581,75 +551,121 @@
         {/if}
       </div>
     </div>
-  {/if}
 
-  <span class="toolbar-divider group-divider"></span>
+    {#if allTags.length > 0}
+      <span class="toolbar-divider group-divider"></span>
 
-  <!-- Save button -->
-  <div class="filter-group">
-    {#if showNameInput}
-      <div class="save-name-input">
-        <input
-          type="text"
-          bind:this={nameInputRef}
-          bind:value={newViewName}
-          placeholder="View name..."
-          onkeydown={handleNameKeydown}
-          class="name-input"
-        />
-        <button
-          class="filter-btn save-confirm-btn"
-          onclick={handleCreateView}
-          disabled={!newViewName.trim() || saving}
-          title="Create view"
-        >
-          <Icon name="check" size={16} />
-        </button>
+      <!-- Tags dropdown -->
+      <div class="filter-group">
+        <div class="dropdown-wrapper" bind:this={tagPopoverRef}>
+          <button
+            class="filter-btn"
+            class:has-filter={activeTagFilter.length > 0}
+            onclick={(e) => {
+              e.stopPropagation();
+              tagPopoverOpen = !tagPopoverOpen;
+            }}
+          >
+            <Icon name="tag" size={16} />
+            <span class="filter-label">{tagFilterLabel}</span>
+            <Icon name="chevron-down" size={12} />
+          </button>
+
+          {#if tagPopoverOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="popover" use:viewportAware onclick={(e) => e.stopPropagation()}>
+              <div class="popover-group-header">
+                <span>Tags</span>
+                {#if activeTagFilter.length > 0}
+                  <button class="select-all-btn" onclick={clearTagFilter}>Clear</button>
+                {/if}
+              </div>
+              <div class="popover-list">
+                {#each allTags as tag}
+                  <label class="check-label">
+                    <input
+                      type="checkbox"
+                      checked={activeTagSet.has(tag)}
+                      onchange={() => toggleTagFilter(tag)}
+                    />
+                    <span class="check-text">{tag}</span>
+                  </label>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
       </div>
-    {:else if showRenameInput}
-      <div class="save-name-input">
-        <input
-          bind:this={renameInputRef}
-          bind:value={renameViewName}
-          class="name-input"
-          placeholder="View name"
-          onkeydown={handleRenameKeydown}
-          onblur={commitRenameView}
-        />
-        <button
-          class="filter-btn save-confirm-btn"
-          onclick={commitRenameView}
-          disabled={!renameViewName.trim()}
-          title="Confirm rename"
-        >
-          <Icon name="check" size={16} />
-        </button>
-      </div>
-    {:else}
-      <button
-        class="filter-btn save-btn"
-        class:has-changes={isEditingView
-          ? feedViewStore.hasUnsavedChanges
-          : ef.sourceMode !== 'all' || activeTypeFilter.length > 0}
-        onclick={handleSave}
-        disabled={isEditingView
-          ? !feedViewStore.hasUnsavedChanges
-          : ef.sourceMode === 'all' && activeTypeFilter.length === 0}
-        title={isEditingView ? 'Update view' : 'Save as new view'}
-      >
-        <Icon name="save" size={16} />
-        <span class="filter-label">{isEditingView ? 'Update' : 'Save'}</span>
-      </button>
-      {#if isEditingView}
-        <button class="filter-btn rename-btn" onclick={startRenameView} title="Rename view">
-          <Icon name="edit" size={16} />
-        </button>
-        <button class="filter-btn delete-btn" onclick={handleDeleteView} title="Delete view">
-          <Icon name="trash" size={16} />
-        </button>
-      {/if}
     {/if}
-  </div>
+
+    <span class="toolbar-divider group-divider"></span>
+
+    <!-- Save button -->
+    <div class="filter-group">
+      {#if showNameInput}
+        <div class="save-name-input">
+          <input
+            type="text"
+            bind:this={nameInputRef}
+            bind:value={newViewName}
+            placeholder="View name..."
+            onkeydown={handleNameKeydown}
+            class="name-input"
+          />
+          <button
+            class="filter-btn save-confirm-btn"
+            onclick={handleCreateView}
+            disabled={!newViewName.trim() || saving}
+            title="Create view"
+          >
+            <Icon name="check" size={16} />
+          </button>
+        </div>
+      {:else if showRenameInput}
+        <div class="save-name-input">
+          <input
+            bind:this={renameInputRef}
+            bind:value={renameViewName}
+            class="name-input"
+            placeholder="View name"
+            onkeydown={handleRenameKeydown}
+            onblur={commitRenameView}
+          />
+          <button
+            class="filter-btn save-confirm-btn"
+            onclick={commitRenameView}
+            disabled={!renameViewName.trim()}
+            title="Confirm rename"
+          >
+            <Icon name="check" size={16} />
+          </button>
+        </div>
+      {:else}
+        <button
+          class="filter-btn save-btn"
+          class:has-changes={isEditingView
+            ? feedViewStore.hasUnsavedChanges
+            : ef.sourceMode !== 'all' || activeTypeFilter.length > 0}
+          onclick={handleSave}
+          disabled={isEditingView
+            ? !feedViewStore.hasUnsavedChanges
+            : ef.sourceMode === 'all' && activeTypeFilter.length === 0}
+          title={isEditingView ? 'Update channel' : 'Save as new channel'}
+        >
+          <Icon name="save" size={16} />
+          <span class="filter-label">{isEditingView ? 'Update' : 'Save'}</span>
+        </button>
+        {#if isEditingView}
+          <button class="filter-btn rename-btn" onclick={startRenameView} title="Rename channel">
+            <Icon name="edit" size={16} />
+          </button>
+          <button class="filter-btn delete-btn" onclick={handleDeleteView} title="Delete channel">
+            <Icon name="trash" size={16} />
+          </button>
+        {/if}
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -8,11 +8,7 @@
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { goto } from '$app/navigation';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
-  import type {
-    SubscriptionSourceType,
-    SavedSourceType,
-    ReadingLengthFilter,
-  } from '$lib/types';
+  import type { SubscriptionSourceType, SavedSourceType, ReadingLengthFilter } from '$lib/types';
   import {
     TYPE_OPTIONS,
     SAVED_SOURCE_OPTIONS,

--- a/frontend/src/lib/components/feed/MobileBottomBar.svelte
+++ b/frontend/src/lib/components/feed/MobileBottomBar.svelte
@@ -9,6 +9,7 @@
     onOpenFeedSwitcher: () => void;
     onOpenFilterSheet: () => void;
     hasActiveFilters: boolean;
+    hideFilterButton?: boolean;
   }
 
   let {
@@ -18,6 +19,7 @@
     onOpenFeedSwitcher,
     onOpenFilterSheet,
     hasActiveFilters,
+    hideFilterButton = false,
   }: Props = $props();
 
   let addMenuOpen = $state(false);
@@ -92,19 +94,21 @@
         </div>
       {/if}
     </div>
-    <span class="bar-divider"></span>
-    <button
-      class="bar-btn"
-      class:has-filters={hasActiveFilters}
-      onclick={onOpenFilterSheet}
-      aria-label="Filters and style"
-      title="Filters & Style"
-    >
-      <Icon name="sliders" size={20} />
-      {#if hasActiveFilters}
-        <span class="filter-dot"></span>
-      {/if}
-    </button>
+    {#if !hideFilterButton}
+      <span class="bar-divider"></span>
+      <button
+        class="bar-btn"
+        class:has-filters={hasActiveFilters}
+        onclick={onOpenFilterSheet}
+        aria-label="Filters and style"
+        title="Filters & Style"
+      >
+        <Icon name="sliders" size={20} />
+        {#if hasActiveFilters}
+          <span class="filter-dot"></span>
+        {/if}
+      </button>
+    {/if}
     <span class="bar-divider"></span>
     <button
       class="bar-btn"

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -13,6 +13,10 @@
     channelSuggestions,
     type ChannelSuggestion,
   } from '$lib/stores/channelSuggestions.svelte';
+  import {
+    savedChannelSuggestions,
+    type SavedChannelSuggestion,
+  } from '$lib/stores/savedChannelSuggestions.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
 
@@ -103,7 +107,11 @@
     }
 
     const filteredChannels = channels.filter(filterItem);
-    if (filteredChannels.length > 0 || channelSuggestions.suggestions.length > 0) {
+    if (
+      filteredChannels.length > 0 ||
+      channelSuggestions.suggestions.length > 0 ||
+      savedChannelSuggestions.suggestions.length > 0
+    ) {
       sections.push({ section: 'Channels', items: filteredChannels });
     }
 
@@ -151,6 +159,21 @@
       autoRule: suggestion.autoRule,
       readFilter: 'unread',
       sortOrder: 'newest',
+    });
+    goto(`/?view=${id}`);
+    onclose();
+  }
+
+  async function acceptSavedSuggestion(suggestion: SavedChannelSuggestion) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      mode: 'saved',
+      savedSourceFilter: suggestion.savedSourceFilter,
+      savedDomainFilter: suggestion.savedDomainFilter,
+      savedReadingLength: suggestion.savedReadingLength,
+      savedDateFilter: suggestion.savedDateFilter,
+      readFilter: suggestion.readFilter ?? 'all',
+      sortOrder: suggestion.sortOrder ?? 'newest',
     });
     goto(`/?view=${id}`);
     onclose();
@@ -249,7 +272,7 @@
           </button>
         {/if}
       {/each}
-      {#if section === 'Channels' && channelSuggestions.suggestions.length > 0 && !searchQuery}
+      {#if section === 'Channels' && (channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.suggestions.length > 0) && !searchQuery}
         {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
           <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
           <div class="nav-item suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
@@ -269,7 +292,26 @@
             </span>
           </div>
         {/each}
-        {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0}
+        {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+          <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+          <div class="nav-item suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
+            <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
+            <span class="item-label">{suggestion.name}</span>
+            <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  savedChannelSuggestions.dismiss(suggestion.id);
+                }}
+              >
+                <Icon name="x" size={14} />
+              </button>
+            </span>
+          </div>
+        {/each}
+        {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.hasMore || savedChannelSuggestions.suggestions.length > 0}
           <a
             href="/channels/discover"
             class="nav-item more-suggestions-link"

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -9,14 +9,21 @@
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import {
+    channelSuggestions,
+    type ChannelSuggestion,
+  } from '$lib/stores/channelSuggestions.svelte';
   import Icon from '$lib/components/Icon.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
 
   interface Props {
     onclose: () => void;
     currentTitle: string;
+    onEditChannel?: (id: number) => void;
+    onCreateChannel?: () => void;
   }
 
-  let { onclose, currentTitle }: Props = $props();
+  let { onclose, currentTitle, onEditChannel, onCreateChannel }: Props = $props();
 
   let searchQuery = $state('');
 
@@ -28,13 +35,21 @@
   let sharedCount = $derived(sharesStore.userShares.size);
   let activityCount = $derived(activityStore.totalReshareCount);
 
-  type IconName = 'inbox' | 'bookmark' | 'share' | 'bell' | 'settings' | 'filter' | 'plus';
+  type IconName =
+    | 'inbox'
+    | 'bookmark'
+    | 'share'
+    | 'bell'
+    | 'settings'
+    | 'filter'
+    | 'plus'
+    | 'newspaper';
 
   type NavItem =
     | { type: 'view'; id: string; label: string; count?: number; icon: IconName }
     | { type: 'feed'; id: number; label: string; count: number; iconUrl: string | null }
     | { type: 'utility'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'filteredView'; id: number; label: string; icon: IconName };
+    | { type: 'filteredView'; id: number; label: string; count?: number; icon: IconName };
 
   type SectionData = {
     section: string;
@@ -45,18 +60,20 @@
     const query = searchQuery.toLowerCase().trim();
 
     const views: NavItem[] = [
-      { type: 'view', id: 'all', label: 'All', count: totalUnread, icon: 'inbox' },
+      { type: 'view', id: 'all', label: 'Everything', count: totalUnread, icon: 'inbox' },
       { type: 'view', id: 'saved', label: 'Saved', count: savedCount, icon: 'bookmark' },
       { type: 'view', id: 'shared', label: 'Shared', count: sharedCount, icon: 'share' },
       { type: 'utility', id: 'activity', label: 'Activity', count: activityCount, icon: 'bell' },
+      { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' as IconName },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' as IconName },
     ];
 
-    const customViews: NavItem[] = filteredViewsStore.views.map((v) => ({
+    const channels: NavItem[] = filteredViewsStore.views.map((v) => ({
       type: 'filteredView' as const,
       id: v.id!,
       label: v.name,
-      icon: 'filter' as const,
+      count: v.id != null ? (unreadCounts.channelCounts.get(v.id) ?? 0) : 0,
+      icon: 'newspaper' as const,
     }));
 
     const feedItems: NavItem[] = subscriptions.map((s) => ({
@@ -80,14 +97,19 @@
 
     const sections: SectionData[] = [];
 
-    const allViews = [...views, ...customViews].filter(filterItem);
-    if (allViews.length > 0) {
-      sections.push({ section: '', items: allViews });
+    const filteredViews = views.filter(filterItem);
+    if (filteredViews.length > 0) {
+      sections.push({ section: '', items: filteredViews });
+    }
+
+    const filteredChannels = channels.filter(filterItem);
+    if (filteredChannels.length > 0 || channelSuggestions.suggestions.length > 0) {
+      sections.push({ section: 'Channels', items: filteredChannels });
     }
 
     const filteredFeeds = feedItems.filter(filterItem);
     if (filteredFeeds.length > 0) {
-      sections.push({ section: 'Feeds', items: filteredFeeds });
+      sections.push({ section: 'Sources', items: filteredFeeds });
     }
 
     return sections;
@@ -118,6 +140,20 @@
     if (item.type === 'filteredView' && filter.type === 'filteredView' && filter.id === item.id)
       return true;
     return false;
+  }
+
+  async function acceptSuggestion(suggestion: ChannelSuggestion) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      sourceMode: suggestion.sourceMode,
+      sourceKeys: suggestion.sourceKeys,
+      typeFilter: suggestion.typeFilter.length > 0 ? suggestion.typeFilter : undefined,
+      autoRule: suggestion.autoRule,
+      readFilter: 'unread',
+      sortOrder: 'newest',
+    });
+    goto(`/?view=${id}`);
+    onclose();
   }
 
   function selectItem(item: NavItem) {
@@ -152,30 +188,98 @@
   <div class="items-list">
     {#each filteredItems as { section, items }}
       {#if section}
-        <div class="section-header">{section}</div>
+        <div class="section-header">
+          <span>{section}</span>
+          {#if section === 'Channels' && onCreateChannel}
+            <button
+              class="section-add-btn"
+              onclick={(e) => {
+                e.stopPropagation();
+                onCreateChannel();
+              }}
+              aria-label="New channel"
+            >
+              <Icon name="plus" size={14} />
+            </button>
+          {/if}
+        </div>
       {/if}
       {#each items as item}
-        <button
-          class="nav-item"
-          class:active={isItemActive(item)}
-          class:section-child={!!section}
-          onclick={() => selectItem(item)}
-        >
-          {#if item.type === 'view' || item.type === 'utility' || item.type === 'filteredView'}
-            <span class="item-icon"><Icon name={item.icon} size={18} /></span>
-          {:else if item.type === 'feed'}
-            {#if item.iconUrl}
-              <img src={item.iconUrl} alt="" class="feed-icon" />
-            {:else}
-              <span class="feed-icon-placeholder"></span>
+        {#if item.type === 'filteredView' && onEditChannel}
+          <div
+            class="nav-item-row"
+            class:active={isItemActive(item)}
+            class:section-child={!!section}
+          >
+            <button class="nav-item-main" onclick={() => selectItem(item)}>
+              <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+              <span class="item-label">{item.label}</span>
+              {#if item.count && item.count > 0}
+                <span class="item-count">{item.count}</span>
+              {/if}
+            </button>
+            <button
+              class="channel-edit-btn"
+              onclick={() => onEditChannel(item.id)}
+              aria-label="Edit channel"
+            >
+              <Icon name="edit" size={14} />
+            </button>
+          </div>
+        {:else}
+          <button
+            class="nav-item"
+            class:active={isItemActive(item)}
+            class:section-child={!!section}
+            onclick={() => selectItem(item)}
+          >
+            {#if item.type === 'view' || item.type === 'utility' || item.type === 'filteredView'}
+              <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+            {:else if item.type === 'feed'}
+              {#if item.iconUrl}
+                <img src={item.iconUrl} alt="" class="feed-icon" />
+              {:else}
+                <span class="feed-icon-placeholder"></span>
+              {/if}
             {/if}
-          {/if}
-          <span class="item-label">{item.label}</span>
-          {#if item.type !== 'filteredView' && item.count && item.count > 0}
-            <span class="item-count">{item.count}</span>
-          {/if}
-        </button>
+            <span class="item-label">{item.label}</span>
+            {#if item.count && item.count > 0}
+              <span class="item-count">{item.count}</span>
+            {/if}
+          </button>
+        {/if}
       {/each}
+      {#if section === 'Channels' && channelSuggestions.suggestions.length > 0 && !searchQuery}
+        {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+          <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+          <div class="nav-item suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+            <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
+            <span class="item-label">{suggestion.name}</span>
+            <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  channelSuggestions.dismiss(suggestion.id);
+                }}
+              >
+                <Icon name="x" size={14} />
+              </button>
+            </span>
+          </div>
+        {/each}
+        {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0}
+          <a
+            href="/channels/discover"
+            class="nav-item more-suggestions-link"
+            onclick={() => onclose()}
+          >
+            <span class="item-icon"><Icon name="arrow-right" size={16} /></span>
+            <span class="item-label">More channel ideas</span>
+          </a>
+        {/if}
+      {/if}
     {/each}
     {#if filteredItems.length === 0 || filteredItems.every((s) => s.items.length === 0)}
       <div class="no-results">No matches found</div>
@@ -221,12 +325,33 @@
   }
 
   .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     padding: 0.75rem 1rem 0.375rem;
     font-size: 0.6875rem;
     font-weight: 600;
     color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  .section-add-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .section-add-btn:active {
+    background: var(--color-bg-secondary, #f5f5f5);
   }
 
   .nav-item {
@@ -253,6 +378,43 @@
     background: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
     color: var(--color-primary);
     font-weight: 500;
+  }
+
+  .nav-item-row {
+    display: flex;
+    align-items: center;
+    margin: 0 0.5rem;
+    border-radius: 8px;
+    transition: background 0.15s;
+  }
+
+  .nav-item-row.active {
+    background: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
+    color: var(--color-primary);
+    font-weight: 500;
+  }
+
+  .nav-item-row.active .item-icon {
+    color: var(--color-primary);
+  }
+
+  .nav-item-main {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+    padding: 0.625rem 0 0.625rem 1rem;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    font-size: 0.9375rem;
+    text-align: left;
+  }
+
+  .nav-item-main:active {
+    opacity: 0.7;
   }
 
   .item-icon {
@@ -299,6 +461,68 @@
     flex-shrink: 0;
   }
 
+  .suggestion-accept {
+    color: var(--color-text-secondary);
+  }
+
+  .suggestion-icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 1.5px dashed currentColor;
+  }
+
+  .suggestion-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  .suggestion-dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    border-radius: 6px;
+    flex-shrink: 0;
+    padding: 0;
+  }
+
+  .suggestion-dismiss:active {
+    background: var(--color-bg-secondary);
+  }
+
+  .more-suggestions-link {
+    text-decoration: none;
+    color: var(--color-text-secondary);
+    font-size: 0.8125rem;
+  }
+
+  .channel-edit-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .channel-edit-btn:active {
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
   .no-results {
     padding: 1.5rem;
     text-align: center;
@@ -316,6 +540,11 @@
     }
 
     .item-count {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .section-add-btn:active,
+    .channel-edit-btn:active {
       background: rgba(255, 255, 255, 0.1);
     }
   }

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -262,10 +262,7 @@
 
   <div class="items-list">
     {#each filteredItems as { section, groupId, items }}
-      <div
-        class="nav-group"
-        class:tinted={groupId === 'everything' || groupId === 'saved'}
-      >
+      <div class="nav-group" class:tinted={groupId === 'everything' || groupId === 'saved'}>
         {#if section}
           <div class="section-header">
             <span>{section}</span>

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -24,7 +24,7 @@
     onclose: () => void;
     currentTitle: string;
     onEditChannel?: (id: number) => void;
-    onCreateChannel?: () => void;
+    onCreateChannel?: (type?: 'feed' | 'saved') => void;
   }
 
   let { onclose, currentTitle, onEditChannel, onCreateChannel }: Props = $props();
@@ -50,35 +50,83 @@
     | 'newspaper';
 
   type NavItem =
-    | { type: 'view'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'feed'; id: number; label: string; count: number; iconUrl: string | null }
-    | { type: 'utility'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'filteredView'; id: string; label: string; count?: number; icon: IconName };
+    | { type: 'view'; id: string; label: string; count?: number; icon: IconName; indent?: boolean }
+    | {
+        type: 'feed';
+        id: number;
+        label: string;
+        count: number;
+        iconUrl: string | null;
+        indent?: boolean;
+      }
+    | {
+        type: 'utility';
+        id: string;
+        label: string;
+        count?: number;
+        icon: IconName;
+        indent?: boolean;
+      }
+    | {
+        type: 'filteredView';
+        id: string;
+        label: string;
+        count?: number;
+        icon: IconName;
+        indent?: boolean;
+      };
 
   type SectionData = {
     section: string;
+    groupId?: 'everything' | 'saved' | 'other' | 'sources';
     items: NavItem[];
   };
 
   let filteredItems = $derived.by((): SectionData[] => {
     const query = searchQuery.toLowerCase().trim();
 
-    const views: NavItem[] = [
-      { type: 'view', id: 'all', label: 'Everything', count: totalUnread, icon: 'inbox' },
-      { type: 'view', id: 'saved', label: 'Saved', count: savedCount, icon: 'bookmark' },
+    const everythingItem: NavItem = {
+      type: 'view',
+      id: 'all',
+      label: 'Everything',
+      count: totalUnread,
+      icon: 'inbox',
+    };
+    const savedItem: NavItem = {
+      type: 'view',
+      id: 'saved',
+      label: 'Saved',
+      count: savedCount,
+      icon: 'bookmark',
+    };
+    const otherItems: NavItem[] = [
       { type: 'view', id: 'shared', label: 'Shared', count: sharedCount, icon: 'share' },
       { type: 'utility', id: 'activity', label: 'Activity', count: activityCount, icon: 'bell' },
       { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' as IconName },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' as IconName },
     ];
 
-    const channels: NavItem[] = filteredViewsStore.views.map((v) => ({
-      type: 'filteredView' as const,
-      id: v.uuid,
-      label: v.name,
-      count: v.id != null ? (unreadCounts.channelCounts.get(v.id) ?? 0) : 0,
-      icon: 'newspaper' as const,
-    }));
+    const sourceChannelItems: NavItem[] = filteredViewsStore.views
+      .filter((v) => v.mode !== 'saved')
+      .map((v) => ({
+        type: 'filteredView' as const,
+        id: v.uuid,
+        label: v.name,
+        count: v.id != null ? (unreadCounts.channelCounts.get(v.id) ?? 0) : 0,
+        icon: 'newspaper' as const,
+        indent: true,
+      }));
+
+    const savedChannelItems: NavItem[] = filteredViewsStore.views
+      .filter((v) => v.mode === 'saved')
+      .map((v) => ({
+        type: 'filteredView' as const,
+        id: v.uuid,
+        label: v.name,
+        count: v.id != null ? (unreadCounts.channelCounts.get(v.id) ?? 0) : 0,
+        icon: 'bookmark' as const,
+        indent: true,
+      }));
 
     const feedItems: NavItem[] = subscriptions.map((s) => ({
       type: 'feed' as const,
@@ -101,23 +149,27 @@
 
     const sections: SectionData[] = [];
 
-    const filteredViews = views.filter(filterItem);
-    if (filteredViews.length > 0) {
-      sections.push({ section: '', items: filteredViews });
+    // Everything group: Everything + source channels (+ suggestions rendered inline in template)
+    const everythingGroup = [everythingItem, ...sourceChannelItems].filter(filterItem);
+    if (everythingGroup.length > 0 || (!query && channelSuggestions.suggestions.length > 0)) {
+      sections.push({ section: '', groupId: 'everything', items: everythingGroup });
     }
 
-    const filteredChannels = channels.filter(filterItem);
-    if (
-      filteredChannels.length > 0 ||
-      channelSuggestions.suggestions.length > 0 ||
-      savedChannelSuggestions.suggestions.length > 0
-    ) {
-      sections.push({ section: 'Channels', items: filteredChannels });
+    // Saved group: Saved + saved channels (+ suggestions rendered inline in template)
+    const savedGroup = [savedItem, ...savedChannelItems].filter(filterItem);
+    if (savedGroup.length > 0 || (!query && savedChannelSuggestions.suggestions.length > 0)) {
+      sections.push({ section: '', groupId: 'saved', items: savedGroup });
+    }
+
+    // Other utility items
+    const filteredOther = otherItems.filter(filterItem);
+    if (filteredOther.length > 0) {
+      sections.push({ section: '', groupId: 'other', items: filteredOther });
     }
 
     const filteredFeeds = feedItems.filter(filterItem);
     if (filteredFeeds.length > 0) {
-      sections.push({ section: 'Sources', items: filteredFeeds });
+      sections.push({ section: 'Sources', groupId: 'sources', items: filteredFeeds });
     }
 
     return sections;
@@ -209,112 +261,99 @@
   </div>
 
   <div class="items-list">
-    {#each filteredItems as { section, items }}
-      {#if section}
-        <div class="section-header">
-          <span>{section}</span>
-          {#if section === 'Channels' && onCreateChannel}
+    {#each filteredItems as { section, groupId, items }}
+      <div
+        class="nav-group"
+        class:tinted={groupId === 'everything' || groupId === 'saved'}
+      >
+        {#if section}
+          <div class="section-header">
+            <span>{section}</span>
+          </div>
+        {/if}
+        {#each items as item}
+          {#if item.type === 'view' && (item.id === 'all' || item.id === 'saved') && onCreateChannel}
+            <div class="nav-item-row" class:active={isItemActive(item)}>
+              <button class="nav-item-main" onclick={() => selectItem(item)}>
+                <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+                <span class="item-label">{item.label}</span>
+              </button>
+              <button
+                class="channel-add-btn"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  onCreateChannel(item.id === 'saved' ? 'saved' : 'feed');
+                }}
+                aria-label="New channel"
+              >
+                <Icon name="plus" size={16} />
+              </button>
+              {#if item.count && item.count > 0}
+                <span class="item-count row-count">{item.count}</span>
+              {/if}
+            </div>
+          {:else if item.type === 'filteredView' && onEditChannel}
+            <div class="nav-item-row" class:active={isItemActive(item)}>
+              <button class="nav-item-main" onclick={() => selectItem(item)}>
+                <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+                <span class="item-label">{item.label}</span>
+              </button>
+              <button
+                class="channel-edit-btn"
+                onclick={() => {
+                  const view = filteredViewsStore.getByUuid(item.id);
+                  if (view?.id != null) onEditChannel(view.id);
+                }}
+                aria-label="Edit channel"
+              >
+                <Icon name="edit" size={14} />
+              </button>
+              {#if item.count && item.count > 0}
+                <span class="item-count row-count">{item.count}</span>
+              {/if}
+            </div>
+          {:else}
             <button
-              class="section-add-btn"
-              onclick={(e) => {
-                e.stopPropagation();
-                onCreateChannel();
-              }}
-              aria-label="New channel"
+              class="nav-item"
+              class:active={isItemActive(item)}
+              onclick={() => selectItem(item)}
             >
-              <Icon name="plus" size={14} />
-            </button>
-          {/if}
-        </div>
-      {/if}
-      {#each items as item}
-        {#if item.type === 'filteredView' && onEditChannel}
-          <div
-            class="nav-item-row"
-            class:active={isItemActive(item)}
-            class:section-child={!!section}
-          >
-            <button class="nav-item-main" onclick={() => selectItem(item)}>
-              <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+              {#if item.type === 'view' || item.type === 'utility' || item.type === 'filteredView'}
+                <span class="item-icon"><Icon name={item.icon} size={18} /></span>
+              {:else if item.type === 'feed'}
+                {#if item.iconUrl}
+                  <img src={item.iconUrl} alt="" class="feed-icon" />
+                {:else}
+                  <span class="feed-icon-placeholder"></span>
+                {/if}
+              {/if}
               <span class="item-label">{item.label}</span>
               {#if item.count && item.count > 0}
                 <span class="item-count">{item.count}</span>
               {/if}
             </button>
-            <button
-              class="channel-edit-btn"
-              onclick={() => {
-                const view = filteredViewsStore.getByUuid(item.id);
-                if (view?.id != null) onEditChannel(view.id);
-              }}
-              aria-label="Edit channel"
-            >
-              <Icon name="edit" size={14} />
-            </button>
-          </div>
-        {:else}
-          <button
-            class="nav-item"
-            class:active={isItemActive(item)}
-            class:section-child={!!section}
-            onclick={() => selectItem(item)}
-          >
-            {#if item.type === 'view' || item.type === 'utility' || item.type === 'filteredView'}
-              <span class="item-icon"><Icon name={item.icon} size={18} /></span>
-            {:else if item.type === 'feed'}
-              {#if item.iconUrl}
-                <img src={item.iconUrl} alt="" class="feed-icon" />
-              {:else}
-                <span class="feed-icon-placeholder"></span>
-              {/if}
-            {/if}
-            <span class="item-label">{item.label}</span>
-            {#if item.count && item.count > 0}
-              <span class="item-count">{item.count}</span>
-            {/if}
-          </button>
-        {/if}
-      {/each}
-      {#if section === 'Channels' && (channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.suggestions.length > 0) && !searchQuery}
-        {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
-          <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-          <div class="nav-item suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
-            <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
-            <span class="item-label">{suggestion.name}</span>
-            <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
-              <Tooltip text={suggestion.description} />
-              <button
-                class="suggestion-dismiss"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  channelSuggestions.dismiss(suggestion.id);
-                }}
-              >
-                <Icon name="x" size={14} />
-              </button>
-            </span>
-          </div>
+          {/if}
         {/each}
-        {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
-          <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-          <div class="nav-item suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
-            <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
-            <span class="item-label">{suggestion.name}</span>
-            <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
-              <Tooltip text={suggestion.description} />
-              <button
-                class="suggestion-dismiss"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  savedChannelSuggestions.dismiss(suggestion.id);
-                }}
-              >
-                <Icon name="x" size={14} />
-              </button>
-            </span>
-          </div>
-        {/each}
-        {#if channelSuggestions.hasMore || channelSuggestions.suggestions.length > 0 || savedChannelSuggestions.hasMore || savedChannelSuggestions.suggestions.length > 0}
+        {#if groupId === 'everything' && !searchQuery}
+          {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+            <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+            <div class="nav-item suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+              <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
+              <span class="item-label">{suggestion.name}</span>
+              <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
+                <Tooltip text={suggestion.description} />
+                <button
+                  class="suggestion-dismiss"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    channelSuggestions.dismiss(suggestion.id);
+                  }}
+                >
+                  <Icon name="x" size={14} />
+                </button>
+              </span>
+            </div>
+          {/each}
           <a
             href="/channels/discover"
             class="nav-item more-suggestions-link"
@@ -324,7 +363,39 @@
             <span class="item-label">More channel ideas</span>
           </a>
         {/if}
-      {/if}
+        {#if groupId === 'saved' && !searchQuery}
+          {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+            <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+            <div
+              class="nav-item suggestion-accept"
+              onclick={() => acceptSavedSuggestion(suggestion)}
+            >
+              <span class="item-icon suggestion-icon"><Icon name="plus" size={16} /></span>
+              <span class="item-label">{suggestion.name}</span>
+              <span class="suggestion-actions" onclick={(e) => e.stopPropagation()}>
+                <Tooltip text={suggestion.description} />
+                <button
+                  class="suggestion-dismiss"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    savedChannelSuggestions.dismiss(suggestion.id);
+                  }}
+                >
+                  <Icon name="x" size={14} />
+                </button>
+              </span>
+            </div>
+          {/each}
+          <a
+            href="/channels/discover"
+            class="nav-item more-suggestions-link"
+            onclick={() => onclose()}
+          >
+            <span class="item-icon"><Icon name="arrow-right" size={16} /></span>
+            <span class="item-label">More channel ideas</span>
+          </a>
+        {/if}
+      </div>
     {/each}
     {#if filteredItems.length === 0 || filteredItems.every((s) => s.items.length === 0)}
       <div class="no-results">No matches found</div>
@@ -381,21 +452,23 @@
     letter-spacing: 0.05em;
   }
 
-  .section-add-btn {
+  .channel-add-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 2rem;
+    height: 2rem;
     padding: 0;
+    margin-right: 0.5rem;
     background: none;
     border: none;
     border-radius: 6px;
     color: var(--color-text-secondary);
     cursor: pointer;
+    flex-shrink: 0;
   }
 
-  .section-add-btn:active {
+  .channel-add-btn:active {
     background: var(--color-bg-secondary, #f5f5f5);
   }
 
@@ -423,6 +496,39 @@
     background: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
     color: var(--color-primary);
     font-weight: 500;
+  }
+
+  .nav-group {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .nav-group.tinted {
+    background: rgba(0, 0, 0, 0.025);
+    border-radius: 12px;
+    margin: 0 0.5rem 0.5rem;
+    padding: 0.25rem 0;
+  }
+
+  .nav-group.tinted .nav-item,
+  .nav-group.tinted .nav-item-row {
+    margin-left: 0;
+    margin-right: 0;
+    width: calc(100% - 0rem);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .nav-group.tinted {
+      background: rgba(255, 255, 255, 0.025);
+    }
+  }
+
+  .row-count {
+    margin-right: 1rem;
+  }
+
+  .nav-item-row.active .row-count {
+    color: var(--color-primary);
   }
 
   .nav-item-row {

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -53,7 +53,7 @@
     | { type: 'view'; id: string; label: string; count?: number; icon: IconName }
     | { type: 'feed'; id: number; label: string; count: number; iconUrl: string | null }
     | { type: 'utility'; id: string; label: string; count?: number; icon: IconName }
-    | { type: 'filteredView'; id: number; label: string; count?: number; icon: IconName };
+    | { type: 'filteredView'; id: string; label: string; count?: number; icon: IconName };
 
   type SectionData = {
     section: string;
@@ -74,7 +74,7 @@
 
     const channels: NavItem[] = filteredViewsStore.views.map((v) => ({
       type: 'filteredView' as const,
-      id: v.id!,
+      id: v.uuid,
       label: v.name,
       count: v.id != null ? (unreadCounts.channelCounts.get(v.id) ?? 0) : 0,
       icon: 'newspaper' as const,
@@ -130,7 +130,7 @@
     const saved = url.searchParams.get('saved');
     const shared = url.searchParams.get('shared');
     const view = url.searchParams.get('view');
-    if (view) return { type: 'filteredView', id: parseInt(view) };
+    if (view) return { type: 'filteredView', id: view };
     if (feed) return { type: 'feed', id: parseInt(feed) };
     if (saved) return { type: 'saved' };
     if (shared) return { type: 'shared' };
@@ -243,7 +243,10 @@
             </button>
             <button
               class="channel-edit-btn"
-              onclick={() => onEditChannel(item.id)}
+              onclick={() => {
+                const view = filteredViewsStore.getByUuid(item.id);
+                if (view?.id != null) onEditChannel(view.id);
+              }}
               aria-label="Edit channel"
             >
               <Icon name="edit" size={14} />

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -38,6 +38,7 @@
     initialTab?: 'filters' | 'channel';
     editingChannelId?: number | null;
     channelCreateMode?: boolean;
+    initialChannelType?: 'feed' | 'saved' | null;
     oncreated?: (uuid: string) => void;
     ondeleted?: () => void;
   }
@@ -51,6 +52,7 @@
     initialTab = 'filters',
     editingChannelId = undefined,
     channelCreateMode = false,
+    initialChannelType = null,
     oncreated,
     ondeleted,
   }: Props = $props();
@@ -231,7 +233,7 @@
     // New channel defaults
     if (channelCreateMode) {
       chName = '';
-      chChannelType = 'feed';
+      chChannelType = initialChannelType ?? 'feed';
       chMode = 'manual';
       chAutoRuleType = 'frequency:high';
       chRecentWithinDays = 14;
@@ -1361,6 +1363,5 @@
     .match-preview.empty {
       background: rgba(255, 255, 255, 0.03);
     }
-
   }
 </style>

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -125,7 +125,7 @@
     initialTab?: 'filters' | 'channel';
     editingChannelId?: number | null;
     channelCreateMode?: boolean;
-    oncreated?: (id: number) => void;
+    oncreated?: (uuid: string) => void;
     ondeleted?: () => void;
   }
 

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -3,48 +3,239 @@
   import AppearanceToolbar from './AppearanceToolbar.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
-  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { articlesStore } from '$lib/stores/articles.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
-  import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
-  import { goto } from '$app/navigation';
-  import type { SubscriptionSourceType } from '$lib/types';
+  import { computeSourceKeys } from '$lib/utils/channelLogic';
+  import type { ChannelAutoRule } from '$lib/types';
 
-  const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
-    { value: 'rss', label: 'RSS Feeds' },
-    { value: 'atproto.shares', label: 'Skyreader Shares' },
-    { value: 'atproto.documents', label: 'Standard.site Documents' },
+  // --- Smart rule options (shared with FilteredViewModal) ---
+
+  type AutoRuleOption =
+    | 'frequency:high'
+    | 'frequency:low'
+    | 'longReads'
+    | 'recent'
+    | 'category'
+    | 'subscriptionTag'
+    | 'domain'
+    | 'people';
+
+  const AUTO_RULE_OPTIONS: { value: AutoRuleOption; label: string; description: string }[] = [
+    {
+      value: 'frequency:high',
+      label: 'Daily Digest',
+      description: 'High-volume feeds that publish 2+ times per day',
+    },
+    {
+      value: 'frequency:low',
+      label: "Don't Miss",
+      description: 'Infrequent feeds where every post counts',
+    },
+    {
+      value: 'longReads',
+      label: 'Long Reads',
+      description: 'Feeds with in-depth, long-form articles',
+    },
+    {
+      value: 'recent',
+      label: 'Recently Added',
+      description: 'Sources you added recently',
+    },
+    {
+      value: 'category',
+      label: 'Category',
+      description: 'All sources in a specific folder',
+    },
+    {
+      value: 'subscriptionTag',
+      label: 'Tag',
+      description: 'All sources with a specific tag',
+    },
+    {
+      value: 'domain',
+      label: 'Domain',
+      description: 'Sources matching URL patterns',
+    },
+    {
+      value: 'people',
+      label: 'People',
+      description: 'Everyone you follow on AT Protocol',
+    },
   ];
 
+  const DEFAULT_NAMES: Record<AutoRuleOption, string> = {
+    'frequency:high': 'Daily Digest',
+    'frequency:low': "Don't Miss",
+    longReads: 'Long Reads',
+    recent: 'New Sources',
+    category: '',
+    subscriptionTag: '',
+    domain: '',
+    people: 'People I Follow',
+  };
+
   interface Props {
-    showSourceFilter: boolean;
     expandAllItems: boolean;
     onToggleExpandAll: (value: boolean) => void;
     isSavedView: boolean;
     onMarkAllAsRead?: () => void;
     onclose: () => void;
+    // Channel editor props
+    initialTab?: 'filters' | 'channel';
+    editingChannelId?: number | null;
+    channelCreateMode?: boolean;
+    oncreated?: (id: number) => void;
+    ondeleted?: () => void;
   }
 
   let {
-    showSourceFilter,
     expandAllItems,
     onToggleExpandAll,
     isSavedView,
     onMarkAllAsRead,
     onclose,
+    initialTab = 'filters',
+    editingChannelId = undefined,
+    channelCreateMode = false,
+    oncreated,
+    ondeleted,
   }: Props = $props();
 
-  // Source filter state
-  let ef = $derived(feedViewStore.effectiveFilters);
-  let sourceKeySet = $derived(new Set(ef.sourceKeys));
-  let sourcesExpanded = $state(false);
-  let feedSearch = $state('');
+  // --- Tab state ---
+  let activeTab = $state<'filters' | 'channel'>('filters');
 
-  let filteredSubscriptions = $derived(
-    feedSearch
+  // Show channel tab when editing a channel or creating one
+  let showChannelTab = $derived(editingChannelId != null || channelCreateMode);
+
+  // Sync activeTab when initialTab prop changes
+  $effect(() => {
+    activeTab = initialTab;
+  });
+
+  // --- Channel editor state ---
+  let chName = $state('');
+  let chMode = $state<'manual' | 'smart'>('manual');
+  let chAutoRuleType = $state<AutoRuleOption>('frequency:high');
+  let chRecentWithinDays = $state(14);
+  let chCategoryValue = $state('');
+  let chTagValue = $state('');
+  let chDomainPatterns = $state<string[]>([]);
+  let chDomainInput = $state('');
+  let chDomainSuggestionsOpen = $state(false);
+  let chDomainHighlightIndex = $state(-1);
+  let chSourceMode = $state<'all' | 'include'>('all');
+  let chSourceKeys = $state<Set<string>>(new Set());
+  let chSaving = $state(false);
+  let chError = $state<string | null>(null);
+  let chNameManuallyEdited = $state(false);
+  let chFeedSearch = $state('');
+
+  let availableCategories = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .map((s) => s.category?.trim())
+          .filter((c): c is string => !!c)
+      ),
+    ].sort()
+  );
+
+  let availableSubTags = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .flatMap((s) => s.tags.map((t) => t.trim().toLowerCase()))
+          .filter(Boolean)
+      ),
+    ].sort()
+  );
+
+  let availableDomains = $derived(
+    [
+      ...new Set(
+        subscriptionsStore.subscriptions
+          .filter((s) => !s.sourceType || s.sourceType === 'rss')
+          .flatMap((s) => {
+            const urls = [s.feedUrl, s.siteUrl].filter(Boolean);
+            return urls
+              .map((u) => {
+                try {
+                  return new URL(u!).hostname;
+                } catch {
+                  return null;
+                }
+              })
+              .filter((h): h is string => !!h);
+          })
+      ),
+    ].sort()
+  );
+
+  let chDomainSuggestions = $derived.by(() => {
+    const q = chDomainInput.trim().toLowerCase();
+    const existing = new Set(chDomainPatterns);
+    return availableDomains.filter((d) => (!q || d.includes(q)) && !existing.has(d));
+  });
+
+  let chCurrentAutoRule = $derived.by((): ChannelAutoRule | undefined => {
+    if (chMode !== 'smart') return undefined;
+    switch (chAutoRuleType) {
+      case 'frequency:high':
+        return { type: 'frequency', threshold: 'high' };
+      case 'frequency:low':
+        return { type: 'frequency', threshold: 'low' };
+      case 'longReads':
+        return { type: 'longReads', minLength: 5000 };
+      case 'recent':
+        return { type: 'recent', withinDays: chRecentWithinDays };
+      case 'category':
+        return chCategoryValue.trim()
+          ? { type: 'category', value: chCategoryValue.trim() }
+          : undefined;
+      case 'subscriptionTag':
+        return chTagValue.trim()
+          ? { type: 'subscriptionTag', value: chTagValue.trim() }
+          : undefined;
+      case 'domain':
+        return chDomainPatterns.length > 0
+          ? { type: 'domain', patterns: chDomainPatterns }
+          : undefined;
+      case 'people':
+        return { type: 'people' };
+    }
+  });
+
+  let chMatchedSourceKeys = $derived.by(() => {
+    if (!chCurrentAutoRule) return [];
+    return computeSourceKeys(
+      chCurrentAutoRule,
+      subscriptionsStore.subscriptions,
+      articlesStore.allArticles
+    );
+  });
+
+  // Auto-fill name
+  $effect(() => {
+    if (chMode === 'smart' && !chNameManuallyEdited) {
+      if (chAutoRuleType === 'category' && chCategoryValue.trim()) {
+        chName = chCategoryValue.trim();
+      } else if (chAutoRuleType === 'subscriptionTag' && chTagValue.trim()) {
+        const t = chTagValue.trim();
+        chName = t.charAt(0).toUpperCase() + t.slice(1);
+      } else if (chAutoRuleType === 'domain' && chDomainPatterns.length > 0) {
+        chName = chDomainPatterns[0];
+      } else {
+        chName = DEFAULT_NAMES[chAutoRuleType];
+      }
+    }
+  });
+
+  let chFilteredSubscriptions = $derived(
+    chFeedSearch
       ? subscriptionsStore.subscriptions.filter((sub) => {
-          const term = feedSearch.toLowerCase();
+          const term = chFeedSearch.toLowerCase();
           return (
             (sub.customTitle || sub.title).toLowerCase().includes(term) ||
             (sub.feedUrl?.toLowerCase().includes(term) ?? false)
@@ -53,394 +244,574 @@
       : subscriptionsStore.subscriptions
   );
 
-  function setSourceMode(mode: 'all' | 'include') {
-    feedViewStore.setToolbarSourceFilter(mode, mode === 'all' ? [] : [...ef.sourceKeys]);
-  }
-
-  function toggleSourceKey(key: string) {
-    const keys = sourceKeySet.has(key)
-      ? ef.sourceKeys.filter((k) => k !== key)
-      : [...ef.sourceKeys, key];
-    feedViewStore.setToolbarSourceFilter(ef.sourceMode, keys);
-  }
-
-  // Type filter state
-  let activeTypeFilter = $derived(feedViewStore.toolbarTypeFilter);
-  let activeTypeSet = $derived(new Set(activeTypeFilter));
-
-  function toggleTypeFilter(type: SubscriptionSourceType) {
-    const newTypes = activeTypeSet.has(type)
-      ? activeTypeFilter.filter((t) => t !== type)
-      : [...activeTypeFilter, type];
-    feedViewStore.setToolbarTypeFilter(newTypes);
-  }
-
-  // Tag filter state
-  let allTags = $derived(itemLabelsStore.allTags);
-  let activeTagFilter = $derived(feedViewStore.toolbarTagFilter);
-  let activeTagSet = $derived(new Set(activeTagFilter));
-
-  function toggleTagFilter(tag: string) {
-    const newTags = activeTagSet.has(tag)
-      ? activeTagFilter.filter((t) => t !== tag)
-      : [...activeTagFilter, tag];
-    feedViewStore.setToolbarTagFilter(newTags);
-  }
-
-  // Save view
-  let isEditingView = $derived(!!feedViewStore.viewFilter);
-  let isRenaming = $state(false);
-  let renameValue = $state('');
-
-  function startRename() {
-    if (!feedViewStore.viewFilter) return;
-    const id = parseInt(feedViewStore.viewFilter);
-    const view = filteredViewsStore.getById(id);
-    if (!view) return;
-    renameValue = view.name;
-    isRenaming = true;
-    requestAnimationFrame(() => {
-      const input = document.querySelector('.rename-input') as HTMLInputElement | null;
-      input?.focus();
-      input?.select();
-    });
-  }
-
-  async function commitRename() {
-    if (!feedViewStore.viewFilter) return;
-    const trimmed = renameValue.trim();
-    if (!trimmed) {
-      isRenaming = false;
-      return;
-    }
-    const id = parseInt(feedViewStore.viewFilter);
-    const view = filteredViewsStore.getById(id);
-    if (view && trimmed !== view.name) {
-      await filteredViewsStore.update(id, { name: trimmed });
-    }
-    isRenaming = false;
-  }
-
-  function handleRenameKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      commitRename();
-    } else if (e.key === 'Escape') {
-      isRenaming = false;
+  function autoRuleToOption(rule: ChannelAutoRule): AutoRuleOption {
+    switch (rule.type) {
+      case 'frequency':
+        return rule.threshold === 'high' ? 'frequency:high' : 'frequency:low';
+      case 'longReads':
+        return 'longReads';
+      case 'recent':
+        return 'recent';
+      case 'category':
+        return 'category';
+      case 'subscriptionTag':
+        return 'subscriptionTag';
+      case 'domain':
+        return 'domain';
+      case 'people':
+        return 'people';
     }
   }
 
-  async function handleDeleteView() {
-    if (!feedViewStore.viewFilter) return;
-    if (!confirm('Delete this view?')) return;
-    const id = parseInt(feedViewStore.viewFilter);
-    await filteredViewsStore.remove(id);
-    onclose();
-    goto('/');
-  }
-
-  async function handleSaveView() {
-    if (isEditingView) {
-      feedViewStore.syncToolbarToSavedView();
-    } else {
-      const id = await filteredViewsStore.create({
-        name: 'new view',
-        sourceMode: ef.sourceMode,
-        sourceKeys: [...ef.sourceKeys],
-        readFilter: feedViewStore.showOnlyUnread ? 'unread' : 'all',
-        sortOrder: feedViewStore.currentSortOrder,
-        tagFilter: activeTagFilter.length > 0 ? [...activeTagFilter] : undefined,
-        typeFilter: activeTypeFilter.length > 0 ? [...activeTypeFilter] : undefined,
-      });
-      goto(`/?view=${id}`);
+  // Reset channel editor when editingChannelId changes
+  $effect(() => {
+    if (editingChannelId != null) {
+      const view = filteredViewsStore.getById(editingChannelId);
+      if (view) {
+        chName = view.name;
+        chNameManuallyEdited = true;
+        const isSmartChannel = !!view.autoRule;
+        if (isSmartChannel) {
+          chMode = 'smart';
+          chAutoRuleType = autoRuleToOption(view.autoRule!);
+          if (view.autoRule!.type === 'recent') chRecentWithinDays = view.autoRule!.withinDays;
+          else if (view.autoRule!.type === 'category') chCategoryValue = view.autoRule!.value;
+          else if (view.autoRule!.type === 'subscriptionTag') chTagValue = view.autoRule!.value;
+          else if (view.autoRule!.type === 'domain')
+            chDomainPatterns = [...view.autoRule!.patterns];
+        } else {
+          chMode = 'manual';
+          const mode = view.sourceMode === 'include' ? 'include' : 'all';
+          chSourceMode = mode;
+          chSourceKeys = mode === 'all' ? new Set() : new Set(view.sourceKeys ?? []);
+        }
+        chFeedSearch = '';
+        chError = null;
+        return;
+      }
     }
-    onclose();
-  }
-
-  let currentViewName = $derived.by(() => {
-    if (!feedViewStore.viewFilter) return '';
-    const id = parseInt(feedViewStore.viewFilter);
-    return filteredViewsStore.getById(id)?.name || '';
+    // New channel defaults
+    if (channelCreateMode) {
+      chName = '';
+      chMode = 'manual';
+      chAutoRuleType = 'frequency:high';
+      chRecentWithinDays = 14;
+      chCategoryValue = '';
+      chTagValue = '';
+      chDomainPatterns = [];
+      chNameManuallyEdited = false;
+      chSourceMode = 'all';
+      chSourceKeys = new Set();
+      chFeedSearch = '';
+      chError = null;
+    }
   });
 
-  let hasFilterChanges = $derived(
-    isEditingView
-      ? feedViewStore.hasUnsavedChanges
-      : ef.sourceMode !== 'all' || activeTypeFilter.length > 0
-  );
+  function addDomainPattern(value?: string) {
+    const v = (value ?? chDomainInput).trim();
+    if (v && !chDomainPatterns.includes(v)) {
+      chDomainPatterns = [...chDomainPatterns, v];
+    }
+    chDomainInput = '';
+    chDomainSuggestionsOpen = false;
+    chDomainHighlightIndex = -1;
+  }
+
+  function removeDomainPattern(pattern: string) {
+    chDomainPatterns = chDomainPatterns.filter((p) => p !== pattern);
+  }
+
+  function handleDomainKeydown(e: KeyboardEvent) {
+    if (chDomainSuggestionsOpen && chDomainSuggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        chDomainHighlightIndex = (chDomainHighlightIndex + 1) % chDomainSuggestions.length;
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        chDomainHighlightIndex =
+          chDomainHighlightIndex <= 0 ? chDomainSuggestions.length - 1 : chDomainHighlightIndex - 1;
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (chDomainHighlightIndex >= 0 && chDomainHighlightIndex < chDomainSuggestions.length) {
+          addDomainPattern(chDomainSuggestions[chDomainHighlightIndex]);
+        } else {
+          addDomainPattern();
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        chDomainSuggestionsOpen = false;
+        chDomainHighlightIndex = -1;
+        return;
+      }
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addDomainPattern();
+    } else if (e.key === 'Backspace' && !chDomainInput && chDomainPatterns.length > 0) {
+      chDomainPatterns = chDomainPatterns.slice(0, -1);
+    }
+  }
+
+  function handleDomainInput() {
+    chDomainSuggestionsOpen = true;
+    chDomainHighlightIndex = -1;
+  }
+
+  function handleDomainBlur() {
+    setTimeout(() => {
+      chDomainSuggestionsOpen = false;
+      addDomainPattern();
+    }, 150);
+  }
+
+  function toggleChSourceKey(key: string) {
+    const next = new Set(chSourceKeys);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    chSourceKeys = next;
+  }
+
+  async function handleChDelete() {
+    if (editingChannelId == null) return;
+    if (!confirm('Delete this channel?')) return;
+    await filteredViewsStore.remove(editingChannelId);
+    ondeleted?.();
+    onclose();
+  }
+
+  async function handleChSave() {
+    if (!chName.trim()) {
+      chError = 'Name is required';
+      return;
+    }
+
+    chError = null;
+    chSaving = true;
+
+    try {
+      const isSmartMode = chMode === 'smart' && chCurrentAutoRule;
+
+      const viewData = {
+        name: chName.trim(),
+        sourceMode: isSmartMode ? ('include' as const) : chSourceMode,
+        sourceKeys: isSmartMode ? chMatchedSourceKeys : Array.from(chSourceKeys),
+        autoRule: isSmartMode ? chCurrentAutoRule : undefined,
+        readFilter: 'unread' as const,
+        sortOrder: 'newest' as const,
+      };
+
+      if (editingChannelId != null) {
+        await filteredViewsStore.update(editingChannelId, viewData);
+      } else {
+        const id = await filteredViewsStore.create(viewData);
+        oncreated?.(id);
+      }
+
+      onclose();
+    } catch (e) {
+      chError = e instanceof Error ? e.message : 'Failed to save';
+    } finally {
+      chSaving = false;
+    }
+  }
 </script>
 
 <div class="filter-sheet">
-  {#if isSavedView}
-    <div class="sheet-section">
-      <div class="section-label">
-        <Icon name="bookmark" size={12} />
-        Saved
-      </div>
-      <div class="toggle-row">
-        <button
-          class="toggle-btn"
-          class:active={feedViewStore.savedView === 'inbox'}
-          onclick={() => feedViewStore.setSavedView('inbox')}
-        >
-          <Icon name="inbox" size={16} />
-          Inbox
-        </button>
-        <button
-          class="toggle-btn"
-          class:active={feedViewStore.savedView === 'archive'}
-          onclick={() => feedViewStore.setSavedView('archive')}
-        >
-          <Icon name="archive" size={16} />
-          Archive
-        </button>
-        <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
-          <Icon
-            name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-            size={16}
-          />
-          {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
-        </button>
-      </div>
+  {#if showChannelTab}
+    <div class="tab-bar">
+      <button
+        class="tab"
+        class:active={activeTab === 'filters'}
+        onclick={() => (activeTab = 'filters')}
+      >
+        <Icon name="sliders" size={14} />
+        Filters
+      </button>
+      <button
+        class="tab"
+        class:active={activeTab === 'channel'}
+        onclick={() => (activeTab = 'channel')}
+      >
+        <Icon name="newspaper" size={14} />
+        Channel
+      </button>
     </div>
-  {:else}
-    <div class="sheet-section">
-      <div class="section-label">View</div>
-      <div class="toggle-row">
-        <button
-          class="toggle-btn"
-          class:active={!expandAllItems}
-          onclick={() => onToggleExpandAll(false)}
-        >
-          <Icon name="list" size={16} />
-          List
-        </button>
-        <button
-          class="toggle-btn"
-          class:active={expandAllItems}
-          onclick={() => onToggleExpandAll(true)}
-        >
-          <Icon name="newspaper" size={16} />
-          Expanded
-        </button>
-      </div>
-    </div>
+  {/if}
 
-    <div class="sheet-section">
-      <div class="section-label">Appearance</div>
-      <div class="toolbar-wrapper">
-        <AppearanceToolbar />
-      </div>
-    </div>
-
-    <div class="sheet-section">
-      <div class="section-label">
-        <Icon name="arrow-down" size={12} />
-        Sort & Read
-      </div>
-      <div class="toggle-row">
-        <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
-          <Icon
-            name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-            size={16}
-          />
-          {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
-        </button>
-        <button
-          class="toggle-btn"
-          class:active={feedViewStore.showOnlyUnread}
-          onclick={() => feedViewStore.setShowOnlyUnread(true)}
-        >
-          <Icon name="circle-dot" size={16} />
-          Unread
-        </button>
-        <button
-          class="toggle-btn"
-          class:active={!feedViewStore.showOnlyUnread}
-          onclick={() => feedViewStore.setShowOnlyUnread(false)}
-        >
-          <Icon name="inbox" size={16} />
-          All
-        </button>
-      </div>
-    </div>
-
-    <div class="sheet-section">
-      <div class="section-label">
-        <Icon name="layers" size={12} />
-        Type
-      </div>
-      <div class="filter-chips">
-        {#each TYPE_OPTIONS as opt}
-          <button
-            class="chip"
-            class:active={activeTypeSet.has(opt.value)}
-            onclick={() => toggleTypeFilter(opt.value)}
-          >
-            <Icon
-              name={opt.value === 'rss'
-                ? 'rss'
-                : opt.value === 'atproto.shares'
-                  ? 'share'
-                  : 'file-text'}
-              size={14}
-            />
-            {opt.label}
-          </button>
-        {/each}
-      </div>
-    </div>
-
-    {#if allTags.length > 0}
+  {#if activeTab === 'filters'}
+    <!-- ===== FILTERS TAB ===== -->
+    {#if isSavedView}
       <div class="sheet-section">
         <div class="section-label">
-          <Icon name="tag" size={12} />
-          Tags
+          <Icon name="bookmark" size={12} />
+          Saved
         </div>
-        <div class="filter-chips">
-          {#each allTags as tag}
+        <div class="toggle-row">
+          <button
+            class="toggle-btn"
+            class:active={feedViewStore.savedView === 'inbox'}
+            onclick={() => feedViewStore.setSavedView('inbox')}
+          >
+            <Icon name="inbox" size={16} />
+            Inbox
+          </button>
+          <button
+            class="toggle-btn"
+            class:active={feedViewStore.savedView === 'archive'}
+            onclick={() => feedViewStore.setSavedView('archive')}
+          >
+            <Icon name="archive" size={16} />
+            Archive
+          </button>
+          <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
+            <Icon
+              name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+              size={16}
+            />
+            {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
+          </button>
+        </div>
+      </div>
+    {:else}
+      <div class="sheet-section">
+        <div class="section-label">View</div>
+        <div class="toggle-row">
+          <button
+            class="toggle-btn"
+            class:active={!expandAllItems}
+            onclick={() => onToggleExpandAll(false)}
+          >
+            <Icon name="list" size={16} />
+            List
+          </button>
+          <button
+            class="toggle-btn"
+            class:active={expandAllItems}
+            onclick={() => onToggleExpandAll(true)}
+          >
+            <Icon name="newspaper" size={16} />
+            Expanded
+          </button>
+        </div>
+      </div>
+
+      <div class="sheet-section">
+        <div class="section-label">Appearance</div>
+        <div class="toolbar-wrapper">
+          <AppearanceToolbar />
+        </div>
+      </div>
+
+      <div class="sheet-section">
+        <div class="section-label">
+          <Icon name="arrow-down" size={12} />
+          Sort & Read
+        </div>
+        <div class="toggle-row">
+          <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
+            <Icon
+              name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+              size={16}
+            />
+            {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
+          </button>
+          <button
+            class="toggle-btn"
+            class:active={feedViewStore.showOnlyUnread}
+            onclick={() => feedViewStore.setShowOnlyUnread(true)}
+          >
+            <Icon name="circle-dot" size={16} />
+            Unread
+          </button>
+          <button
+            class="toggle-btn"
+            class:active={!feedViewStore.showOnlyUnread}
+            onclick={() => feedViewStore.setShowOnlyUnread(false)}
+          >
+            <Icon name="inbox" size={16} />
+            All
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    {#if onMarkAllAsRead}
+      <div class="sheet-section">
+        <button
+          class="mark-all-btn"
+          onclick={() => {
+            onMarkAllAsRead?.();
+            onclose();
+          }}
+        >
+          <Icon name="check" size={16} />
+          Mark all as read
+        </button>
+      </div>
+    {/if}
+  {:else}
+    <!-- ===== CHANNEL TAB ===== -->
+    <div class="sheet-section">
+      <div class="section-label">Name</div>
+      <input
+        type="text"
+        class="ch-input"
+        bind:value={chName}
+        oninput={() => (chNameManuallyEdited = true)}
+        placeholder="My channel"
+      />
+    </div>
+
+    <div class="sheet-section">
+      <div class="section-label">Source Selection</div>
+      <div class="toggle-row">
+        <button
+          class="toggle-btn"
+          class:active={chMode === 'manual'}
+          onclick={() => (chMode = 'manual')}
+        >
+          Manual
+        </button>
+        <button
+          class="toggle-btn"
+          class:active={chMode === 'smart'}
+          onclick={() => {
+            chMode = 'smart';
+            if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
+          }}
+        >
+          Smart
+        </button>
+      </div>
+    </div>
+
+    {#if chMode === 'smart'}
+      <div class="sheet-section">
+        <div class="section-label">Rule</div>
+        <div class="rule-cards">
+          {#each AUTO_RULE_OPTIONS as opt (opt.value)}
             <button
-              class="chip"
-              class:active={activeTagSet.has(tag)}
-              onclick={() => toggleTagFilter(tag)}
+              class="rule-card"
+              class:selected={chAutoRuleType === opt.value}
+              onclick={() => {
+                chAutoRuleType = opt.value;
+                if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
+              }}
             >
-              <Icon name="tag" size={14} />
-              {tag}
+              <span class="rule-card-label">{opt.label}</span>
+              <span class="rule-card-desc">{opt.description}</span>
             </button>
           {/each}
         </div>
       </div>
-    {/if}
 
-    {#if showSourceFilter}
-      <div class="sheet-section">
-        <div class="section-label">
-          <Icon name="filter" size={12} />
-          Sources
-        </div>
-        <div class="source-filter">
-          <div class="toggle-row">
-            <button
-              class="toggle-btn small"
-              class:active={ef.sourceMode === 'all'}
-              onclick={() => setSourceMode('all')}
-            >
-              All sources
-            </button>
-            <button
-              class="toggle-btn small"
-              class:active={ef.sourceMode === 'include'}
-              onclick={() => setSourceMode('include')}
-            >
-              Include only
-            </button>
+      {#if chAutoRuleType === 'recent'}
+        <div class="sheet-section">
+          <div class="section-label">Within the last</div>
+          <div class="inline-input">
+            <input
+              type="number"
+              bind:value={chRecentWithinDays}
+              min="1"
+              max="90"
+              class="days-input"
+            />
+            <span class="input-suffix">days</span>
           </div>
-
-          {#if ef.sourceMode === 'include'}
-            {#if subscriptionsStore.subscriptions.length > 0}
-              {#if subscriptionsStore.subscriptions.length > 6}
-                <input
-                  type="text"
-                  class="source-search"
-                  placeholder="Search subscriptions..."
-                  aria-label="Search subscriptions"
-                  bind:value={feedSearch}
-                />
-              {/if}
-              <div class="source-list">
-                {#each filteredSubscriptions as sub}
-                  {@const key = subscriptionSourceKey(sub)}
-                  {#if key}
-                    {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
-                    {@const iconUrl =
-                      sub.customIconUrl ||
-                      (isAtProto
-                        ? sub.siteUrl
-                          ? getFaviconUrl(sub.siteUrl)
-                          : '/icons/icon-192.svg'
-                        : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
-                    <label class="source-item">
-                      <input
-                        type="checkbox"
-                        checked={sourceKeySet.has(key)}
-                        onchange={() => toggleSourceKey(key)}
-                      />
-                      {#if iconUrl}
-                        <img src={iconUrl} alt="" class="source-icon" />
-                      {/if}
-                      <span class="source-name">{sub.customTitle || sub.title}</span>
-                    </label>
-                  {/if}
+        </div>
+      {:else if chAutoRuleType === 'category'}
+        <div class="sheet-section">
+          <div class="section-label">Category</div>
+          <input
+            type="text"
+            list="ch-category-options"
+            class="ch-input"
+            bind:value={chCategoryValue}
+            placeholder="e.g. Technology"
+          />
+          <datalist id="ch-category-options">
+            {#each availableCategories as cat}
+              <option value={cat}></option>
+            {/each}
+          </datalist>
+        </div>
+      {:else if chAutoRuleType === 'subscriptionTag'}
+        <div class="sheet-section">
+          <div class="section-label">Tag</div>
+          <input
+            type="text"
+            list="ch-tag-options"
+            class="ch-input"
+            bind:value={chTagValue}
+            placeholder="e.g. news"
+          />
+          <datalist id="ch-tag-options">
+            {#each availableSubTags as tag}
+              <option value={tag}></option>
+            {/each}
+          </datalist>
+        </div>
+      {:else if chAutoRuleType === 'domain'}
+        <div class="sheet-section">
+          <div class="section-label">Domain patterns</div>
+          <div class="chip-input-wrapper">
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div
+              class="chip-input"
+              onclick={(e) => {
+                const input = (e.currentTarget as HTMLElement).querySelector('input');
+                input?.focus();
+              }}
+            >
+              {#each chDomainPatterns as pattern}
+                <span class="domain-chip">
+                  {pattern}
+                  <button
+                    type="button"
+                    class="chip-remove"
+                    onclick={() => removeDomainPattern(pattern)}
+                    aria-label="Remove {pattern}"
+                  >
+                    &times;
+                  </button>
+                </span>
+              {/each}
+              <input
+                type="text"
+                bind:value={chDomainInput}
+                onkeydown={handleDomainKeydown}
+                oninput={handleDomainInput}
+                onblur={handleDomainBlur}
+                onfocus={() => (chDomainSuggestionsOpen = true)}
+                placeholder={chDomainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
+                class="chip-text-input"
+                autocomplete="off"
+              />
+            </div>
+            {#if chDomainSuggestionsOpen && chDomainSuggestions.length > 0}
+              <ul class="chip-suggestions" role="listbox">
+                {#each chDomainSuggestions as suggestion, i (suggestion)}
+                  <!-- svelte-ignore a11y_click_events_have_key_events -->
+                  <li
+                    class="chip-suggestion"
+                    class:highlighted={i === chDomainHighlightIndex}
+                    role="option"
+                    aria-selected={i === chDomainHighlightIndex}
+                    onmousedown={(e) => {
+                      e.preventDefault();
+                      addDomainPattern(suggestion);
+                    }}
+                    onmouseenter={() => (chDomainHighlightIndex = i)}
+                  >
+                    {suggestion}
+                  </li>
                 {/each}
-                {#if feedSearch && filteredSubscriptions.length === 0}
-                  <div class="no-results">No subscriptions match</div>
-                {/if}
-              </div>
+              </ul>
             {/if}
-          {/if}
+          </div>
         </div>
-      </div>
-    {/if}
+      {/if}
 
-    {#if isEditingView}
+      <div class="match-preview" class:empty={chMatchedSourceKeys.length === 0}>
+        {#if chMatchedSourceKeys.length > 0}
+          Matches <strong>{chMatchedSourceKeys.length}</strong>
+          {chMatchedSourceKeys.length === 1 ? 'source' : 'sources'}
+        {:else}
+          No sources match this rule yet
+        {/if}
+      </div>
+    {:else}
+      <!-- Manual source picker -->
       <div class="sheet-section">
-        <div class="section-label">
-          <Icon name="filter" size={12} />
-          View
+        <div class="section-label">Sources</div>
+        <div class="toggle-row">
+          <button
+            class="toggle-btn small"
+            class:active={chSourceMode === 'all'}
+            onclick={() => (chSourceMode = 'all')}
+          >
+            All sources
+          </button>
+          <button
+            class="toggle-btn small"
+            class:active={chSourceMode === 'include'}
+            onclick={() => (chSourceMode = 'include')}
+          >
+            Include only
+          </button>
         </div>
-        {#if isRenaming}
-          <div class="rename-row">
+
+        {#if chSourceMode === 'include' && subscriptionsStore.subscriptions.length > 0}
+          {#if subscriptionsStore.subscriptions.length > 6}
             <input
               type="text"
-              class="rename-input"
-              bind:value={renameValue}
-              onkeydown={handleRenameKeydown}
-              onblur={commitRename}
+              class="source-search"
+              placeholder="Search subscriptions..."
+              aria-label="Search subscriptions"
+              bind:value={chFeedSearch}
             />
-            <button class="rename-confirm-btn" onclick={commitRename}>
-              <Icon name="check" size={16} />
-            </button>
-          </div>
-        {:else}
-          <div class="view-actions">
-            <button class="view-name-btn" onclick={startRename}>
-              <span class="view-name-text">{currentViewName}</span>
-              <Icon name="edit" size={14} />
-            </button>
-            <button class="view-delete-btn" onclick={handleDeleteView}>
-              <Icon name="trash" size={16} />
-            </button>
+          {/if}
+          <div class="source-list">
+            {#each chFilteredSubscriptions as sub}
+              {@const key = subscriptionSourceKey(sub)}
+              {#if key}
+                {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
+                {@const iconUrl =
+                  sub.customIconUrl ||
+                  (isAtProto
+                    ? sub.siteUrl
+                      ? getFaviconUrl(sub.siteUrl)
+                      : '/icons/icon-192.svg'
+                    : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
+                <label class="source-item">
+                  <input
+                    type="checkbox"
+                    checked={chSourceKeys.has(key)}
+                    onchange={() => toggleChSourceKey(key)}
+                  />
+                  {#if iconUrl}
+                    <img src={iconUrl} alt="" class="source-icon" />
+                  {/if}
+                  <span class="source-name">{sub.customTitle || sub.title}</span>
+                </label>
+              {/if}
+            {/each}
+            {#if chFeedSearch && chFilteredSubscriptions.length === 0}
+              <div class="no-results">No subscriptions match</div>
+            {/if}
           </div>
         {/if}
-        {#if hasFilterChanges}
-          <button class="save-view-btn" onclick={handleSaveView}>
-            <Icon name="save" size={16} />
-            Update view
-          </button>
-        {/if}
-      </div>
-    {:else if hasFilterChanges}
-      <div class="sheet-section">
-        <button class="save-view-btn" onclick={handleSaveView}>
-          <Icon name="save" size={16} />
-          Save as view
-        </button>
       </div>
     {/if}
-  {/if}
 
-  {#if onMarkAllAsRead}
-    <div class="sheet-section">
-      <button
-        class="mark-all-btn"
-        onclick={() => {
-          onMarkAllAsRead?.();
-          onclose();
-        }}
-      >
-        <Icon name="check" size={16} />
-        Mark all as read
+    {#if chError}
+      <p class="ch-error">{chError}</p>
+    {/if}
+
+    <div class="sheet-section ch-actions">
+      <button class="save-btn" onclick={handleChSave} disabled={chSaving}>
+        {#if chSaving}
+          Saving...
+        {:else if editingChannelId != null}
+          Save Channel
+        {:else}
+          Create Channel
+        {/if}
       </button>
+      {#if editingChannelId != null}
+        <button class="delete-btn" onclick={handleChDelete} disabled={chSaving}>
+          Delete channel
+        </button>
+      {/if}
     </div>
   {/if}
 </div>
@@ -453,6 +824,40 @@
     gap: 1rem;
   }
 
+  /* --- Tabs --- */
+
+  .tab-bar {
+    display: flex;
+    gap: 0;
+    background: var(--color-bg-secondary, #f5f5f5);
+    border-radius: 8px;
+    padding: 0.1875rem;
+  }
+
+  .tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    transition: all 0.15s;
+  }
+
+  .tab.active {
+    background: var(--color-bg, #fff);
+    color: var(--color-text);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+
+  /* --- Shared section styles --- */
+
   .sheet-section {
     display: flex;
     flex-direction: column;
@@ -462,6 +867,11 @@
   .sheet-section + .sheet-section {
     padding-top: 0.25rem;
     border-top: 1px solid var(--color-border);
+  }
+
+  .tab-bar + .sheet-section {
+    padding-top: 0;
+    border-top: none;
   }
 
   .section-label {
@@ -507,13 +917,19 @@
     background: var(--color-border);
   }
 
+  .toggle-btn.small {
+    font-size: 0.8125rem;
+    padding: 0.5rem;
+  }
+
+  /* --- Filter tab styles --- */
+
   .toolbar-wrapper {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
   }
 
-  /* Override toolbar styles to not be pill-shaped in sheet context */
   .toolbar-wrapper :global(.appearance-toolbar) {
     background: none;
     box-shadow: none;
@@ -549,46 +965,6 @@
   .toolbar-wrapper :global(.group-label) {
     display: block;
     font-size: 0.75rem;
-  }
-
-  .filter-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-  }
-
-  .chip {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.75rem;
-    background: var(--color-bg-secondary, #f5f5f5);
-    border: 1px solid transparent;
-    border-radius: 999px;
-    color: var(--color-text-secondary);
-    font-size: 0.8125rem;
-    font-weight: 500;
-  }
-
-  .chip.active {
-    background: rgba(37, 99, 235, 0.08);
-    border-color: var(--color-primary);
-    color: var(--color-primary);
-  }
-
-  .chip:active:not(.active) {
-    background: var(--color-border);
-  }
-
-  .source-filter {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .toggle-btn.small {
-    font-size: 0.8125rem;
-    padding: 0.5rem;
   }
 
   .source-search {
@@ -653,111 +1029,6 @@
     color: var(--color-text-secondary);
   }
 
-  .view-actions {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .view-name-btn {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    padding: 0.625rem 0.75rem;
-    background: var(--color-bg-secondary, #f5f5f5);
-    border: 1px solid transparent;
-    border-radius: 8px;
-    color: var(--color-text);
-    font-size: 0.875rem;
-    font-weight: 500;
-    text-align: left;
-    min-width: 0;
-  }
-
-  .view-name-btn :global(.icon) {
-    color: var(--color-text-secondary);
-    flex-shrink: 0;
-  }
-
-  .view-name-btn:active {
-    border-color: var(--color-primary);
-  }
-
-  .view-name-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .view-delete-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.625rem;
-    background: var(--color-bg-secondary, #f5f5f5);
-    border: 1px solid transparent;
-    border-radius: 8px;
-    color: var(--color-text-secondary);
-    flex-shrink: 0;
-  }
-
-  .view-delete-btn:active {
-    color: var(--color-error, #dc2626);
-    border-color: var(--color-error, #dc2626);
-    background: rgba(220, 38, 38, 0.08);
-  }
-
-  .rename-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .rename-input {
-    flex: 1;
-    padding: 0.625rem 0.75rem;
-    border: 1px solid var(--color-primary);
-    border-radius: 8px;
-    background: var(--color-bg);
-    color: var(--color-text);
-    font-size: 1rem;
-    font-weight: 500;
-    outline: none;
-  }
-
-  .rename-confirm-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.625rem;
-    background: var(--color-primary);
-    border: none;
-    border-radius: 8px;
-    color: white;
-    flex-shrink: 0;
-  }
-
-  .save-view-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.625rem;
-    background: rgba(37, 99, 235, 0.08);
-    border: 1px solid var(--color-primary);
-    border-radius: 8px;
-    color: var(--color-primary);
-    font-size: 0.875rem;
-    font-weight: 500;
-    width: 100%;
-  }
-
-  .save-view-btn:active {
-    background: rgba(37, 99, 235, 0.15);
-  }
-
   .mark-all-btn {
     display: flex;
     align-items: center;
@@ -777,7 +1048,269 @@
     background: var(--color-border);
   }
 
+  /* --- Channel tab styles --- */
+
+  .ch-input {
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-size: 1rem;
+    outline: none;
+  }
+
+  .ch-input:focus {
+    border-color: var(--color-primary);
+  }
+
+  .ch-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .rule-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .rule-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.5rem 0.625rem;
+    border: 1.5px solid var(--color-border);
+    border-radius: 8px;
+    cursor: pointer;
+    background: var(--color-bg);
+    text-align: left;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .rule-card:active {
+    border-color: var(--color-text-secondary);
+  }
+
+  .rule-card.selected {
+    border-color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.04);
+  }
+
+  .rule-card-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .rule-card-desc {
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.3;
+  }
+
+  .inline-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .days-input {
+    width: 4rem;
+    padding: 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    font-size: 1rem;
+    background: var(--color-bg);
+    color: var(--color-text);
+    text-align: center;
+    outline: none;
+  }
+
+  .days-input:focus {
+    border-color: var(--color-primary);
+  }
+
+  .input-suffix {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+  }
+
+  .chip-input-wrapper {
+    position: relative;
+  }
+
+  .chip-input {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-bg);
+    cursor: text;
+    min-height: 2.5rem;
+  }
+
+  .chip-input:focus-within {
+    border-color: var(--color-primary);
+  }
+
+  .domain-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.25rem 0.125rem 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+  }
+
+  .chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    border-radius: 3px;
+  }
+
+  .chip-remove:active {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .chip-text-input {
+    flex: 1;
+    min-width: 8rem;
+    border: none;
+    background: none;
+    outline: none;
+    font: inherit;
+    font-size: 0.875rem;
+    color: var(--color-text);
+    padding: 0.25rem 0;
+  }
+
+  .chip-text-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .chip-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: 0.25rem 0 0;
+    padding: 0.25rem;
+    list-style: none;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    z-index: 10;
+    max-height: 160px;
+    overflow-y: auto;
+  }
+
+  .chip-suggestion {
+    padding: 0.5rem;
+    font-size: 0.875rem;
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .chip-suggestion.highlighted {
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
+  }
+
+  .match-preview {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    background: rgba(0, 102, 204, 0.04);
+    border: 1px solid rgba(0, 102, 204, 0.1);
+  }
+
+  .match-preview.empty {
+    background: rgba(0, 0, 0, 0.02);
+    border-color: var(--color-border);
+    font-style: italic;
+  }
+
+  .ch-error {
+    color: var(--color-error);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .ch-actions {
+    gap: 0.75rem;
+  }
+
+  .save-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    background: var(--color-primary);
+    border: none;
+    border-radius: 8px;
+    color: white;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    width: 100%;
+  }
+
+  .save-btn:active:not(:disabled) {
+    opacity: 0.85;
+  }
+
+  .save-btn:disabled {
+    opacity: 0.6;
+  }
+
+  .delete-btn {
+    width: 100%;
+    padding: 0.625rem;
+    border: none;
+    border-radius: 8px;
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+
+  .delete-btn:active:not(:disabled) {
+    color: var(--color-error, #dc2626);
+  }
+
+  .delete-btn:disabled {
+    opacity: 0.6;
+  }
+
+  /* --- Dark mode --- */
+
   @media (prefers-color-scheme: dark) {
+    .tab-bar {
+      background: var(--color-bg-secondary, #2a2a2a);
+    }
+
+    .tab.active {
+      background: var(--color-bg, #1a1a1a);
+    }
+
     .toggle-btn {
       background: var(--color-bg-secondary, #2a2a2a);
     }
@@ -790,41 +1323,11 @@
       background: rgba(255, 255, 255, 0.1);
     }
 
-    .chip {
-      background: var(--color-bg-secondary, #2a2a2a);
-    }
-
-    .chip.active {
-      background: rgba(37, 99, 235, 0.2);
-    }
-
-    .chip:active:not(.active) {
-      background: rgba(255, 255, 255, 0.1);
-    }
-
-    .source-search {
+    .source-search,
+    .source-list,
+    .ch-input,
+    .days-input {
       background: var(--color-bg, #1a1a1a);
-    }
-
-    .source-list {
-      background: var(--color-bg, #1a1a1a);
-    }
-
-    .view-name-btn,
-    .view-delete-btn {
-      background: var(--color-bg-secondary, #2a2a2a);
-    }
-
-    .rename-input {
-      background: var(--color-bg, #1a1a1a);
-    }
-
-    .save-view-btn {
-      background: rgba(37, 99, 235, 0.15);
-    }
-
-    .save-view-btn:active {
-      background: rgba(37, 99, 235, 0.25);
     }
 
     .mark-all-btn {
@@ -832,6 +1335,30 @@
     }
 
     .mark-all-btn:active {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .rule-card {
+      background: var(--color-bg, #1a1a1a);
+    }
+
+    .rule-card.selected {
+      background: rgba(0, 102, 204, 0.1);
+    }
+
+    .chip-input {
+      background: var(--color-bg, #1a1a1a);
+    }
+
+    .chip-suggestions {
+      background: var(--color-bg, #1a1a1a);
+    }
+
+    .match-preview.empty {
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .domain-chip {
       background: rgba(255, 255, 255, 0.1);
     }
   }

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -8,6 +8,7 @@
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
   import { computeSourceKeys } from '$lib/utils/channelLogic';
+  import DomainPatternInput from '$lib/components/DomainPatternInput.svelte';
   import type {
     ChannelAutoRule,
     SavedSourceType,
@@ -16,104 +17,16 @@
     SortOrder,
   } from '$lib/types';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
-
-  const DATE_PRESET_OPTIONS: { value: DateAddedPreset | ''; label: string }[] = [
-    { value: '', label: 'Any time' },
-    { value: 'last-week', label: 'Week' },
-    { value: 'last-month', label: 'Month' },
-    { value: 'last-3-months', label: '3 months' },
-    { value: 'last-year', label: 'Year' },
-  ];
-
-  const READING_LENGTH_OPTIONS: { value: ReadingLengthFilter; label: string }[] = [
-    { value: 'quick', label: 'Quick' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'long', label: 'Long' },
-  ];
-
-  const SAVED_SORT_OPTIONS: { value: SortOrder; label: string }[] = [
-    { value: 'newest', label: 'Saved ↓' },
-    { value: 'oldest', label: 'Saved ↑' },
-    { value: 'published-newest', label: 'Published ↓' },
-    { value: 'published-oldest', label: 'Published ↑' },
-    { value: 'shortest', label: 'Short' },
-    { value: 'longest', label: 'Long' },
-    { value: 'domain-asc', label: 'Domain A–Z' },
-    { value: 'domain-desc', label: 'Domain Z–A' },
-  ];
-
-  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
-    { value: 'url', label: 'URL Saves' },
-    { value: 'feed', label: 'Feed Articles' },
-    { value: 'share', label: 'Shared Articles' },
-    { value: 'document', label: 'Documents' },
-  ];
-
-  // --- Smart rule options (shared with FilteredViewModal) ---
-
-  type AutoRuleOption =
-    | 'frequency:high'
-    | 'frequency:low'
-    | 'longReads'
-    | 'recent'
-    | 'category'
-    | 'subscriptionTag'
-    | 'domain'
-    | 'people';
-
-  const AUTO_RULE_OPTIONS: { value: AutoRuleOption; label: string; description: string }[] = [
-    {
-      value: 'frequency:high',
-      label: 'Daily Digest',
-      description: 'High-volume feeds that publish 2+ times per day',
-    },
-    {
-      value: 'frequency:low',
-      label: "Don't Miss",
-      description: 'Infrequent feeds where every post counts',
-    },
-    {
-      value: 'longReads',
-      label: 'Long Reads',
-      description: 'Feeds with in-depth, long-form articles',
-    },
-    {
-      value: 'recent',
-      label: 'Recently Added',
-      description: 'Sources you added recently',
-    },
-    {
-      value: 'category',
-      label: 'Category',
-      description: 'All sources in a specific folder',
-    },
-    {
-      value: 'subscriptionTag',
-      label: 'Tag',
-      description: 'All sources with a specific tag',
-    },
-    {
-      value: 'domain',
-      label: 'Domain',
-      description: 'Sources matching URL patterns',
-    },
-    {
-      value: 'people',
-      label: 'People',
-      description: 'Everyone you follow on AT Protocol',
-    },
-  ];
-
-  const DEFAULT_NAMES: Record<AutoRuleOption, string> = {
-    'frequency:high': 'Daily Digest',
-    'frequency:low': "Don't Miss",
-    longReads: 'Long Reads',
-    recent: 'New Sources',
-    category: '',
-    subscriptionTag: '',
-    domain: '',
-    people: 'People I Follow',
-  };
+  import {
+    SAVED_SOURCE_OPTIONS,
+    DATE_PRESET_OPTIONS_SHORT as DATE_PRESET_OPTIONS,
+    READING_LENGTH_OPTIONS_SHORT as READING_LENGTH_OPTIONS,
+    SAVED_SORT_OPTIONS_SHORT as SAVED_SORT_OPTIONS,
+    AUTO_RULE_OPTIONS,
+    AUTO_RULE_DEFAULT_NAMES as DEFAULT_NAMES,
+    autoRuleToOption,
+    type AutoRuleOption,
+  } from '$lib/constants/channelOptions';
 
   interface Props {
     expandAllItems: boolean;
@@ -168,9 +81,6 @@
   let chCategoryValue = $state('');
   let chTagValue = $state('');
   let chDomainPatterns = $state<string[]>([]);
-  let chDomainInput = $state('');
-  let chDomainSuggestionsOpen = $state(false);
-  let chDomainHighlightIndex = $state(-1);
   let chSourceMode = $state<'all' | 'include'>('all');
   let chSourceKeys = $state<Set<string>>(new Set());
   let chSaving = $state(false);
@@ -218,12 +128,6 @@
       ),
     ].sort()
   );
-
-  let chDomainSuggestions = $derived.by(() => {
-    const q = chDomainInput.trim().toLowerCase();
-    const existing = new Set(chDomainPatterns);
-    return availableDomains.filter((d) => (!q || d.includes(q)) && !existing.has(d));
-  });
 
   let chCurrentAutoRule = $derived.by((): ChannelAutoRule | undefined => {
     if (chMode !== 'smart') return undefined;
@@ -290,25 +194,6 @@
       : subscriptionsStore.subscriptions
   );
 
-  function autoRuleToOption(rule: ChannelAutoRule): AutoRuleOption {
-    switch (rule.type) {
-      case 'frequency':
-        return rule.threshold === 'high' ? 'frequency:high' : 'frequency:low';
-      case 'longReads':
-        return 'longReads';
-      case 'recent':
-        return 'recent';
-      case 'category':
-        return 'category';
-      case 'subscriptionTag':
-        return 'subscriptionTag';
-      case 'domain':
-        return 'domain';
-      case 'people':
-        return 'people';
-    }
-  }
-
   // Reset channel editor when editingChannelId changes
   $effect(() => {
     if (editingChannelId != null) {
@@ -366,69 +251,6 @@
       chError = null;
     }
   });
-
-  function addDomainPattern(value?: string) {
-    const v = (value ?? chDomainInput).trim();
-    if (v && !chDomainPatterns.includes(v)) {
-      chDomainPatterns = [...chDomainPatterns, v];
-    }
-    chDomainInput = '';
-    chDomainSuggestionsOpen = false;
-    chDomainHighlightIndex = -1;
-  }
-
-  function removeDomainPattern(pattern: string) {
-    chDomainPatterns = chDomainPatterns.filter((p) => p !== pattern);
-  }
-
-  function handleDomainKeydown(e: KeyboardEvent) {
-    if (chDomainSuggestionsOpen && chDomainSuggestions.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        chDomainHighlightIndex = (chDomainHighlightIndex + 1) % chDomainSuggestions.length;
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        chDomainHighlightIndex =
-          chDomainHighlightIndex <= 0 ? chDomainSuggestions.length - 1 : chDomainHighlightIndex - 1;
-        return;
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        if (chDomainHighlightIndex >= 0 && chDomainHighlightIndex < chDomainSuggestions.length) {
-          addDomainPattern(chDomainSuggestions[chDomainHighlightIndex]);
-        } else {
-          addDomainPattern();
-        }
-        return;
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        chDomainSuggestionsOpen = false;
-        chDomainHighlightIndex = -1;
-        return;
-      }
-    }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      addDomainPattern();
-    } else if (e.key === 'Backspace' && !chDomainInput && chDomainPatterns.length > 0) {
-      chDomainPatterns = chDomainPatterns.slice(0, -1);
-    }
-  }
-
-  function handleDomainInput() {
-    chDomainSuggestionsOpen = true;
-    chDomainHighlightIndex = -1;
-  }
-
-  function handleDomainBlur() {
-    setTimeout(() => {
-      chDomainSuggestionsOpen = false;
-      addDomainPattern();
-    }, 150);
-  }
 
   function toggleChSourceKey(key: string) {
     const next = new Set(chSourceKeys);
@@ -987,61 +809,12 @@
         {:else if chAutoRuleType === 'domain'}
           <div class="sheet-section">
             <div class="section-label">Domain patterns</div>
-            <div class="chip-input-wrapper">
-              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-              <div
-                class="chip-input"
-                onclick={(e) => {
-                  const input = (e.currentTarget as HTMLElement).querySelector('input');
-                  input?.focus();
-                }}
-              >
-                {#each chDomainPatterns as pattern}
-                  <span class="domain-chip">
-                    {pattern}
-                    <button
-                      type="button"
-                      class="chip-remove"
-                      onclick={() => removeDomainPattern(pattern)}
-                      aria-label="Remove {pattern}"
-                    >
-                      &times;
-                    </button>
-                  </span>
-                {/each}
-                <input
-                  type="text"
-                  bind:value={chDomainInput}
-                  onkeydown={handleDomainKeydown}
-                  oninput={handleDomainInput}
-                  onblur={handleDomainBlur}
-                  onfocus={() => (chDomainSuggestionsOpen = true)}
-                  placeholder={chDomainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
-                  class="chip-text-input"
-                  autocomplete="off"
-                />
-              </div>
-              {#if chDomainSuggestionsOpen && chDomainSuggestions.length > 0}
-                <ul class="chip-suggestions" role="listbox">
-                  {#each chDomainSuggestions as suggestion, i (suggestion)}
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <li
-                      class="chip-suggestion"
-                      class:highlighted={i === chDomainHighlightIndex}
-                      role="option"
-                      aria-selected={i === chDomainHighlightIndex}
-                      onmousedown={(e) => {
-                        e.preventDefault();
-                        addDomainPattern(suggestion);
-                      }}
-                      onmouseenter={() => (chDomainHighlightIndex = i)}
-                    >
-                      {suggestion}
-                    </li>
-                  {/each}
-                </ul>
-              {/if}
-            </div>
+            <DomainPatternInput
+              patterns={chDomainPatterns}
+              {availableDomains}
+              onchange={(p) => (chDomainPatterns = p)}
+              hint=""
+            />
           </div>
         {/if}
 
@@ -1472,102 +1245,6 @@
     color: var(--color-text-secondary);
   }
 
-  .chip-input-wrapper {
-    position: relative;
-  }
-
-  .chip-input {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    background: var(--color-bg);
-    cursor: text;
-    min-height: 2.5rem;
-  }
-
-  .chip-input:focus-within {
-    border-color: var(--color-primary);
-  }
-
-  .domain-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.125rem 0.25rem 0.125rem 0.5rem;
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
-    border-radius: 4px;
-    font-size: 0.8125rem;
-    color: var(--color-text);
-  }
-
-  .chip-remove {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.25rem;
-    height: 1.25rem;
-    padding: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: var(--color-text-secondary);
-    font-size: 0.875rem;
-    border-radius: 3px;
-  }
-
-  .chip-remove:active {
-    background: rgba(0, 0, 0, 0.1);
-  }
-
-  .chip-text-input {
-    flex: 1;
-    min-width: 8rem;
-    border: none;
-    background: none;
-    outline: none;
-    font: inherit;
-    font-size: 0.875rem;
-    color: var(--color-text);
-    padding: 0.25rem 0;
-  }
-
-  .chip-text-input::placeholder {
-    color: var(--color-text-secondary);
-  }
-
-  .chip-suggestions {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin: 0.25rem 0 0;
-    padding: 0.25rem;
-    list-style: none;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-    z-index: 10;
-    max-height: 160px;
-    overflow-y: auto;
-  }
-
-  .chip-suggestion {
-    padding: 0.5rem;
-    font-size: 0.875rem;
-    border-radius: 6px;
-    cursor: pointer;
-    color: var(--color-text);
-  }
-
-  .chip-suggestion.highlighted {
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.06));
-  }
-
   .match-preview {
     font-size: 0.8125rem;
     color: var(--color-text-secondary);
@@ -1681,20 +1358,9 @@
       background: rgba(0, 102, 204, 0.1);
     }
 
-    .chip-input {
-      background: var(--color-bg, #1a1a1a);
-    }
-
-    .chip-suggestions {
-      background: var(--color-bg, #1a1a1a);
-    }
-
     .match-preview.empty {
       background: rgba(255, 255, 255, 0.03);
     }
 
-    .domain-chip {
-      background: rgba(255, 255, 255, 0.1);
-    }
   }
 </style>

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -8,7 +8,46 @@
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { subscriptionSourceKey } from '$lib/utils/sourceKeys';
   import { computeSourceKeys } from '$lib/utils/channelLogic';
-  import type { ChannelAutoRule } from '$lib/types';
+  import type {
+    ChannelAutoRule,
+    SavedSourceType,
+    DateAddedPreset,
+    ReadingLengthFilter,
+    SortOrder,
+  } from '$lib/types';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+
+  const DATE_PRESET_OPTIONS: { value: DateAddedPreset | ''; label: string }[] = [
+    { value: '', label: 'Any time' },
+    { value: 'last-week', label: 'Week' },
+    { value: 'last-month', label: 'Month' },
+    { value: 'last-3-months', label: '3 months' },
+    { value: 'last-year', label: 'Year' },
+  ];
+
+  const READING_LENGTH_OPTIONS: { value: ReadingLengthFilter; label: string }[] = [
+    { value: 'quick', label: 'Quick' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'long', label: 'Long' },
+  ];
+
+  const SAVED_SORT_OPTIONS: { value: SortOrder; label: string }[] = [
+    { value: 'newest', label: 'Saved ↓' },
+    { value: 'oldest', label: 'Saved ↑' },
+    { value: 'published-newest', label: 'Published ↓' },
+    { value: 'published-oldest', label: 'Published ↑' },
+    { value: 'shortest', label: 'Short' },
+    { value: 'longest', label: 'Long' },
+    { value: 'domain-asc', label: 'Domain A–Z' },
+    { value: 'domain-desc', label: 'Domain Z–A' },
+  ];
+
+  const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
+    { value: 'url', label: 'URL Saves' },
+    { value: 'feed', label: 'Feed Articles' },
+    { value: 'share', label: 'Shared Articles' },
+    { value: 'document', label: 'Documents' },
+  ];
 
   // --- Smart rule options (shared with FilteredViewModal) ---
 
@@ -116,7 +155,14 @@
 
   // --- Channel editor state ---
   let chName = $state('');
+  let chChannelType = $state<'feed' | 'saved'>('feed');
   let chMode = $state<'manual' | 'smart'>('manual');
+  let chSavedSourceFilter = $state<Set<SavedSourceType>>(new Set());
+  let chSavedDateFilter = $state<DateAddedPreset | ''>('');
+  let chSavedReadingLength = $state<Set<ReadingLengthFilter>>(new Set());
+  let chSavedDomainFilter = $state<Set<string>>(new Set());
+  let chSavedTagFilter = $state<Set<string>>(new Set());
+  let chSortOrder = $state<SortOrder>('newest');
   let chAutoRuleType = $state<AutoRuleOption>('frequency:high');
   let chRecentWithinDays = $state(14);
   let chCategoryValue = $state('');
@@ -270,6 +316,13 @@
       if (view) {
         chName = view.name;
         chNameManuallyEdited = true;
+        chChannelType = view.mode === 'saved' ? 'saved' : 'feed';
+        chSavedSourceFilter = new Set(view.savedSourceFilter ?? []);
+        chSavedDateFilter = view.savedDateFilter ?? '';
+        chSavedReadingLength = new Set(view.savedReadingLength ?? []);
+        chSavedDomainFilter = new Set(view.savedDomainFilter ?? []);
+        chSavedTagFilter = new Set(view.tagFilter ?? []);
+        chSortOrder = view.sortOrder;
         const isSmartChannel = !!view.autoRule;
         if (isSmartChannel) {
           chMode = 'smart';
@@ -293,6 +346,7 @@
     // New channel defaults
     if (channelCreateMode) {
       chName = '';
+      chChannelType = 'feed';
       chMode = 'manual';
       chAutoRuleType = 'frequency:high';
       chRecentWithinDays = 14;
@@ -302,6 +356,12 @@
       chNameManuallyEdited = false;
       chSourceMode = 'all';
       chSourceKeys = new Set();
+      chSavedSourceFilter = new Set();
+      chSavedDateFilter = '';
+      chSavedReadingLength = new Set();
+      chSavedDomainFilter = new Set();
+      chSavedTagFilter = new Set();
+      chSortOrder = 'newest';
       chFeedSearch = '';
       chError = null;
     }
@@ -400,14 +460,31 @@
     try {
       const isSmartMode = chMode === 'smart' && chCurrentAutoRule;
 
-      const viewData = {
-        name: chName.trim(),
-        sourceMode: isSmartMode ? ('include' as const) : chSourceMode,
-        sourceKeys: isSmartMode ? chMatchedSourceKeys : Array.from(chSourceKeys),
-        autoRule: isSmartMode ? chCurrentAutoRule : undefined,
-        readFilter: 'unread' as const,
-        sortOrder: 'newest' as const,
-      };
+      const viewData =
+        chChannelType === 'saved'
+          ? {
+              name: chName.trim(),
+              mode: 'saved' as const,
+              savedSourceFilter:
+                chSavedSourceFilter.size > 0 ? Array.from(chSavedSourceFilter) : undefined,
+              savedDateFilter: chSavedDateFilter || undefined,
+              savedReadingLength:
+                chSavedReadingLength.size > 0 ? Array.from(chSavedReadingLength) : undefined,
+              savedDomainFilter:
+                chSavedDomainFilter.size > 0 ? Array.from(chSavedDomainFilter) : undefined,
+              tagFilter: chSavedTagFilter.size > 0 ? Array.from(chSavedTagFilter) : undefined,
+              readFilter: 'unread' as const,
+              sortOrder: chSortOrder,
+            }
+          : {
+              name: chName.trim(),
+              mode: 'feed' as const,
+              sourceMode: isSmartMode ? ('include' as const) : chSourceMode,
+              sourceKeys: isSmartMode ? chMatchedSourceKeys : Array.from(chSourceKeys),
+              autoRule: isSmartMode ? chCurrentAutoRule : undefined,
+              readFilter: 'unread' as const,
+              sortOrder: 'newest' as const,
+            };
 
       if (editingChannelId != null) {
         await filteredViewsStore.update(editingChannelId, viewData);
@@ -472,15 +549,109 @@
             <Icon name="archive" size={16} />
             Archive
           </button>
-          <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
-            <Icon
-              name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
-              size={16}
-            />
-            {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
-          </button>
+          {#if !feedViewStore.isSavedChannel}
+            <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
+              <Icon
+                name={feedViewStore.currentSortOrder === 'newest' ? 'arrow-down' : 'arrow-up'}
+                size={16}
+              />
+              {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
+            </button>
+          {/if}
         </div>
       </div>
+
+      {#if feedViewStore.isSavedChannel}
+        <!-- Sort (saved channel: expanded options) -->
+        <div class="sheet-section">
+          <div class="section-label">
+            <Icon name="arrow-down" size={12} />
+            Sort
+          </div>
+          <div class="toggle-row wrap">
+            {#each SAVED_SORT_OPTIONS as opt}
+              <button
+                class="toggle-btn"
+                class:active={feedViewStore.currentSortOrder === opt.value}
+                onclick={() => feedViewStore.setSortOrder(opt.value)}
+              >
+                {opt.label}
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        <!-- Date Added -->
+        <div class="sheet-section">
+          <div class="section-label">
+            <Icon name="clock" size={12} />
+            Date Added
+          </div>
+          <div class="toggle-row wrap">
+            {#each DATE_PRESET_OPTIONS as opt}
+              <button
+                class="toggle-btn"
+                class:active={(feedViewStore.toolbarDateFilter ?? '') === opt.value}
+                onclick={() => feedViewStore.setToolbarDateFilter(opt.value || null)}
+              >
+                {opt.label}
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        <!-- Reading Length -->
+        <div class="sheet-section">
+          <div class="section-label">
+            <Icon name="file-text" size={12} />
+            Reading Length
+          </div>
+          <div class="toggle-row">
+            {#each READING_LENGTH_OPTIONS as opt}
+              {@const isActive = feedViewStore.toolbarReadingLength.includes(opt.value)}
+              <button
+                class="toggle-btn"
+                class:active={isActive}
+                onclick={() => {
+                  const current = feedViewStore.toolbarReadingLength;
+                  feedViewStore.setToolbarReadingLength(
+                    isActive ? current.filter((l) => l !== opt.value) : [...current, opt.value]
+                  );
+                }}
+              >
+                {opt.label}
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        <!-- Domain -->
+        {#if feedViewStore.availableSavedDomains.length > 0}
+          <div class="sheet-section">
+            <div class="section-label">
+              <Icon name="globe" size={12} />
+              Domain
+            </div>
+            <div class="toggle-row wrap">
+              {#each feedViewStore.availableSavedDomains as domain}
+                {@const isActive = feedViewStore.toolbarDomainFilter.includes(domain)}
+                <button
+                  class="toggle-btn chip"
+                  class:active={isActive}
+                  onclick={() => {
+                    const current = feedViewStore.toolbarDomainFilter;
+                    feedViewStore.setToolbarDomainFilter(
+                      isActive ? current.filter((d) => d !== domain) : [...current, domain]
+                    );
+                  }}
+                >
+                  {domain}
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      {/if}
     {:else}
       <div class="sheet-section">
         <div class="section-label">View</div>
@@ -572,225 +743,379 @@
     </div>
 
     <div class="sheet-section">
-      <div class="section-label">Source Selection</div>
+      <div class="section-label">Channel Type</div>
       <div class="toggle-row">
         <button
           class="toggle-btn"
-          class:active={chMode === 'manual'}
-          onclick={() => (chMode = 'manual')}
+          class:active={chChannelType === 'feed'}
+          onclick={() => (chChannelType = 'feed')}
         >
-          Manual
+          Feed
         </button>
         <button
           class="toggle-btn"
-          class:active={chMode === 'smart'}
-          onclick={() => {
-            chMode = 'smart';
-            if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
-          }}
+          class:active={chChannelType === 'saved'}
+          onclick={() => (chChannelType = 'saved')}
         >
-          Smart
+          Saved
         </button>
       </div>
     </div>
 
-    {#if chMode === 'smart'}
+    {#if chChannelType === 'saved'}
       <div class="sheet-section">
-        <div class="section-label">Rule</div>
-        <div class="rule-cards">
-          {#each AUTO_RULE_OPTIONS as opt (opt.value)}
+        <div class="section-label">Include Sources</div>
+        <div class="source-list">
+          {#each SAVED_SOURCE_OPTIONS as opt}
+            <label class="source-item">
+              <input
+                type="checkbox"
+                checked={chSavedSourceFilter.has(opt.value)}
+                onchange={() => {
+                  const next = new Set(chSavedSourceFilter);
+                  if (next.has(opt.value)) {
+                    next.delete(opt.value);
+                  } else {
+                    next.add(opt.value);
+                  }
+                  chSavedSourceFilter = next;
+                }}
+              />
+              <span class="source-name">{opt.label}</span>
+            </label>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Date Added -->
+      <div class="sheet-section">
+        <div class="section-label">Date Added</div>
+        <div class="toggle-row wrap">
+          {#each DATE_PRESET_OPTIONS as opt}
             <button
-              class="rule-card"
-              class:selected={chAutoRuleType === opt.value}
-              onclick={() => {
-                chAutoRuleType = opt.value;
-                if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
-              }}
+              class="toggle-btn"
+              class:active={chSavedDateFilter === opt.value}
+              onclick={() => (chSavedDateFilter = opt.value as DateAddedPreset | '')}
             >
-              <span class="rule-card-label">{opt.label}</span>
-              <span class="rule-card-desc">{opt.description}</span>
+              {opt.label}
             </button>
           {/each}
         </div>
       </div>
 
-      {#if chAutoRuleType === 'recent'}
-        <div class="sheet-section">
-          <div class="section-label">Within the last</div>
-          <div class="inline-input">
-            <input
-              type="number"
-              bind:value={chRecentWithinDays}
-              min="1"
-              max="90"
-              class="days-input"
-            />
-            <span class="input-suffix">days</span>
-          </div>
-        </div>
-      {:else if chAutoRuleType === 'category'}
-        <div class="sheet-section">
-          <div class="section-label">Category</div>
-          <input
-            type="text"
-            list="ch-category-options"
-            class="ch-input"
-            bind:value={chCategoryValue}
-            placeholder="e.g. Technology"
-          />
-          <datalist id="ch-category-options">
-            {#each availableCategories as cat}
-              <option value={cat}></option>
-            {/each}
-          </datalist>
-        </div>
-      {:else if chAutoRuleType === 'subscriptionTag'}
-        <div class="sheet-section">
-          <div class="section-label">Tag</div>
-          <input
-            type="text"
-            list="ch-tag-options"
-            class="ch-input"
-            bind:value={chTagValue}
-            placeholder="e.g. news"
-          />
-          <datalist id="ch-tag-options">
-            {#each availableSubTags as tag}
-              <option value={tag}></option>
-            {/each}
-          </datalist>
-        </div>
-      {:else if chAutoRuleType === 'domain'}
-        <div class="sheet-section">
-          <div class="section-label">Domain patterns</div>
-          <div class="chip-input-wrapper">
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-            <div
-              class="chip-input"
-              onclick={(e) => {
-                const input = (e.currentTarget as HTMLElement).querySelector('input');
-                input?.focus();
+      <!-- Reading Length -->
+      <div class="sheet-section">
+        <div class="section-label">Reading Length</div>
+        <div class="toggle-row">
+          {#each READING_LENGTH_OPTIONS as opt}
+            <button
+              class="toggle-btn"
+              class:active={chSavedReadingLength.has(opt.value)}
+              onclick={() => {
+                const next = new Set(chSavedReadingLength);
+                if (next.has(opt.value)) {
+                  next.delete(opt.value);
+                } else {
+                  next.add(opt.value);
+                }
+                chSavedReadingLength = next;
               }}
             >
-              {#each chDomainPatterns as pattern}
-                <span class="domain-chip">
-                  {pattern}
-                  <button
-                    type="button"
-                    class="chip-remove"
-                    onclick={() => removeDomainPattern(pattern)}
-                    aria-label="Remove {pattern}"
-                  >
-                    &times;
-                  </button>
-                </span>
-              {/each}
-              <input
-                type="text"
-                bind:value={chDomainInput}
-                onkeydown={handleDomainKeydown}
-                oninput={handleDomainInput}
-                onblur={handleDomainBlur}
-                onfocus={() => (chDomainSuggestionsOpen = true)}
-                placeholder={chDomainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
-                class="chip-text-input"
-                autocomplete="off"
-              />
-            </div>
-            {#if chDomainSuggestionsOpen && chDomainSuggestions.length > 0}
-              <ul class="chip-suggestions" role="listbox">
-                {#each chDomainSuggestions as suggestion, i (suggestion)}
-                  <!-- svelte-ignore a11y_click_events_have_key_events -->
-                  <li
-                    class="chip-suggestion"
-                    class:highlighted={i === chDomainHighlightIndex}
-                    role="option"
-                    aria-selected={i === chDomainHighlightIndex}
-                    onmousedown={(e) => {
-                      e.preventDefault();
-                      addDomainPattern(suggestion);
-                    }}
-                    onmouseenter={() => (chDomainHighlightIndex = i)}
-                  >
-                    {suggestion}
-                  </li>
-                {/each}
-              </ul>
-            {/if}
+              {opt.label}
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Domain -->
+      {#if feedViewStore.availableSavedDomains.length > 0}
+        <div class="sheet-section">
+          <div class="section-label">Domains</div>
+          <div class="toggle-row wrap">
+            {#each feedViewStore.availableSavedDomains as domain}
+              <button
+                class="toggle-btn chip"
+                class:active={chSavedDomainFilter.has(domain)}
+                onclick={() => {
+                  const next = new Set(chSavedDomainFilter);
+                  if (next.has(domain)) {
+                    next.delete(domain);
+                  } else {
+                    next.add(domain);
+                  }
+                  chSavedDomainFilter = next;
+                }}
+              >
+                {domain}
+              </button>
+            {/each}
           </div>
         </div>
       {/if}
 
-      <div class="match-preview" class:empty={chMatchedSourceKeys.length === 0}>
-        {#if chMatchedSourceKeys.length > 0}
-          Matches <strong>{chMatchedSourceKeys.length}</strong>
-          {chMatchedSourceKeys.length === 1 ? 'source' : 'sources'}
-        {:else}
-          No sources match this rule yet
-        {/if}
+      <!-- Tags -->
+      {#if itemLabelsStore.allTags.length > 0}
+        <div class="sheet-section">
+          <div class="section-label">Tags</div>
+          <div class="toggle-row wrap">
+            {#each itemLabelsStore.allTags as tag}
+              <button
+                class="toggle-btn chip"
+                class:active={chSavedTagFilter.has(tag)}
+                onclick={() => {
+                  const next = new Set(chSavedTagFilter);
+                  if (next.has(tag)) {
+                    next.delete(tag);
+                  } else {
+                    next.add(tag);
+                  }
+                  chSavedTagFilter = next;
+                }}
+              >
+                {tag}
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <!-- Sort -->
+      <div class="sheet-section">
+        <div class="section-label">Sort Order</div>
+        <div class="toggle-row wrap">
+          {#each SAVED_SORT_OPTIONS as opt}
+            <button
+              class="toggle-btn"
+              class:active={chSortOrder === opt.value}
+              onclick={() => (chSortOrder = opt.value)}
+            >
+              {opt.label}
+            </button>
+          {/each}
+        </div>
       </div>
     {:else}
-      <!-- Manual source picker -->
       <div class="sheet-section">
-        <div class="section-label">Sources</div>
+        <div class="section-label">Source Selection</div>
         <div class="toggle-row">
           <button
-            class="toggle-btn small"
-            class:active={chSourceMode === 'all'}
-            onclick={() => (chSourceMode = 'all')}
+            class="toggle-btn"
+            class:active={chMode === 'manual'}
+            onclick={() => (chMode = 'manual')}
           >
-            All sources
+            Manual
           </button>
           <button
-            class="toggle-btn small"
-            class:active={chSourceMode === 'include'}
-            onclick={() => (chSourceMode = 'include')}
+            class="toggle-btn"
+            class:active={chMode === 'smart'}
+            onclick={() => {
+              chMode = 'smart';
+              if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
+            }}
           >
-            Include only
+            Smart
           </button>
         </div>
+      </div>
 
-        {#if chSourceMode === 'include' && subscriptionsStore.subscriptions.length > 0}
-          {#if subscriptionsStore.subscriptions.length > 6}
+      {#if chMode === 'smart'}
+        <div class="sheet-section">
+          <div class="section-label">Rule</div>
+          <div class="rule-cards">
+            {#each AUTO_RULE_OPTIONS as opt (opt.value)}
+              <button
+                class="rule-card"
+                class:selected={chAutoRuleType === opt.value}
+                onclick={() => {
+                  chAutoRuleType = opt.value;
+                  if (!chNameManuallyEdited) chName = DEFAULT_NAMES[chAutoRuleType];
+                }}
+              >
+                <span class="rule-card-label">{opt.label}</span>
+                <span class="rule-card-desc">{opt.description}</span>
+              </button>
+            {/each}
+          </div>
+        </div>
+
+        {#if chAutoRuleType === 'recent'}
+          <div class="sheet-section">
+            <div class="section-label">Within the last</div>
+            <div class="inline-input">
+              <input
+                type="number"
+                bind:value={chRecentWithinDays}
+                min="1"
+                max="90"
+                class="days-input"
+              />
+              <span class="input-suffix">days</span>
+            </div>
+          </div>
+        {:else if chAutoRuleType === 'category'}
+          <div class="sheet-section">
+            <div class="section-label">Category</div>
             <input
               type="text"
-              class="source-search"
-              placeholder="Search subscriptions..."
-              aria-label="Search subscriptions"
-              bind:value={chFeedSearch}
+              list="ch-category-options"
+              class="ch-input"
+              bind:value={chCategoryValue}
+              placeholder="e.g. Technology"
             />
-          {/if}
-          <div class="source-list">
-            {#each chFilteredSubscriptions as sub}
-              {@const key = subscriptionSourceKey(sub)}
-              {#if key}
-                {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
-                {@const iconUrl =
-                  sub.customIconUrl ||
-                  (isAtProto
-                    ? sub.siteUrl
-                      ? getFaviconUrl(sub.siteUrl)
-                      : '/icons/icon-192.svg'
-                    : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
-                <label class="source-item">
-                  <input
-                    type="checkbox"
-                    checked={chSourceKeys.has(key)}
-                    onchange={() => toggleChSourceKey(key)}
-                  />
-                  {#if iconUrl}
-                    <img src={iconUrl} alt="" class="source-icon" />
-                  {/if}
-                  <span class="source-name">{sub.customTitle || sub.title}</span>
-                </label>
+            <datalist id="ch-category-options">
+              {#each availableCategories as cat}
+                <option value={cat}></option>
+              {/each}
+            </datalist>
+          </div>
+        {:else if chAutoRuleType === 'subscriptionTag'}
+          <div class="sheet-section">
+            <div class="section-label">Tag</div>
+            <input
+              type="text"
+              list="ch-tag-options"
+              class="ch-input"
+              bind:value={chTagValue}
+              placeholder="e.g. news"
+            />
+            <datalist id="ch-tag-options">
+              {#each availableSubTags as tag}
+                <option value={tag}></option>
+              {/each}
+            </datalist>
+          </div>
+        {:else if chAutoRuleType === 'domain'}
+          <div class="sheet-section">
+            <div class="section-label">Domain patterns</div>
+            <div class="chip-input-wrapper">
+              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+              <div
+                class="chip-input"
+                onclick={(e) => {
+                  const input = (e.currentTarget as HTMLElement).querySelector('input');
+                  input?.focus();
+                }}
+              >
+                {#each chDomainPatterns as pattern}
+                  <span class="domain-chip">
+                    {pattern}
+                    <button
+                      type="button"
+                      class="chip-remove"
+                      onclick={() => removeDomainPattern(pattern)}
+                      aria-label="Remove {pattern}"
+                    >
+                      &times;
+                    </button>
+                  </span>
+                {/each}
+                <input
+                  type="text"
+                  bind:value={chDomainInput}
+                  onkeydown={handleDomainKeydown}
+                  oninput={handleDomainInput}
+                  onblur={handleDomainBlur}
+                  onfocus={() => (chDomainSuggestionsOpen = true)}
+                  placeholder={chDomainPatterns.length === 0 ? 'Type a domain and press Enter' : ''}
+                  class="chip-text-input"
+                  autocomplete="off"
+                />
+              </div>
+              {#if chDomainSuggestionsOpen && chDomainSuggestions.length > 0}
+                <ul class="chip-suggestions" role="listbox">
+                  {#each chDomainSuggestions as suggestion, i (suggestion)}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <li
+                      class="chip-suggestion"
+                      class:highlighted={i === chDomainHighlightIndex}
+                      role="option"
+                      aria-selected={i === chDomainHighlightIndex}
+                      onmousedown={(e) => {
+                        e.preventDefault();
+                        addDomainPattern(suggestion);
+                      }}
+                      onmouseenter={() => (chDomainHighlightIndex = i)}
+                    >
+                      {suggestion}
+                    </li>
+                  {/each}
+                </ul>
               {/if}
-            {/each}
-            {#if chFeedSearch && chFilteredSubscriptions.length === 0}
-              <div class="no-results">No subscriptions match</div>
-            {/if}
+            </div>
           </div>
         {/if}
-      </div>
+
+        <div class="match-preview" class:empty={chMatchedSourceKeys.length === 0}>
+          {#if chMatchedSourceKeys.length > 0}
+            Matches <strong>{chMatchedSourceKeys.length}</strong>
+            {chMatchedSourceKeys.length === 1 ? 'source' : 'sources'}
+          {:else}
+            No sources match this rule yet
+          {/if}
+        </div>
+      {:else}
+        <!-- Manual source picker -->
+        <div class="sheet-section">
+          <div class="section-label">Sources</div>
+          <div class="toggle-row">
+            <button
+              class="toggle-btn small"
+              class:active={chSourceMode === 'all'}
+              onclick={() => (chSourceMode = 'all')}
+            >
+              All sources
+            </button>
+            <button
+              class="toggle-btn small"
+              class:active={chSourceMode === 'include'}
+              onclick={() => (chSourceMode = 'include')}
+            >
+              Include only
+            </button>
+          </div>
+
+          {#if chSourceMode === 'include' && subscriptionsStore.subscriptions.length > 0}
+            {#if subscriptionsStore.subscriptions.length > 6}
+              <input
+                type="text"
+                class="source-search"
+                placeholder="Search subscriptions..."
+                aria-label="Search subscriptions"
+                bind:value={chFeedSearch}
+              />
+            {/if}
+            <div class="source-list">
+              {#each chFilteredSubscriptions as sub}
+                {@const key = subscriptionSourceKey(sub)}
+                {#if key}
+                  {@const isAtProto = sub.sourceType?.startsWith('atproto.') ?? false}
+                  {@const iconUrl =
+                    sub.customIconUrl ||
+                    (isAtProto
+                      ? sub.siteUrl
+                        ? getFaviconUrl(sub.siteUrl)
+                        : '/icons/icon-192.svg'
+                      : getFaviconUrl(sub.siteUrl || sub.feedUrl || ''))}
+                  <label class="source-item">
+                    <input
+                      type="checkbox"
+                      checked={chSourceKeys.has(key)}
+                      onchange={() => toggleChSourceKey(key)}
+                    />
+                    {#if iconUrl}
+                      <img src={iconUrl} alt="" class="source-icon" />
+                    {/if}
+                    <span class="source-name">{sub.customTitle || sub.title}</span>
+                  </label>
+                {/if}
+              {/each}
+              {#if chFeedSearch && chFilteredSubscriptions.length === 0}
+                <div class="no-results">No subscriptions match</div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
     {/if}
 
     {#if chError}
@@ -891,6 +1216,10 @@
     gap: 0.5rem;
   }
 
+  .toggle-row.wrap {
+    flex-wrap: wrap;
+  }
+
   .toggle-btn {
     flex: 1;
     display: flex;
@@ -915,6 +1244,12 @@
 
   .toggle-btn:active:not(.active) {
     background: var(--color-border);
+  }
+
+  .toggle-btn.chip {
+    flex: 0 0 auto;
+    font-size: 0.8125rem;
+    padding: 0.375rem 0.75rem;
   }
 
   .toggle-btn.small {

--- a/frontend/src/lib/components/sidebar/ContextMenu.svelte
+++ b/frontend/src/lib/components/sidebar/ContextMenu.svelte
@@ -9,9 +9,10 @@
     onRename?: () => void;
     onDelete: () => void;
     onClose: () => void;
+    deleteLabel?: string;
   }
 
-  let { x, y, onEdit, onRename, onDelete, onClose }: Props = $props();
+  let { x, y, onEdit, onRename, onDelete, onClose, deleteLabel = 'Delete' }: Props = $props();
 
   let menuRef: HTMLDivElement | null = $state(null);
   let adjustedX = $state(0);
@@ -87,7 +88,7 @@
   {/if}
   <button class="context-menu-item danger" onclick={handleDelete} role="menuitem">
     <span class="context-menu-icon"><Icon name="trash" size={16} /></span>
-    Delete
+    {deleteLabel}
   </button>
 </div>
 

--- a/frontend/src/lib/components/sidebar/NavSection.svelte
+++ b/frontend/src/lib/components/sidebar/NavSection.svelte
@@ -12,7 +12,7 @@
     onAdd?: () => void;
     onToggle: () => void;
     onLabelClick: () => void;
-    onUnreadToggle: () => void;
+    onUnreadToggle?: () => void;
     children: Snippet;
   }
 
@@ -49,17 +49,19 @@
           <Icon name="plus" size={14} strokeWidth={2} />
         </button>
       {/if}
-      <button
-        class="filter-toggle"
-        class:active={showOnlyUnread}
-        onclick={(e) => {
-          e.stopPropagation();
-          onUnreadToggle();
-        }}
-        title={showOnlyUnread ? 'Show all' : 'Show only unread'}
-      >
-        <Icon name={showOnlyUnread ? 'circle-dot' : 'circle'} size={12} strokeWidth={2} />
-      </button>
+      {#if onUnreadToggle}
+        <button
+          class="filter-toggle"
+          class:active={showOnlyUnread}
+          onclick={(e) => {
+            e.stopPropagation();
+            onUnreadToggle();
+          }}
+          title={showOnlyUnread ? 'Show all' : 'Show only unread'}
+        >
+          <Icon name={showOnlyUnread ? 'circle-dot' : 'circle'} size={12} strokeWidth={2} />
+        </button>
+      {/if}
       <button class="disclosure-btn" onclick={onToggle} aria-label="Toggle section">
         <Icon name={isExpanded ? 'chevron-down' : 'chevron-right'} size={14} strokeWidth={2.5} />
       </button>

--- a/frontend/src/lib/components/sidebar/ViewItem.svelte
+++ b/frontend/src/lib/components/sidebar/ViewItem.svelte
@@ -7,6 +7,7 @@
     view: FilteredView;
     isActive: boolean;
     isRenaming: boolean;
+    unreadCount?: number;
     onSelect: () => void;
     onContextMenu: (e: MouseEvent) => void;
     onTouchStart: (e: TouchEvent) => void;
@@ -21,6 +22,7 @@
     view,
     isActive,
     isRenaming,
+    unreadCount = 0,
     onSelect,
     onContextMenu,
     onTouchStart,
@@ -63,7 +65,7 @@
   ontouchend={onTouchEnd}
   ontouchmove={onTouchMove}
 >
-  <span class="view-icon"><Icon name="filter" size={14} /></span>
+  <span class="view-icon"><Icon name="newspaper" size={14} /></span>
   {#if isRenaming}
     <!-- svelte-ignore a11y_autofocus -->
     <input
@@ -84,6 +86,9 @@
     />
   {:else}
     <span class="nav-label">{view.name}</span>
+    {#if unreadCount > 0}
+      <span class="nav-count">{unreadCount}</span>
+    {/if}
     <span
       class="more-btn"
       role="button"
@@ -152,6 +157,16 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 0.875rem;
+  }
+
+  .nav-count {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .nav-item.active .nav-count {
+    color: var(--color-primary);
   }
 
   .view-item {

--- a/frontend/src/lib/components/sidebar/ViewItem.svelte
+++ b/frontend/src/lib/components/sidebar/ViewItem.svelte
@@ -65,7 +65,9 @@
   ontouchend={onTouchEnd}
   ontouchmove={onTouchMove}
 >
-  <span class="view-icon"><Icon name="newspaper" size={14} /></span>
+  <span class="view-icon"
+    ><Icon name={view.mode === 'saved' ? 'bookmark' : 'newspaper'} size={14} /></span
+  >
   {#if isRenaming}
     <!-- svelte-ignore a11y_autofocus -->
     <input

--- a/frontend/src/lib/components/sources/BulkActionBar.svelte
+++ b/frontend/src/lib/components/sources/BulkActionBar.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+  import type { FilteredView } from '$lib/types';
+
+  interface Props {
+    selectionCount: number;
+    channels: FilteredView[];
+    onAssignToChannel: (channelId: number) => void;
+    onBulkDelete: () => void;
+    onClearSelection: () => void;
+  }
+
+  let { selectionCount, channels, onAssignToChannel, onBulkDelete, onClearSelection }: Props =
+    $props();
+
+  let assignChannelOpen = $state(false);
+</script>
+
+<div class="bulk-bar">
+  <span class="bulk-count">{selectionCount} selected</span>
+  <div class="bulk-actions">
+    <div class="assign-wrapper">
+      <button class="bulk-btn" onclick={() => (assignChannelOpen = !assignChannelOpen)}>
+        <Icon name="filter" size={14} />
+        Add to channel
+      </button>
+      {#if assignChannelOpen && channels.length > 0}
+        <div class="assign-dropdown">
+          {#each channels as view (view.id)}
+            <button
+              class="assign-item"
+              onclick={() => {
+                if (view.id != null) onAssignToChannel(view.id);
+                assignChannelOpen = false;
+              }}
+            >
+              {view.name}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+    <button class="bulk-btn danger" onclick={onBulkDelete}>
+      <Icon name="trash" size={14} />
+      Remove
+    </button>
+  </div>
+  <button class="bulk-clear" onclick={onClearSelection}>
+    <Icon name="x" size={14} />
+  </button>
+</div>
+
+<style>
+  .bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-primary);
+    color: #fff;
+    border-radius: 10px;
+    margin-bottom: 1rem;
+    font-size: 0.8125rem;
+  }
+
+  .bulk-count {
+    font-weight: 500;
+  }
+
+  .bulk-actions {
+    display: flex;
+    gap: 0.375rem;
+    flex: 1;
+  }
+
+  .bulk-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 6px;
+    background: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  .bulk-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .bulk-btn.danger:hover {
+    background: rgba(220, 38, 38, 0.3);
+  }
+
+  .bulk-clear {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+  }
+
+  .bulk-clear:hover {
+    color: #fff;
+  }
+
+  .assign-wrapper {
+    position: relative;
+  }
+
+  .assign-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 0.25rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 0.25rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    min-width: 160px;
+  }
+
+  .assign-item {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    border-radius: 4px;
+  }
+
+  .assign-item:hover {
+    background: var(--color-bg-hover);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .assign-dropdown {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/sources/BulkActionBar.svelte
+++ b/frontend/src/lib/components/sources/BulkActionBar.svelte
@@ -1,42 +1,124 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
-  import type { FilteredView } from '$lib/types';
 
   interface Props {
     selectionCount: number;
-    channels: FilteredView[];
-    onAssignToChannel: (channelId: number) => void;
+    folders: string[];
+    hasCategory: boolean;
+    onAssignToFolder: (folderName: string) => void;
+    onRemoveFromFolder: () => void;
     onBulkDelete: () => void;
     onClearSelection: () => void;
   }
 
-  let { selectionCount, channels, onAssignToChannel, onBulkDelete, onClearSelection }: Props =
-    $props();
+  let {
+    selectionCount,
+    folders,
+    hasCategory,
+    onAssignToFolder,
+    onRemoveFromFolder,
+    onBulkDelete,
+    onClearSelection,
+  }: Props = $props();
 
-  let assignChannelOpen = $state(false);
+  let dropdownOpen = $state(false);
+  let showNewFolderInput = $state(false);
+  let newFolderName = $state('');
+  let wrapperRef = $state<HTMLDivElement | null>(null);
+  let newFolderInputRef = $state<HTMLInputElement | null>(null);
+
+  function selectFolder(name: string) {
+    onAssignToFolder(name);
+    dropdownOpen = false;
+    showNewFolderInput = false;
+    newFolderName = '';
+  }
+
+  function confirmNewFolder() {
+    const trimmed = newFolderName.trim();
+    if (!trimmed) return;
+    selectFolder(trimmed);
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (wrapperRef && !wrapperRef.contains(e.target as Node)) {
+      dropdownOpen = false;
+      showNewFolderInput = false;
+      newFolderName = '';
+    }
+  }
+
+  $effect(() => {
+    if (dropdownOpen) {
+      document.addEventListener('click', handleClickOutside, true);
+      return () => document.removeEventListener('click', handleClickOutside, true);
+    }
+  });
+
+  $effect(() => {
+    if (showNewFolderInput && newFolderInputRef) {
+      newFolderInputRef.focus();
+    }
+  });
 </script>
 
 <div class="bulk-bar">
   <span class="bulk-count">{selectionCount} selected</span>
   <div class="bulk-actions">
-    <div class="assign-wrapper">
-      <button class="bulk-btn" onclick={() => (assignChannelOpen = !assignChannelOpen)}>
-        <Icon name="filter" size={14} />
-        Add to channel
+    <div class="assign-wrapper" bind:this={wrapperRef}>
+      <button class="bulk-btn" onclick={() => (dropdownOpen = !dropdownOpen)}>
+        <Icon name="folder-plus" size={14} />
+        Add to folder
       </button>
-      {#if assignChannelOpen && channels.length > 0}
+      {#if dropdownOpen}
         <div class="assign-dropdown">
-          {#each channels as view (view.id)}
-            <button
-              class="assign-item"
-              onclick={() => {
-                if (view.id != null) onAssignToChannel(view.id);
-                assignChannelOpen = false;
-              }}
-            >
-              {view.name}
+          {#each folders as folder (folder)}
+            <button class="assign-item" onclick={() => selectFolder(folder)}>
+              {folder}
             </button>
           {/each}
+          {#if hasCategory}
+            <button
+              class="assign-item remove-folder-btn"
+              onclick={() => {
+                onRemoveFromFolder();
+                dropdownOpen = false;
+              }}
+            >
+              <Icon name="x" size={12} />
+              Remove from folder
+            </button>
+          {/if}
+          {#if !showNewFolderInput}
+            <button class="assign-item new-folder-btn" onclick={() => (showNewFolderInput = true)}>
+              <Icon name="plus" size={12} />
+              New folder…
+            </button>
+          {:else}
+            <div class="new-folder-row">
+              <input
+                type="text"
+                class="new-folder-input"
+                placeholder="Folder name"
+                bind:value={newFolderName}
+                bind:this={newFolderInputRef}
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') confirmNewFolder();
+                  if (e.key === 'Escape') {
+                    showNewFolderInput = false;
+                    newFolderName = '';
+                  }
+                }}
+              />
+              <button
+                class="new-folder-confirm"
+                disabled={!newFolderName.trim()}
+                onclick={confirmNewFolder}
+              >
+                <Icon name="check" size={12} />
+              </button>
+            </div>
+          {/if}
         </div>
       {/if}
     </div>
@@ -61,6 +143,13 @@
     border-radius: 10px;
     margin-bottom: 1rem;
     font-size: 0.8125rem;
+    position: fixed;
+    bottom: 1.5rem;
+    left: calc(var(--sidebar-width, 320px) + (100% - var(--sidebar-width, 320px)) / 2);
+    transform: translateX(-50%);
+    max-width: 600px;
+    width: calc(100% - var(--sidebar-width, 320px) - 2rem);
+    z-index: 50;
   }
 
   .bulk-count {
@@ -115,16 +204,16 @@
 
   .assign-dropdown {
     position: absolute;
-    top: 100%;
+    bottom: 100%;
     left: 0;
-    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
     background: var(--color-bg);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.25rem;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 100;
-    min-width: 160px;
+    min-width: 180px;
   }
 
   .assign-item {
@@ -142,6 +231,78 @@
 
   .assign-item:hover {
     background: var(--color-bg-hover);
+  }
+
+  .remove-folder-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-text-secondary);
+    border-top: 1px solid var(--color-border);
+    margin-top: 0.25rem;
+    padding-top: 0.5rem;
+    border-radius: 0;
+  }
+
+  .new-folder-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-text-secondary);
+    border-top: 1px solid var(--color-border);
+    margin-top: 0.25rem;
+    padding-top: 0.5rem;
+    border-radius: 0 0 4px 4px;
+  }
+
+  .new-folder-row {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.25rem;
+    border-top: 1px solid var(--color-border);
+    margin-top: 0.25rem;
+    padding-top: 0.5rem;
+  }
+
+  .new-folder-input {
+    flex: 1;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    background: var(--color-bg);
+    color: var(--color-text);
+    outline: none;
+  }
+
+  .new-folder-input:focus {
+    border-color: var(--color-primary);
+  }
+
+  .new-folder-confirm {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.375rem;
+    border: 1px solid var(--color-primary);
+    border-radius: 4px;
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  .new-folder-confirm:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 1000px) {
+    .bulk-bar {
+      left: 50%;
+      width: calc(100% - 2rem);
+      bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 0.75rem);
+    }
   }
 
   @media (prefers-color-scheme: dark) {

--- a/frontend/src/lib/components/sources/SourceGroupHeader.svelte
+++ b/frontend/src/lib/components/sources/SourceGroupHeader.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+
+  interface Props {
+    avatarUrl: string | null;
+    displayName: string;
+    handle: string;
+    totalUnread: number;
+    onRemoveAll: () => void;
+  }
+
+  let { avatarUrl, displayName, handle, totalUnread, onRemoveAll }: Props = $props();
+</script>
+
+<div class="group-header">
+  <div class="header-icon">
+    {#if avatarUrl}
+      <img src={avatarUrl} alt="" class="avatar" />
+    {:else}
+      <Icon name="user" size={16} />
+    {/if}
+  </div>
+  <div class="header-info">
+    <span class="header-name">{displayName}</span>
+    <span class="header-handle">@{handle}</span>
+  </div>
+  {#if totalUnread > 0}
+    <span class="unread-badge">{totalUnread}</span>
+  {/if}
+  <button class="remove-all-btn" onclick={onRemoveAll} title="Remove all">
+    <Icon name="trash" size={14} />
+  </button>
+</div>
+
+<style>
+  .group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.06));
+  }
+
+  .header-icon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-secondary);
+  }
+
+  .avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+
+  .header-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 0.375rem;
+  }
+
+  .header-name {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .header-handle {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .unread-badge {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.1);
+    padding: 0.125rem 0.375rem;
+    border-radius: 10px;
+  }
+
+  .remove-all-btn {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 4px;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .group-header:hover .remove-all-btn {
+    opacity: 1;
+  }
+
+  .remove-all-btn:hover {
+    color: var(--color-error, #dc2626);
+    background: var(--color-bg-hover);
+  }
+
+  @media (max-width: 640px) {
+    .remove-all-btn {
+      opacity: 1;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/sources/SourceRow.svelte
+++ b/frontend/src/lib/components/sources/SourceRow.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+  import PopoverMenu from '$lib/components/PopoverMenu.svelte';
+
+  interface Props {
+    iconUrl: string | null;
+    iconRound?: boolean;
+    title: string;
+    subtitle: string;
+    sourceLabel: string;
+    pillClass: string;
+    unreadCount?: number;
+    hasError?: boolean;
+    subscribed?: boolean;
+    selected?: boolean;
+    fallbackIcon?: string;
+    onToggleSelect?: () => void;
+    onEdit?: (() => void) | null;
+    onRefresh?: (() => void) | null;
+    onRemove?: (() => void) | null;
+    onSubscribe?: (() => void) | null;
+  }
+
+  let {
+    iconUrl,
+    iconRound = false,
+    title,
+    subtitle,
+    sourceLabel,
+    pillClass,
+    unreadCount = 0,
+    hasError = false,
+    subscribed = true,
+    selected = false,
+    fallbackIcon = 'rss',
+    onToggleSelect,
+    onEdit = null,
+    onRefresh = null,
+    onRemove = null,
+    onSubscribe = null,
+  }: Props = $props();
+
+  let menuItems = $derived.by(() => {
+    const items: {
+      label: string;
+      icon?: string;
+      variant?: 'default' | 'danger';
+      onclick: () => void;
+    }[] = [];
+    if (onSubscribe) items.push({ label: 'Subscribe', icon: 'plus', onclick: onSubscribe });
+    if (onEdit) items.push({ label: 'Edit', icon: 'edit', onclick: onEdit });
+    if (onRefresh) items.push({ label: 'Refresh', icon: 'refresh-cw', onclick: onRefresh });
+    if (onRemove)
+      items.push({ label: 'Remove', icon: 'trash', variant: 'danger', onclick: onRemove });
+    return items;
+  });
+</script>
+
+<div class="source-row" class:unsubscribed={!subscribed}>
+  {#if subscribed && onToggleSelect}
+    <label class="row-checkbox">
+      <input type="checkbox" checked={selected} onchange={onToggleSelect} />
+    </label>
+  {:else if !subscribed}
+    <div class="checkbox-spacer"></div>
+  {/if}
+
+  <div class="source-icon" class:round={iconRound}>
+    {#if iconUrl}
+      <img src={iconUrl} alt="" class="icon-img" class:round={iconRound} />
+    {:else}
+      <Icon name={fallbackIcon as any} size={16} />
+    {/if}
+  </div>
+
+  <div class="source-info">
+    <span class="source-title">{title}</span>
+    <span class="source-meta">{subtitle}</span>
+  </div>
+
+  <span class="source-type-pill {pillClass}">{sourceLabel}</span>
+
+  {#if subscribed && hasError}
+    <span class="error-badge" title="Feed error">
+      <Icon name="alert-triangle" size={14} />
+    </span>
+  {/if}
+
+  {#if subscribed && unreadCount > 0}
+    <span class="unread-badge">{unreadCount}</span>
+  {/if}
+
+  {#if menuItems.length > 0}
+    <div class="source-actions">
+      <PopoverMenu items={menuItems} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .source-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    background: var(--color-bg);
+    transition: background-color 0.15s;
+  }
+
+  .source-row:hover {
+    background: var(--color-bg-hover, rgba(0, 0, 0, 0.02));
+  }
+
+  .source-row.unsubscribed {
+    opacity: 0.55;
+  }
+
+  .source-row.unsubscribed:hover {
+    opacity: 0.8;
+  }
+
+  .row-checkbox {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .row-checkbox input {
+    cursor: pointer;
+  }
+
+  .checkbox-spacer {
+    width: 16px;
+    flex-shrink: 0;
+  }
+
+  .source-icon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-secondary);
+  }
+
+  .icon-img {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+  }
+
+  .icon-img.round {
+    border-radius: 50%;
+  }
+
+  .source-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .source-title {
+    font-size: 0.875rem;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .source-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .source-type-pill {
+    flex-shrink: 0;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
+
+  .pill-rss {
+    color: var(--color-text-secondary);
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+  }
+
+  .pill-shares {
+    color: #16a34a;
+    background: rgba(22, 163, 74, 0.1);
+  }
+
+  .pill-documents {
+    color: #7c3aed;
+    background: rgba(124, 58, 237, 0.1);
+  }
+
+  .pill-publication {
+    color: #ea580c;
+    background: rgba(234, 88, 12, 0.1);
+  }
+
+  .pill-collection {
+    color: var(--color-text-secondary);
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+  }
+
+  .unread-badge {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.1);
+    padding: 0.125rem 0.375rem;
+    border-radius: 10px;
+  }
+
+  .error-badge {
+    flex-shrink: 0;
+    color: var(--color-error, #dc2626);
+    display: flex;
+    align-items: center;
+  }
+
+  .source-actions {
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .source-row:hover .source-actions {
+    opacity: 1;
+  }
+
+  @media (max-width: 640px) {
+    .source-actions {
+      opacity: 1;
+    }
+
+    .source-type-pill {
+      display: none;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .source-row:hover {
+      background: var(--color-bg-hover, rgba(255, 255, 255, 0.03));
+    }
+  }
+</style>

--- a/frontend/src/lib/components/sources/SourcesToolbar.svelte
+++ b/frontend/src/lib/components/sources/SourcesToolbar.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+
+  interface Props {
+    searchQuery: string;
+    onSearchChange: (value: string) => void;
+    onAddRss: () => void;
+    onAddHandle: () => void;
+  }
+
+  let { searchQuery, onSearchChange, onAddRss, onAddHandle }: Props = $props();
+</script>
+
+<div class="sources-toolbar">
+  <div class="search-wrapper">
+    <Icon name="search" size={16} />
+    <input
+      type="text"
+      value={searchQuery}
+      oninput={(e) => onSearchChange(e.currentTarget.value)}
+      placeholder="Search sources..."
+      class="search-input"
+    />
+  </div>
+  <button class="add-btn" onclick={onAddRss}>
+    <Icon name="plus" size={16} />
+    <span>Add RSS</span>
+  </button>
+  <button class="add-btn" onclick={onAddHandle}>
+    <Icon name="at-sign" size={16} />
+    <span>Add @handle</span>
+  </button>
+</div>
+
+<style>
+  .sources-toolbar {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .search-wrapper {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .search-input {
+    flex: 1;
+    border: none;
+    background: none;
+    font: inherit;
+    font-size: 0.875rem;
+    color: var(--color-text);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .add-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: none;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    white-space: nowrap;
+  }
+
+  .add-btn:hover {
+    background: var(--color-bg-hover);
+  }
+
+  @media (max-width: 640px) {
+    .sources-toolbar {
+      flex-wrap: wrap;
+    }
+
+    .add-btn span {
+      display: none;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .search-wrapper {
+      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.06));
+    }
+  }
+</style>

--- a/frontend/src/lib/constants/channelOptions.ts
+++ b/frontend/src/lib/constants/channelOptions.ts
@@ -1,0 +1,164 @@
+import type {
+  SubscriptionSourceType,
+  SavedSourceType,
+  DateAddedPreset,
+  ReadingLengthFilter,
+  SortOrder,
+  ChannelAutoRule,
+} from '$lib/types';
+
+// --- Content type options ---
+
+export const TYPE_OPTIONS: { value: SubscriptionSourceType; label: string }[] = [
+  { value: 'rss', label: 'RSS Feeds' },
+  { value: 'atproto.shares', label: 'Skyreader Shares' },
+  { value: 'atproto.documents', label: 'Standard.site Documents' },
+];
+
+export const SAVED_SOURCE_OPTIONS: { value: SavedSourceType; label: string }[] = [
+  { value: 'url', label: 'URL Saves' },
+  { value: 'feed', label: 'Feed Articles' },
+  { value: 'share', label: 'Shared Articles' },
+  { value: 'document', label: 'Documents' },
+];
+
+// --- Smart rule options ---
+
+export type AutoRuleOption =
+  | 'frequency:high'
+  | 'frequency:low'
+  | 'longReads'
+  | 'recent'
+  | 'category'
+  | 'subscriptionTag'
+  | 'domain'
+  | 'people';
+
+export const AUTO_RULE_OPTIONS: { value: AutoRuleOption; label: string; description: string }[] = [
+  {
+    value: 'frequency:high',
+    label: 'Daily Digest',
+    description: 'High-volume feeds that publish 2+ times per day',
+  },
+  {
+    value: 'frequency:low',
+    label: "Don't Miss",
+    description: 'Infrequent feeds where every post counts',
+  },
+  {
+    value: 'longReads',
+    label: 'Long Reads',
+    description: 'Feeds with in-depth, long-form articles',
+  },
+  {
+    value: 'recent',
+    label: 'Recently Added',
+    description: 'Sources you added recently',
+  },
+  {
+    value: 'category',
+    label: 'Category',
+    description: 'All sources in a specific folder',
+  },
+  {
+    value: 'subscriptionTag',
+    label: 'Tag',
+    description: 'All sources with a specific tag',
+  },
+  {
+    value: 'domain',
+    label: 'Domain',
+    description: 'Sources matching URL patterns',
+  },
+  {
+    value: 'people',
+    label: 'People',
+    description: 'Everyone you follow on AT Protocol',
+  },
+];
+
+export const AUTO_RULE_DEFAULT_NAMES: Record<AutoRuleOption, string> = {
+  'frequency:high': 'Daily Digest',
+  'frequency:low': "Don't Miss",
+  longReads: 'Long Reads',
+  recent: 'New Sources',
+  category: '',
+  subscriptionTag: '',
+  domain: '',
+  people: 'People I Follow',
+};
+
+/** Map a stored ChannelAutoRule back to an AutoRuleOption string. */
+export function autoRuleToOption(rule: ChannelAutoRule): AutoRuleOption {
+  switch (rule.type) {
+    case 'frequency':
+      return rule.threshold === 'high' ? 'frequency:high' : 'frequency:low';
+    case 'longReads':
+      return 'longReads';
+    case 'recent':
+      return 'recent';
+    case 'category':
+      return 'category';
+    case 'subscriptionTag':
+      return 'subscriptionTag';
+    case 'domain':
+      return 'domain';
+    case 'people':
+      return 'people';
+  }
+}
+
+// --- Date & reading length options ---
+// Desktop and mobile use different labels for space reasons.
+
+export const DATE_PRESET_OPTIONS: { value: DateAddedPreset | ''; label: string }[] = [
+  { value: '', label: 'Any time' },
+  { value: 'last-week', label: 'Last week' },
+  { value: 'last-month', label: 'Last month' },
+  { value: 'last-3-months', label: 'Last 3 months' },
+  { value: 'last-year', label: 'Last year' },
+];
+
+export const DATE_PRESET_OPTIONS_SHORT: { value: DateAddedPreset | ''; label: string }[] = [
+  { value: '', label: 'Any time' },
+  { value: 'last-week', label: 'Week' },
+  { value: 'last-month', label: 'Month' },
+  { value: 'last-3-months', label: '3 months' },
+  { value: 'last-year', label: 'Year' },
+];
+
+export const READING_LENGTH_OPTIONS: { value: ReadingLengthFilter; label: string }[] = [
+  { value: 'quick', label: 'Quick (< 5 min)' },
+  { value: 'medium', label: 'Medium (5–15 min)' },
+  { value: 'long', label: 'Long (15+ min)' },
+];
+
+export const READING_LENGTH_OPTIONS_SHORT: { value: ReadingLengthFilter; label: string }[] = [
+  { value: 'quick', label: 'Quick' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'long', label: 'Long' },
+];
+
+// --- Sort options ---
+
+export const SAVED_SORT_OPTIONS: { value: SortOrder; label: string }[] = [
+  { value: 'newest', label: 'Saved (newest)' },
+  { value: 'oldest', label: 'Saved (oldest)' },
+  { value: 'published-newest', label: 'Published (newest)' },
+  { value: 'published-oldest', label: 'Published (oldest)' },
+  { value: 'shortest', label: 'Reading time (short)' },
+  { value: 'longest', label: 'Reading time (long)' },
+  { value: 'domain-asc', label: 'Domain (A–Z)' },
+  { value: 'domain-desc', label: 'Domain (Z–A)' },
+];
+
+export const SAVED_SORT_OPTIONS_SHORT: { value: SortOrder; label: string }[] = [
+  { value: 'newest', label: 'Saved ↓' },
+  { value: 'oldest', label: 'Saved ↑' },
+  { value: 'published-newest', label: 'Published ↓' },
+  { value: 'published-oldest', label: 'Published ↑' },
+  { value: 'shortest', label: 'Short' },
+  { value: 'longest', label: 'Long' },
+  { value: 'domain-asc', label: 'Domain A–Z' },
+  { value: 'domain-desc', label: 'Domain Z–A' },
+];

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -778,6 +778,53 @@ class ApiClient {
   }> {
     return this.fetch('/api/sync/status');
   }
+
+  // Channels
+  async getChannels(): Promise<{
+    channels: Array<{
+      uuid: string;
+      name: string;
+      config: string;
+      position: number;
+      createdAt: number;
+      updatedAt: number;
+    }>;
+    deletedUuids: string[];
+  }> {
+    return this.fetch('/api/channels');
+  }
+
+  async syncChannels(
+    channels: Array<{
+      uuid: string;
+      name: string;
+      config: string;
+      position: number;
+      createdAt: number;
+      updatedAt: number;
+    }>
+  ): Promise<{ success: boolean }> {
+    return this.fetch('/api/channels', {
+      method: 'PUT',
+      body: JSON.stringify({ channels }),
+    });
+  }
+
+  async upsertChannel(
+    uuid: string,
+    data: { name: string; config: string; position: number; createdAt: number; updatedAt: number }
+  ): Promise<{ success: boolean }> {
+    return this.fetch(`/api/channels/${uuid}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteChannel(uuid: string): Promise<{ success: boolean }> {
+    return this.fetch(`/api/channels/${uuid}`, {
+      method: 'DELETE',
+    });
+  }
 }
 
 export const api = new ApiClient();

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -296,7 +296,11 @@ class ApiClient {
 
   async updateSubscription(
     rkey: string,
-    updates: { customTitle?: string | null; customIconUrl?: string | null }
+    updates: {
+      customTitle?: string | null;
+      customIconUrl?: string | null;
+      category?: string | null;
+    }
   ): Promise<{ success: boolean }> {
     return this.fetch(`/api/subscriptions/${rkey}`, {
       method: 'PATCH',
@@ -323,6 +327,20 @@ class ApiClient {
     return this.fetch('/api/subscriptions/bulk', {
       method: 'POST',
       body: JSON.stringify({ subscriptions }),
+    });
+  }
+
+  async bulkUpdateSubscriptions(
+    rkeys: string[],
+    updates: {
+      customTitle?: string | null;
+      customIconUrl?: string | null;
+      category?: string | null;
+    }
+  ): Promise<{ success: boolean; updated: number }> {
+    return this.fetch('/api/subscriptions/bulk-update', {
+      method: 'POST',
+      body: JSON.stringify({ rkeys, updates }),
     });
   }
 

--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -287,6 +287,22 @@ class SkyreaderDatabase extends Dexie {
     // Channels redesign: sourceMode/sourceKeys/autoRule/typeFilter stored as non-indexed fields.
     // Version bump ensures any pending upgrades run before we access the new fields.
     this.version(26).stores({});
+
+    // Add uuid to filteredViews for cross-device sync
+    this.version(27)
+      .stores({
+        filteredViews: '++id, uuid, name, position',
+      })
+      .upgrade(async (tx) => {
+        const views = await tx.table('filteredViews').toArray();
+        for (const view of views) {
+          if (!view.uuid) {
+            await tx.table('filteredViews').update(view.id, {
+              uuid: crypto.randomUUID(),
+            });
+          }
+        }
+      });
   }
 }
 

--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -283,6 +283,10 @@ class SkyreaderDatabase extends Dexie {
       subscriptions:
         '++id, rkey, feedUrl, category, fetchStatus, source, localUpdatedAt, sourceType, subjectDid',
     });
+
+    // Channels redesign: sourceMode/sourceKeys/autoRule/typeFilter stored as non-indexed fields.
+    // Version bump ensures any pending upgrades run before we access the new fields.
+    this.version(26).stores({});
   }
 }
 

--- a/frontend/src/lib/services/liveDb.svelte.ts
+++ b/frontend/src/lib/services/liveDb.svelte.ts
@@ -261,6 +261,13 @@ class LiveDatabase {
   }
 
   /**
+   * Get a subscription by rkey
+   */
+  getSubscriptionByRkey(rkey: string): Subscription | undefined {
+    return this._subscriptions.find((s) => s.rkey === rkey);
+  }
+
+  /**
    * Get a subscription by feed URL
    */
   getSubscriptionByUrl(feedUrl: string): Subscription | undefined {

--- a/frontend/src/lib/services/liveDb.svelte.ts
+++ b/frontend/src/lib/services/liveDb.svelte.ts
@@ -91,10 +91,17 @@ class LiveDatabase {
    */
   async updateSubscriptionLocal(
     id: number,
-    updates: { customTitle?: string; customIconUrl?: string }
+    updates: { customTitle?: string; customIconUrl?: string; category?: string | null }
   ): Promise<void> {
-    await safeUpdate(db.subscriptions, id, updates);
-    this._subscriptions = this._subscriptions.map((s) => (s.id === id ? { ...s, ...updates } : s));
+    // Dexie doesn't accept null — use undefined to clear fields
+    const dexieUpdates: Record<string, string | undefined> = {};
+    if (updates.customTitle !== undefined) dexieUpdates.customTitle = updates.customTitle;
+    if (updates.customIconUrl !== undefined) dexieUpdates.customIconUrl = updates.customIconUrl;
+    if (updates.category !== undefined) dexieUpdates.category = updates.category ?? undefined;
+    await safeUpdate(db.subscriptions, id, dexieUpdates);
+    this._subscriptions = this._subscriptions.map((s) =>
+      s.id === id ? { ...s, ...dexieUpdates } : s
+    );
     this.subscriptionsVersion++;
   }
 

--- a/frontend/src/lib/stores/app.svelte.ts
+++ b/frontend/src/lib/stores/app.svelte.ts
@@ -89,6 +89,7 @@ function createAppManager() {
       }
 
       // Phase 2: Refresh from backend (background, skip when offline)
+      // This also syncs channels bidirectionally via filteredViewsStore.syncWithBackend()
       if (syncStore.isOnline) {
         phase = 'refreshing';
         await refreshFromBackend();
@@ -124,12 +125,13 @@ function createAppManager() {
     let newArticles = 0;
 
     try {
-      // Sync subscriptions, read positions, and social data in parallel
+      // Sync subscriptions, read positions, social data, and channels in parallel
       const [syncResult] = await Promise.all([
         syncSubscriptions(),
         itemLabelsStore.load(),
         shareReadingStore.load(),
         socialStore.loadFeed(true),
+        filteredViewsStore.syncWithBackend(),
       ]);
 
       // One-time migration: push existing local custom fields to backend

--- a/frontend/src/lib/stores/channelAutoUpdate.svelte.ts
+++ b/frontend/src/lib/stores/channelAutoUpdate.svelte.ts
@@ -1,0 +1,40 @@
+import { subscriptionsStore } from './subscriptions.svelte';
+import { filteredViewsStore } from './filteredViews.svelte';
+import { articlesStore } from './articles.svelte';
+import {
+  isValidAutoRule,
+  computeSourceKeys as computeSourceKeysPure,
+} from '$lib/utils/channelLogic';
+
+/**
+ * Check all channels with autoRules and update their sourceKeys if needed.
+ */
+export async function syncAutoRuleChannels() {
+  for (const view of filteredViewsStore.views) {
+    if (!view.autoRule || view.id == null) continue;
+
+    if (!isValidAutoRule(view.autoRule)) {
+      console.warn(
+        `Channel "${view.name}" (id=${view.id}) has invalid autoRule, skipping:`,
+        view.autoRule
+      );
+      continue;
+    }
+
+    const newKeys = computeSourceKeysPure(
+      view.autoRule,
+      subscriptionsStore.subscriptions,
+      articlesStore.allArticles
+    );
+    const currentKeys = view.sourceKeys ?? [];
+
+    // Compare: only update if different
+    const currentSet = new Set(currentKeys);
+    const newSet = new Set(newKeys);
+    if (currentSet.size === newSet.size && [...currentSet].every((k) => newSet.has(k))) {
+      continue;
+    }
+
+    await filteredViewsStore.update(view.id, { sourceKeys: newKeys });
+  }
+}

--- a/frontend/src/lib/stores/channelSuggestions.svelte.ts
+++ b/frontend/src/lib/stores/channelSuggestions.svelte.ts
@@ -1,0 +1,74 @@
+import { browser } from '$app/environment';
+import { subscriptionsStore } from './subscriptions.svelte';
+import { filteredViewsStore } from './filteredViews.svelte';
+import { articlesStore } from './articles.svelte';
+import { generateAllSuggestions } from '$lib/utils/channelLogic';
+import type { ChannelSuggestion } from '$lib/utils/channelLogic';
+
+export type { ChannelSuggestion };
+
+const STORAGE_KEY = 'skyreader-dismissed-suggestions';
+const MAX_INLINE_SUGGESTIONS = 3;
+
+function createChannelSuggestionsStore() {
+  let dismissedIds = $state<Set<string>>(new Set());
+
+  // Restore dismissed suggestions from localStorage
+  if (browser) {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        dismissedIds = new Set(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  function persistDismissals() {
+    if (browser) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([...dismissedIds]));
+    }
+  }
+
+  function dismiss(id: string) {
+    dismissedIds = new Set([...dismissedIds, id]);
+    persistDismissals();
+  }
+
+  let allSuggestions = $derived.by((): ChannelSuggestion[] => {
+    // Access reactive dependencies
+    subscriptionsStore.subscriptions;
+    filteredViewsStore.views;
+    articlesStore.allArticles;
+
+    return generateAllSuggestions(
+      {
+        subscriptions: subscriptionsStore.subscriptions,
+        articles: articlesStore.allArticles,
+        views: filteredViewsStore.views,
+      },
+      dismissedIds
+    );
+  });
+
+  let topSuggestions = $derived(allSuggestions.slice(0, MAX_INLINE_SUGGESTIONS));
+  let hasMoreSuggestions = $derived(allSuggestions.length > MAX_INLINE_SUGGESTIONS);
+
+  return {
+    /** Top 3 suggestions for inline display in sidebar/mobile switcher */
+    get suggestions() {
+      return topSuggestions;
+    },
+    /** All active suggestions for the discovery page */
+    get allSuggestions() {
+      return allSuggestions;
+    },
+    get hasMore() {
+      return hasMoreSuggestions;
+    },
+    dismiss,
+  };
+}
+
+export const channelSuggestions = createChannelSuggestionsStore();

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -14,6 +14,10 @@ import type {
   UserShare,
   SavedItem,
   SubscriptionSourceType,
+  SavedSourceType,
+  DateAddedPreset,
+  ReadingLengthFilter,
+  SortOrder,
 } from '$lib/types';
 import {
   isRssSource,
@@ -42,7 +46,7 @@ export interface EffectiveFilters {
   sourceMode: 'all' | 'include';
   sourceKeys: string[];
   readFilter: 'all' | 'unread' | 'read';
-  sortOrder: 'newest' | 'oldest';
+  sortOrder: SortOrder;
   typeFilter: SubscriptionSourceType[];
 }
 
@@ -108,6 +112,78 @@ function getSavedDate(item: FeedDisplayItem): number {
   return getItemDate(item);
 }
 
+function getItemPublishedDate(item: FeedDisplayItem): number {
+  if (item.type === 'saved') {
+    return item.item.publishedAt
+      ? new Date(item.item.publishedAt).getTime()
+      : new Date(item.item.savedAt).getTime();
+  }
+  return getItemDate(item);
+}
+
+function getItemWordCount(item: FeedDisplayItem): number | null {
+  if (item.type === 'saved') return item.item.wordCount;
+  if (item.type === 'article') {
+    const text = item.item.content || item.item.summary || '';
+    return text ? text.split(/\s+/).length : null;
+  }
+  if (item.type === 'share') {
+    const text = item.item.content || item.item.itemDescription || '';
+    return text ? text.split(/\s+/).length : null;
+  }
+  if (item.type === 'document') {
+    const text = item.item.textContent || item.item.description || '';
+    return text ? text.split(/\s+/).length : null;
+  }
+  return null;
+}
+
+function getItemDomain(item: FeedDisplayItem): string | null {
+  if (item.type === 'saved') return item.item.domain;
+  const url =
+    item.type === 'article'
+      ? item.item.url
+      : item.type === 'share'
+        ? item.item.itemUrl
+        : item.type === 'document'
+          ? item.item.canonicalUrl || item.item.path
+          : null;
+  if (!url) return null;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function datePresetToMs(preset: DateAddedPreset): number {
+  const DAY = 86400000;
+  switch (preset) {
+    case 'last-week':
+      return Date.now() - 7 * DAY;
+    case 'last-month':
+      return Date.now() - 30 * DAY;
+    case 'last-3-months':
+      return Date.now() - 90 * DAY;
+    case 'last-year':
+      return Date.now() - 365 * DAY;
+  }
+}
+
+const WPM = 200;
+function matchesReadingLength(wc: number | null, bucket: ReadingLengthFilter): boolean {
+  if (wc === null) return false;
+  const minutes = wc / WPM;
+  switch (bucket) {
+    case 'quick':
+      return minutes < 5;
+    case 'medium':
+      return minutes >= 5 && minutes < 15;
+    case 'long':
+      return minutes >= 15;
+  }
+}
+
 function createFeedViewStore() {
   // UI state
   let showOnlyUnread = $state(true);
@@ -127,11 +203,19 @@ function createFeedViewStore() {
   let toolbarSourceMode = $state<'all' | 'include'>('all');
   let toolbarSourceKeys = $state<string[]>([]);
   // View-local sort order override (null = use global preferences.sortOrder)
-  let toolbarSortOrder = $state<'newest' | 'oldest' | null>(null);
+  let toolbarSortOrder = $state<SortOrder | null>(null);
   // Tag filter (empty = no tag filter)
   let toolbarTagFilter = $state<string[]>([]);
   // Type filter (empty = all types shown)
   let toolbarTypeFilter = $state<SubscriptionSourceType[]>([]);
+  // Saved source filter (for saved-mode channels: url, feed, share, document)
+  let toolbarSavedSourceFilter = $state<SavedSourceType[]>([]);
+  // Saved channel: date added filter
+  let toolbarDateFilter = $state<DateAddedPreset | null>(null);
+  // Saved channel: reading length filter (multi-select)
+  let toolbarReadingLength = $state<ReadingLengthFilter[]>([]);
+  // Saved channel: domain filter (list of domains to include)
+  let toolbarDomainFilter = $state<string[]>([]);
 
   // Bookmarks view sub-filter (inbox vs archive)
   let savedView = $state<'inbox' | 'archive'>('inbox');
@@ -151,6 +235,12 @@ function createFeedViewStore() {
     if (!viewFilter) return null;
     return filteredViewsStore.getById(parseInt(viewFilter)) ?? null;
   });
+
+  // Derived: whether the active channel is a saved-mode channel
+  let isSavedChannel = $derived(activeFilteredView?.mode === 'saved');
+
+  // Derived: whether we're in any saved view (URL param or saved channel)
+  let isSavedView = $derived(Boolean(savedFilter) || isSavedChannel);
 
   // Helper to get current subscription IDs and follow DIDs for migration
   function getAllSubIds(): number[] {
@@ -190,22 +280,46 @@ function createFeedViewStore() {
   let hasUnsavedChanges = $derived.by(() => {
     if (!activeFilteredView) return false;
     const view = activeFilteredView;
-    const savedMode = view.sourceMode === 'all' ? 'all' : 'include';
-    const savedKeys = new Set(view.sourceKeys ?? []);
     const currentReadFilter = showOnlyUnread ? 'unread' : 'all';
     const currentSortOrder = toolbarSortOrder ?? preferences.sortOrder;
 
-    if (toolbarSourceMode !== savedMode) return true;
     if (currentReadFilter !== view.readFilter) return true;
     if (currentSortOrder !== view.sortOrder) return true;
-    if (toolbarSourceKeys.length !== savedKeys.size) return true;
-    for (const key of toolbarSourceKeys) {
-      if (!savedKeys.has(key)) return true;
-    }
-    const savedTypeFilter = new Set(view.typeFilter ?? []);
-    if (toolbarTypeFilter.length !== savedTypeFilter.size) return true;
-    for (const t of toolbarTypeFilter) {
-      if (!savedTypeFilter.has(t)) return true;
+
+    if (view.mode === 'saved') {
+      // Compare saved source filter
+      const savedSources = new Set(view.savedSourceFilter ?? []);
+      if (toolbarSavedSourceFilter.length !== savedSources.size) return true;
+      for (const s of toolbarSavedSourceFilter) {
+        if (!savedSources.has(s)) return true;
+      }
+      // Compare date filter
+      if ((toolbarDateFilter ?? null) !== (view.savedDateFilter ?? null)) return true;
+      // Compare reading length filter
+      const savedRL = new Set(view.savedReadingLength ?? []);
+      if (toolbarReadingLength.length !== savedRL.size) return true;
+      for (const r of toolbarReadingLength) {
+        if (!savedRL.has(r)) return true;
+      }
+      // Compare domain filter
+      const savedDomains = new Set(view.savedDomainFilter ?? []);
+      if (toolbarDomainFilter.length !== savedDomains.size) return true;
+      for (const d of toolbarDomainFilter) {
+        if (!savedDomains.has(d)) return true;
+      }
+    } else {
+      const savedMode = view.sourceMode === 'all' ? 'all' : 'include';
+      const savedKeys = new Set(view.sourceKeys ?? []);
+      if (toolbarSourceMode !== savedMode) return true;
+      if (toolbarSourceKeys.length !== savedKeys.size) return true;
+      for (const key of toolbarSourceKeys) {
+        if (!savedKeys.has(key)) return true;
+      }
+      const savedTypeFilter = new Set(view.typeFilter ?? []);
+      if (toolbarTypeFilter.length !== savedTypeFilter.size) return true;
+      for (const t of toolbarTypeFilter) {
+        if (!savedTypeFilter.has(t)) return true;
+      }
     }
     return false;
   });
@@ -219,6 +333,7 @@ function createFeedViewStore() {
 
   // Derived: view mode
   let viewMode = $derived.by((): ViewMode => {
+    if (isSavedChannel) return 'articles'; // saved channels use their own rendering path
     if (activeFilteredView) return 'combined';
     if (sharedFilter) return 'userShares';
     if (sharerFilter || followingFilter) return 'shares';
@@ -277,7 +392,7 @@ function createFeedViewStore() {
 
     let articles: Article[];
 
-    if (savedFilter) {
+    if (isSavedView) {
       // Starred view with inbox/archive sub-filter
       if (savedView === 'inbox') {
         articles = allArticles.filter((a) => {
@@ -525,42 +640,56 @@ function createFeedViewStore() {
     let items: FeedDisplayItem[];
 
     // Special handling for bookmarks view: include starred items of all types
-    if (savedFilter) {
+    if (isSavedView) {
       const sortOrder = effectiveFilters.sortOrder;
       const isArchiveView = savedView === 'archive';
+      const sourceFilter =
+        isSavedChannel && toolbarSavedSourceFilter.length > 0
+          ? new Set(toolbarSavedSourceFilter)
+          : null;
 
       // Start with starred articles from filteredArticles (already filtered by savedView)
-      const articleItems: FeedDisplayItem[] = displayedArticles.map((item) => ({
-        type: 'article' as const,
-        item,
-        key: item.guid,
-      }));
+      // For saved channels with source filter, only include if 'feed' source is allowed
+      const articleItems: FeedDisplayItem[] =
+        sourceFilter && !sourceFilter.has('feed')
+          ? []
+          : displayedArticles.map((item) => ({
+              type: 'article' as const,
+              item,
+              key: item.guid,
+            }));
 
-      // Add starred shares
-      const starredShareItems: FeedDisplayItem[] = socialStore.shares
-        .filter((s) => {
-          if (!itemLabelsStore.isSaved(s.recordUri)) return false;
-          if (isArchiveView) return itemLabelsStore.isArchived(s.recordUri);
-          return !itemLabelsStore.isArchived(s.recordUri);
-        })
-        .map((s) => ({
-          type: 'share' as const,
-          item: s,
-          key: s.recordUri,
-        }));
+      // Add starred shares (source type 'share')
+      const starredShareItems: FeedDisplayItem[] =
+        sourceFilter && !sourceFilter.has('share')
+          ? []
+          : socialStore.shares
+              .filter((s) => {
+                if (!itemLabelsStore.isSaved(s.recordUri)) return false;
+                if (isArchiveView) return itemLabelsStore.isArchived(s.recordUri);
+                return !itemLabelsStore.isArchived(s.recordUri);
+              })
+              .map((s) => ({
+                type: 'share' as const,
+                item: s,
+                key: s.recordUri,
+              }));
 
-      // Add starred documents
-      const starredDocumentItems: FeedDisplayItem[] = socialStore.documents
-        .filter((d) => {
-          if (!itemLabelsStore.isSaved(d.recordUri)) return false;
-          if (isArchiveView) return itemLabelsStore.isArchived(d.recordUri);
-          return !itemLabelsStore.isArchived(d.recordUri);
-        })
-        .map((d) => ({
-          type: 'document' as const,
-          item: d,
-          key: d.recordUri,
-        }));
+      // Add starred documents (source type 'document')
+      const starredDocumentItems: FeedDisplayItem[] =
+        sourceFilter && !sourceFilter.has('document')
+          ? []
+          : socialStore.documents
+              .filter((d) => {
+                if (!itemLabelsStore.isSaved(d.recordUri)) return false;
+                if (isArchiveView) return itemLabelsStore.isArchived(d.recordUri);
+                return !itemLabelsStore.isArchived(d.recordUri);
+              })
+              .map((d) => ({
+                type: 'document' as const,
+                item: d,
+                key: d.recordUri,
+              }));
 
       // Add bookmarks — exclude bookmarks already shown via articles/shares/documents
       // Use ALL saved article guids for dedup (not just displayed ones) to prevent
@@ -572,6 +701,8 @@ function createFeedViewStore() {
       const documentRecordUris = new Set(starredDocumentItems.map((d) => d.key));
       const bookmarkItems: FeedDisplayItem[] = savesStore.articles
         .filter((bm) => {
+          // Apply saved source filter for saved channels
+          if (sourceFilter && bm.source && !sourceFilter.has(bm.source)) return false;
           // Skip feed-source bookmarks whose guid matches a saved article in the articles store
           if (bm.source === 'feed' && bm.itemGuid && allSavedArticleGuids.has(bm.itemGuid))
             return false;
@@ -595,17 +726,66 @@ function createFeedViewStore() {
 
       items = [...articleItems, ...starredShareItems, ...starredDocumentItems, ...bookmarkItems];
 
-      // Sort by saved date (when the item was bookmarked, not published)
+      // Sort saved items
+      const sort = isSavedChannel ? (toolbarSortOrder ?? 'newest') : sortOrder;
       items.sort((a, b) => {
-        const dateA = getSavedDate(a);
-        const dateB = getSavedDate(b);
-        return sortOrder === 'newest' ? dateB - dateA : dateA - dateB;
+        switch (sort) {
+          case 'published-newest':
+          case 'published-oldest': {
+            const dateA = getItemPublishedDate(a);
+            const dateB = getItemPublishedDate(b);
+            return sort === 'published-newest' ? dateB - dateA : dateA - dateB;
+          }
+          case 'shortest':
+          case 'longest': {
+            const wcA = getItemWordCount(a) ?? 0;
+            const wcB = getItemWordCount(b) ?? 0;
+            return sort === 'shortest' ? wcA - wcB : wcB - wcA;
+          }
+          case 'domain-asc':
+          case 'domain-desc': {
+            const domA = (getItemDomain(a) ?? '').toLowerCase();
+            const domB = (getItemDomain(b) ?? '').toLowerCase();
+            const cmp = domA.localeCompare(domB);
+            return sort === 'domain-asc' ? cmp : -cmp;
+          }
+          default: {
+            // newest / oldest — sort by savedAt
+            const dateA = getSavedDate(a);
+            const dateB = getSavedDate(b);
+            return sort === 'oldest' ? dateA - dateB : dateB - dateA;
+          }
+        }
       });
 
       // Apply tag filter
       if (toolbarTagFilter.length > 0) {
         const _tags = itemLabelsStore.tagsByItem;
         items = items.filter((item) => itemLabelsStore.itemHasAnyTag(item.key, toolbarTagFilter));
+      }
+
+      // Apply date added filter
+      if (toolbarDateFilter) {
+        const cutoff = datePresetToMs(toolbarDateFilter);
+        items = items.filter((item) => getSavedDate(item) >= cutoff);
+      }
+
+      // Apply reading length filter
+      if (toolbarReadingLength.length > 0) {
+        items = items.filter((item) => {
+          const wc = getItemWordCount(item);
+          if (wc === null) return true; // include items with unknown word count
+          return toolbarReadingLength.some((bucket) => matchesReadingLength(wc, bucket));
+        });
+      }
+
+      // Apply domain filter
+      if (toolbarDomainFilter.length > 0) {
+        const domainSet = new Set(toolbarDomainFilter.map((d) => d.toLowerCase()));
+        items = items.filter((item) => {
+          const domain = getItemDomain(item);
+          return domain !== null && domainSet.has(domain.toLowerCase());
+        });
       }
 
       return items;
@@ -711,7 +891,7 @@ function createFeedViewStore() {
     loadedArticleCount = DEFAULT_PAGE_SIZE;
 
     // For unread view, load more articles until we have enough unread ones
-    if (showOnlyUnread && !savedFilter) {
+    if (showOnlyUnread && !isSavedView) {
       const targetCount = DEFAULT_PAGE_SIZE;
       const maxCount = DEFAULT_PAGE_SIZE * 10;
 
@@ -825,19 +1005,48 @@ function createFeedViewStore() {
     readDocumentUrisThisSession = new Set();
   }
 
+  // Derived: all unique domains from saved items (for domain filter picker)
+  let availableSavedDomains = $derived.by((): string[] => {
+    if (!isSavedView) return [];
+    const domains = new Set<string>();
+    for (const bm of savesStore.articles) {
+      if (bm.domain) {
+        domains.add(bm.domain);
+      } else if (bm.url) {
+        try {
+          domains.add(new URL(bm.url).hostname);
+        } catch {
+          // ignore invalid URLs
+        }
+      }
+    }
+    return [...domains].sort();
+  });
+
   function syncToolbarToSavedView() {
     if (!viewFilter) return;
     const id = parseInt(viewFilter);
     const fv = filteredViewsStore.getById(id);
     if (!fv) return;
-    filteredViewsStore.update(id, {
-      sourceMode: toolbarSourceMode,
-      sourceKeys: [...toolbarSourceKeys],
+    const updates: Partial<import('$lib/types').FilteredView> = {
       readFilter: showOnlyUnread ? 'unread' : 'all',
       sortOrder: toolbarSortOrder ?? preferences.sortOrder,
       tagFilter: toolbarTagFilter.length > 0 ? [...toolbarTagFilter] : undefined,
-      typeFilter: toolbarTypeFilter.length > 0 ? [...toolbarTypeFilter] : undefined,
-    });
+    };
+    if (fv.mode === 'saved') {
+      updates.savedSourceFilter =
+        toolbarSavedSourceFilter.length > 0 ? [...toolbarSavedSourceFilter] : undefined;
+      updates.savedDateFilter = toolbarDateFilter ?? undefined;
+      updates.savedReadingLength =
+        toolbarReadingLength.length > 0 ? [...toolbarReadingLength] : undefined;
+      updates.savedDomainFilter =
+        toolbarDomainFilter.length > 0 ? [...toolbarDomainFilter] : undefined;
+    } else {
+      updates.sourceMode = toolbarSourceMode;
+      updates.sourceKeys = [...toolbarSourceKeys];
+      updates.typeFilter = toolbarTypeFilter.length > 0 ? [...toolbarTypeFilter] : undefined;
+    }
+    filteredViewsStore.update(id, updates);
   }
 
   function resetToolbarFilters() {
@@ -846,6 +1055,10 @@ function createFeedViewStore() {
     toolbarSortOrder = null;
     toolbarTagFilter = [];
     toolbarTypeFilter = [];
+    toolbarSavedSourceFilter = [];
+    toolbarDateFilter = null;
+    toolbarReadingLength = [];
+    toolbarDomainFilter = [];
   }
 
   function toggleUnreadFilter() {
@@ -964,6 +1177,18 @@ function createFeedViewStore() {
     get toolbarTypeFilter() {
       return toolbarTypeFilter;
     },
+    get toolbarDateFilter() {
+      return toolbarDateFilter;
+    },
+    get toolbarReadingLength() {
+      return toolbarReadingLength;
+    },
+    get toolbarDomainFilter() {
+      return toolbarDomainFilter;
+    },
+    get availableSavedDomains() {
+      return availableSavedDomains;
+    },
     get currentSortOrder() {
       return toolbarSortOrder ?? preferences.sortOrder;
     },
@@ -972,6 +1197,15 @@ function createFeedViewStore() {
     },
     get savedView() {
       return savedView;
+    },
+    get isSavedView() {
+      return isSavedView;
+    },
+    get isSavedChannel() {
+      return isSavedChannel;
+    },
+    get toolbarSavedSourceFilter() {
+      return toolbarSavedSourceFilter;
     },
 
     // All filtered items (not paginated) — for bulk operations like mark-all-as-read
@@ -1020,9 +1254,26 @@ function createFeedViewStore() {
     setToolbarTypeFilter(types: SubscriptionSourceType[]) {
       toolbarTypeFilter = types;
     },
+    setToolbarSavedSourceFilter(sources: SavedSourceType[]) {
+      toolbarSavedSourceFilter = sources;
+    },
+    setToolbarDateFilter(preset: DateAddedPreset | null) {
+      toolbarDateFilter = preset;
+    },
+    setToolbarReadingLength(lengths: ReadingLengthFilter[]) {
+      toolbarReadingLength = lengths;
+    },
+    setToolbarDomainFilter(domains: string[]) {
+      toolbarDomainFilter = domains;
+    },
     setToolbarSourceFilter(mode: 'all' | 'include', keys: string[]) {
       toolbarSourceMode = mode;
       toolbarSourceKeys = keys;
+    },
+    setSortOrder(order: SortOrder) {
+      if (viewFilter) {
+        toolbarSortOrder = order;
+      }
     },
     toggleSortOrder() {
       if (viewFilter) {
@@ -1067,10 +1318,20 @@ function createFeedViewStore() {
       if (filters.view) {
         const fv = filteredViewsStore.getById(parseInt(filters.view));
         if (fv) {
-          if (fv.sourceMode != null) {
+          if (fv.mode === 'saved') {
+            // Saved channel — load saved-specific filters
+            toolbarSavedSourceFilter = fv.savedSourceFilter ? [...fv.savedSourceFilter] : [];
+            toolbarDateFilter = fv.savedDateFilter ?? null;
+            toolbarReadingLength = fv.savedReadingLength ? [...fv.savedReadingLength] : [];
+            toolbarDomainFilter = fv.savedDomainFilter ? [...fv.savedDomainFilter] : [];
+            toolbarSourceMode = 'all';
+            toolbarSourceKeys = [];
+            toolbarTypeFilter = [];
+          } else if (fv.sourceMode != null) {
             // New format (coerce any stale 'exclude' to 'include')
             toolbarSourceMode = fv.sourceMode === 'all' ? 'all' : 'include';
             toolbarSourceKeys = toolbarSourceMode === 'all' ? [] : [...(fv.sourceKeys ?? [])];
+            toolbarSavedSourceFilter = [];
           } else {
             // Legacy format — migrate
             const migrated = migrateLegacyView(
@@ -1088,13 +1349,14 @@ function createFeedViewStore() {
             );
             toolbarSourceMode = migrated.sourceMode;
             toolbarSourceKeys = migrated.sourceKeys;
+            toolbarSavedSourceFilter = [];
           }
           showOnlyUnread = fv.readFilter === 'unread';
           toolbarSortOrder = fv.sortOrder;
           toolbarTagFilter = fv.tagFilter ? [...fv.tagFilter] : [];
           toolbarTypeFilter = fv.typeFilter ? [...fv.typeFilter] : [];
           // Fire-and-forget legacy migration write-back
-          if (fv.sourceMode == null && fv.id != null) {
+          if (fv.sourceMode == null && fv.mode !== 'saved' && fv.id != null) {
             filteredViewsStore.update(fv.id, {
               sourceMode: toolbarSourceMode,
               sourceKeys: [...toolbarSourceKeys],

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -234,6 +234,19 @@ function createFeedViewStore() {
   let feedsFilter = $state<string | null>(null); // deprecated, kept for setFilters compat
   let contentTypeFilter = $state<'shares' | 'documents' | null>(null);
   let viewFilter = $state<string | null>(null);
+  let categoryFilter = $state<string | null>(null);
+
+  // Derived: subscription IDs that belong to the selected category
+  let categorySubscriptionIds = $derived.by(() => {
+    if (!categoryFilter) return null;
+    const ids = new Set<number>();
+    for (const sub of subscriptionsStore.subscriptions) {
+      if (sub.category === categoryFilter && sub.id) {
+        ids.add(sub.id);
+      }
+    }
+    return ids;
+  });
 
   // Derived: active filtered view (looked up by uuid, with fallback to Dexie id for old bookmarks)
   let activeFilteredView = $derived.by(() => {
@@ -361,6 +374,7 @@ function createFeedViewStore() {
       }
       return 'articles';
     }
+    if (categoryFilter) return 'combined';
     if (savedFilter) return 'articles';
     return 'combined';
   });
@@ -426,6 +440,11 @@ function createFeedViewStore() {
       if (feedFilter) {
         const feedId = parseInt(feedFilter);
         articles = articles.filter((a) => a.subscriptionId === feedId);
+      }
+
+      // Filter by category
+      if (categorySubscriptionIds) {
+        articles = articles.filter((a) => categorySubscriptionIds.has(a.subscriptionId));
       }
 
       // Apply source-based RSS filtering
@@ -494,6 +513,17 @@ function createFeedViewStore() {
     const allowedDids = deriveAllowedDids(fv, isSharesSource);
     if (allowedDids !== null) {
       filtered = filtered.filter((s) => allowedDids.has(s.authorDid));
+    }
+
+    // Filter by category: only show shares from subscriptions in the category
+    if (categorySubscriptionIds) {
+      const categoryDids = new Set<string>();
+      for (const sub of subscriptionsStore.subscriptions) {
+        if (sub.category === categoryFilter && sub.subjectDid) {
+          categoryDids.add(sub.subjectDid);
+        }
+      }
+      filtered = filtered.filter((s) => categoryDids.has(s.authorDid));
     }
 
     // Apply read filter
@@ -567,6 +597,17 @@ function createFeedViewStore() {
     const allowedDids = deriveAllowedDids(fv, isDocumentsSource);
     if (allowedDids !== null) {
       filtered = filtered.filter((d) => allowedDids.has(d.authorDid));
+    }
+
+    // Filter by category: only show documents from subscriptions in the category
+    if (categorySubscriptionIds) {
+      const categoryDids = new Set<string>();
+      for (const sub of subscriptionsStore.subscriptions) {
+        if (sub.category === categoryFilter && sub.subjectDid) {
+          categoryDids.add(sub.subjectDid);
+        }
+      }
+      filtered = filtered.filter((d) => categoryDids.has(d.authorDid));
     }
 
     // Apply read filter
@@ -1169,6 +1210,9 @@ function createFeedViewStore() {
     get viewFilter() {
       return viewFilter;
     },
+    get categoryFilter() {
+      return categoryFilter;
+    },
     get activeFilteredView() {
       return activeFilteredView;
     },
@@ -1319,6 +1363,7 @@ function createFeedViewStore() {
       feeds: string | null;
       contentType?: 'shares' | 'documents' | null;
       view?: string | null;
+      category?: string | null;
     }) {
       feedFilter = filters.feed;
       savedFilter = filters.saved;
@@ -1328,6 +1373,7 @@ function createFeedViewStore() {
       feedsFilter = filters.feeds;
       contentTypeFilter = filters.contentType ?? null;
       viewFilter = filters.view ?? null;
+      categoryFilter = filters.category ?? null;
       // Reset pagination when filters change
       loadedArticleCount = DEFAULT_PAGE_SIZE;
       // Populate toolbar from saved view, or reset to defaults

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -23,7 +23,7 @@ import {
   isRssSource,
   isSharesSource,
   isDocumentsSource,
-  getRssSubscriptionId,
+  getRssSubscriptionRkey,
   getSourceDid,
   migrateLegacyView,
 } from '$lib/utils/sourceKeys';
@@ -52,6 +52,7 @@ export interface EffectiveFilters {
 
 /**
  * Derive allowed RSS subscription IDs from effective filters.
+ * Converts rkeys in sourceKeys to Dexie IDs for article filtering.
  * Returns null if all RSS sources are allowed.
  */
 function deriveAllowedRssIds(fv: EffectiveFilters): Set<number> | null {
@@ -59,7 +60,11 @@ function deriveAllowedRssIds(fv: EffectiveFilters): Set<number> | null {
 
   const ids = new Set<number>();
   for (const key of fv.sourceKeys) {
-    if (isRssSource(key)) ids.add(getRssSubscriptionId(key));
+    if (isRssSource(key)) {
+      const rkey = getRssSubscriptionRkey(key);
+      const sub = subscriptionsStore.getByRkey(rkey);
+      if (sub?.id != null) ids.add(sub.id);
+    }
   }
   return ids;
 }
@@ -230,10 +235,15 @@ function createFeedViewStore() {
   let contentTypeFilter = $state<'shares' | 'documents' | null>(null);
   let viewFilter = $state<string | null>(null);
 
-  // Derived: active filtered view (looked up from store)
+  // Derived: active filtered view (looked up by uuid, with fallback to Dexie id for old bookmarks)
   let activeFilteredView = $derived.by(() => {
     if (!viewFilter) return null;
-    return filteredViewsStore.getById(parseInt(viewFilter)) ?? null;
+    // Try uuid first, fall back to numeric Dexie id for old bookmarks
+    const byUuid = filteredViewsStore.getByUuid(viewFilter);
+    if (byUuid) return byUuid;
+    const asNum = parseInt(viewFilter, 10);
+    if (!isNaN(asNum)) return filteredViewsStore.getById(asNum) ?? null;
+    return null;
   });
 
   // Derived: whether the active channel is a saved-mode channel
@@ -242,11 +252,17 @@ function createFeedViewStore() {
   // Derived: whether we're in any saved view (URL param or saved channel)
   let isSavedView = $derived(Boolean(savedFilter) || isSavedChannel);
 
-  // Helper to get current subscription IDs and follow DIDs for migration
-  function getAllSubIds(): number[] {
-    return subscriptionsStore.subscriptions
-      .map((s) => s.id)
-      .filter((id): id is number => id != null);
+  // Helper to get current subscription rkeys, ID→rkey map, and follow DIDs for migration
+  function getAllSubRkeys(): string[] {
+    return subscriptionsStore.subscriptions.map((s) => s.rkey).filter(Boolean);
+  }
+
+  function getIdToRkeyMap(): Map<number, string> {
+    const map = new Map<number, string>();
+    for (const s of subscriptionsStore.subscriptions) {
+      if (s.id != null && s.rkey) map.set(s.id, s.rkey);
+    }
+    return map;
   }
 
   function getAllFollowDids(): string[] {
@@ -1025,9 +1041,9 @@ function createFeedViewStore() {
 
   function syncToolbarToSavedView() {
     if (!viewFilter) return;
-    const id = parseInt(viewFilter);
-    const fv = filteredViewsStore.getById(id);
-    if (!fv) return;
+    const fv = activeFilteredView;
+    if (!fv || fv.id == null) return;
+    const id = fv.id;
     const updates: Partial<import('$lib/types').FilteredView> = {
       readFilter: showOnlyUnread ? 'unread' : 'all',
       sortOrder: toolbarSortOrder ?? preferences.sortOrder,
@@ -1316,7 +1332,9 @@ function createFeedViewStore() {
       loadedArticleCount = DEFAULT_PAGE_SIZE;
       // Populate toolbar from saved view, or reset to defaults
       if (filters.view) {
-        const fv = filteredViewsStore.getById(parseInt(filters.view));
+        const fv =
+          filteredViewsStore.getByUuid(filters.view) ??
+          filteredViewsStore.getById(parseInt(filters.view, 10));
         if (fv) {
           if (fv.mode === 'saved') {
             // Saved channel — load saved-specific filters
@@ -1344,8 +1362,9 @@ function createFeedViewStore() {
                 accountMode: fv.accountMode,
                 accountDids: fv.accountDids,
               },
-              getAllSubIds(),
-              getAllFollowDids()
+              getAllSubRkeys(),
+              getAllFollowDids(),
+              getIdToRkeyMap()
             );
             toolbarSourceMode = migrated.sourceMode;
             toolbarSourceKeys = migrated.sourceKeys;

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -758,17 +758,19 @@ function createFeedViewStore() {
       const documentRecordUris = new Set(starredDocumentItems.map((d) => d.key));
       const bookmarkItems: FeedDisplayItem[] = savesStore.articles
         .filter((bm) => {
-          // Apply saved source filter for saved channels
-          if (sourceFilter && bm.source && !sourceFilter.has(bm.source)) return false;
-          // Skip feed-source bookmarks whose guid matches a saved article in the articles store
-          if (bm.source === 'feed' && bm.itemGuid && allSavedArticleGuids.has(bm.itemGuid))
-            return false;
-          // Skip share-source bookmarks whose itemGuid matches a displayed share
-          if (bm.source === 'share' && bm.itemGuid && shareRecordUris.has(bm.itemGuid))
-            return false;
-          // Skip document-source bookmarks whose itemGuid matches a displayed document
-          if (bm.source === 'document' && bm.itemGuid && documentRecordUris.has(bm.itemGuid))
-            return false;
+          // Apply saved source filter for saved channels. Treat a missing
+          // source as 'url' (the default for legacy rows) so the filter still
+          // applies instead of silently letting the bookmark through.
+          const src = bm.source ?? 'url';
+          if (sourceFilter && !sourceFilter.has(src)) return false;
+          // Dedup against items already displayed via the primary stores.
+          // Checked regardless of bm.source so legacy rows with undefined
+          // source can't slip through and show up twice.
+          if (bm.itemGuid) {
+            if (allSavedArticleGuids.has(bm.itemGuid)) return false;
+            if (shareRecordUris.has(bm.itemGuid)) return false;
+            if (documentRecordUris.has(bm.itemGuid)) return false;
+          }
           // Use itemGuid (article guid) for archive checks when available, since archive
           // labels are stored against the article guid, not the AT Protocol URI
           const archiveKey = bm.itemGuid || bm.uri || '';

--- a/frontend/src/lib/stores/filteredViews.svelte.ts
+++ b/frontend/src/lib/stores/filteredViews.svelte.ts
@@ -121,16 +121,37 @@ function createFilteredViewsStore() {
         pendingDeletes
       );
 
-      // Apply local deletions
+      // Build the new views state without mutating `views` until all DB ops succeed.
+      let updatedViews = [...views];
+
+      // Apply local deletions to DB
       for (const uuid of ops.deleteLocally) {
-        const local = views.find((v) => v.uuid === uuid);
+        const local = updatedViews.find((v) => v.uuid === uuid);
         if (local?.id != null) {
           await db.filteredViews.delete(local.id);
         }
-        views = views.filter((v) => v.uuid !== uuid);
+        updatedViews = updatedViews.filter((v) => v.uuid !== uuid);
       }
 
-      // Retry pending deletes
+      // Add new channels from remote to DB
+      for (const parsed of ops.addLocally) {
+        const id = await safeAdd(db.filteredViews, parsed);
+        updatedViews = [...updatedViews, { ...parsed, id: id as number }];
+      }
+
+      // Update local channels from remote in DB
+      for (const { uuid, data } of ops.updateLocally) {
+        const local = updatedViews.find((v) => v.uuid === uuid);
+        if (local?.id != null) {
+          await safeUpdate(db.filteredViews, local.id, data);
+        }
+        updatedViews = updatedViews.map((v) => (v.uuid === uuid ? { ...v, ...data } : v));
+      }
+
+      // All DB ops succeeded — commit the in-memory state atomically
+      views = updatedViews;
+
+      // Retry pending deletes (network-only, doesn't affect local state)
       const retriedOk = new Set<string>();
       for (const uuid of ops.retryDeletes) {
         try {
@@ -142,21 +163,6 @@ function createFilteredViewsStore() {
       }
       for (const uuid of retriedOk) ops.pendingDeletesAfter.delete(uuid);
       await savePendingDeletes(ops.pendingDeletesAfter);
-
-      // Add new channels from remote
-      for (const parsed of ops.addLocally) {
-        const id = await safeAdd(db.filteredViews, parsed);
-        views = [...views, { ...parsed, id: id as number }];
-      }
-
-      // Update local channels from remote
-      for (const { uuid, data } of ops.updateLocally) {
-        const local = views.find((v) => v.uuid === uuid);
-        if (local?.id != null) {
-          await safeUpdate(db.filteredViews, local.id, data);
-        }
-        views = views.map((v) => (v.uuid === uuid ? { ...v, ...data } : v));
-      }
 
       // Push local-only channels to remote
       if (ops.pushToRemote.length > 0) {

--- a/frontend/src/lib/stores/filteredViews.svelte.ts
+++ b/frontend/src/lib/stores/filteredViews.svelte.ts
@@ -1,12 +1,54 @@
 import { db } from '$lib/services/db';
 import { safeAdd, safeUpdate } from '$lib/services/safeDb.svelte';
 import type { FilteredView } from '$lib/types';
+import { migrateLegacyView } from '$lib/utils/sourceKeys';
 
 function createFilteredViewsStore() {
   let views = $state<FilteredView[]>([]);
 
   async function load() {
     const all = await db.filteredViews.orderBy('position').toArray();
+
+    // One-time migration: convert legacy views (sourceMode undefined) to new format
+    const needsMigration = all.some((v) => v.sourceMode == null);
+    if (needsMigration) {
+      const subscriptions = await db.subscriptions.toArray();
+      const allSubIds = subscriptions.map((s) => s.id).filter((id): id is number => id != null);
+      const allDids = [
+        ...new Set(
+          subscriptions
+            .filter((s) => s.sourceType?.startsWith('atproto.') && s.subjectDid)
+            .map((s) => s.subjectDid!)
+        ),
+      ];
+
+      for (const view of all) {
+        if (view.sourceMode != null) continue;
+        const migrated = migrateLegacyView(
+          {
+            showArticles: view.showArticles,
+            showShares: view.showShares,
+            showDocuments: view.showDocuments,
+            feedMode: view.feedMode,
+            feedIds: view.feedIds,
+            accountMode: view.accountMode,
+            accountDids: view.accountDids,
+          },
+          allSubIds,
+          allDids
+        );
+        const updates: Partial<FilteredView> = {
+          sourceMode: migrated.sourceMode,
+          sourceKeys: migrated.sourceKeys,
+          updatedAt: Date.now(),
+        };
+        Object.assign(view, updates);
+        if (view.id != null) {
+          await safeUpdate(db.filteredViews, view.id, updates);
+        }
+      }
+    }
+
     views = all;
   }
 

--- a/frontend/src/lib/stores/filteredViews.svelte.ts
+++ b/frontend/src/lib/stores/filteredViews.svelte.ts
@@ -1,51 +1,11 @@
 import { db, getMetadata, setMetadata } from '$lib/services/db';
 import { safeAdd, safeUpdate } from '$lib/services/safeDb.svelte';
 import { api } from '$lib/services/api';
-import type { FilteredView } from '$lib/types';
+import type { FilteredView, Channel } from '$lib/types';
 import { migrateLegacyView, isRssSource } from '$lib/utils/sourceKeys';
+import { toConfig, fromRemote, computeSyncOperations } from '$lib/utils/channelSync';
 
 const PENDING_DELETES_KEY = 'channelsPendingDelete';
-
-/** Extract the JSON config blob from a FilteredView (everything except id, uuid, name, position, timestamps). */
-function toConfig(view: FilteredView): Record<string, unknown> {
-  const {
-    id: _id,
-    uuid: _uuid,
-    name: _name,
-    position: _pos,
-    createdAt: _ca,
-    updatedAt: _ua,
-    ...config
-  } = view;
-  return config;
-}
-
-/** Reconstruct a partial FilteredView from a remote channel row. */
-function fromRemote(remote: {
-  uuid: string;
-  name: string;
-  config: string;
-  position: number;
-  createdAt: number;
-  updatedAt: number;
-}): Omit<FilteredView, 'id'> {
-  let config: Record<string, unknown> = {};
-  try {
-    config = JSON.parse(remote.config);
-  } catch {
-    // invalid config, use defaults
-  }
-  return {
-    uuid: remote.uuid,
-    name: remote.name,
-    position: remote.position,
-    createdAt: remote.createdAt,
-    updatedAt: remote.updatedAt,
-    readFilter: (config.readFilter as FilteredView['readFilter']) ?? 'all',
-    sortOrder: (config.sortOrder as FilteredView['sortOrder']) ?? 'newest',
-    ...config,
-  } as Omit<FilteredView, 'id'>;
-}
 
 /** Load the set of UUIDs we've deleted locally but may not have confirmed with the backend. */
 async function loadPendingDeletes(): Promise<Set<string>> {
@@ -152,70 +112,56 @@ function createFilteredViewsStore() {
   async function syncWithBackend() {
     try {
       const { channels: remoteChannels, deletedUuids } = await api.getChannels();
-
-      const localByUuid = new Map(views.filter((v) => v.uuid).map((v) => [v.uuid, v]));
-      const remoteByUuid = new Map(remoteChannels.map((r) => [r.uuid, r]));
-      const remoteDeletedSet = new Set(deletedUuids ?? []);
-
-      // Load locally-pending deletes (channels we deleted but haven't confirmed with backend)
       const pendingDeletes = await loadPendingDeletes();
 
-      // Remove locally any channels that were deleted on another device
-      for (const uuid of remoteDeletedSet) {
-        const local = localByUuid.get(uuid);
+      const ops = computeSyncOperations(
+        views,
+        remoteChannels,
+        deletedUuids ?? [],
+        pendingDeletes
+      );
+
+      // Apply local deletions
+      for (const uuid of ops.deleteLocally) {
+        const local = views.find((v) => v.uuid === uuid);
         if (local?.id != null) {
           await db.filteredViews.delete(local.id);
-          views = views.filter((v) => v.uuid !== uuid);
-          localByUuid.delete(uuid);
         }
-        // If we also had a pending delete for this, the backend already knows — clear it
-        pendingDeletes.delete(uuid);
+        views = views.filter((v) => v.uuid !== uuid);
       }
 
-      // Retry sending any pending deletes to the backend
-      for (const uuid of pendingDeletes) {
+      // Retry pending deletes
+      const retriedOk = new Set<string>();
+      for (const uuid of ops.retryDeletes) {
         try {
           await api.deleteChannel(uuid);
-          pendingDeletes.delete(uuid);
+          retriedOk.add(uuid);
         } catch {
           // Still can't reach backend — keep in pending set for next sync
         }
       }
+      for (const uuid of retriedOk) ops.pendingDeletesAfter.delete(uuid);
+      await savePendingDeletes(ops.pendingDeletesAfter);
 
-      // Persist the (possibly reduced) pending-delete set
-      await savePendingDeletes(pendingDeletes);
-
-      // All UUIDs we consider "deleted" — both remote and locally-pending
-      const allDeletedUuids = new Set([...remoteDeletedSet, ...pendingDeletes]);
-
-      // Remote channels not in local → add from other device
-      // But skip any that we've deleted locally (pending deletes)
-      for (const [uuid, remote] of remoteByUuid) {
-        if (allDeletedUuids.has(uuid)) continue;
-        const local = localByUuid.get(uuid);
-        if (!local) {
-          const parsed = fromRemote(remote);
-          const id = await safeAdd(db.filteredViews, parsed);
-          const newView = { ...parsed, id: id as number };
-          views = [...views, newView];
-        } else if (remote.updatedAt > local.updatedAt) {
-          // Remote is newer → update local
-          const parsed = fromRemote(remote);
-          const { ...updates } = parsed;
-          if (local.id != null) {
-            await safeUpdate(db.filteredViews, local.id, updates);
-          }
-          views = views.map((v) => (v.uuid === uuid ? { ...v, ...updates } : v));
-        }
+      // Add new channels from remote
+      for (const parsed of ops.addLocally) {
+        const id = await safeAdd(db.filteredViews, parsed);
+        views = [...views, { ...parsed, id: id as number }];
       }
 
-      // Local channels not in remote (and not deleted) → push to backend
-      const toPush = views.filter(
-        (v) => v.uuid && !remoteByUuid.has(v.uuid) && !allDeletedUuids.has(v.uuid)
-      );
-      if (toPush.length > 0) {
+      // Update local channels from remote
+      for (const { uuid, data } of ops.updateLocally) {
+        const local = views.find((v) => v.uuid === uuid);
+        if (local?.id != null) {
+          await safeUpdate(db.filteredViews, local.id, data);
+        }
+        views = views.map((v) => (v.uuid === uuid ? { ...v, ...data } : v));
+      }
+
+      // Push local-only channels to remote
+      if (ops.pushToRemote.length > 0) {
         await api.syncChannels(
-          toPush.map((v) => ({
+          ops.pushToRemote.map((v) => ({
             uuid: v.uuid,
             name: v.name,
             config: JSON.stringify(toConfig(v)),
@@ -311,6 +257,10 @@ function createFilteredViewsStore() {
 
   return {
     get views() {
+      return views;
+    },
+    /** Alias for views — prefer this in new code. */
+    get channels(): Channel[] {
       return views;
     },
     load,

--- a/frontend/src/lib/stores/filteredViews.svelte.ts
+++ b/frontend/src/lib/stores/filteredViews.svelte.ts
@@ -1,7 +1,66 @@
-import { db } from '$lib/services/db';
+import { db, getMetadata, setMetadata } from '$lib/services/db';
 import { safeAdd, safeUpdate } from '$lib/services/safeDb.svelte';
+import { api } from '$lib/services/api';
 import type { FilteredView } from '$lib/types';
-import { migrateLegacyView } from '$lib/utils/sourceKeys';
+import { migrateLegacyView, isRssSource } from '$lib/utils/sourceKeys';
+
+const PENDING_DELETES_KEY = 'channelsPendingDelete';
+
+/** Extract the JSON config blob from a FilteredView (everything except id, uuid, name, position, timestamps). */
+function toConfig(view: FilteredView): Record<string, unknown> {
+  const {
+    id: _id,
+    uuid: _uuid,
+    name: _name,
+    position: _pos,
+    createdAt: _ca,
+    updatedAt: _ua,
+    ...config
+  } = view;
+  return config;
+}
+
+/** Reconstruct a partial FilteredView from a remote channel row. */
+function fromRemote(remote: {
+  uuid: string;
+  name: string;
+  config: string;
+  position: number;
+  createdAt: number;
+  updatedAt: number;
+}): Omit<FilteredView, 'id'> {
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(remote.config);
+  } catch {
+    // invalid config, use defaults
+  }
+  return {
+    uuid: remote.uuid,
+    name: remote.name,
+    position: remote.position,
+    createdAt: remote.createdAt,
+    updatedAt: remote.updatedAt,
+    readFilter: (config.readFilter as FilteredView['readFilter']) ?? 'all',
+    sortOrder: (config.sortOrder as FilteredView['sortOrder']) ?? 'newest',
+    ...config,
+  } as Omit<FilteredView, 'id'>;
+}
+
+/** Load the set of UUIDs we've deleted locally but may not have confirmed with the backend. */
+async function loadPendingDeletes(): Promise<Set<string>> {
+  const arr = await getMetadata<string[]>(PENDING_DELETES_KEY);
+  return new Set(arr ?? []);
+}
+
+/** Persist the pending-delete set. */
+async function savePendingDeletes(uuids: Set<string>): Promise<void> {
+  if (uuids.size === 0) {
+    await setMetadata(PENDING_DELETES_KEY, []);
+  } else {
+    await setMetadata(PENDING_DELETES_KEY, [...uuids]);
+  }
+}
 
 function createFilteredViewsStore() {
   let views = $state<FilteredView[]>([]);
@@ -9,11 +68,16 @@ function createFilteredViewsStore() {
   async function load() {
     const all = await db.filteredViews.orderBy('position').toArray();
 
+    const subscriptions = await db.subscriptions.toArray();
+
     // One-time migration: convert legacy views (sourceMode undefined) to new format
-    const needsMigration = all.some((v) => v.sourceMode == null);
-    if (needsMigration) {
-      const subscriptions = await db.subscriptions.toArray();
-      const allSubIds = subscriptions.map((s) => s.id).filter((id): id is number => id != null);
+    const needsLegacyMigration = all.some((v) => v.sourceMode == null);
+    if (needsLegacyMigration) {
+      const allSubRkeys = subscriptions.map((s) => s.rkey).filter(Boolean);
+      const idToRkey = new Map<number, string>();
+      for (const s of subscriptions) {
+        if (s.id != null && s.rkey) idToRkey.set(s.id, s.rkey);
+      }
       const allDids = [
         ...new Set(
           subscriptions
@@ -34,8 +98,9 @@ function createFilteredViewsStore() {
             accountMode: view.accountMode,
             accountDids: view.accountDids,
           },
-          allSubIds,
-          allDids
+          allSubRkeys,
+          allDids,
+          idToRkey
         );
         const updates: Partial<FilteredView> = {
           sourceMode: migrated.sourceMode,
@@ -49,16 +114,147 @@ function createFilteredViewsStore() {
       }
     }
 
+    // One-time migration: convert sourceKeys from rss~{dexieId} to rss~{rkey}
+    const idToRkeyMap = new Map<string, string>();
+    for (const s of subscriptions) {
+      if (s.id != null && s.rkey) idToRkeyMap.set(String(s.id), s.rkey);
+    }
+    const hasNumericRssKeys = all.some(
+      (v) => v.sourceKeys?.some((key) => isRssSource(key) && /^rss~\d+$/.test(key))
+    );
+    if (hasNumericRssKeys) {
+      for (const view of all) {
+        if (!view.sourceKeys?.length) continue;
+        let changed = false;
+        const newKeys = view.sourceKeys.map((key) => {
+          if (!isRssSource(key)) return key;
+          const match = key.match(/^rss~(\d+)$/);
+          if (!match) return key;
+          const rkey = idToRkeyMap.get(match[1]);
+          if (!rkey) return key; // can't resolve, keep as-is
+          changed = true;
+          return `rss~${rkey}`;
+        });
+        if (changed) {
+          const updates: Partial<FilteredView> = { sourceKeys: newKeys, updatedAt: Date.now() };
+          Object.assign(view, updates);
+          if (view.id != null) {
+            await safeUpdate(db.filteredViews, view.id, updates);
+          }
+        }
+      }
+    }
+
     views = all;
   }
 
+  /** Sync with backend: merge remote channels with local, bidirectionally. */
+  async function syncWithBackend() {
+    try {
+      const { channels: remoteChannels, deletedUuids } = await api.getChannels();
+
+      const localByUuid = new Map(views.filter((v) => v.uuid).map((v) => [v.uuid, v]));
+      const remoteByUuid = new Map(remoteChannels.map((r) => [r.uuid, r]));
+      const remoteDeletedSet = new Set(deletedUuids ?? []);
+
+      // Load locally-pending deletes (channels we deleted but haven't confirmed with backend)
+      const pendingDeletes = await loadPendingDeletes();
+
+      // Remove locally any channels that were deleted on another device
+      for (const uuid of remoteDeletedSet) {
+        const local = localByUuid.get(uuid);
+        if (local?.id != null) {
+          await db.filteredViews.delete(local.id);
+          views = views.filter((v) => v.uuid !== uuid);
+          localByUuid.delete(uuid);
+        }
+        // If we also had a pending delete for this, the backend already knows — clear it
+        pendingDeletes.delete(uuid);
+      }
+
+      // Retry sending any pending deletes to the backend
+      for (const uuid of pendingDeletes) {
+        try {
+          await api.deleteChannel(uuid);
+          pendingDeletes.delete(uuid);
+        } catch {
+          // Still can't reach backend — keep in pending set for next sync
+        }
+      }
+
+      // Persist the (possibly reduced) pending-delete set
+      await savePendingDeletes(pendingDeletes);
+
+      // All UUIDs we consider "deleted" — both remote and locally-pending
+      const allDeletedUuids = new Set([...remoteDeletedSet, ...pendingDeletes]);
+
+      // Remote channels not in local → add from other device
+      // But skip any that we've deleted locally (pending deletes)
+      for (const [uuid, remote] of remoteByUuid) {
+        if (allDeletedUuids.has(uuid)) continue;
+        const local = localByUuid.get(uuid);
+        if (!local) {
+          const parsed = fromRemote(remote);
+          const id = await safeAdd(db.filteredViews, parsed);
+          const newView = { ...parsed, id: id as number };
+          views = [...views, newView];
+        } else if (remote.updatedAt > local.updatedAt) {
+          // Remote is newer → update local
+          const parsed = fromRemote(remote);
+          const { ...updates } = parsed;
+          if (local.id != null) {
+            await safeUpdate(db.filteredViews, local.id, updates);
+          }
+          views = views.map((v) => (v.uuid === uuid ? { ...v, ...updates } : v));
+        }
+      }
+
+      // Local channels not in remote (and not deleted) → push to backend
+      const toPush = views.filter(
+        (v) => v.uuid && !remoteByUuid.has(v.uuid) && !allDeletedUuids.has(v.uuid)
+      );
+      if (toPush.length > 0) {
+        await api.syncChannels(
+          toPush.map((v) => ({
+            uuid: v.uuid,
+            name: v.name,
+            config: JSON.stringify(toConfig(v)),
+            position: v.position,
+            createdAt: v.createdAt,
+            updatedAt: v.updatedAt,
+          }))
+        );
+      }
+    } catch (e) {
+      // Sync failed (offline, auth expired, etc.) — continue with local data
+      console.warn('Channel sync failed:', e);
+    }
+  }
+
+  /** Push a single channel to the backend (fire-and-forget). */
+  function pushToBackend(view: FilteredView) {
+    api
+      .upsertChannel(view.uuid, {
+        name: view.name,
+        config: JSON.stringify(toConfig(view)),
+        position: view.position,
+        createdAt: view.createdAt,
+        updatedAt: view.updatedAt,
+      })
+      .catch((e) => {
+        console.warn('Failed to push channel to backend:', e);
+      });
+  }
+
   async function create(
-    view: Omit<FilteredView, 'id' | 'createdAt' | 'updatedAt' | 'position'>
-  ): Promise<number> {
+    view: Omit<FilteredView, 'id' | 'uuid' | 'createdAt' | 'updatedAt' | 'position'>
+  ): Promise<string> {
     const now = Date.now();
     const maxPosition = views.length > 0 ? Math.max(...views.map((v) => v.position)) : -1;
+    const uuid = crypto.randomUUID();
     const newView: FilteredView = {
       ...view,
+      uuid,
       createdAt: now,
       updatedAt: now,
       position: maxPosition + 1,
@@ -66,7 +262,8 @@ function createFilteredViewsStore() {
     const id = await safeAdd(db.filteredViews, newView);
     newView.id = id as number;
     views = [...views, newView];
-    return id as number;
+    pushToBackend(newView);
+    return uuid;
   }
 
   async function update(id: number, changes: Partial<FilteredView>) {
@@ -74,15 +271,42 @@ function createFilteredViewsStore() {
     // Update in-memory first for immediate reactivity, then persist
     views = views.map((v) => (v.id === id ? { ...v, ...updated } : v));
     await safeUpdate(db.filteredViews, id, updated);
+    const view = views.find((v) => v.id === id);
+    if (view) pushToBackend(view);
   }
 
   async function remove(id: number) {
+    const view = views.find((v) => v.id === id);
     await db.filteredViews.delete(id);
     views = views.filter((v) => v.id !== id);
+    if (view?.uuid) {
+      // Persist the delete intent BEFORE the fire-and-forget API call.
+      // This prevents syncWithBackend from re-adding the channel if the DELETE fails.
+      const pendingDeletes = await loadPendingDeletes();
+      pendingDeletes.add(view.uuid);
+      await savePendingDeletes(pendingDeletes);
+
+      // Fire-and-forget DELETE to backend; if it fails, sync will retry
+      api
+        .deleteChannel(view.uuid)
+        .then(async () => {
+          // Success — remove from pending deletes
+          const current = await loadPendingDeletes();
+          current.delete(view.uuid);
+          await savePendingDeletes(current);
+        })
+        .catch((e) => {
+          console.warn('Failed to delete channel remotely, will retry on next sync:', e);
+        });
+    }
   }
 
   function getById(id: number): FilteredView | undefined {
     return views.find((v) => v.id === id);
+  }
+
+  function getByUuid(uuid: string): FilteredView | undefined {
+    return views.find((v) => v.uuid === uuid);
   }
 
   return {
@@ -90,10 +314,12 @@ function createFilteredViewsStore() {
       return views;
     },
     load,
+    syncWithBackend,
     create,
     update,
     remove,
     getById,
+    getByUuid,
   };
 }
 

--- a/frontend/src/lib/stores/filteredViews.svelte.ts
+++ b/frontend/src/lib/stores/filteredViews.svelte.ts
@@ -79,8 +79,8 @@ function createFilteredViewsStore() {
     for (const s of subscriptions) {
       if (s.id != null && s.rkey) idToRkeyMap.set(String(s.id), s.rkey);
     }
-    const hasNumericRssKeys = all.some(
-      (v) => v.sourceKeys?.some((key) => isRssSource(key) && /^rss~\d+$/.test(key))
+    const hasNumericRssKeys = all.some((v) =>
+      v.sourceKeys?.some((key) => isRssSource(key) && /^rss~\d+$/.test(key))
     );
     if (hasNumericRssKeys) {
       for (const view of all) {
@@ -114,12 +114,7 @@ function createFilteredViewsStore() {
       const { channels: remoteChannels, deletedUuids } = await api.getChannels();
       const pendingDeletes = await loadPendingDeletes();
 
-      const ops = computeSyncOperations(
-        views,
-        remoteChannels,
-        deletedUuids ?? [],
-        pendingDeletes
-      );
+      const ops = computeSyncOperations(views, remoteChannels, deletedUuids ?? [], pendingDeletes);
 
       // Build the new views state without mutating `views` until all DB ops succeed.
       let updatedViews = [...views];

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -2,7 +2,7 @@ import { browser } from '$app/environment';
 
 export type ArticleFont = 'sans-serif' | 'serif' | 'mono';
 export type ArticleFontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-export type SortOrder = 'newest' | 'oldest';
+export type BaseSortOrder = 'newest' | 'oldest';
 
 const FONT_SIZE_ORDER: ArticleFontSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
 
@@ -11,7 +11,7 @@ interface PreferencesState {
   articleFontSize: ArticleFontSize;
   scrollToMarkAsRead: boolean;
   expandAllItems: boolean;
-  sortOrder: SortOrder;
+  sortOrder: BaseSortOrder;
 }
 
 const STORAGE_KEY = 'skyreader-preferences';
@@ -99,7 +99,7 @@ function createPreferencesStore() {
     save();
   }
 
-  function setSortOrder(order: SortOrder) {
+  function setSortOrder(order: BaseSortOrder) {
     state.sortOrder = order;
     save();
   }

--- a/frontend/src/lib/stores/savedChannelSuggestions.svelte.ts
+++ b/frontend/src/lib/stores/savedChannelSuggestions.svelte.ts
@@ -1,0 +1,71 @@
+import { browser } from '$app/environment';
+import { savesStore } from './saves.svelte';
+import { filteredViewsStore } from './filteredViews.svelte';
+import { generateAllSavedSuggestions } from '$lib/utils/channelLogic';
+import type { SavedChannelSuggestion } from '$lib/utils/channelLogic';
+
+export type { SavedChannelSuggestion };
+
+const STORAGE_KEY = 'skyreader-dismissed-saved-suggestions';
+const MAX_INLINE_SUGGESTIONS = 3;
+
+function createSavedChannelSuggestionsStore() {
+  let dismissedIds = $state<Set<string>>(new Set());
+
+  // Restore dismissed suggestions from localStorage
+  if (browser) {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        dismissedIds = new Set(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  function persistDismissals() {
+    if (browser) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([...dismissedIds]));
+    }
+  }
+
+  function dismiss(id: string) {
+    dismissedIds = new Set([...dismissedIds, id]);
+    persistDismissals();
+  }
+
+  let allSuggestions = $derived.by((): SavedChannelSuggestion[] => {
+    // Access reactive dependencies
+    savesStore.articles;
+    filteredViewsStore.views;
+
+    return generateAllSavedSuggestions(
+      {
+        savedItems: savesStore.articles,
+        views: filteredViewsStore.views,
+      },
+      dismissedIds
+    );
+  });
+
+  let topSuggestions = $derived(allSuggestions.slice(0, MAX_INLINE_SUGGESTIONS));
+  let hasMoreSuggestions = $derived(allSuggestions.length > MAX_INLINE_SUGGESTIONS);
+
+  return {
+    /** Top 3 suggestions for inline display in sidebar/mobile switcher */
+    get suggestions() {
+      return topSuggestions;
+    },
+    /** All active suggestions for the discovery page */
+    get allSuggestions() {
+      return allSuggestions;
+    },
+    get hasMore() {
+      return hasMoreSuggestions;
+    },
+    dismiss,
+  };
+}
+
+export const savedChannelSuggestions = createSavedChannelSuggestionsStore();

--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -9,6 +9,7 @@ interface SidebarState {
   expandedSections: {
     shared: boolean;
     feeds: boolean;
+    channels: boolean;
   };
   showOnlyUnread: {
     shared: boolean;
@@ -27,7 +28,8 @@ function createSidebarStore() {
     navigationDropdownOpen: false,
     expandedSections: {
       shared: false,
-      feeds: true,
+      feeds: false,
+      channels: true,
     },
     showOnlyUnread: {
       shared: false,
@@ -44,7 +46,8 @@ function createSidebarStore() {
         const parsed = JSON.parse(stored);
         state.expandedSections = {
           shared: false,
-          feeds: true,
+          feeds: false,
+          channels: true,
           ...parsed.expandedSections,
         };
         state.showOnlyUnread = parsed.showOnlyUnread ?? { shared: false, feeds: false };
@@ -74,7 +77,7 @@ function createSidebarStore() {
     state.isOpen = false;
   }
 
-  function toggleSection(section: 'shared' | 'feeds') {
+  function toggleSection(section: 'shared' | 'feeds' | 'channels') {
     state.expandedSections[section] = !state.expandedSections[section];
     persist();
   }
@@ -85,6 +88,9 @@ function createSidebarStore() {
   }
 
   let addFeedModalInitialDid = $state<string | null>(null);
+  let addSourceInitialValue = $state<string>('');
+  let channelModalOpen = $state(false);
+  let editingChannelId = $state<number | null>(null);
 
   function openAddFeedModal() {
     state.addFeedModalOpen = true;
@@ -97,6 +103,7 @@ function createSidebarStore() {
 
   function closeAddFeedModal() {
     state.addFeedModalOpen = false;
+    addSourceInitialValue = '';
   }
 
   function openAddHandleModal() {
@@ -106,6 +113,11 @@ function createSidebarStore() {
   function closeAddHandleModal() {
     state.addHandleModalOpen = false;
     addFeedModalInitialDid = null;
+    addSourceInitialValue = '';
+  }
+
+  function setAddSourceInitialValue(value: string) {
+    addSourceInitialValue = value;
   }
 
   function openSaveArticleModal() {
@@ -114,6 +126,15 @@ function createSidebarStore() {
 
   function closeSaveArticleModal() {
     state.saveArticleModalOpen = false;
+  }
+
+  function openChannelModal(viewId: number | null = null) {
+    editingChannelId = viewId;
+    channelModalOpen = true;
+  }
+
+  function closeChannelModal() {
+    channelModalOpen = false;
   }
 
   function toggleNavigationDropdown() {
@@ -141,6 +162,9 @@ function createSidebarStore() {
     get addFeedModalInitialDid() {
       return addFeedModalInitialDid;
     },
+    get addSourceInitialValue() {
+      return addSourceInitialValue;
+    },
     get saveArticleModalOpen() {
       return state.saveArticleModalOpen;
     },
@@ -156,11 +180,18 @@ function createSidebarStore() {
     get sortedFeedIds() {
       return state.sortedFeedIds;
     },
+    get channelModalOpen() {
+      return channelModalOpen;
+    },
+    get editingChannelId() {
+      return editingChannelId;
+    },
     toggleMobile,
     closeMobile,
     toggleSection,
     toggleShowOnlyUnread,
     openAddFeedModal,
+    setAddSourceInitialValue,
     openAddFeedModalForDid,
     closeAddFeedModal,
     openAddHandleModal,
@@ -170,6 +201,8 @@ function createSidebarStore() {
     toggleNavigationDropdown,
     closeNavigationDropdown,
     setSortedFeedIds,
+    openChannelModal,
+    closeChannelModal,
   };
 }
 

--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -9,7 +9,8 @@ interface SidebarState {
   expandedSections: {
     shared: boolean;
     feeds: boolean;
-    channels: boolean;
+    everything: boolean;
+    saved: boolean;
   };
   showOnlyUnread: {
     shared: boolean;
@@ -31,7 +32,8 @@ function createSidebarStore() {
     expandedSections: {
       shared: false,
       feeds: false,
-      channels: true,
+      everything: true,
+      saved: true,
     },
     showOnlyUnread: {
       shared: false,
@@ -47,11 +49,20 @@ function createSidebarStore() {
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
+        // Migrate legacy `channels` key → both `everything` and `saved`
+        const legacyChannels = parsed.expandedSections?.channels;
+        const migrated = { ...parsed.expandedSections };
+        if (legacyChannels != null) {
+          if (migrated.everything == null) migrated.everything = legacyChannels;
+          if (migrated.saved == null) migrated.saved = legacyChannels;
+          delete migrated.channels;
+        }
         state.expandedSections = {
           shared: false,
           feeds: false,
-          channels: true,
-          ...parsed.expandedSections,
+          everything: true,
+          saved: true,
+          ...migrated,
         };
         state.showOnlyUnread = parsed.showOnlyUnread ?? { shared: false, feeds: false };
         state.expandedCategories = parsed.expandedCategories ?? {};
@@ -82,7 +93,7 @@ function createSidebarStore() {
     state.isOpen = false;
   }
 
-  function toggleSection(section: 'shared' | 'feeds' | 'channels') {
+  function toggleSection(section: 'shared' | 'feeds' | 'everything' | 'saved') {
     state.expandedSections[section] = !state.expandedSections[section];
     persist();
   }
@@ -105,6 +116,7 @@ function createSidebarStore() {
   let addSourceInitialValue = $state<string>('');
   let channelModalOpen = $state(false);
   let editingChannelId = $state<number | null>(null);
+  let initialChannelType = $state<'feed' | 'saved' | null>(null);
 
   function openAddFeedModal() {
     state.addFeedModalOpen = true;
@@ -142,8 +154,12 @@ function createSidebarStore() {
     state.saveArticleModalOpen = false;
   }
 
-  function openChannelModal(viewId: number | null = null) {
+  function openChannelModal(
+    viewId: number | null = null,
+    initialType: 'feed' | 'saved' | null = null
+  ) {
     editingChannelId = viewId;
+    initialChannelType = initialType;
     channelModalOpen = true;
   }
 
@@ -199,6 +215,9 @@ function createSidebarStore() {
     },
     get editingChannelId() {
       return editingChannelId;
+    },
+    get initialChannelType() {
+      return initialChannelType;
     },
     get expandedCategories() {
       return state.expandedCategories;

--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -17,6 +17,8 @@ interface SidebarState {
   };
   // Sorted IDs for keyboard navigation (matches visual sidebar order)
   sortedFeedIds: number[];
+  // Which categories are expanded in the Sources section
+  expandedCategories: Record<string, boolean>;
 }
 
 function createSidebarStore() {
@@ -36,6 +38,7 @@ function createSidebarStore() {
       feeds: false,
     },
     sortedFeedIds: [],
+    expandedCategories: {},
   });
 
   // Restore from localStorage on init
@@ -51,6 +54,7 @@ function createSidebarStore() {
           ...parsed.expandedSections,
         };
         state.showOnlyUnread = parsed.showOnlyUnread ?? { shared: false, feeds: false };
+        state.expandedCategories = parsed.expandedCategories ?? {};
       } catch {
         // Ignore parse errors
       }
@@ -64,6 +68,7 @@ function createSidebarStore() {
         JSON.stringify({
           expandedSections: state.expandedSections,
           showOnlyUnread: state.showOnlyUnread,
+          expandedCategories: state.expandedCategories,
         })
       );
     }
@@ -80,6 +85,15 @@ function createSidebarStore() {
   function toggleSection(section: 'shared' | 'feeds' | 'channels') {
     state.expandedSections[section] = !state.expandedSections[section];
     persist();
+  }
+
+  function toggleCategory(category: string) {
+    state.expandedCategories[category] = !state.expandedCategories[category];
+    persist();
+  }
+
+  function isCategoryExpanded(category: string): boolean {
+    return state.expandedCategories[category] ?? true; // default expanded
   }
 
   function toggleShowOnlyUnread(section: 'shared' | 'feeds') {
@@ -186,9 +200,14 @@ function createSidebarStore() {
     get editingChannelId() {
       return editingChannelId;
     },
+    get expandedCategories() {
+      return state.expandedCategories;
+    },
     toggleMobile,
     closeMobile,
     toggleSection,
+    toggleCategory,
+    isCategoryExpanded,
     toggleShowOnlyUnread,
     openAddFeedModal,
     setAddSourceInitialValue,

--- a/frontend/src/lib/stores/social.svelte.ts
+++ b/frontend/src/lib/stores/social.svelte.ts
@@ -47,8 +47,15 @@ function createSocialStore() {
           await safeBulkPut(db.socialDocuments, result.documents);
         }
       } else {
-        shares = [...shares, ...result.shares];
-        documents = [...documents, ...(result.documents || [])];
+        const existingShareUris = new Set(shares.map((s) => s.recordUri));
+        const newShares = result.shares.filter((s) => !existingShareUris.has(s.recordUri));
+        shares = [...shares, ...newShares];
+
+        const newDocs = result.documents || [];
+        const existingDocUris = new Set(documents.map((d) => d.recordUri));
+        const uniqueNewDocs = newDocs.filter((d) => !existingDocUris.has(d.recordUri));
+        documents = [...documents, ...uniqueNewDocs];
+
         await safeBulkPut(db.socialShares, result.shares);
         if (result.documents && result.documents.length > 0) {
           await safeBulkPut(db.socialDocuments, result.documents);

--- a/frontend/src/lib/stores/subscriptions.svelte.ts
+++ b/frontend/src/lib/stores/subscriptions.svelte.ts
@@ -277,22 +277,57 @@ function createSubscriptionsStore() {
    */
   async function updateLocal(
     id: number,
-    updates: { customTitle?: string; customIconUrl?: string }
+    updates: { customTitle?: string; customIconUrl?: string; category?: string | null }
   ): Promise<void> {
     // Update IndexedDB immediately for instant UI
     await liveDb.updateSubscriptionLocal(id, updates);
 
-    // Sync to backend in background
+    // Sync to backend in background — only send fields that were explicitly passed
     const sub = liveDb.getSubscriptionById(id);
     if (sub) {
-      api
-        .updateSubscription(sub.rkey, {
-          customTitle: updates.customTitle ?? null,
-          customIconUrl: updates.customIconUrl ?? null,
-        })
-        .catch((err) => {
-          console.error('[Subscriptions] Failed to sync custom fields to backend:', err);
-        });
+      const patch: {
+        customTitle?: string | null;
+        customIconUrl?: string | null;
+        category?: string | null;
+      } = {};
+      if (updates.customTitle !== undefined) patch.customTitle = updates.customTitle ?? null;
+      if (updates.customIconUrl !== undefined) patch.customIconUrl = updates.customIconUrl ?? null;
+      if (updates.category !== undefined) patch.category = updates.category ?? null;
+
+      api.updateSubscription(sub.rkey, patch).catch((err) => {
+        console.error('[Subscriptions] Failed to sync custom fields to backend:', err);
+      });
+    }
+  }
+
+  /**
+   * Bulk update subscription custom fields (instant local + single backend request)
+   */
+  async function bulkUpdateLocal(
+    ids: number[],
+    updates: { customTitle?: string; customIconUrl?: string; category?: string | null }
+  ): Promise<void> {
+    // Update IndexedDB immediately for instant UI
+    await Promise.all(ids.map((id) => liveDb.updateSubscriptionLocal(id, updates)));
+
+    // Sync to backend in a single request
+    const rkeys = ids
+      .map((id) => liveDb.getSubscriptionById(id)?.rkey)
+      .filter((rkey): rkey is string => !!rkey);
+
+    if (rkeys.length > 0) {
+      const patch: {
+        customTitle?: string | null;
+        customIconUrl?: string | null;
+        category?: string | null;
+      } = {};
+      if (updates.customTitle !== undefined) patch.customTitle = updates.customTitle ?? null;
+      if (updates.customIconUrl !== undefined) patch.customIconUrl = updates.customIconUrl ?? null;
+      if (updates.category !== undefined) patch.category = updates.category ?? null;
+
+      api.bulkUpdateSubscriptions(rkeys, patch).catch((err) => {
+        console.error('[Subscriptions] Failed to bulk sync custom fields to backend:', err);
+      });
     }
   }
 
@@ -377,6 +412,7 @@ function createSubscriptionsStore() {
     addBulk,
     update,
     updateLocal,
+    bulkUpdateLocal,
     remove,
     removeAll,
 

--- a/frontend/src/lib/stores/subscriptions.svelte.ts
+++ b/frontend/src/lib/stores/subscriptions.svelte.ts
@@ -337,6 +337,13 @@ function createSubscriptionsStore() {
   }
 
   /**
+   * Get a subscription by rkey
+   */
+  function getByRkey(rkey: string): Subscription | undefined {
+    return liveDb.getSubscriptionByRkey(rkey);
+  }
+
+  /**
    * Get a subscription by feed URL
    */
   function getByUrl(feedUrl: string): Subscription | undefined {
@@ -375,6 +382,7 @@ function createSubscriptionsStore() {
 
     // Lookups
     getById,
+    getByRkey,
     getByUrl,
   };
 }

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -2,7 +2,15 @@ import { articlesStore } from './articles.svelte';
 import { subscriptionsStore } from './subscriptions.svelte';
 import { socialStore } from './social.svelte';
 import { itemLabelsStore } from './itemLabels.svelte';
+import { filteredViewsStore } from './filteredViews.svelte';
 import { liveDb } from '$lib/services/liveDb.svelte';
+import {
+  isRssSource,
+  isSharesSource,
+  isDocumentsSource,
+  getRssSubscriptionId,
+  getSourceDid,
+} from '$lib/utils/sourceKeys';
 
 /**
  * Centralized unread count computations.
@@ -67,6 +75,78 @@ function createUnreadCountsStore() {
       Array.from(sharerDocCounts.values()).reduce((a, b) => a + b, 0)
   );
 
+  // Per-channel (FilteredView) unread counts
+  let channelCounts = $derived.by(() => {
+    // Access reactive dependencies
+    liveDb.articlesVersion;
+    itemLabelsStore.readPositions;
+    itemLabelsStore.socialPositions;
+
+    const counts = new Map<number, number>();
+    for (const view of filteredViewsStore.views) {
+      if (view.id == null) continue;
+
+      const sourceMode = view.sourceMode ?? 'all';
+      const sourceKeys = view.sourceKeys ?? [];
+      const typeFilter = view.typeFilter ?? [];
+
+      // Determine which content types this channel shows
+      const showRss =
+        (typeFilter.length === 0 || typeFilter.includes('rss')) &&
+        (sourceMode === 'all' || sourceKeys.some(isRssSource));
+      const showShares =
+        (typeFilter.length === 0 || typeFilter.includes('atproto.shares')) &&
+        (sourceMode === 'all' || sourceKeys.some(isSharesSource));
+      const showDocs =
+        (typeFilter.length === 0 || typeFilter.includes('atproto.documents')) &&
+        (sourceMode === 'all' || sourceKeys.some(isDocumentsSource));
+
+      let count = 0;
+
+      // Count unread articles
+      if (showRss) {
+        const allowedIds =
+          sourceMode === 'all'
+            ? null
+            : new Set(sourceKeys.filter(isRssSource).map(getRssSubscriptionId));
+        const seen = new Set<string>();
+        for (const article of articlesStore.allArticles) {
+          if (seen.has(article.guid)) continue;
+          seen.add(article.guid);
+          if (allowedIds && !allowedIds.has(article.subscriptionId)) continue;
+          if (!itemLabelsStore.isRead(article.guid)) count++;
+        }
+      }
+
+      // Count unread shares
+      if (showShares) {
+        const allowedDids =
+          sourceMode === 'all'
+            ? null
+            : new Set(sourceKeys.filter(isSharesSource).map(getSourceDid));
+        for (const share of socialStore.shares) {
+          if (allowedDids && !allowedDids.has(share.authorDid)) continue;
+          if (!itemLabelsStore.isSocialRead(share.recordUri)) count++;
+        }
+      }
+
+      // Count unread documents
+      if (showDocs) {
+        const allowedDids =
+          sourceMode === 'all'
+            ? null
+            : new Set(sourceKeys.filter(isDocumentsSource).map(getSourceDid));
+        for (const doc of socialStore.documents) {
+          if (allowedDids && !allowedDids.has(doc.authorDid)) continue;
+          if (!itemLabelsStore.isSocialRead(doc.recordUri)) count++;
+        }
+      }
+
+      counts.set(view.id, count);
+    }
+    return counts;
+  });
+
   return {
     get feedCounts() {
       return feedCounts;
@@ -82,6 +162,9 @@ function createUnreadCountsStore() {
     },
     get totalSocial() {
       return totalSocial;
+    },
+    get channelCounts() {
+      return channelCounts;
     },
     getUnreadForSharer(did: string): number {
       return (sharerShareCounts.get(did) || 0) + (sharerDocCounts.get(did) || 0);

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -9,7 +9,7 @@ import {
   isRssSource,
   isSharesSource,
   isDocumentsSource,
-  getRssSubscriptionId,
+  getRssSubscriptionRkey,
   getSourceDid,
 } from '$lib/utils/sourceKeys';
 
@@ -182,7 +182,15 @@ function createUnreadCountsStore() {
         const allowedIds =
           sourceMode === 'all'
             ? null
-            : new Set(sourceKeys.filter(isRssSource).map(getRssSubscriptionId));
+            : new Set(
+                sourceKeys
+                  .filter(isRssSource)
+                  .map((key) => {
+                    const sub = subscriptionsStore.getByRkey(getRssSubscriptionRkey(key));
+                    return sub?.id;
+                  })
+                  .filter((id): id is number => id != null)
+              );
         const seen = new Set<string>();
         for (const article of articlesStore.allArticles) {
           if (seen.has(article.guid)) continue;

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -179,48 +179,50 @@ function createUnreadCountsStore() {
 
       // Count unread articles
       if (showRss) {
-        const allowedIds =
-          sourceMode === 'all'
-            ? null
-            : new Set(
-                sourceKeys
-                  .filter(isRssSource)
-                  .map((key) => {
-                    const sub = subscriptionsStore.getByRkey(getRssSubscriptionRkey(key));
-                    return sub?.id;
-                  })
-                  .filter((id): id is number => id != null)
-              );
-        const seen = new Set<string>();
-        for (const article of articlesStore.allArticles) {
-          if (seen.has(article.guid)) continue;
-          seen.add(article.guid);
-          if (allowedIds && !allowedIds.has(article.subscriptionId)) continue;
-          if (!itemLabelsStore.isRead(article.guid)) count++;
+        if (sourceMode === 'all') {
+          // Reuse already-computed total (deduped by guid)
+          count += totalArticles;
+        } else {
+          const allowedIds = new Set(
+            sourceKeys
+              .filter(isRssSource)
+              .map((key) => {
+                const sub = subscriptionsStore.getByRkey(getRssSubscriptionRkey(key));
+                return sub?.id;
+              })
+              .filter((id): id is number => id != null)
+          );
+          const seen = new Set<string>();
+          for (const article of articlesStore.allArticles) {
+            if (seen.has(article.guid)) continue;
+            seen.add(article.guid);
+            if (!allowedIds.has(article.subscriptionId)) continue;
+            if (!itemLabelsStore.isRead(article.guid)) count++;
+          }
         }
       }
 
-      // Count unread shares
+      // Count unread shares — sum from pre-computed per-author map
       if (showShares) {
-        const allowedDids =
-          sourceMode === 'all'
-            ? null
-            : new Set(sourceKeys.filter(isSharesSource).map(getSourceDid));
-        for (const share of socialStore.shares) {
-          if (allowedDids && !allowedDids.has(share.authorDid)) continue;
-          if (!itemLabelsStore.isSocialRead(share.recordUri)) count++;
+        if (sourceMode === 'all') {
+          for (const c of sharerShareCounts.values()) count += c;
+        } else {
+          const allowedDids = new Set(sourceKeys.filter(isSharesSource).map(getSourceDid));
+          for (const did of allowedDids) {
+            count += sharerShareCounts.get(did) || 0;
+          }
         }
       }
 
-      // Count unread documents
+      // Count unread documents — sum from pre-computed per-author map
       if (showDocs) {
-        const allowedDids =
-          sourceMode === 'all'
-            ? null
-            : new Set(sourceKeys.filter(isDocumentsSource).map(getSourceDid));
-        for (const doc of socialStore.documents) {
-          if (allowedDids && !allowedDids.has(doc.authorDid)) continue;
-          if (!itemLabelsStore.isSocialRead(doc.recordUri)) count++;
+        if (sourceMode === 'all') {
+          for (const c of sharerDocCounts.values()) count += c;
+        } else {
+          const allowedDids = new Set(sourceKeys.filter(isDocumentsSource).map(getSourceDid));
+          for (const did of allowedDids) {
+            count += sharerDocCounts.get(did) || 0;
+          }
         }
       }
 

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -2,6 +2,7 @@ import { articlesStore } from './articles.svelte';
 import { subscriptionsStore } from './subscriptions.svelte';
 import { socialStore } from './social.svelte';
 import { itemLabelsStore } from './itemLabels.svelte';
+import { savesStore } from './saves.svelte';
 import { filteredViewsStore } from './filteredViews.svelte';
 import { liveDb } from '$lib/services/liveDb.svelte';
 import {
@@ -85,6 +86,79 @@ function createUnreadCountsStore() {
     const counts = new Map<number, number>();
     for (const view of filteredViewsStore.views) {
       if (view.id == null) continue;
+
+      // Saved channels: count non-archived saved items
+      if (view.mode === 'saved') {
+        const sourceFilter =
+          view.savedSourceFilter && view.savedSourceFilter.length > 0
+            ? new Set(view.savedSourceFilter)
+            : null;
+        let count = 0;
+
+        // Count non-archived saved articles (source = 'feed')
+        if (!sourceFilter || sourceFilter.has('feed')) {
+          for (const article of articlesStore.allArticles) {
+            if (
+              itemLabelsStore.isSaved(article.guid) &&
+              !itemLabelsStore.isArchived(article.guid)
+            ) {
+              count++;
+            }
+          }
+        }
+
+        // Count non-archived saved shares (source = 'share')
+        if (!sourceFilter || sourceFilter.has('share')) {
+          for (const share of socialStore.shares) {
+            if (
+              itemLabelsStore.isSaved(share.recordUri) &&
+              !itemLabelsStore.isArchived(share.recordUri)
+            ) {
+              count++;
+            }
+          }
+        }
+
+        // Count non-archived saved documents (source = 'document')
+        if (!sourceFilter || sourceFilter.has('document')) {
+          for (const doc of socialStore.documents) {
+            if (
+              itemLabelsStore.isSaved(doc.recordUri) &&
+              !itemLabelsStore.isArchived(doc.recordUri)
+            ) {
+              count++;
+            }
+          }
+        }
+
+        // Count non-archived bookmarks (deduped against above)
+        const savedArticleGuids = new Set(
+          articlesStore.allArticles
+            .filter((a) => itemLabelsStore.isSaved(a.guid))
+            .map((a) => a.guid)
+        );
+        const savedShareUris = new Set(
+          socialStore.shares
+            .filter((s) => itemLabelsStore.isSaved(s.recordUri))
+            .map((s) => s.recordUri)
+        );
+        const savedDocUris = new Set(
+          socialStore.documents
+            .filter((d) => itemLabelsStore.isSaved(d.recordUri))
+            .map((d) => d.recordUri)
+        );
+        for (const bm of savesStore.articles) {
+          if (sourceFilter && bm.source && !sourceFilter.has(bm.source)) continue;
+          if (bm.source === 'feed' && bm.itemGuid && savedArticleGuids.has(bm.itemGuid)) continue;
+          if (bm.source === 'share' && bm.itemGuid && savedShareUris.has(bm.itemGuid)) continue;
+          if (bm.source === 'document' && bm.itemGuid && savedDocUris.has(bm.itemGuid)) continue;
+          const archiveKey = bm.itemGuid || bm.uri || '';
+          if (!itemLabelsStore.isArchived(archiveKey)) count++;
+        }
+
+        counts.set(view.id, count);
+        continue;
+      }
 
       const sourceMode = view.sourceMode ?? 'all';
       const sourceKeys = view.sourceKeys ?? [];

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -93,16 +93,21 @@ function createUnreadCountsStore() {
           view.savedSourceFilter && view.savedSourceFilter.length > 0
             ? new Set(view.savedSourceFilter)
             : null;
-        let count = 0;
+
+        // Use a Set of item keys so the same item can't be counted twice —
+        // e.g. when a guid exists in multiple subscriptions, or when a
+        // bookmark and its primary-store counterpart refer to the same item.
+        const seen = new Set<string>();
 
         // Count non-archived saved articles (source = 'feed')
         if (!sourceFilter || sourceFilter.has('feed')) {
           for (const article of articlesStore.allArticles) {
+            if (seen.has(article.guid)) continue;
             if (
               itemLabelsStore.isSaved(article.guid) &&
               !itemLabelsStore.isArchived(article.guid)
             ) {
-              count++;
+              seen.add(article.guid);
             }
           }
         }
@@ -110,11 +115,12 @@ function createUnreadCountsStore() {
         // Count non-archived saved shares (source = 'share')
         if (!sourceFilter || sourceFilter.has('share')) {
           for (const share of socialStore.shares) {
+            if (seen.has(share.recordUri)) continue;
             if (
               itemLabelsStore.isSaved(share.recordUri) &&
               !itemLabelsStore.isArchived(share.recordUri)
             ) {
-              count++;
+              seen.add(share.recordUri);
             }
           }
         }
@@ -122,41 +128,29 @@ function createUnreadCountsStore() {
         // Count non-archived saved documents (source = 'document')
         if (!sourceFilter || sourceFilter.has('document')) {
           for (const doc of socialStore.documents) {
+            if (seen.has(doc.recordUri)) continue;
             if (
               itemLabelsStore.isSaved(doc.recordUri) &&
               !itemLabelsStore.isArchived(doc.recordUri)
             ) {
-              count++;
+              seen.add(doc.recordUri);
             }
           }
         }
 
-        // Count non-archived bookmarks (deduped against above)
-        const savedArticleGuids = new Set(
-          articlesStore.allArticles
-            .filter((a) => itemLabelsStore.isSaved(a.guid))
-            .map((a) => a.guid)
-        );
-        const savedShareUris = new Set(
-          socialStore.shares
-            .filter((s) => itemLabelsStore.isSaved(s.recordUri))
-            .map((s) => s.recordUri)
-        );
-        const savedDocUris = new Set(
-          socialStore.documents
-            .filter((d) => itemLabelsStore.isSaved(d.recordUri))
-            .map((d) => d.recordUri)
-        );
+        // Count non-archived bookmarks, deduping against items already counted
+        // above via itemGuid (regardless of bm.source — legacy rows may lack it).
         for (const bm of savesStore.articles) {
-          if (sourceFilter && bm.source && !sourceFilter.has(bm.source)) continue;
-          if (bm.source === 'feed' && bm.itemGuid && savedArticleGuids.has(bm.itemGuid)) continue;
-          if (bm.source === 'share' && bm.itemGuid && savedShareUris.has(bm.itemGuid)) continue;
-          if (bm.source === 'document' && bm.itemGuid && savedDocUris.has(bm.itemGuid)) continue;
+          const src = bm.source ?? 'url';
+          if (sourceFilter && !sourceFilter.has(src)) continue;
+          const key = bm.itemGuid || bm.uri || bm.rkey;
+          if (seen.has(key)) continue;
           const archiveKey = bm.itemGuid || bm.uri || '';
-          if (!itemLabelsStore.isArchived(archiveKey)) count++;
+          if (itemLabelsStore.isArchived(archiveKey)) continue;
+          seen.add(key);
         }
 
-        counts.set(view.id, count);
+        counts.set(view.id, seen.size);
         continue;
       }
 

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -656,12 +656,27 @@ export type CombinedFeedItem =
   | { type: 'share'; item: SocialShare; date: string }
   | { type: 'document'; item: SocialDocument; date: string };
 
+/**
+ * Auto-update rule for a channel. When set, sourceKeys are automatically
+ * recomputed when subscriptions change.
+ */
+export type ChannelAutoRule =
+  | { type: 'category'; value: string }
+  | { type: 'subscriptionTag'; value: string }
+  | { type: 'domain'; patterns: string[] }
+  | { type: 'people' }
+  | { type: 'frequency'; threshold: 'high' | 'low' }
+  | { type: 'longReads'; minLength: number }
+  | { type: 'recent'; withinDays: number };
+
 export interface FilteredView {
   id?: number;
   name: string;
   // Unified source filter (new format)
   sourceMode?: 'all' | 'include';
   sourceKeys?: string[];
+  // Auto-update rule: when set, sourceKeys are kept in sync with subscriptions
+  autoRule?: ChannelAutoRule;
   // Legacy fields (kept for backward compat with existing IndexedDB records)
   showArticles?: boolean;
   showShares?: boolean;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -669,14 +669,35 @@ export type ChannelAutoRule =
   | { type: 'longReads'; minLength: number }
   | { type: 'recent'; withinDays: number };
 
+export type SavedSourceType = 'url' | 'feed' | 'share' | 'document';
+export type DateAddedPreset = 'last-week' | 'last-month' | 'last-3-months' | 'last-year';
+export type ReadingLengthFilter = 'quick' | 'medium' | 'long';
+export type SortOrder =
+  | 'newest'
+  | 'oldest'
+  | 'published-newest'
+  | 'published-oldest'
+  | 'shortest'
+  | 'longest'
+  | 'domain-asc'
+  | 'domain-desc';
+
 export interface FilteredView {
   id?: number;
   name: string;
-  // Unified source filter (new format)
+  // Channel mode: 'feed' (default) shows normal content, 'saved' shows only saved items
+  mode?: 'feed' | 'saved';
+  // Unified source filter (new format) — applies to feed-mode channels
   sourceMode?: 'all' | 'include';
   sourceKeys?: string[];
   // Auto-update rule: when set, sourceKeys are kept in sync with subscriptions
   autoRule?: ChannelAutoRule;
+  // Saved channel: filter by save source type (url, feed, share, document)
+  savedSourceFilter?: SavedSourceType[];
+  // Saved channel filters
+  savedDateFilter?: DateAddedPreset;
+  savedReadingLength?: ReadingLengthFilter[];
+  savedDomainFilter?: string[];
   // Legacy fields (kept for backward compat with existing IndexedDB records)
   showArticles?: boolean;
   showShares?: boolean;
@@ -686,7 +707,7 @@ export interface FilteredView {
   accountMode?: 'none' | 'all' | 'include' | 'exclude';
   accountDids?: string[];
   readFilter: 'all' | 'unread' | 'read';
-  sortOrder: 'newest' | 'oldest';
+  sortOrder: SortOrder;
   tagFilter?: string[];
   typeFilter?: SubscriptionSourceType[];
   createdAt: number;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -716,6 +716,9 @@ export interface FilteredView {
   position: number;
 }
 
+/** Alias for FilteredView — use Channel in new code. */
+export type Channel = FilteredView;
+
 export interface ItemTags {
   itemKey: string;
   tags: string[];

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -684,6 +684,7 @@ export type SortOrder =
 
 export interface FilteredView {
   id?: number;
+  uuid: string;
   name: string;
   // Channel mode: 'feed' (default) shows normal content, 'saved' shows only saved items
   mode?: 'feed' | 'saved';

--- a/frontend/src/lib/utils/channelLogic.test.ts
+++ b/frontend/src/lib/utils/channelLogic.test.ts
@@ -385,7 +385,9 @@ describe('isAlreadyCovered', () => {
       }),
     ];
     // 1 out of 4 overlap (25%)
-    expect(isAlreadyCovered(['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3', 'rss~rkey-4'], [], views)).toBe(false);
+    expect(
+      isAlreadyCovered(['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3', 'rss~rkey-4'], [], views)
+    ).toBe(false);
   });
 
   it('returns false when no views exist', () => {

--- a/frontend/src/lib/utils/channelLogic.test.ts
+++ b/frontend/src/lib/utils/channelLogic.test.ts
@@ -47,6 +47,7 @@ function makeArticle(
 
 function makeView(overrides: Partial<FilteredView> & { id: number }): FilteredView {
   return {
+    uuid: crypto.randomUUID(),
     name: `View ${overrides.id}`,
     readFilter: 'all',
     sortOrder: 'newest',
@@ -134,7 +135,7 @@ describe('computeSourceKeys', () => {
         makeSub({ id: 3, category: 'News' }),
       ];
       const keys = computeSourceKeys({ type: 'category', value: 'tech' }, subs, []);
-      expect(keys).toEqual(['rss~1', 'rss~2']);
+      expect(keys).toEqual(['rss~rkey-1', 'rss~rkey-2']);
     });
 
     it('includes atproto subscriptions with matching category', () => {
@@ -156,8 +157,8 @@ describe('computeSourceKeys', () => {
       expect(keys).toEqual(['did:plc:a~shares', 'did:plc:b~documents']);
     });
 
-    it('skips subscriptions without id', () => {
-      const subs = [{ ...makeSub({ id: 1, category: 'Tech' }), id: undefined }];
+    it('skips subscriptions without rkey', () => {
+      const subs = [{ ...makeSub({ id: 1, category: 'Tech' }), rkey: '' }];
       const keys = computeSourceKeys({ type: 'category', value: 'Tech' }, subs as any, []);
       expect(keys).toEqual([]);
     });
@@ -171,7 +172,7 @@ describe('computeSourceKeys', () => {
         makeSub({ id: 3, tags: ['sports'] }),
       ];
       const keys = computeSourceKeys({ type: 'subscriptionTag', value: 'tech' }, subs, []);
-      expect(keys).toEqual(['rss~1', 'rss~2']);
+      expect(keys).toEqual(['rss~rkey-1', 'rss~rkey-2']);
     });
   });
 
@@ -183,7 +184,7 @@ describe('computeSourceKeys', () => {
         makeSub({ id: 3, siteUrl: 'https://news.substack.com' }),
       ];
       const keys = computeSourceKeys({ type: 'domain', patterns: ['substack.com'] }, subs, []);
-      expect(keys).toEqual(['rss~1', 'rss~3']);
+      expect(keys).toEqual(['rss~rkey-1', 'rss~rkey-3']);
     });
 
     it('skips non-RSS subscriptions', () => {
@@ -239,7 +240,7 @@ describe('computeSourceKeys', () => {
       articles.push(makeArticle({ subscriptionId: 2, guid: 'b2', publishedAt: recentDate }));
 
       const keys = computeSourceKeys({ type: 'frequency', threshold: 'high' }, subs, articles);
-      expect(keys).toEqual(['rss~1']);
+      expect(keys).toEqual(['rss~rkey-1']);
     });
 
     it('selects low-frequency feeds (0 < rate < 0.3/day)', () => {
@@ -255,7 +256,7 @@ describe('computeSourceKeys', () => {
       ];
 
       const keys = computeSourceKeys({ type: 'frequency', threshold: 'low' }, subs, articles);
-      expect(keys).toEqual(['rss~1']);
+      expect(keys).toEqual(['rss~rkey-1']);
     });
 
     it('excludes feeds with zero articles from low-frequency', () => {
@@ -275,7 +276,7 @@ describe('computeSourceKeys', () => {
         makeArticle({ subscriptionId: 2, guid: 'b2', content: 'x'.repeat(200) }),
       ];
       const keys = computeSourceKeys({ type: 'longReads', minLength: 5000 }, subs, articles);
-      expect(keys).toEqual(['rss~1']);
+      expect(keys).toEqual(['rss~rkey-1']);
     });
   });
 
@@ -296,7 +297,7 @@ describe('computeSourceKeys', () => {
         }),
       ];
       const keys = computeSourceKeys({ type: 'recent', withinDays: 14 }, subs, []);
-      expect(keys).toEqual(['rss~1', 'did:plc:a~shares']);
+      expect(keys).toEqual(['rss~rkey-1', 'did:plc:a~shares']);
     });
   });
 });
@@ -368,11 +369,11 @@ describe('isAlreadyCovered', () => {
       makeView({
         id: 1,
         sourceMode: 'include',
-        sourceKeys: ['rss~1', 'rss~2', 'rss~3'],
+        sourceKeys: ['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3'],
       }),
     ];
     // 2 out of 2 overlap (100%) with the view
-    expect(isAlreadyCovered(['rss~1', 'rss~2'], [], views)).toBe(true);
+    expect(isAlreadyCovered(['rss~rkey-1', 'rss~rkey-2'], [], views)).toBe(true);
   });
 
   it('returns false when less than 70% overlap', () => {
@@ -380,15 +381,15 @@ describe('isAlreadyCovered', () => {
       makeView({
         id: 1,
         sourceMode: 'include',
-        sourceKeys: ['rss~1'],
+        sourceKeys: ['rss~rkey-1'],
       }),
     ];
     // 1 out of 4 overlap (25%)
-    expect(isAlreadyCovered(['rss~1', 'rss~2', 'rss~3', 'rss~4'], [], views)).toBe(false);
+    expect(isAlreadyCovered(['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3', 'rss~rkey-4'], [], views)).toBe(false);
   });
 
   it('returns false when no views exist', () => {
-    expect(isAlreadyCovered(['rss~1'], [], [])).toBe(false);
+    expect(isAlreadyCovered(['rss~rkey-1'], [], [])).toBe(false);
   });
 });
 
@@ -410,7 +411,7 @@ describe('getCategorySuggestions', () => {
     expect(suggestions).toHaveLength(1);
     expect(suggestions[0].name).toBe('Tech');
     expect(suggestions[0].autoRule).toEqual({ type: 'category', value: 'Tech' });
-    expect(suggestions[0].sourceKeys).toEqual(['rss~1', 'rss~2', 'rss~3']);
+    expect(suggestions[0].sourceKeys).toEqual(['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3']);
   });
 
   it('skips categories with fewer than 3 feeds', () => {
@@ -434,7 +435,7 @@ describe('getCategorySuggestions', () => {
         makeView({
           id: 1,
           sourceMode: 'include',
-          sourceKeys: ['rss~1', 'rss~2', 'rss~3'],
+          sourceKeys: ['rss~rkey-1', 'rss~rkey-2', 'rss~rkey-3'],
         }),
       ],
     };

--- a/frontend/src/lib/utils/channelLogic.test.ts
+++ b/frontend/src/lib/utils/channelLogic.test.ts
@@ -1,0 +1,708 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Subscription, Article, FilteredView } from '$lib/types';
+import {
+  isValidAutoRule,
+  computeSourceKeys,
+  getArticleFrequencyByFeed,
+  getAvgContentLengthByFeed,
+  isAlreadyCovered,
+  getCategorySuggestions,
+  getTypeSuggestions,
+  getTagSuggestions,
+  getPeopleSuggestion,
+  getDomainSuggestions,
+  getFrequencySuggestions,
+  getLongReadsSuggestion,
+  getRecentSuggestion,
+  generateAllSuggestions,
+  getSuggestionPriority,
+  MIN_SOURCES_FOR_SUGGESTION,
+  type SuggestionContext,
+} from './channelLogic';
+
+// ─── Test helpers ──────────────────────────────────────────────────────
+
+function makeSub(overrides: Partial<Subscription> & { id: number }): Subscription {
+  return {
+    rkey: `rkey-${overrides.id}`,
+    title: `Feed ${overrides.id}`,
+    tags: [],
+    createdAt: '2024-01-01T00:00:00Z',
+    localUpdatedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeArticle(
+  overrides: Partial<Article> & { subscriptionId: number; guid: string }
+): Article {
+  return {
+    url: `https://example.com/${overrides.guid}`,
+    title: `Article ${overrides.guid}`,
+    publishedAt: new Date().toISOString(),
+    fetchedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeView(overrides: Partial<FilteredView> & { id: number }): FilteredView {
+  return {
+    name: `View ${overrides.id}`,
+    readFilter: 'all',
+    sortOrder: 'newest',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    position: 0,
+    ...overrides,
+  };
+}
+
+function emptyCtx(): SuggestionContext {
+  return { subscriptions: [], articles: [], views: [] };
+}
+
+// ─── isValidAutoRule ───────────────────────────────────────────────────
+
+describe('isValidAutoRule', () => {
+  it('rejects null/undefined', () => {
+    expect(isValidAutoRule(null)).toBe(false);
+    expect(isValidAutoRule(undefined)).toBe(false);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isValidAutoRule('category')).toBe(false);
+    expect(isValidAutoRule(42)).toBe(false);
+  });
+
+  it('rejects objects without type', () => {
+    expect(isValidAutoRule({ value: 'Tech' })).toBe(false);
+  });
+
+  it('rejects unknown rule types', () => {
+    expect(isValidAutoRule({ type: 'unknown' })).toBe(false);
+  });
+
+  it('validates category rules', () => {
+    expect(isValidAutoRule({ type: 'category', value: 'Tech' })).toBe(true);
+    expect(isValidAutoRule({ type: 'category' })).toBe(false);
+    expect(isValidAutoRule({ type: 'category', value: 42 })).toBe(false);
+  });
+
+  it('validates subscriptionTag rules', () => {
+    expect(isValidAutoRule({ type: 'subscriptionTag', value: 'news' })).toBe(true);
+    expect(isValidAutoRule({ type: 'subscriptionTag' })).toBe(false);
+  });
+
+  it('validates domain rules', () => {
+    expect(isValidAutoRule({ type: 'domain', patterns: ['substack.com'] })).toBe(true);
+    expect(isValidAutoRule({ type: 'domain' })).toBe(false);
+    expect(isValidAutoRule({ type: 'domain', patterns: 'not-array' })).toBe(false);
+  });
+
+  it('validates people rules', () => {
+    expect(isValidAutoRule({ type: 'people' })).toBe(true);
+  });
+
+  it('validates frequency rules', () => {
+    expect(isValidAutoRule({ type: 'frequency', threshold: 'high' })).toBe(true);
+    expect(isValidAutoRule({ type: 'frequency', threshold: 'low' })).toBe(true);
+    expect(isValidAutoRule({ type: 'frequency', threshold: 'medium' })).toBe(false);
+    expect(isValidAutoRule({ type: 'frequency' })).toBe(false);
+  });
+
+  it('validates longReads rules', () => {
+    expect(isValidAutoRule({ type: 'longReads', minLength: 5000 })).toBe(true);
+    expect(isValidAutoRule({ type: 'longReads' })).toBe(false);
+    expect(isValidAutoRule({ type: 'longReads', minLength: 'many' })).toBe(false);
+  });
+
+  it('validates recent rules', () => {
+    expect(isValidAutoRule({ type: 'recent', withinDays: 14 })).toBe(true);
+    expect(isValidAutoRule({ type: 'recent' })).toBe(false);
+    expect(isValidAutoRule({ type: 'recent', withinDays: 'two weeks' })).toBe(false);
+  });
+});
+
+// ─── computeSourceKeys ─────────────────────────────────────────────────
+
+describe('computeSourceKeys', () => {
+  describe('category rule', () => {
+    it('matches subscriptions by category (case-insensitive)', () => {
+      const subs = [
+        makeSub({ id: 1, category: 'Tech' }),
+        makeSub({ id: 2, category: 'tech' }),
+        makeSub({ id: 3, category: 'News' }),
+      ];
+      const keys = computeSourceKeys({ type: 'category', value: 'tech' }, subs, []);
+      expect(keys).toEqual(['rss~1', 'rss~2']);
+    });
+
+    it('includes atproto subscriptions with matching category', () => {
+      const subs = [
+        makeSub({
+          id: 1,
+          category: 'Social',
+          sourceType: 'atproto.shares',
+          subjectDid: 'did:plc:a',
+        }),
+        makeSub({
+          id: 2,
+          category: 'Social',
+          sourceType: 'atproto.documents',
+          subjectDid: 'did:plc:b',
+        }),
+      ];
+      const keys = computeSourceKeys({ type: 'category', value: 'Social' }, subs, []);
+      expect(keys).toEqual(['did:plc:a~shares', 'did:plc:b~documents']);
+    });
+
+    it('skips subscriptions without id', () => {
+      const subs = [{ ...makeSub({ id: 1, category: 'Tech' }), id: undefined }];
+      const keys = computeSourceKeys({ type: 'category', value: 'Tech' }, subs as any, []);
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe('subscriptionTag rule', () => {
+    it('matches by tag (case-insensitive, trimmed)', () => {
+      const subs = [
+        makeSub({ id: 1, tags: ['News', 'tech'] }),
+        makeSub({ id: 2, tags: [' Tech '] }),
+        makeSub({ id: 3, tags: ['sports'] }),
+      ];
+      const keys = computeSourceKeys({ type: 'subscriptionTag', value: 'tech' }, subs, []);
+      expect(keys).toEqual(['rss~1', 'rss~2']);
+    });
+  });
+
+  describe('domain rule', () => {
+    it('matches feeds by URL hostname pattern', () => {
+      const subs = [
+        makeSub({ id: 1, feedUrl: 'https://blog.substack.com/feed' }),
+        makeSub({ id: 2, feedUrl: 'https://example.com/rss' }),
+        makeSub({ id: 3, siteUrl: 'https://news.substack.com' }),
+      ];
+      const keys = computeSourceKeys({ type: 'domain', patterns: ['substack.com'] }, subs, []);
+      expect(keys).toEqual(['rss~1', 'rss~3']);
+    });
+
+    it('skips non-RSS subscriptions', () => {
+      const subs = [
+        makeSub({
+          id: 1,
+          feedUrl: 'https://substack.com/feed',
+          sourceType: 'atproto.shares',
+          subjectDid: 'did:plc:a',
+        }),
+      ];
+      const keys = computeSourceKeys({ type: 'domain', patterns: ['substack.com'] }, subs, []);
+      expect(keys).toEqual([]);
+    });
+
+    it('handles invalid URLs gracefully', () => {
+      const subs = [makeSub({ id: 1, feedUrl: 'not a url' })];
+      const keys = computeSourceKeys({ type: 'domain', patterns: ['example'] }, subs, []);
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe('people rule', () => {
+    it('collects all atproto subscriptions', () => {
+      const subs = [
+        makeSub({ id: 1, sourceType: 'atproto.shares', subjectDid: 'did:plc:a' }),
+        makeSub({ id: 2, sourceType: 'atproto.documents', subjectDid: 'did:plc:b' }),
+        makeSub({ id: 3 }), // RSS, no subjectDid
+      ];
+      const keys = computeSourceKeys({ type: 'people' }, subs, []);
+      expect(keys).toEqual(['did:plc:a~shares', 'did:plc:b~documents']);
+    });
+
+    it('skips subscriptions without subjectDid', () => {
+      const subs = [makeSub({ id: 1, sourceType: 'atproto.shares' })];
+      const keys = computeSourceKeys({ type: 'people' }, subs, []);
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe('frequency rule', () => {
+    const now = Date.now();
+    const recentDate = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString(); // 1 day ago
+
+    it('selects high-frequency feeds (2+ articles/day)', () => {
+      const subs = [makeSub({ id: 1 }), makeSub({ id: 2 })];
+      // 30 articles in 14 days = ~2.14/day for sub 1
+      const articles = Array.from({ length: 30 }, (_, i) =>
+        makeArticle({ subscriptionId: 1, guid: `a${i}`, publishedAt: recentDate })
+      );
+      // 2 articles for sub 2 = ~0.14/day
+      articles.push(makeArticle({ subscriptionId: 2, guid: 'b1', publishedAt: recentDate }));
+      articles.push(makeArticle({ subscriptionId: 2, guid: 'b2', publishedAt: recentDate }));
+
+      const keys = computeSourceKeys({ type: 'frequency', threshold: 'high' }, subs, articles);
+      expect(keys).toEqual(['rss~1']);
+    });
+
+    it('selects low-frequency feeds (0 < rate < 0.3/day)', () => {
+      const subs = [makeSub({ id: 1 }), makeSub({ id: 2 })];
+      // 2 articles in 14 days = ~0.14/day → low freq
+      const articles = [
+        makeArticle({ subscriptionId: 1, guid: 'a1', publishedAt: recentDate }),
+        makeArticle({ subscriptionId: 1, guid: 'a2', publishedAt: recentDate }),
+        // 30 articles for sub 2 → high freq, not low
+        ...Array.from({ length: 30 }, (_, i) =>
+          makeArticle({ subscriptionId: 2, guid: `b${i}`, publishedAt: recentDate })
+        ),
+      ];
+
+      const keys = computeSourceKeys({ type: 'frequency', threshold: 'low' }, subs, articles);
+      expect(keys).toEqual(['rss~1']);
+    });
+
+    it('excludes feeds with zero articles from low-frequency', () => {
+      const subs = [makeSub({ id: 1 })];
+      const keys = computeSourceKeys({ type: 'frequency', threshold: 'low' }, subs, []);
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe('longReads rule', () => {
+    it('selects feeds with high average content length', () => {
+      const subs = [makeSub({ id: 1 }), makeSub({ id: 2 })];
+      const articles = [
+        makeArticle({ subscriptionId: 1, guid: 'a1', content: 'x'.repeat(6000) }),
+        makeArticle({ subscriptionId: 1, guid: 'a2', content: 'x'.repeat(7000) }),
+        makeArticle({ subscriptionId: 2, guid: 'b1', content: 'x'.repeat(100) }),
+        makeArticle({ subscriptionId: 2, guid: 'b2', content: 'x'.repeat(200) }),
+      ];
+      const keys = computeSourceKeys({ type: 'longReads', minLength: 5000 }, subs, articles);
+      expect(keys).toEqual(['rss~1']);
+    });
+  });
+
+  describe('recent rule', () => {
+    it('selects recently added subscriptions', () => {
+      const now = new Date();
+      const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString(); // 3 days ago
+      const old = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days ago
+
+      const subs = [
+        makeSub({ id: 1, createdAt: recent }),
+        makeSub({ id: 2, createdAt: old }),
+        makeSub({
+          id: 3,
+          createdAt: recent,
+          sourceType: 'atproto.shares',
+          subjectDid: 'did:plc:a',
+        }),
+      ];
+      const keys = computeSourceKeys({ type: 'recent', withinDays: 14 }, subs, []);
+      expect(keys).toEqual(['rss~1', 'did:plc:a~shares']);
+    });
+  });
+});
+
+// ─── Article frequency & content length helpers ────────────────────────
+
+describe('getArticleFrequencyByFeed', () => {
+  it('computes per-day rates over 14-day window', () => {
+    const now = Date.now();
+    const recentDate = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const articles = Array.from({ length: 14 }, (_, i) =>
+      makeArticle({ subscriptionId: 1, guid: `a${i}`, publishedAt: recentDate })
+    );
+    const result = getArticleFrequencyByFeed(articles);
+    expect(result.get(1)).toBe(1); // 14 articles / 14 days = 1/day
+  });
+
+  it('ignores articles older than 14 days', () => {
+    const oldDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    const articles = [makeArticle({ subscriptionId: 1, guid: 'old', publishedAt: oldDate })];
+    const result = getArticleFrequencyByFeed(articles);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('getAvgContentLengthByFeed', () => {
+  it('computes average content length', () => {
+    const articles = [
+      makeArticle({ subscriptionId: 1, guid: 'a1', content: 'x'.repeat(1000) }),
+      makeArticle({ subscriptionId: 1, guid: 'a2', content: 'x'.repeat(3000) }),
+    ];
+    const result = getAvgContentLengthByFeed(articles);
+    expect(result.get(1)).toBe(2000);
+  });
+
+  it('falls back to summary when content is missing', () => {
+    const articles = [makeArticle({ subscriptionId: 1, guid: 'a1', summary: 'x'.repeat(500) })];
+    const result = getAvgContentLengthByFeed(articles);
+    expect(result.get(1)).toBe(500);
+  });
+
+  it('skips articles with no content or summary', () => {
+    const articles = [makeArticle({ subscriptionId: 1, guid: 'a1' })];
+    const result = getAvgContentLengthByFeed(articles);
+    expect(result.size).toBe(0);
+  });
+});
+
+// ─── isAlreadyCovered ──────────────────────────────────────────────────
+
+describe('isAlreadyCovered', () => {
+  it('returns true when a view with sourceMode all and no type filter exists', () => {
+    const views = [makeView({ id: 1, sourceMode: 'all' })];
+    expect(isAlreadyCovered([], [], views)).toBe(true);
+  });
+
+  it('returns true when a view covers the type filter', () => {
+    const views = [makeView({ id: 1, sourceMode: 'all', typeFilter: ['rss'] })];
+    expect(isAlreadyCovered([], ['rss'], views)).toBe(true);
+  });
+
+  it('returns false when type filters do not match', () => {
+    const views = [makeView({ id: 1, sourceMode: 'all', typeFilter: ['rss'] })];
+    expect(isAlreadyCovered([], ['atproto.shares'], views)).toBe(false);
+  });
+
+  it('returns true when 70%+ of source keys overlap', () => {
+    const views = [
+      makeView({
+        id: 1,
+        sourceMode: 'include',
+        sourceKeys: ['rss~1', 'rss~2', 'rss~3'],
+      }),
+    ];
+    // 2 out of 2 overlap (100%) with the view
+    expect(isAlreadyCovered(['rss~1', 'rss~2'], [], views)).toBe(true);
+  });
+
+  it('returns false when less than 70% overlap', () => {
+    const views = [
+      makeView({
+        id: 1,
+        sourceMode: 'include',
+        sourceKeys: ['rss~1'],
+      }),
+    ];
+    // 1 out of 4 overlap (25%)
+    expect(isAlreadyCovered(['rss~1', 'rss~2', 'rss~3', 'rss~4'], [], views)).toBe(false);
+  });
+
+  it('returns false when no views exist', () => {
+    expect(isAlreadyCovered(['rss~1'], [], [])).toBe(false);
+  });
+});
+
+// ─── Suggestion generators ─────────────────────────────────────────────
+
+describe('getCategorySuggestions', () => {
+  it('suggests channels for categories with 3+ feeds', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, category: 'Tech' }),
+        makeSub({ id: 2, category: 'Tech' }),
+        makeSub({ id: 3, category: 'Tech' }),
+        makeSub({ id: 4, category: 'News' }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getCategorySuggestions(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].name).toBe('Tech');
+    expect(suggestions[0].autoRule).toEqual({ type: 'category', value: 'Tech' });
+    expect(suggestions[0].sourceKeys).toEqual(['rss~1', 'rss~2', 'rss~3']);
+  });
+
+  it('skips categories with fewer than 3 feeds', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [makeSub({ id: 1, category: 'Tech' }), makeSub({ id: 2, category: 'Tech' })],
+      articles: [],
+      views: [],
+    };
+    expect(getCategorySuggestions(ctx)).toHaveLength(0);
+  });
+
+  it('skips categories already covered by existing channels', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, category: 'Tech' }),
+        makeSub({ id: 2, category: 'Tech' }),
+        makeSub({ id: 3, category: 'Tech' }),
+      ],
+      articles: [],
+      views: [
+        makeView({
+          id: 1,
+          sourceMode: 'include',
+          sourceKeys: ['rss~1', 'rss~2', 'rss~3'],
+        }),
+      ],
+    };
+    expect(getCategorySuggestions(ctx)).toHaveLength(0);
+  });
+});
+
+describe('getTypeSuggestions', () => {
+  it('suggests Articles and Social when both types present', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1 }),
+        makeSub({ id: 2 }),
+        makeSub({ id: 3, sourceType: 'atproto.shares', subjectDid: 'did:plc:a' }),
+        makeSub({ id: 4, sourceType: 'atproto.documents', subjectDid: 'did:plc:b' }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getTypeSuggestions(ctx);
+    expect(suggestions.map((s) => s.id)).toContain('type:articles');
+    expect(suggestions.map((s) => s.id)).toContain('type:social');
+  });
+
+  it('does not suggest when only RSS feeds exist', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [makeSub({ id: 1 }), makeSub({ id: 2 })],
+      articles: [],
+      views: [],
+    };
+    expect(getTypeSuggestions(ctx)).toHaveLength(0);
+  });
+});
+
+describe('getTagSuggestions', () => {
+  it('suggests channels for tags with 3+ subscriptions', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, tags: ['dev'] }),
+        makeSub({ id: 2, tags: ['dev'] }),
+        makeSub({ id: 3, tags: ['dev'] }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getTagSuggestions(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].name).toBe('Dev');
+    expect(suggestions[0].id).toBe('tag:dev');
+  });
+});
+
+describe('getPeopleSuggestion', () => {
+  it('suggests People I Follow with 3+ atproto subscriptions', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, sourceType: 'atproto.shares', subjectDid: 'did:plc:a' }),
+        makeSub({ id: 2, sourceType: 'atproto.shares', subjectDid: 'did:plc:b' }),
+        makeSub({ id: 3, sourceType: 'atproto.documents', subjectDid: 'did:plc:c' }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getPeopleSuggestion(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].id).toBe('people:all');
+    expect(suggestions[0].sourceKeys).toHaveLength(3);
+  });
+
+  it('returns empty with fewer than 3 atproto subscriptions', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [makeSub({ id: 1, sourceType: 'atproto.shares', subjectDid: 'did:plc:a' })],
+      articles: [],
+      views: [],
+    };
+    expect(getPeopleSuggestion(ctx)).toHaveLength(0);
+  });
+});
+
+describe('getDomainSuggestions', () => {
+  it('clusters substack feeds as Newsletters', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, feedUrl: 'https://blog1.substack.com/feed' }),
+        makeSub({ id: 2, feedUrl: 'https://blog2.substack.com/feed' }),
+        makeSub({ id: 3, feedUrl: 'https://blog3.substack.com/feed' }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getDomainSuggestions(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].id).toBe('domain:newsletters');
+    expect(suggestions[0].name).toBe('Newsletters');
+  });
+
+  it('clusters github feeds', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, feedUrl: 'https://github.com/org/repo/releases.atom' }),
+        makeSub({ id: 2, feedUrl: 'https://github.com/org/repo2/releases.atom' }),
+        makeSub({ id: 3, siteUrl: 'https://user.github.io' }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = getDomainSuggestions(ctx);
+    expect(suggestions.some((s) => s.id === 'domain:github')).toBe(true);
+  });
+});
+
+describe('getFrequencySuggestions', () => {
+  const now = Date.now();
+  const recentDate = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
+
+  it('suggests Daily Digest for high-frequency feeds', () => {
+    const subs = [makeSub({ id: 1 }), makeSub({ id: 2 }), makeSub({ id: 3 }), makeSub({ id: 4 })];
+    // 30+ articles each for subs 1-3 in last 14 days
+    const articles = [1, 2, 3].flatMap((subId) =>
+      Array.from({ length: 30 }, (_, i) =>
+        makeArticle({ subscriptionId: subId, guid: `${subId}-${i}`, publishedAt: recentDate })
+      )
+    );
+    const ctx: SuggestionContext = { subscriptions: subs, articles, views: [] };
+    const suggestions = getFrequencySuggestions(ctx);
+    expect(suggestions.some((s) => s.id === 'frequency:high')).toBe(true);
+  });
+
+  it("suggests Don't Miss for low-frequency feeds", () => {
+    const subs = [makeSub({ id: 1 }), makeSub({ id: 2 }), makeSub({ id: 3 }), makeSub({ id: 4 })];
+    // 1-3 articles each → low freq
+    const articles = [1, 2, 3].flatMap((subId) => [
+      makeArticle({ subscriptionId: subId, guid: `${subId}-0`, publishedAt: recentDate }),
+      makeArticle({ subscriptionId: subId, guid: `${subId}-1`, publishedAt: recentDate }),
+    ]);
+    const ctx: SuggestionContext = { subscriptions: subs, articles, views: [] };
+    const suggestions = getFrequencySuggestions(ctx);
+    expect(suggestions.some((s) => s.id === 'frequency:low')).toBe(true);
+  });
+
+  it('returns empty when fewer than 4 feeds', () => {
+    const ctx: SuggestionContext = {
+      subscriptions: [makeSub({ id: 1 }), makeSub({ id: 2 })],
+      articles: [],
+      views: [],
+    };
+    expect(getFrequencySuggestions(ctx)).toHaveLength(0);
+  });
+});
+
+describe('getLongReadsSuggestion', () => {
+  it('suggests Long Reads when 3+ feeds have high avg content length', () => {
+    const subs = [makeSub({ id: 1 }), makeSub({ id: 2 }), makeSub({ id: 3 })];
+    const articles = subs.flatMap((sub) => [
+      makeArticle({ subscriptionId: sub.id!, guid: `${sub.id}-a`, content: 'x'.repeat(6000) }),
+      makeArticle({ subscriptionId: sub.id!, guid: `${sub.id}-b`, content: 'x'.repeat(7000) }),
+    ]);
+    const ctx: SuggestionContext = { subscriptions: subs, articles, views: [] };
+    const suggestions = getLongReadsSuggestion(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].id).toBe('content:longreads');
+  });
+
+  it('returns empty when feeds have short content', () => {
+    const subs = [makeSub({ id: 1 }), makeSub({ id: 2 }), makeSub({ id: 3 })];
+    const articles = subs.flatMap((sub) => [
+      makeArticle({ subscriptionId: sub.id!, guid: `${sub.id}-a`, content: 'x'.repeat(100) }),
+      makeArticle({ subscriptionId: sub.id!, guid: `${sub.id}-b`, content: 'x'.repeat(200) }),
+    ]);
+    const ctx: SuggestionContext = { subscriptions: subs, articles, views: [] };
+    expect(getLongReadsSuggestion(ctx)).toHaveLength(0);
+  });
+});
+
+describe('getRecentSuggestion', () => {
+  it('suggests New Sources for recently added subscriptions', () => {
+    const now = new Date();
+    const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const subs = [
+      makeSub({ id: 1, createdAt: recent }),
+      makeSub({ id: 2, createdAt: recent }),
+      makeSub({ id: 3, createdAt: recent }),
+    ];
+    const ctx: SuggestionContext = { subscriptions: subs, articles: [], views: [] };
+    const suggestions = getRecentSuggestion(ctx);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].id).toBe('recent:new');
+  });
+
+  it('returns empty when all subscriptions are old', () => {
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const subs = [
+      makeSub({ id: 1, createdAt: old }),
+      makeSub({ id: 2, createdAt: old }),
+      makeSub({ id: 3, createdAt: old }),
+    ];
+    const ctx: SuggestionContext = { subscriptions: subs, articles: [], views: [] };
+    expect(getRecentSuggestion(ctx)).toHaveLength(0);
+  });
+});
+
+// ─── getSuggestionPriority ─────────────────────────────────────────────
+
+describe('getSuggestionPriority', () => {
+  it('assigns known priorities', () => {
+    expect(getSuggestionPriority('frequency:high')).toBe(1);
+    expect(getSuggestionPriority('frequency:low')).toBe(2);
+    expect(getSuggestionPriority('people:all')).toBe(4);
+    expect(getSuggestionPriority('recent:new')).toBe(7);
+  });
+
+  it('assigns group priorities for dynamic IDs', () => {
+    expect(getSuggestionPriority('category:tech')).toBe(10);
+    expect(getSuggestionPriority('tag:news')).toBe(11);
+    expect(getSuggestionPriority('domain:newsletters')).toBe(12);
+  });
+
+  it('defaults to 20 for unknown IDs', () => {
+    expect(getSuggestionPriority('unknown:something')).toBe(20);
+  });
+});
+
+// ─── generateAllSuggestions ────────────────────────────────────────────
+
+describe('generateAllSuggestions', () => {
+  it('filters out dismissed suggestions', () => {
+    const now = new Date();
+    const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        makeSub({ id: 1, category: 'Tech', createdAt: recent }),
+        makeSub({ id: 2, category: 'Tech', createdAt: recent }),
+        makeSub({ id: 3, category: 'Tech', createdAt: recent }),
+      ],
+      articles: [],
+      views: [],
+    };
+    const dismissed = new Set(['category:tech']);
+    const suggestions = generateAllSuggestions(ctx, dismissed);
+    expect(suggestions.find((s) => s.id === 'category:tech')).toBeUndefined();
+  });
+
+  it('sorts by priority', () => {
+    const now = new Date();
+    const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const ctx: SuggestionContext = {
+      subscriptions: [
+        // Category suggestion
+        makeSub({ id: 1, category: 'Tech', createdAt: recent }),
+        makeSub({ id: 2, category: 'Tech', createdAt: recent }),
+        makeSub({ id: 3, category: 'Tech', createdAt: recent }),
+        // Recent suggestion (also these 3 are recent)
+      ],
+      articles: [],
+      views: [],
+    };
+    const suggestions = generateAllSuggestions(ctx, new Set());
+    if (suggestions.length >= 2) {
+      // recent:new (priority 7) should come before category:tech (priority 10)
+      const recentIdx = suggestions.findIndex((s) => s.id === 'recent:new');
+      const categoryIdx = suggestions.findIndex((s) => s.id === 'category:tech');
+      if (recentIdx >= 0 && categoryIdx >= 0) {
+        expect(recentIdx).toBeLessThan(categoryIdx);
+      }
+    }
+  });
+
+  it('returns empty for empty context', () => {
+    expect(generateAllSuggestions(emptyCtx(), new Set())).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/utils/channelLogic.ts
+++ b/frontend/src/lib/utils/channelLogic.ts
@@ -110,10 +110,10 @@ export function computeSourceKeys(
   switch (rule.type) {
     case 'category': {
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey) continue;
         if (sub.category?.trim().toLowerCase() === rule.value.toLowerCase()) {
           if (!sub.sourceType || sub.sourceType === 'rss') {
-            keys.push(rssSourceKey(sub.id));
+            keys.push(rssSourceKey(sub.rkey));
           } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
             keys.push(sharesSourceKey(sub.subjectDid));
           } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
@@ -126,10 +126,10 @@ export function computeSourceKeys(
     case 'subscriptionTag': {
       const tagLower = rule.value.toLowerCase();
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey) continue;
         if (sub.tags.some((t) => t.trim().toLowerCase() === tagLower)) {
           if (!sub.sourceType || sub.sourceType === 'rss') {
-            keys.push(rssSourceKey(sub.id));
+            keys.push(rssSourceKey(sub.rkey));
           } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
             keys.push(sharesSourceKey(sub.subjectDid));
           } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
@@ -141,14 +141,14 @@ export function computeSourceKeys(
     }
     case 'domain': {
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey) continue;
         if (sub.sourceType && sub.sourceType !== 'rss') continue;
         const url = sub.feedUrl || sub.siteUrl;
         if (!url) continue;
         try {
           const hostname = new URL(url).hostname;
           if (rule.patterns.some((p) => hostname.includes(p))) {
-            keys.push(rssSourceKey(sub.id));
+            keys.push(rssSourceKey(sub.rkey));
           }
         } catch {
           continue;
@@ -170,13 +170,13 @@ export function computeSourceKeys(
     case 'frequency': {
       const stats = getArticleFrequencyByFeed(articles);
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey || sub.id == null) continue;
         if (sub.sourceType && sub.sourceType !== 'rss') continue;
         const perDay = stats.get(sub.id) ?? 0;
         if (rule.threshold === 'high' && perDay >= 2) {
-          keys.push(rssSourceKey(sub.id));
+          keys.push(rssSourceKey(sub.rkey));
         } else if (rule.threshold === 'low' && perDay < 0.3 && perDay > 0) {
-          keys.push(rssSourceKey(sub.id));
+          keys.push(rssSourceKey(sub.rkey));
         }
       }
       break;
@@ -184,11 +184,11 @@ export function computeSourceKeys(
     case 'longReads': {
       const lengths = getAvgContentLengthByFeed(articles);
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey || sub.id == null) continue;
         if (sub.sourceType && sub.sourceType !== 'rss') continue;
         const avgLen = lengths.get(sub.id) ?? 0;
         if (avgLen >= rule.minLength) {
-          keys.push(rssSourceKey(sub.id));
+          keys.push(rssSourceKey(sub.rkey));
         }
       }
       break;
@@ -196,11 +196,11 @@ export function computeSourceKeys(
     case 'recent': {
       const cutoff = Date.now() - rule.withinDays * 24 * 60 * 60 * 1000;
       for (const sub of subscriptions) {
-        if (sub.id == null) continue;
+        if (!sub.rkey) continue;
         const created = new Date(sub.createdAt).getTime();
         if (created >= cutoff) {
           if (!sub.sourceType || sub.sourceType === 'rss') {
-            keys.push(rssSourceKey(sub.id));
+            keys.push(rssSourceKey(sub.rkey));
           } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
             keys.push(sharesSourceKey(sub.subjectDid));
           } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
@@ -265,27 +265,27 @@ export interface SuggestionContext {
 }
 
 export function getCategorySuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
-  const byCategory = new Map<string, number[]>();
+  const byCategory = new Map<string, string[]>();
 
   for (const sub of ctx.subscriptions) {
-    if (sub.category && sub.id != null) {
+    if (sub.category && sub.rkey) {
       const cat = sub.category.trim();
       if (!cat) continue;
       const existing = byCategory.get(cat) || [];
-      existing.push(sub.id);
+      existing.push(sub.rkey);
       byCategory.set(cat, existing);
     }
   }
 
   const suggestions: ChannelSuggestion[] = [];
-  for (const [category, ids] of byCategory) {
-    if (ids.length < MIN_SOURCES_FOR_SUGGESTION) continue;
-    const sourceKeys = ids.map(rssSourceKey);
+  for (const [category, rkeys] of byCategory) {
+    if (rkeys.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = rkeys.map(rssSourceKey);
     if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
     suggestions.push({
       id: `category:${category.toLowerCase()}`,
       name: category,
-      description: `${ids.length} feeds from your "${category}" folder`,
+      description: `${rkeys.length} feeds from your "${category}" folder`,
       sourceMode: 'include',
       sourceKeys,
       typeFilter: [],
@@ -335,29 +335,29 @@ export function getTypeSuggestions(ctx: SuggestionContext): ChannelSuggestion[] 
 }
 
 export function getTagSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
-  const byTag = new Map<string, number[]>();
+  const byTag = new Map<string, string[]>();
 
   for (const sub of ctx.subscriptions) {
-    if (sub.id == null) continue;
+    if (!sub.rkey) continue;
     for (const tag of sub.tags) {
       const t = tag.trim().toLowerCase();
       if (!t) continue;
       const existing = byTag.get(t) || [];
-      existing.push(sub.id);
+      existing.push(sub.rkey);
       byTag.set(t, existing);
     }
   }
 
   const suggestions: ChannelSuggestion[] = [];
-  for (const [tag, ids] of byTag) {
-    if (ids.length < MIN_SOURCES_FOR_SUGGESTION) continue;
-    const sourceKeys = ids.map(rssSourceKey);
+  for (const [tag, rkeys] of byTag) {
+    if (rkeys.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = rkeys.map(rssSourceKey);
     if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
     const displayName = tag.charAt(0).toUpperCase() + tag.slice(1);
     suggestions.push({
       id: `tag:${tag}`,
       name: displayName,
-      description: `${ids.length} sources tagged "${tag}"`,
+      description: `${rkeys.length} sources tagged "${tag}"`,
       sourceMode: 'include',
       sourceKeys,
       typeFilter: [],
@@ -448,30 +448,30 @@ export const DOMAIN_CLUSTERS = [
 export function getDomainSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
   const suggestions: ChannelSuggestion[] = [];
   const subs = ctx.subscriptions.filter(
-    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.rkey
   );
 
   for (const cluster of DOMAIN_CLUSTERS) {
-    const matchingIds: number[] = [];
+    const matchingRkeys: string[] = [];
     for (const sub of subs) {
       const url = sub.feedUrl || sub.siteUrl;
       if (!url) continue;
       try {
         const hostname = new URL(url).hostname;
         if (cluster.patterns.some((p) => hostname.includes(p))) {
-          matchingIds.push(sub.id!);
+          matchingRkeys.push(sub.rkey);
         }
       } catch {
         continue;
       }
     }
-    if (matchingIds.length < MIN_SOURCES_FOR_SUGGESTION) continue;
-    const sourceKeys = matchingIds.map(rssSourceKey);
+    if (matchingRkeys.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = matchingRkeys.map(rssSourceKey);
     if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
     suggestions.push({
       id: cluster.id,
       name: cluster.name,
-      description: `${matchingIds.length} ${cluster.description.toLowerCase()}`,
+      description: `${matchingRkeys.length} ${cluster.description.toLowerCase()}`,
       sourceMode: 'include',
       sourceKeys,
       typeFilter: [],
@@ -484,7 +484,7 @@ export function getDomainSuggestions(ctx: SuggestionContext): ChannelSuggestion[
 export function getFrequencySuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
   const suggestions: ChannelSuggestion[] = [];
   const subs = ctx.subscriptions.filter(
-    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.rkey && s.id != null
   );
   if (subs.length < 4) return [];
 
@@ -500,22 +500,22 @@ export function getFrequencySuggestions(ctx: SuggestionContext): ChannelSuggesti
     counts.set(article.subscriptionId, (counts.get(article.subscriptionId) || 0) + 1);
   }
 
-  const highFreqIds: number[] = [];
-  const lowFreqIds: number[] = [];
+  const highFreqRkeys: string[] = [];
+  const lowFreqRkeys: string[] = [];
   for (const sub of subs) {
     const count = counts.get(sub.id!) || 0;
     const perDay = count / days;
-    if (perDay >= 2) highFreqIds.push(sub.id!);
-    else if (perDay > 0 && perDay < 0.3) lowFreqIds.push(sub.id!);
+    if (perDay >= 2) highFreqRkeys.push(sub.rkey);
+    else if (perDay > 0 && perDay < 0.3) lowFreqRkeys.push(sub.rkey);
   }
 
-  if (highFreqIds.length >= MIN_SOURCES_FOR_SUGGESTION) {
-    const sourceKeys = highFreqIds.map(rssSourceKey);
+  if (highFreqRkeys.length >= MIN_SOURCES_FOR_SUGGESTION) {
+    const sourceKeys = highFreqRkeys.map(rssSourceKey);
     if (!isAlreadyCovered(sourceKeys, [], ctx.views)) {
       suggestions.push({
         id: 'frequency:high',
         name: 'Daily Digest',
-        description: `${highFreqIds.length} high-volume feeds that publish multiple times per day`,
+        description: `${highFreqRkeys.length} high-volume feeds that publish multiple times per day`,
         sourceMode: 'include',
         sourceKeys,
         typeFilter: [],
@@ -524,13 +524,13 @@ export function getFrequencySuggestions(ctx: SuggestionContext): ChannelSuggesti
     }
   }
 
-  if (lowFreqIds.length >= MIN_SOURCES_FOR_SUGGESTION) {
-    const sourceKeys = lowFreqIds.map(rssSourceKey);
+  if (lowFreqRkeys.length >= MIN_SOURCES_FOR_SUGGESTION) {
+    const sourceKeys = lowFreqRkeys.map(rssSourceKey);
     if (!isAlreadyCovered(sourceKeys, [], ctx.views)) {
       suggestions.push({
         id: 'frequency:low',
         name: "Don't Miss",
-        description: `${lowFreqIds.length} feeds that publish infrequently — every post counts`,
+        description: `${lowFreqRkeys.length} feeds that publish infrequently — every post counts`,
         sourceMode: 'include',
         sourceKeys,
         typeFilter: [],
@@ -544,7 +544,7 @@ export function getFrequencySuggestions(ctx: SuggestionContext): ChannelSuggesti
 export function getLongReadsSuggestion(ctx: SuggestionContext): ChannelSuggestion[] {
   const MIN_AVG_LENGTH = 5000;
   const subs = ctx.subscriptions.filter(
-    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.rkey && s.id != null
   );
 
   const totals = new Map<number, { sum: number; count: number }>();
@@ -557,24 +557,24 @@ export function getLongReadsSuggestion(ctx: SuggestionContext): ChannelSuggestio
     totals.set(article.subscriptionId, existing);
   }
 
-  const longReadIds: number[] = [];
+  const longReadRkeys: string[] = [];
   for (const sub of subs) {
     const stats = totals.get(sub.id!);
     if (!stats || stats.count < 2) continue;
     if (stats.sum / stats.count >= MIN_AVG_LENGTH) {
-      longReadIds.push(sub.id!);
+      longReadRkeys.push(sub.rkey);
     }
   }
 
-  if (longReadIds.length < MIN_SOURCES_FOR_SUGGESTION) return [];
-  const sourceKeys = longReadIds.map(rssSourceKey);
+  if (longReadRkeys.length < MIN_SOURCES_FOR_SUGGESTION) return [];
+  const sourceKeys = longReadRkeys.map(rssSourceKey);
   if (isAlreadyCovered(sourceKeys, [], ctx.views)) return [];
 
   return [
     {
       id: 'content:longreads',
       name: 'Long Reads',
-      description: `${longReadIds.length} feeds with in-depth, long-form articles`,
+      description: `${longReadRkeys.length} feeds with in-depth, long-form articles`,
       sourceMode: 'include',
       sourceKeys,
       typeFilter: [],
@@ -591,11 +591,11 @@ export function getRecentSuggestion(
   const recentKeys: string[] = [];
 
   for (const sub of ctx.subscriptions) {
-    if (sub.id == null) continue;
+    if (!sub.rkey) continue;
     const created = new Date(sub.createdAt).getTime();
     if (created < cutoff) continue;
     if (!sub.sourceType || sub.sourceType === 'rss') {
-      recentKeys.push(rssSourceKey(sub.id));
+      recentKeys.push(rssSourceKey(sub.rkey));
     } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
       recentKeys.push(sharesSourceKey(sub.subjectDid));
     } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {

--- a/frontend/src/lib/utils/channelLogic.ts
+++ b/frontend/src/lib/utils/channelLogic.ts
@@ -1,0 +1,653 @@
+/**
+ * Pure functions for channel auto-update and suggestion logic.
+ * Extracted from stores so they can be unit-tested without Svelte reactivity.
+ */
+
+import type { Subscription, Article, FilteredView, SubscriptionSourceType } from '$lib/types';
+import type { ChannelAutoRule } from '$lib/types';
+import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
+
+// ─── Auto-rule validation ─────────────────────────────────────────────
+
+const VALID_RULE_TYPES = new Set([
+  'category',
+  'subscriptionTag',
+  'domain',
+  'people',
+  'frequency',
+  'longReads',
+  'recent',
+]);
+
+export function isValidAutoRule(rule: unknown): rule is ChannelAutoRule {
+  if (!rule || typeof rule !== 'object' || !('type' in rule)) return false;
+  const r = rule as { type: string };
+  if (!VALID_RULE_TYPES.has(r.type)) return false;
+  switch (r.type) {
+    case 'category':
+    case 'subscriptionTag':
+      return 'value' in r && typeof (r as { value: unknown }).value === 'string';
+    case 'domain':
+      return 'patterns' in r && Array.isArray((r as { patterns: unknown }).patterns);
+    case 'frequency':
+      return (
+        'threshold' in r &&
+        ((r as { threshold: unknown }).threshold === 'high' ||
+          (r as { threshold: unknown }).threshold === 'low')
+      );
+    case 'longReads':
+      return 'minLength' in r && typeof (r as { minLength: unknown }).minLength === 'number';
+    case 'recent':
+      return 'withinDays' in r && typeof (r as { withinDays: unknown }).withinDays === 'number';
+    case 'people':
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ─── Auto-rule source key computation ─────────────────────────────────
+
+export function getArticleFrequencyByFeed(articles: Article[]): Map<number, number> {
+  const now = Date.now();
+  const windowMs = 14 * 24 * 60 * 60 * 1000;
+  const cutoff = now - windowMs;
+  const counts = new Map<number, number>();
+
+  for (const article of articles) {
+    const pubTime = new Date(article.publishedAt).getTime();
+    if (pubTime < cutoff) continue;
+    counts.set(article.subscriptionId, (counts.get(article.subscriptionId) || 0) + 1);
+  }
+
+  const perDay = new Map<number, number>();
+  const days = windowMs / (24 * 60 * 60 * 1000);
+  for (const [id, count] of counts) {
+    perDay.set(id, count / days);
+  }
+  return perDay;
+}
+
+export function getAvgContentLengthByFeed(articles: Article[]): Map<number, number> {
+  const totals = new Map<number, { sum: number; count: number }>();
+
+  for (const article of articles) {
+    const text = article.content || article.summary;
+    if (!text) continue;
+    const existing = totals.get(article.subscriptionId) || { sum: 0, count: 0 };
+    existing.sum += text.length;
+    existing.count++;
+    totals.set(article.subscriptionId, existing);
+  }
+
+  const avgs = new Map<number, number>();
+  for (const [id, { sum, count }] of totals) {
+    if (count > 0) avgs.set(id, sum / count);
+  }
+  return avgs;
+}
+
+/**
+ * Compute source keys for a given auto-rule based on provided subscriptions/articles.
+ */
+export function computeSourceKeys(
+  rule: ChannelAutoRule,
+  subscriptions: Subscription[],
+  articles: Article[]
+): string[] {
+  const keys: string[] = [];
+
+  switch (rule.type) {
+    case 'category': {
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        if (sub.category?.trim().toLowerCase() === rule.value.toLowerCase()) {
+          if (!sub.sourceType || sub.sourceType === 'rss') {
+            keys.push(rssSourceKey(sub.id));
+          } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
+            keys.push(sharesSourceKey(sub.subjectDid));
+          } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
+            keys.push(documentsSourceKey(sub.subjectDid));
+          }
+        }
+      }
+      break;
+    }
+    case 'subscriptionTag': {
+      const tagLower = rule.value.toLowerCase();
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        if (sub.tags.some((t) => t.trim().toLowerCase() === tagLower)) {
+          if (!sub.sourceType || sub.sourceType === 'rss') {
+            keys.push(rssSourceKey(sub.id));
+          } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
+            keys.push(sharesSourceKey(sub.subjectDid));
+          } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
+            keys.push(documentsSourceKey(sub.subjectDid));
+          }
+        }
+      }
+      break;
+    }
+    case 'domain': {
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        if (sub.sourceType && sub.sourceType !== 'rss') continue;
+        const url = sub.feedUrl || sub.siteUrl;
+        if (!url) continue;
+        try {
+          const hostname = new URL(url).hostname;
+          if (rule.patterns.some((p) => hostname.includes(p))) {
+            keys.push(rssSourceKey(sub.id));
+          }
+        } catch {
+          continue;
+        }
+      }
+      break;
+    }
+    case 'people': {
+      for (const sub of subscriptions) {
+        if (!sub.subjectDid) continue;
+        if (sub.sourceType === 'atproto.shares') {
+          keys.push(sharesSourceKey(sub.subjectDid));
+        } else if (sub.sourceType === 'atproto.documents') {
+          keys.push(documentsSourceKey(sub.subjectDid));
+        }
+      }
+      break;
+    }
+    case 'frequency': {
+      const stats = getArticleFrequencyByFeed(articles);
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        if (sub.sourceType && sub.sourceType !== 'rss') continue;
+        const perDay = stats.get(sub.id) ?? 0;
+        if (rule.threshold === 'high' && perDay >= 2) {
+          keys.push(rssSourceKey(sub.id));
+        } else if (rule.threshold === 'low' && perDay < 0.3 && perDay > 0) {
+          keys.push(rssSourceKey(sub.id));
+        }
+      }
+      break;
+    }
+    case 'longReads': {
+      const lengths = getAvgContentLengthByFeed(articles);
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        if (sub.sourceType && sub.sourceType !== 'rss') continue;
+        const avgLen = lengths.get(sub.id) ?? 0;
+        if (avgLen >= rule.minLength) {
+          keys.push(rssSourceKey(sub.id));
+        }
+      }
+      break;
+    }
+    case 'recent': {
+      const cutoff = Date.now() - rule.withinDays * 24 * 60 * 60 * 1000;
+      for (const sub of subscriptions) {
+        if (sub.id == null) continue;
+        const created = new Date(sub.createdAt).getTime();
+        if (created >= cutoff) {
+          if (!sub.sourceType || sub.sourceType === 'rss') {
+            keys.push(rssSourceKey(sub.id));
+          } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
+            keys.push(sharesSourceKey(sub.subjectDid));
+          } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
+            keys.push(documentsSourceKey(sub.subjectDid));
+          }
+        }
+      }
+      break;
+    }
+  }
+
+  return keys;
+}
+
+// ─── Channel suggestions (pure logic) ─────────────────────────────────
+
+export interface ChannelSuggestion {
+  id: string;
+  name: string;
+  description: string;
+  sourceMode: 'all' | 'include';
+  sourceKeys: string[];
+  typeFilter: SubscriptionSourceType[];
+  autoRule?: ChannelAutoRule;
+}
+
+export const MIN_SOURCES_FOR_SUGGESTION = 3;
+
+/**
+ * Check if an existing channel already covers a given set of source keys.
+ * A channel "covers" sources if 70%+ of suggested sources overlap.
+ */
+export function isAlreadyCovered(
+  sourceKeys: string[],
+  typeFilter: SubscriptionSourceType[],
+  views: FilteredView[]
+): boolean {
+  for (const view of views) {
+    const viewSourceMode = view.sourceMode ?? 'all';
+    const viewTypeFilter = view.typeFilter ?? [];
+
+    if (viewSourceMode === 'all') {
+      if (typeFilter.length > 0 && viewTypeFilter.length > 0) {
+        if (typeFilter.every((t) => viewTypeFilter.includes(t))) return true;
+      }
+      if (typeFilter.length === 0 && viewTypeFilter.length === 0) return true;
+    }
+
+    if (viewSourceMode === 'include' && view.sourceKeys) {
+      const viewKeySet = new Set(view.sourceKeys);
+      const overlap = sourceKeys.filter((k) => viewKeySet.has(k));
+      if (overlap.length >= sourceKeys.length * 0.7) return true;
+    }
+  }
+  return false;
+}
+
+export interface SuggestionContext {
+  subscriptions: Subscription[];
+  articles: Article[];
+  views: FilteredView[];
+}
+
+export function getCategorySuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
+  const byCategory = new Map<string, number[]>();
+
+  for (const sub of ctx.subscriptions) {
+    if (sub.category && sub.id != null) {
+      const cat = sub.category.trim();
+      if (!cat) continue;
+      const existing = byCategory.get(cat) || [];
+      existing.push(sub.id);
+      byCategory.set(cat, existing);
+    }
+  }
+
+  const suggestions: ChannelSuggestion[] = [];
+  for (const [category, ids] of byCategory) {
+    if (ids.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = ids.map(rssSourceKey);
+    if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
+    suggestions.push({
+      id: `category:${category.toLowerCase()}`,
+      name: category,
+      description: `${ids.length} feeds from your "${category}" folder`,
+      sourceMode: 'include',
+      sourceKeys,
+      typeFilter: [],
+      autoRule: { type: 'category', value: category },
+    });
+  }
+  return suggestions;
+}
+
+export function getTypeSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
+  const suggestions: ChannelSuggestion[] = [];
+  const subs = ctx.subscriptions;
+
+  const rssSubs = subs.filter((s) => !s.sourceType || s.sourceType === 'rss');
+  const shareSubs = subs.filter((s) => s.sourceType === 'atproto.shares');
+  const docSubs = subs.filter((s) => s.sourceType === 'atproto.documents');
+  const atprotoSubs = [...shareSubs, ...docSubs];
+
+  if (rssSubs.length >= 2 && atprotoSubs.length >= 2) {
+    if (!isAlreadyCovered([], ['rss'], ctx.views)) {
+      suggestions.push({
+        id: 'type:articles',
+        name: 'Articles',
+        description: `${rssSubs.length} RSS feeds, without social content`,
+        sourceMode: 'all',
+        sourceKeys: [],
+        typeFilter: ['rss'],
+      });
+    }
+
+    const socialTypes: SubscriptionSourceType[] = [];
+    if (shareSubs.length > 0) socialTypes.push('atproto.shares');
+    if (docSubs.length > 0) socialTypes.push('atproto.documents');
+
+    if (socialTypes.length > 0 && !isAlreadyCovered([], socialTypes, ctx.views)) {
+      suggestions.push({
+        id: 'type:social',
+        name: 'Social',
+        description: `${atprotoSubs.length} people you follow`,
+        sourceMode: 'all',
+        sourceKeys: [],
+        typeFilter: socialTypes,
+      });
+    }
+  }
+  return suggestions;
+}
+
+export function getTagSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
+  const byTag = new Map<string, number[]>();
+
+  for (const sub of ctx.subscriptions) {
+    if (sub.id == null) continue;
+    for (const tag of sub.tags) {
+      const t = tag.trim().toLowerCase();
+      if (!t) continue;
+      const existing = byTag.get(t) || [];
+      existing.push(sub.id);
+      byTag.set(t, existing);
+    }
+  }
+
+  const suggestions: ChannelSuggestion[] = [];
+  for (const [tag, ids] of byTag) {
+    if (ids.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = ids.map(rssSourceKey);
+    if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
+    const displayName = tag.charAt(0).toUpperCase() + tag.slice(1);
+    suggestions.push({
+      id: `tag:${tag}`,
+      name: displayName,
+      description: `${ids.length} sources tagged "${tag}"`,
+      sourceMode: 'include',
+      sourceKeys,
+      typeFilter: [],
+      autoRule: { type: 'subscriptionTag', value: tag },
+    });
+  }
+  return suggestions;
+}
+
+export function getPeopleSuggestion(ctx: SuggestionContext): ChannelSuggestion[] {
+  const atprotoSubs = ctx.subscriptions.filter(
+    (s) =>
+      s.subjectDid && (s.sourceType === 'atproto.shares' || s.sourceType === 'atproto.documents')
+  );
+  if (atprotoSubs.length < MIN_SOURCES_FOR_SUGGESTION) return [];
+
+  const sourceKeys: string[] = [];
+  const seenDids = new Set<string>();
+  for (const sub of atprotoSubs) {
+    if (!sub.subjectDid) continue;
+    if (sub.sourceType === 'atproto.shares') {
+      sourceKeys.push(sharesSourceKey(sub.subjectDid));
+    } else if (sub.sourceType === 'atproto.documents') {
+      sourceKeys.push(documentsSourceKey(sub.subjectDid));
+    }
+    seenDids.add(sub.subjectDid);
+  }
+  if (isAlreadyCovered(sourceKeys, [], ctx.views)) return [];
+
+  return [
+    {
+      id: 'people:all',
+      name: 'People I Follow',
+      description: `${seenDids.size} people, all shares and articles`,
+      sourceMode: 'include',
+      sourceKeys,
+      typeFilter: [],
+      autoRule: { type: 'people' },
+    },
+  ];
+}
+
+// Known domain patterns for clustering
+export const DOMAIN_CLUSTERS = [
+  {
+    name: 'Newsletters',
+    id: 'domain:newsletters',
+    description: 'Substack, Buttondown, and other newsletter platforms',
+    patterns: [
+      'substack.com',
+      'buttondown.',
+      'newsletter.',
+      'mailchi.mp',
+      'beehiiv.com',
+      'ghost.io',
+      'convertkit.com',
+    ],
+  },
+  {
+    name: 'Podcasts',
+    id: 'domain:podcasts',
+    description: 'Podcast feeds',
+    patterns: [
+      'anchor.fm',
+      'transistor.fm',
+      'buzzsprout.com',
+      'simplecast.com',
+      'megaphone.fm',
+      'podcast',
+      'libsyn.com',
+      'podbean.com',
+    ],
+  },
+  {
+    name: 'Reddit',
+    id: 'domain:reddit',
+    description: 'Reddit feeds',
+    patterns: ['reddit.com'],
+  },
+  {
+    name: 'GitHub',
+    id: 'domain:github',
+    description: 'GitHub release and activity feeds',
+    patterns: ['github.com', 'github.io'],
+  },
+] as const;
+
+export function getDomainSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
+  const suggestions: ChannelSuggestion[] = [];
+  const subs = ctx.subscriptions.filter(
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+  );
+
+  for (const cluster of DOMAIN_CLUSTERS) {
+    const matchingIds: number[] = [];
+    for (const sub of subs) {
+      const url = sub.feedUrl || sub.siteUrl;
+      if (!url) continue;
+      try {
+        const hostname = new URL(url).hostname;
+        if (cluster.patterns.some((p) => hostname.includes(p))) {
+          matchingIds.push(sub.id!);
+        }
+      } catch {
+        continue;
+      }
+    }
+    if (matchingIds.length < MIN_SOURCES_FOR_SUGGESTION) continue;
+    const sourceKeys = matchingIds.map(rssSourceKey);
+    if (isAlreadyCovered(sourceKeys, [], ctx.views)) continue;
+    suggestions.push({
+      id: cluster.id,
+      name: cluster.name,
+      description: `${matchingIds.length} ${cluster.description.toLowerCase()}`,
+      sourceMode: 'include',
+      sourceKeys,
+      typeFilter: [],
+      autoRule: { type: 'domain', patterns: [...cluster.patterns] },
+    });
+  }
+  return suggestions;
+}
+
+export function getFrequencySuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
+  const suggestions: ChannelSuggestion[] = [];
+  const subs = ctx.subscriptions.filter(
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+  );
+  if (subs.length < 4) return [];
+
+  const now = Date.now();
+  const windowMs = 14 * 24 * 60 * 60 * 1000;
+  const cutoff = now - windowMs;
+  const days = 14;
+  const counts = new Map<number, number>();
+
+  for (const article of ctx.articles) {
+    const pubTime = new Date(article.publishedAt).getTime();
+    if (pubTime < cutoff) continue;
+    counts.set(article.subscriptionId, (counts.get(article.subscriptionId) || 0) + 1);
+  }
+
+  const highFreqIds: number[] = [];
+  const lowFreqIds: number[] = [];
+  for (const sub of subs) {
+    const count = counts.get(sub.id!) || 0;
+    const perDay = count / days;
+    if (perDay >= 2) highFreqIds.push(sub.id!);
+    else if (perDay > 0 && perDay < 0.3) lowFreqIds.push(sub.id!);
+  }
+
+  if (highFreqIds.length >= MIN_SOURCES_FOR_SUGGESTION) {
+    const sourceKeys = highFreqIds.map(rssSourceKey);
+    if (!isAlreadyCovered(sourceKeys, [], ctx.views)) {
+      suggestions.push({
+        id: 'frequency:high',
+        name: 'Daily Digest',
+        description: `${highFreqIds.length} high-volume feeds that publish multiple times per day`,
+        sourceMode: 'include',
+        sourceKeys,
+        typeFilter: [],
+        autoRule: { type: 'frequency', threshold: 'high' },
+      });
+    }
+  }
+
+  if (lowFreqIds.length >= MIN_SOURCES_FOR_SUGGESTION) {
+    const sourceKeys = lowFreqIds.map(rssSourceKey);
+    if (!isAlreadyCovered(sourceKeys, [], ctx.views)) {
+      suggestions.push({
+        id: 'frequency:low',
+        name: "Don't Miss",
+        description: `${lowFreqIds.length} feeds that publish infrequently — every post counts`,
+        sourceMode: 'include',
+        sourceKeys,
+        typeFilter: [],
+        autoRule: { type: 'frequency', threshold: 'low' },
+      });
+    }
+  }
+  return suggestions;
+}
+
+export function getLongReadsSuggestion(ctx: SuggestionContext): ChannelSuggestion[] {
+  const MIN_AVG_LENGTH = 5000;
+  const subs = ctx.subscriptions.filter(
+    (s) => (!s.sourceType || s.sourceType === 'rss') && s.id != null
+  );
+
+  const totals = new Map<number, { sum: number; count: number }>();
+  for (const article of ctx.articles) {
+    const text = article.content || article.summary;
+    if (!text) continue;
+    const existing = totals.get(article.subscriptionId) || { sum: 0, count: 0 };
+    existing.sum += text.length;
+    existing.count++;
+    totals.set(article.subscriptionId, existing);
+  }
+
+  const longReadIds: number[] = [];
+  for (const sub of subs) {
+    const stats = totals.get(sub.id!);
+    if (!stats || stats.count < 2) continue;
+    if (stats.sum / stats.count >= MIN_AVG_LENGTH) {
+      longReadIds.push(sub.id!);
+    }
+  }
+
+  if (longReadIds.length < MIN_SOURCES_FOR_SUGGESTION) return [];
+  const sourceKeys = longReadIds.map(rssSourceKey);
+  if (isAlreadyCovered(sourceKeys, [], ctx.views)) return [];
+
+  return [
+    {
+      id: 'content:longreads',
+      name: 'Long Reads',
+      description: `${longReadIds.length} feeds with in-depth, long-form articles`,
+      sourceMode: 'include',
+      sourceKeys,
+      typeFilter: [],
+      autoRule: { type: 'longReads', minLength: MIN_AVG_LENGTH },
+    },
+  ];
+}
+
+export function getRecentSuggestion(
+  ctx: SuggestionContext,
+  withinDays: number = 14
+): ChannelSuggestion[] {
+  const cutoff = Date.now() - withinDays * 24 * 60 * 60 * 1000;
+  const recentKeys: string[] = [];
+
+  for (const sub of ctx.subscriptions) {
+    if (sub.id == null) continue;
+    const created = new Date(sub.createdAt).getTime();
+    if (created < cutoff) continue;
+    if (!sub.sourceType || sub.sourceType === 'rss') {
+      recentKeys.push(rssSourceKey(sub.id));
+    } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
+      recentKeys.push(sharesSourceKey(sub.subjectDid));
+    } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
+      recentKeys.push(documentsSourceKey(sub.subjectDid));
+    }
+  }
+
+  if (recentKeys.length < MIN_SOURCES_FOR_SUGGESTION) return [];
+  if (isAlreadyCovered(recentKeys, [], ctx.views)) return [];
+
+  return [
+    {
+      id: 'recent:new',
+      name: 'New Sources',
+      description: `${recentKeys.length} sources added in the last 2 weeks`,
+      sourceMode: 'include',
+      sourceKeys: recentKeys,
+      typeFilter: [],
+      autoRule: { type: 'recent', withinDays },
+    },
+  ];
+}
+
+/** Priority order for suggestion sorting (lower = shown first). */
+const PRIORITY: Record<string, number> = {
+  'frequency:high': 1,
+  'frequency:low': 2,
+  'content:longreads': 3,
+  'people:all': 4,
+  'type:articles': 5,
+  'type:social': 6,
+  'recent:new': 7,
+};
+
+export function getSuggestionPriority(id: string): number {
+  if (PRIORITY[id] != null) return PRIORITY[id];
+  if (id.startsWith('category:')) return 10;
+  if (id.startsWith('tag:')) return 11;
+  if (id.startsWith('domain:')) return 12;
+  return 20;
+}
+
+/**
+ * Generate all channel suggestions, filtering out dismissed ones,
+ * sorted by priority.
+ */
+export function generateAllSuggestions(
+  ctx: SuggestionContext,
+  dismissedIds: Set<string>
+): ChannelSuggestion[] {
+  const all = [
+    ...getCategorySuggestions(ctx),
+    ...getTypeSuggestions(ctx),
+    ...getTagSuggestions(ctx),
+    ...getPeopleSuggestion(ctx),
+    ...getDomainSuggestions(ctx),
+    ...getFrequencySuggestions(ctx),
+    ...getLongReadsSuggestion(ctx),
+    ...getRecentSuggestion(ctx),
+  ];
+
+  return all
+    .filter((s) => !dismissedIds.has(s.id))
+    .sort((a, b) => getSuggestionPriority(a.id) - getSuggestionPriority(b.id));
+}

--- a/frontend/src/lib/utils/channelLogic.ts
+++ b/frontend/src/lib/utils/channelLogic.ts
@@ -447,9 +447,7 @@ export const DOMAIN_CLUSTERS = [
 
 export function getDomainSuggestions(ctx: SuggestionContext): ChannelSuggestion[] {
   const suggestions: ChannelSuggestion[] = [];
-  const subs = ctx.subscriptions.filter(
-    (s) => (!s.sourceType || s.sourceType === 'rss') && s.rkey
-  );
+  const subs = ctx.subscriptions.filter((s) => (!s.sourceType || s.sourceType === 'rss') && s.rkey);
 
   for (const cluster of DOMAIN_CLUSTERS) {
     const matchingRkeys: string[] = [];

--- a/frontend/src/lib/utils/channelLogic.ts
+++ b/frontend/src/lib/utils/channelLogic.ts
@@ -3,7 +3,17 @@
  * Extracted from stores so they can be unit-tested without Svelte reactivity.
  */
 
-import type { Subscription, Article, FilteredView, SubscriptionSourceType } from '$lib/types';
+import type {
+  Subscription,
+  Article,
+  FilteredView,
+  SubscriptionSourceType,
+  SavedItem,
+  SavedSourceType,
+  ReadingLengthFilter,
+  SortOrder,
+  DateAddedPreset,
+} from '$lib/types';
 import type { ChannelAutoRule } from '$lib/types';
 import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
 
@@ -650,4 +660,232 @@ export function generateAllSuggestions(
   return all
     .filter((s) => !dismissedIds.has(s.id))
     .sort((a, b) => getSuggestionPriority(a.id) - getSuggestionPriority(b.id));
+}
+
+// ─── Saved channel suggestions (pure logic) ─────────────────────────
+
+export interface SavedChannelSuggestion {
+  id: string;
+  name: string;
+  description: string;
+  savedSourceFilter?: SavedSourceType[];
+  savedDateFilter?: DateAddedPreset;
+  savedReadingLength?: ReadingLengthFilter[];
+  savedDomainFilter?: string[];
+  readFilter?: 'all' | 'unread' | 'read';
+  sortOrder?: SortOrder;
+}
+
+export interface SavedSuggestionContext {
+  savedItems: SavedItem[];
+  views: FilteredView[];
+}
+
+const MIN_SAVED_FOR_SUGGESTION = 3;
+
+// Reading length thresholds (matches feedView.svelte.ts WPM=200)
+const QUICK_MAX_WORDS = 1000; // < 5 min
+const LONG_MIN_WORDS = 3000; // >= 15 min
+
+function isSavedSuggestionCovered(
+  suggestion: {
+    savedSourceFilter?: SavedSourceType[];
+    savedReadingLength?: ReadingLengthFilter[];
+    savedDomainFilter?: string[];
+  },
+  views: FilteredView[]
+): boolean {
+  const savedViews = views.filter((v) => v.mode === 'saved');
+  for (const view of savedViews) {
+    // Source filter match
+    if (suggestion.savedSourceFilter && suggestion.savedSourceFilter.length > 0) {
+      const viewSources = view.savedSourceFilter ?? [];
+      if (
+        viewSources.length > 0 &&
+        suggestion.savedSourceFilter.every((s) => viewSources.includes(s))
+      ) {
+        return true;
+      }
+    }
+    // Reading length match
+    if (suggestion.savedReadingLength && suggestion.savedReadingLength.length > 0) {
+      const viewLengths = view.savedReadingLength ?? [];
+      if (
+        viewLengths.length > 0 &&
+        suggestion.savedReadingLength.every((l) => viewLengths.includes(l))
+      ) {
+        return true;
+      }
+    }
+    // Domain match
+    if (suggestion.savedDomainFilter && suggestion.savedDomainFilter.length > 0) {
+      const viewDomains = new Set(view.savedDomainFilter ?? []);
+      if (viewDomains.size > 0) {
+        const overlap = suggestion.savedDomainFilter.filter((d) => viewDomains.has(d));
+        if (overlap.length >= suggestion.savedDomainFilter.length * 0.7) return true;
+      }
+    }
+    // A generic saved channel with no filters covers a generic suggestion
+    if (
+      !suggestion.savedSourceFilter?.length &&
+      !suggestion.savedReadingLength?.length &&
+      !suggestion.savedDomainFilter?.length
+    ) {
+      const noFilters =
+        !view.savedSourceFilter?.length &&
+        !view.savedReadingLength?.length &&
+        !view.savedDomainFilter?.length;
+      if (noFilters) return true;
+    }
+  }
+  return false;
+}
+
+export function getSavedSourceTypeSuggestions(
+  ctx: SavedSuggestionContext
+): SavedChannelSuggestion[] {
+  const suggestions: SavedChannelSuggestion[] = [];
+  const bySource = new Map<SavedSourceType, number>();
+
+  for (const item of ctx.savedItems) {
+    const src = item.source ?? 'url';
+    bySource.set(src, (bySource.get(src) ?? 0) + 1);
+  }
+
+  // Only suggest source filters if the user saves from multiple source types
+  if (bySource.size < 2) return [];
+
+  const sourceConfigs: { source: SavedSourceType; name: string; desc: string }[] = [
+    { source: 'feed', name: 'Saved from Feeds', desc: 'articles saved from your RSS feeds' },
+    { source: 'url', name: 'Saved from Web', desc: 'pages saved by URL' },
+    { source: 'share', name: 'Saved Shares', desc: 'shared articles you bookmarked' },
+    { source: 'document', name: 'Saved Documents', desc: 'published documents you bookmarked' },
+  ];
+
+  for (const cfg of sourceConfigs) {
+    const count = bySource.get(cfg.source) ?? 0;
+    if (count < MIN_SAVED_FOR_SUGGESTION) continue;
+    const filter = { savedSourceFilter: [cfg.source] };
+    if (isSavedSuggestionCovered(filter, ctx.views)) continue;
+    suggestions.push({
+      id: `saved:source-${cfg.source}`,
+      name: cfg.name,
+      description: `${count} ${cfg.desc}`,
+      savedSourceFilter: [cfg.source],
+      readFilter: 'all',
+      sortOrder: 'newest',
+    });
+  }
+  return suggestions;
+}
+
+export function getSavedReadingLengthSuggestions(
+  ctx: SavedSuggestionContext
+): SavedChannelSuggestion[] {
+  const suggestions: SavedChannelSuggestion[] = [];
+  let longCount = 0;
+  let quickCount = 0;
+
+  for (const item of ctx.savedItems) {
+    if (item.wordCount == null) continue;
+    if (item.wordCount >= LONG_MIN_WORDS) longCount++;
+    if (item.wordCount < QUICK_MAX_WORDS && item.wordCount > 0) quickCount++;
+  }
+
+  if (longCount >= MIN_SAVED_FOR_SUGGESTION) {
+    const filter = { savedReadingLength: ['long' as ReadingLengthFilter] };
+    if (!isSavedSuggestionCovered(filter, ctx.views)) {
+      suggestions.push({
+        id: 'saved:long-reads',
+        name: 'Saved Long Reads',
+        description: `${longCount} saved items with 15+ minute read time`,
+        savedReadingLength: ['long'],
+        readFilter: 'all',
+        sortOrder: 'longest',
+      });
+    }
+  }
+
+  if (quickCount >= MIN_SAVED_FOR_SUGGESTION) {
+    const filter = { savedReadingLength: ['quick' as ReadingLengthFilter] };
+    if (!isSavedSuggestionCovered(filter, ctx.views)) {
+      suggestions.push({
+        id: 'saved:quick-reads',
+        name: 'Saved Quick Reads',
+        description: `${quickCount} saved items you can finish in under 5 minutes`,
+        savedReadingLength: ['quick'],
+        readFilter: 'all',
+        sortOrder: 'shortest',
+      });
+    }
+  }
+
+  return suggestions;
+}
+
+export function getSavedDomainSuggestions(ctx: SavedSuggestionContext): SavedChannelSuggestion[] {
+  const domainCounts = new Map<string, number>();
+
+  for (const item of ctx.savedItems) {
+    if (!item.domain) continue;
+    domainCounts.set(item.domain, (domainCounts.get(item.domain) ?? 0) + 1);
+  }
+
+  const suggestions: SavedChannelSuggestion[] = [];
+  for (const [domain, count] of domainCounts) {
+    if (count < MIN_SAVED_FOR_SUGGESTION) continue;
+    const filter = { savedDomainFilter: [domain] };
+    if (isSavedSuggestionCovered(filter, ctx.views)) continue;
+    // Clean up domain for display name
+    const displayName = domain.replace(/^www\./, '');
+    suggestions.push({
+      id: `saved:domain-${domain}`,
+      name: `Saved from ${displayName}`,
+      description: `${count} saved items from ${displayName}`,
+      savedDomainFilter: [domain],
+      readFilter: 'all',
+      sortOrder: 'newest',
+    });
+  }
+
+  // Sort by count descending, take top 3
+  return suggestions
+    .sort((a, b) => {
+      const countA = domainCounts.get(a.savedDomainFilter![0]) ?? 0;
+      const countB = domainCounts.get(b.savedDomainFilter![0]) ?? 0;
+      return countB - countA;
+    })
+    .slice(0, 3);
+}
+
+const SAVED_PRIORITY: Record<string, number> = {
+  'saved:source-feed': 1,
+  'saved:source-url': 2,
+  'saved:long-reads': 3,
+  'saved:quick-reads': 4,
+  'saved:source-share': 5,
+  'saved:source-document': 6,
+};
+
+export function getSavedSuggestionPriority(id: string): number {
+  if (SAVED_PRIORITY[id] != null) return SAVED_PRIORITY[id];
+  if (id.startsWith('saved:domain-')) return 10;
+  return 20;
+}
+
+export function generateAllSavedSuggestions(
+  ctx: SavedSuggestionContext,
+  dismissedIds: Set<string>
+): SavedChannelSuggestion[] {
+  if (ctx.savedItems.length < MIN_SAVED_FOR_SUGGESTION) return [];
+
+  const all = [
+    ...getSavedSourceTypeSuggestions(ctx),
+    ...getSavedReadingLengthSuggestions(ctx),
+    ...getSavedDomainSuggestions(ctx),
+  ];
+
+  return all
+    .filter((s) => !dismissedIds.has(s.id))
+    .sort((a, b) => getSavedSuggestionPriority(a.id) - getSavedSuggestionPriority(b.id));
 }

--- a/frontend/src/lib/utils/channelSync.test.ts
+++ b/frontend/src/lib/utils/channelSync.test.ts
@@ -52,7 +52,8 @@ describe('fromRemote', () => {
     const remote = makeRemote({
       uuid: 'a',
       name: 'News',
-      config: '{"readFilter":"unread","sortOrder":"oldest","sourceMode":"include","sourceKeys":["rss~abc"]}',
+      config:
+        '{"readFilter":"unread","sortOrder":"oldest","sourceMode":"include","sourceKeys":["rss~abc"]}',
     });
     const result = fromRemote(remote);
     expect(result.uuid).toBe('a');

--- a/frontend/src/lib/utils/channelSync.test.ts
+++ b/frontend/src/lib/utils/channelSync.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { toConfig, fromRemote, computeSyncOperations, type RemoteChannel } from './channelSync';
+import type { FilteredView } from '$lib/types';
+
+function makeView(overrides: Partial<FilteredView> & { uuid: string }): FilteredView {
+  return {
+    id: 1,
+    name: 'Test',
+    readFilter: 'all',
+    sortOrder: 'newest',
+    createdAt: 1000,
+    updatedAt: 1000,
+    position: 0,
+    ...overrides,
+  };
+}
+
+function makeRemote(overrides: Partial<RemoteChannel> & { uuid: string }): RemoteChannel {
+  return {
+    name: 'Test',
+    config: '{"readFilter":"all","sortOrder":"newest"}',
+    position: 0,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe('toConfig', () => {
+  it('strips id, uuid, name, position, timestamps', () => {
+    const view = makeView({
+      uuid: 'a',
+      sourceMode: 'all',
+      typeFilter: ['rss'],
+    });
+    const config = toConfig(view);
+    expect(config).not.toHaveProperty('id');
+    expect(config).not.toHaveProperty('uuid');
+    expect(config).not.toHaveProperty('name');
+    expect(config).not.toHaveProperty('position');
+    expect(config).not.toHaveProperty('createdAt');
+    expect(config).not.toHaveProperty('updatedAt');
+    expect(config.readFilter).toBe('all');
+    expect(config.sortOrder).toBe('newest');
+    expect(config.sourceMode).toBe('all');
+    expect(config.typeFilter).toEqual(['rss']);
+  });
+});
+
+describe('fromRemote', () => {
+  it('parses valid config JSON', () => {
+    const remote = makeRemote({
+      uuid: 'a',
+      name: 'News',
+      config: '{"readFilter":"unread","sortOrder":"oldest","sourceMode":"include","sourceKeys":["rss~abc"]}',
+    });
+    const result = fromRemote(remote);
+    expect(result.uuid).toBe('a');
+    expect(result.name).toBe('News');
+    expect(result.readFilter).toBe('unread');
+    expect(result.sortOrder).toBe('oldest');
+    expect(result.sourceMode).toBe('include');
+    expect(result.sourceKeys).toEqual(['rss~abc']);
+  });
+
+  it('falls back to defaults on invalid JSON', () => {
+    const remote = makeRemote({ uuid: 'b', config: 'not-json' });
+    const result = fromRemote(remote);
+    expect(result.readFilter).toBe('all');
+    expect(result.sortOrder).toBe('newest');
+  });
+
+  it('falls back to defaults on empty config', () => {
+    const remote = makeRemote({ uuid: 'c', config: '{}' });
+    const result = fromRemote(remote);
+    expect(result.readFilter).toBe('all');
+    expect(result.sortOrder).toBe('newest');
+  });
+});
+
+describe('computeSyncOperations', () => {
+  it('adds remote-only channels locally', () => {
+    const local: FilteredView[] = [];
+    const remote = [makeRemote({ uuid: 'r1', name: 'Remote Channel' })];
+    const ops = computeSyncOperations(local, remote, [], new Set());
+    expect(ops.addLocally).toHaveLength(1);
+    expect(ops.addLocally[0].uuid).toBe('r1');
+    expect(ops.addLocally[0].name).toBe('Remote Channel');
+    expect(ops.pushToRemote).toHaveLength(0);
+  });
+
+  it('pushes local-only channels to remote', () => {
+    const local = [makeView({ uuid: 'l1', name: 'Local Channel' })];
+    const remote: RemoteChannel[] = [];
+    const ops = computeSyncOperations(local, remote, [], new Set());
+    expect(ops.pushToRemote).toHaveLength(1);
+    expect(ops.pushToRemote[0].uuid).toBe('l1');
+    expect(ops.addLocally).toHaveLength(0);
+  });
+
+  it('updates local when remote is newer', () => {
+    const local = [makeView({ uuid: 'c1', updatedAt: 1000 })];
+    const remote = [makeRemote({ uuid: 'c1', updatedAt: 2000, name: 'Updated' })];
+    const ops = computeSyncOperations(local, remote, [], new Set());
+    expect(ops.updateLocally).toHaveLength(1);
+    expect(ops.updateLocally[0].uuid).toBe('c1');
+    expect(ops.updateLocally[0].data.name).toBe('Updated');
+  });
+
+  it('does not update local when local is newer', () => {
+    const local = [makeView({ uuid: 'c1', updatedAt: 3000 })];
+    const remote = [makeRemote({ uuid: 'c1', updatedAt: 2000 })];
+    const ops = computeSyncOperations(local, remote, [], new Set());
+    expect(ops.updateLocally).toHaveLength(0);
+    expect(ops.pushToRemote).toHaveLength(0); // both sides have it
+  });
+
+  it('does nothing when timestamps match', () => {
+    const local = [makeView({ uuid: 'c1', updatedAt: 1000 })];
+    const remote = [makeRemote({ uuid: 'c1', updatedAt: 1000 })];
+    const ops = computeSyncOperations(local, remote, [], new Set());
+    expect(ops.updateLocally).toHaveLength(0);
+    expect(ops.addLocally).toHaveLength(0);
+    expect(ops.pushToRemote).toHaveLength(0);
+    expect(ops.deleteLocally).toHaveLength(0);
+  });
+
+  it('deletes local channels that were deleted on remote', () => {
+    const local = [makeView({ uuid: 'c1' }), makeView({ uuid: 'c2', id: 2 })];
+    const remote: RemoteChannel[] = [];
+    const ops = computeSyncOperations(local, remote, ['c1'], new Set());
+    expect(ops.deleteLocally).toEqual(['c1']);
+    expect(ops.pushToRemote).toHaveLength(1);
+    expect(ops.pushToRemote[0].uuid).toBe('c2');
+  });
+
+  it('does not re-add remotely-deleted channels', () => {
+    const local: FilteredView[] = [];
+    const remote = [makeRemote({ uuid: 'c1' })];
+    const ops = computeSyncOperations(local, remote, ['c1'], new Set());
+    expect(ops.addLocally).toHaveLength(0);
+  });
+
+  it('clears pending delete when remote confirms deletion', () => {
+    const local = [makeView({ uuid: 'c1' })];
+    const pendingDeletes = new Set(['c1']);
+    const ops = computeSyncOperations(local, [], ['c1'], pendingDeletes);
+    expect(ops.pendingDeletesAfter.has('c1')).toBe(false);
+  });
+
+  it('retries pending deletes not yet confirmed by remote', () => {
+    const local: FilteredView[] = [];
+    const pendingDeletes = new Set(['c1']);
+    const ops = computeSyncOperations(local, [], [], pendingDeletes);
+    expect(ops.retryDeletes).toContain('c1');
+    expect(ops.pendingDeletesAfter.has('c1')).toBe(true);
+  });
+
+  it('does not push channels that are pending-deleted locally', () => {
+    const local = [makeView({ uuid: 'c1' })];
+    const pendingDeletes = new Set(['c1']);
+    const ops = computeSyncOperations(local, [], [], pendingDeletes);
+    expect(ops.pushToRemote).toHaveLength(0);
+  });
+
+  it('does not add remote channels that are pending-deleted locally', () => {
+    const local: FilteredView[] = [];
+    const remote = [makeRemote({ uuid: 'c1' })];
+    const pendingDeletes = new Set(['c1']);
+    const ops = computeSyncOperations(local, remote, [], pendingDeletes);
+    expect(ops.addLocally).toHaveLength(0);
+  });
+
+  it('handles complex multi-channel scenario', () => {
+    const local = [
+      makeView({ uuid: 'shared', id: 1, updatedAt: 1000 }),
+      makeView({ uuid: 'local-only', id: 2 }),
+      makeView({ uuid: 'to-delete', id: 3 }),
+    ];
+    const remote = [
+      makeRemote({ uuid: 'shared', updatedAt: 2000, name: 'Shared Updated' }),
+      makeRemote({ uuid: 'remote-only', name: 'From Other Device' }),
+    ];
+    const ops = computeSyncOperations(local, remote, ['to-delete'], new Set());
+
+    expect(ops.updateLocally).toHaveLength(1);
+    expect(ops.updateLocally[0].uuid).toBe('shared');
+    expect(ops.addLocally).toHaveLength(1);
+    expect(ops.addLocally[0].uuid).toBe('remote-only');
+    expect(ops.pushToRemote).toHaveLength(1);
+    expect(ops.pushToRemote[0].uuid).toBe('local-only');
+    expect(ops.deleteLocally).toEqual(['to-delete']);
+  });
+});

--- a/frontend/src/lib/utils/channelSync.ts
+++ b/frontend/src/lib/utils/channelSync.ts
@@ -1,0 +1,125 @@
+import type { FilteredView } from '$lib/types';
+
+export interface RemoteChannel {
+  uuid: string;
+  name: string;
+  config: string;
+  position: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SyncOperations {
+  /** Remote channels to add locally (not present locally, not deleted). */
+  addLocally: Array<Omit<FilteredView, 'id'>>;
+  /** Local channels to update from remote (remote is newer). */
+  updateLocally: Array<{ uuid: string; data: Omit<FilteredView, 'id'> }>;
+  /** Local channel UUIDs to delete (deleted on remote). */
+  deleteLocally: string[];
+  /** Local channels to push to remote (not present on remote). */
+  pushToRemote: FilteredView[];
+  /** UUIDs to send DELETE to backend (locally-pending deletes that need retrying). */
+  retryDeletes: string[];
+  /** Updated pending-delete set after reconciliation. */
+  pendingDeletesAfter: Set<string>;
+}
+
+/** Extract the JSON config blob from a FilteredView (everything except id, uuid, name, position, timestamps). */
+export function toConfig(view: FilteredView): Record<string, unknown> {
+  const {
+    id: _id,
+    uuid: _uuid,
+    name: _name,
+    position: _pos,
+    createdAt: _ca,
+    updatedAt: _ua,
+    ...config
+  } = view;
+  return config;
+}
+
+/** Reconstruct a partial FilteredView from a remote channel row. */
+export function fromRemote(remote: RemoteChannel): Omit<FilteredView, 'id'> {
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(remote.config);
+  } catch {
+    // invalid config, use defaults
+  }
+  return {
+    uuid: remote.uuid,
+    name: remote.name,
+    position: remote.position,
+    createdAt: remote.createdAt,
+    updatedAt: remote.updatedAt,
+    readFilter: (config.readFilter as FilteredView['readFilter']) ?? 'all',
+    sortOrder: (config.sortOrder as FilteredView['sortOrder']) ?? 'newest',
+    ...config,
+  } as Omit<FilteredView, 'id'>;
+}
+
+/**
+ * Compute the set of sync operations needed to reconcile local and remote state.
+ * Pure function — no side effects, no I/O.
+ */
+export function computeSyncOperations(
+  localViews: FilteredView[],
+  remoteChannels: RemoteChannel[],
+  deletedUuids: string[],
+  pendingDeletes: Set<string>
+): SyncOperations {
+  const localByUuid = new Map(localViews.filter((v) => v.uuid).map((v) => [v.uuid, v]));
+  const remoteByUuid = new Map(remoteChannels.map((r) => [r.uuid, r]));
+  const remoteDeletedSet = new Set(deletedUuids);
+
+  const pendingDeletesAfter = new Set(pendingDeletes);
+
+  const deleteLocally: string[] = [];
+  const addLocally: Array<Omit<FilteredView, 'id'>> = [];
+  const updateLocally: Array<{ uuid: string; data: Omit<FilteredView, 'id'> }> = [];
+  const retryDeletes: string[] = [];
+
+  // Remove locally any channels that were deleted on another device
+  for (const uuid of remoteDeletedSet) {
+    if (localByUuid.has(uuid)) {
+      deleteLocally.push(uuid);
+    }
+    // If we also had a pending delete for this, the backend already knows — clear it
+    pendingDeletesAfter.delete(uuid);
+  }
+
+  // Retry sending any pending deletes to the backend
+  for (const uuid of pendingDeletes) {
+    if (!remoteDeletedSet.has(uuid)) {
+      retryDeletes.push(uuid);
+    }
+  }
+
+  // All UUIDs we consider "deleted" — both remote and locally-pending
+  const allDeletedUuids = new Set([...remoteDeletedSet, ...pendingDeletesAfter]);
+
+  // Merge remote → local
+  for (const [uuid, remote] of remoteByUuid) {
+    if (allDeletedUuids.has(uuid)) continue;
+    const local = localByUuid.get(uuid);
+    if (!local) {
+      addLocally.push(fromRemote(remote));
+    } else if (remote.updatedAt > local.updatedAt) {
+      updateLocally.push({ uuid, data: fromRemote(remote) });
+    }
+  }
+
+  // Local channels not in remote (and not deleted) → push to backend
+  const pushToRemote = localViews.filter(
+    (v) => v.uuid && !remoteByUuid.has(v.uuid) && !allDeletedUuids.has(v.uuid)
+  );
+
+  return {
+    addLocally,
+    updateLocally,
+    deleteLocally,
+    pushToRemote,
+    retryDeletes,
+    pendingDeletesAfter,
+  };
+}

--- a/frontend/src/lib/utils/sourceDisplay.ts
+++ b/frontend/src/lib/utils/sourceDisplay.ts
@@ -1,0 +1,26 @@
+import type { SubscriptionSourceType } from '$lib/types';
+
+export interface SourceDisplayInfo {
+  label: string;
+  iconName: string;
+  pillClass: string;
+}
+
+export function getSourceDisplay(
+  sourceType: SubscriptionSourceType | undefined,
+  feedUrl?: string
+): SourceDisplayInfo {
+  switch (sourceType) {
+    case 'atproto.shares':
+      return { label: 'Shares', iconName: 'share', pillClass: 'pill-shares' };
+    case 'atproto.documents':
+      if (feedUrl && feedUrl !== '__freestanding__') {
+        return { label: 'Publication', iconName: 'newspaper', pillClass: 'pill-publication' };
+      }
+      return { label: 'Documents', iconName: 'file-text', pillClass: 'pill-documents' };
+    case 'atproto.collection':
+      return { label: 'Collection', iconName: 'folder', pillClass: 'pill-collection' };
+    default:
+      return { label: 'RSS', iconName: 'rss', pillClass: 'pill-rss' };
+  }
+}

--- a/frontend/src/lib/utils/sourceKeys.test.ts
+++ b/frontend/src/lib/utils/sourceKeys.test.ts
@@ -7,7 +7,7 @@ import {
   isRssSource,
   isSharesSource,
   isDocumentsSource,
-  getRssSubscriptionId,
+  getRssSubscriptionRkey,
   getSourceDid,
   subscriptionSourceKey,
   migrateLegacyView,
@@ -18,8 +18,8 @@ import type { Subscription } from '$lib/types';
 
 describe('source key construction', () => {
   it('creates RSS source keys', () => {
-    expect(rssSourceKey(42)).toBe('rss~42');
-    expect(rssSourceKey(0)).toBe('rss~0');
+    expect(rssSourceKey('3l7e5x2b7ik2c')).toBe('rss~3l7e5x2b7ik2c');
+    expect(rssSourceKey('abc')).toBe('rss~abc');
   });
 
   it('creates shares source keys', () => {
@@ -35,7 +35,7 @@ describe('source key construction', () => {
 
 describe('parseSourceKey', () => {
   it('parses RSS keys', () => {
-    expect(parseSourceKey('rss~42')).toEqual({ kind: 'rss', id: '42' });
+    expect(parseSourceKey('rss~3l7e5x2b7ik2c')).toEqual({ kind: 'rss', id: '3l7e5x2b7ik2c' });
   });
 
   it('parses shares keys', () => {
@@ -61,13 +61,13 @@ describe('parseSourceKey', () => {
 
 describe('type guards', () => {
   it('isRssSource', () => {
-    expect(isRssSource('rss~42')).toBe(true);
+    expect(isRssSource('rss~3l7e5x2b7ik2c')).toBe(true);
     expect(isRssSource('did:plc:abc~shares')).toBe(false);
   });
 
   it('isSharesSource', () => {
     expect(isSharesSource('did:plc:abc~shares')).toBe(true);
-    expect(isSharesSource('rss~42')).toBe(false);
+    expect(isSharesSource('rss~abc')).toBe(false);
   });
 
   it('isDocumentsSource', () => {
@@ -79,8 +79,8 @@ describe('type guards', () => {
 // ─── Extractors ────────────────────────────────────────────────────────
 
 describe('extractors', () => {
-  it('getRssSubscriptionId', () => {
-    expect(getRssSubscriptionId('rss~42')).toBe(42);
+  it('getRssSubscriptionRkey', () => {
+    expect(getRssSubscriptionRkey('rss~3l7e5x2b7ik2c')).toBe('3l7e5x2b7ik2c');
   });
 
   it('getSourceDid', () => {
@@ -100,8 +100,8 @@ describe('subscriptionSourceKey', () => {
   };
 
   it('returns RSS key for RSS subscriptions', () => {
-    expect(subscriptionSourceKey({ ...baseSub, id: 1 })).toBe('rss~1');
-    expect(subscriptionSourceKey({ ...baseSub, id: 1, sourceType: 'rss' })).toBe('rss~1');
+    expect(subscriptionSourceKey({ ...baseSub, id: 1 })).toBe('rss~abc');
+    expect(subscriptionSourceKey({ ...baseSub, id: 1, sourceType: 'rss' })).toBe('rss~abc');
   });
 
   it('returns shares key for atproto.shares', () => {
@@ -126,8 +126,8 @@ describe('subscriptionSourceKey', () => {
     ).toBe('did:plc:x~documents');
   });
 
-  it('returns null when id is missing', () => {
-    expect(subscriptionSourceKey(baseSub)).toBeNull();
+  it('returns null when rkey is missing', () => {
+    expect(subscriptionSourceKey({ ...baseSub, rkey: '' })).toBeNull();
   });
 
   it('returns null for atproto types without subjectDid', () => {
@@ -138,11 +138,16 @@ describe('subscriptionSourceKey', () => {
 // ─── migrateLegacyView ────────────────────────────────────────────────
 
 describe('migrateLegacyView', () => {
-  const allSubIds = [1, 2, 3];
+  const allSubRkeys = ['rk1', 'rk2', 'rk3'];
   const allDids = ['did:plc:a', 'did:plc:b'];
+  const idToRkey = new Map([
+    [1, 'rk1'],
+    [2, 'rk2'],
+    [3, 'rk3'],
+  ]);
 
   it('all feeds + all accounts + all types → sourceMode all', () => {
-    const result = migrateLegacyView({}, allSubIds, allDids);
+    const result = migrateLegacyView({}, allSubRkeys, allDids);
     expect(result.sourceMode).toBe('all');
     expect(result.sourceKeys).toEqual([]);
   });
@@ -150,7 +155,7 @@ describe('migrateLegacyView', () => {
   it('no feeds + no accounts → include with empty keys', () => {
     const result = migrateLegacyView(
       { showArticles: false, showShares: false, showDocuments: false },
-      allSubIds,
+      allSubRkeys,
       allDids
     );
     expect(result.sourceMode).toBe('include');
@@ -160,33 +165,35 @@ describe('migrateLegacyView', () => {
   it('include specific feeds', () => {
     const result = migrateLegacyView(
       { feedMode: 'include', feedIds: [1, 3], showShares: false, showDocuments: false },
-      allSubIds,
-      allDids
+      allSubRkeys,
+      allDids,
+      idToRkey
     );
     expect(result.sourceMode).toBe('include');
-    expect(result.sourceKeys).toEqual(['rss~1', 'rss~3']);
+    expect(result.sourceKeys).toEqual(['rss~rk1', 'rss~rk3']);
   });
 
   it('exclude specific feeds', () => {
     const result = migrateLegacyView(
       { feedMode: 'exclude', feedIds: [2], showShares: false, showDocuments: false },
-      allSubIds,
-      allDids
+      allSubRkeys,
+      allDids,
+      idToRkey
     );
     expect(result.sourceMode).toBe('include');
-    expect(result.sourceKeys).toEqual(['rss~1', 'rss~3']);
+    expect(result.sourceKeys).toEqual(['rss~rk1', 'rss~rk3']);
   });
 
   it('all feeds + include specific accounts with shares only', () => {
     const result = migrateLegacyView(
       { accountMode: 'include', accountDids: ['did:plc:a'], showDocuments: false },
-      allSubIds,
+      allSubRkeys,
       allDids
     );
     expect(result.sourceMode).toBe('include');
-    expect(result.sourceKeys).toContain('rss~1');
-    expect(result.sourceKeys).toContain('rss~2');
-    expect(result.sourceKeys).toContain('rss~3');
+    expect(result.sourceKeys).toContain('rss~rk1');
+    expect(result.sourceKeys).toContain('rss~rk2');
+    expect(result.sourceKeys).toContain('rss~rk3');
     expect(result.sourceKeys).toContain('did:plc:a~shares');
     expect(result.sourceKeys).not.toContain('did:plc:a~documents');
     expect(result.sourceKeys).not.toContain('did:plc:b~shares');

--- a/frontend/src/lib/utils/sourceKeys.test.ts
+++ b/frontend/src/lib/utils/sourceKeys.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rssSourceKey,
+  sharesSourceKey,
+  documentsSourceKey,
+  parseSourceKey,
+  isRssSource,
+  isSharesSource,
+  isDocumentsSource,
+  getRssSubscriptionId,
+  getSourceDid,
+  subscriptionSourceKey,
+  migrateLegacyView,
+} from './sourceKeys';
+import type { Subscription } from '$lib/types';
+
+// ─── Construction ──────────────────────────────────────────────────────
+
+describe('source key construction', () => {
+  it('creates RSS source keys', () => {
+    expect(rssSourceKey(42)).toBe('rss~42');
+    expect(rssSourceKey(0)).toBe('rss~0');
+  });
+
+  it('creates shares source keys', () => {
+    expect(sharesSourceKey('did:plc:abc123')).toBe('did:plc:abc123~shares');
+  });
+
+  it('creates documents source keys', () => {
+    expect(documentsSourceKey('did:plc:abc123')).toBe('did:plc:abc123~documents');
+  });
+});
+
+// ─── Parsing ───────────────────────────────────────────────────────────
+
+describe('parseSourceKey', () => {
+  it('parses RSS keys', () => {
+    expect(parseSourceKey('rss~42')).toEqual({ kind: 'rss', id: '42' });
+  });
+
+  it('parses shares keys', () => {
+    expect(parseSourceKey('did:plc:abc123~shares')).toEqual({
+      kind: 'shares',
+      id: 'did:plc:abc123',
+    });
+  });
+
+  it('parses documents keys', () => {
+    expect(parseSourceKey('did:plc:abc123~documents')).toEqual({
+      kind: 'documents',
+      id: 'did:plc:abc123',
+    });
+  });
+
+  it('handles keys with no separator', () => {
+    expect(parseSourceKey('nosep')).toEqual({ kind: 'nosep', id: '' });
+  });
+});
+
+// ─── Type guards ───────────────────────────────────────────────────────
+
+describe('type guards', () => {
+  it('isRssSource', () => {
+    expect(isRssSource('rss~42')).toBe(true);
+    expect(isRssSource('did:plc:abc~shares')).toBe(false);
+  });
+
+  it('isSharesSource', () => {
+    expect(isSharesSource('did:plc:abc~shares')).toBe(true);
+    expect(isSharesSource('rss~42')).toBe(false);
+  });
+
+  it('isDocumentsSource', () => {
+    expect(isDocumentsSource('did:plc:abc~documents')).toBe(true);
+    expect(isDocumentsSource('did:plc:abc~shares')).toBe(false);
+  });
+});
+
+// ─── Extractors ────────────────────────────────────────────────────────
+
+describe('extractors', () => {
+  it('getRssSubscriptionId', () => {
+    expect(getRssSubscriptionId('rss~42')).toBe(42);
+  });
+
+  it('getSourceDid', () => {
+    expect(getSourceDid('did:plc:abc123~shares')).toBe('did:plc:abc123');
+  });
+});
+
+// ─── subscriptionSourceKey ─────────────────────────────────────────────
+
+describe('subscriptionSourceKey', () => {
+  const baseSub: Subscription = {
+    rkey: 'abc',
+    title: 'Test',
+    tags: [],
+    createdAt: '2024-01-01',
+    localUpdatedAt: 0,
+  };
+
+  it('returns RSS key for RSS subscriptions', () => {
+    expect(subscriptionSourceKey({ ...baseSub, id: 1 })).toBe('rss~1');
+    expect(subscriptionSourceKey({ ...baseSub, id: 1, sourceType: 'rss' })).toBe('rss~1');
+  });
+
+  it('returns shares key for atproto.shares', () => {
+    expect(
+      subscriptionSourceKey({
+        ...baseSub,
+        id: 1,
+        sourceType: 'atproto.shares',
+        subjectDid: 'did:plc:x',
+      })
+    ).toBe('did:plc:x~shares');
+  });
+
+  it('returns documents key for atproto.documents', () => {
+    expect(
+      subscriptionSourceKey({
+        ...baseSub,
+        id: 1,
+        sourceType: 'atproto.documents',
+        subjectDid: 'did:plc:x',
+      })
+    ).toBe('did:plc:x~documents');
+  });
+
+  it('returns null when id is missing', () => {
+    expect(subscriptionSourceKey(baseSub)).toBeNull();
+  });
+
+  it('returns null for atproto types without subjectDid', () => {
+    expect(subscriptionSourceKey({ ...baseSub, id: 1, sourceType: 'atproto.shares' })).toBeNull();
+  });
+});
+
+// ─── migrateLegacyView ────────────────────────────────────────────────
+
+describe('migrateLegacyView', () => {
+  const allSubIds = [1, 2, 3];
+  const allDids = ['did:plc:a', 'did:plc:b'];
+
+  it('all feeds + all accounts + all types → sourceMode all', () => {
+    const result = migrateLegacyView({}, allSubIds, allDids);
+    expect(result.sourceMode).toBe('all');
+    expect(result.sourceKeys).toEqual([]);
+  });
+
+  it('no feeds + no accounts → include with empty keys', () => {
+    const result = migrateLegacyView(
+      { showArticles: false, showShares: false, showDocuments: false },
+      allSubIds,
+      allDids
+    );
+    expect(result.sourceMode).toBe('include');
+    expect(result.sourceKeys).toEqual([]);
+  });
+
+  it('include specific feeds', () => {
+    const result = migrateLegacyView(
+      { feedMode: 'include', feedIds: [1, 3], showShares: false, showDocuments: false },
+      allSubIds,
+      allDids
+    );
+    expect(result.sourceMode).toBe('include');
+    expect(result.sourceKeys).toEqual(['rss~1', 'rss~3']);
+  });
+
+  it('exclude specific feeds', () => {
+    const result = migrateLegacyView(
+      { feedMode: 'exclude', feedIds: [2], showShares: false, showDocuments: false },
+      allSubIds,
+      allDids
+    );
+    expect(result.sourceMode).toBe('include');
+    expect(result.sourceKeys).toEqual(['rss~1', 'rss~3']);
+  });
+
+  it('all feeds + include specific accounts with shares only', () => {
+    const result = migrateLegacyView(
+      { accountMode: 'include', accountDids: ['did:plc:a'], showDocuments: false },
+      allSubIds,
+      allDids
+    );
+    expect(result.sourceMode).toBe('include');
+    expect(result.sourceKeys).toContain('rss~1');
+    expect(result.sourceKeys).toContain('rss~2');
+    expect(result.sourceKeys).toContain('rss~3');
+    expect(result.sourceKeys).toContain('did:plc:a~shares');
+    expect(result.sourceKeys).not.toContain('did:plc:a~documents');
+    expect(result.sourceKeys).not.toContain('did:plc:b~shares');
+  });
+});

--- a/frontend/src/lib/utils/sourceKeys.ts
+++ b/frontend/src/lib/utils/sourceKeys.ts
@@ -1,12 +1,12 @@
 // Source key utilities for unified source filter model
-// Format: "rss~{subscriptionId}", "{did}~shares", "{did}~documents"
+// Format: "rss~{rkey}", "{did}~shares", "{did}~documents"
 
 const SEP = '~';
 
 // --- Construction ---
 
-export function rssSourceKey(subscriptionId: number): string {
-  return `rss${SEP}${subscriptionId}`;
+export function rssSourceKey(rkey: string): string {
+  return `rss${SEP}${rkey}`;
 }
 
 export function sharesSourceKey(did: string): string {
@@ -54,9 +54,8 @@ export function isDocumentsSource(key: string): boolean {
 
 // --- Extractors ---
 
-export function getRssSubscriptionId(key: string): number {
-  const parsed = parseSourceKey(key);
-  return parseInt(parsed.id, 10);
+export function getRssSubscriptionRkey(key: string): string {
+  return parseSourceKey(key).id;
 }
 
 export function getSourceDid(key: string): string {
@@ -68,9 +67,9 @@ export function getSourceDid(key: string): string {
 import type { Subscription } from '$lib/types';
 
 export function subscriptionSourceKey(sub: Subscription): string | null {
-  if (sub.id == null) return null;
+  if (!sub.rkey) return null;
   if (!sub.sourceType || sub.sourceType === 'rss') {
-    return rssSourceKey(sub.id);
+    return rssSourceKey(sub.rkey);
   }
   if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
     return sharesSourceKey(sub.subjectDid);
@@ -110,13 +109,15 @@ export interface MigratedSourceFilter {
  * Always produces 'all' or 'include' mode (no exclude).
  *
  * @param view - Legacy view fields
- * @param allSubIds - All current subscription IDs
+ * @param allSubRkeys - All current subscription rkeys
  * @param allDids - All current followed DIDs
+ * @param idToRkey - Map from Dexie ID to rkey (for feedIds migration)
  */
 export function migrateLegacyView(
   view: LegacyViewFields,
-  allSubIds: number[],
-  allDids: string[]
+  allSubRkeys: string[],
+  allDids: string[],
+  idToRkey?: Map<number, string>
 ): MigratedSourceFilter {
   const {
     showArticles = true,
@@ -145,15 +146,21 @@ export function migrateLegacyView(
   // Otherwise, enumerate the included sources explicitly
   const keys: string[] = [];
 
+  // Helper: resolve legacy Dexie IDs to rkeys
+  const resolveIds = (ids: number[]): string[] => {
+    if (!idToRkey) return [];
+    return ids.map((id) => idToRkey.get(id)).filter((rkey): rkey is string => rkey != null);
+  };
+
   // Collect RSS sources
   if (effFeedMode === 'all') {
-    for (const id of allSubIds) keys.push(rssSourceKey(id));
+    for (const rkey of allSubRkeys) keys.push(rssSourceKey(rkey));
   } else if (effFeedMode === 'include') {
-    for (const id of feedIds) keys.push(rssSourceKey(id));
+    for (const rkey of resolveIds(feedIds)) keys.push(rssSourceKey(rkey));
   } else if (effFeedMode === 'exclude') {
-    const excludedSet = new Set(feedIds);
-    for (const id of allSubIds) {
-      if (!excludedSet.has(id)) keys.push(rssSourceKey(id));
+    const excludedRkeys = new Set(resolveIds(feedIds));
+    for (const rkey of allSubRkeys) {
+      if (!excludedRkeys.has(rkey)) keys.push(rssSourceKey(rkey));
     }
   }
   // effFeedMode === 'none' → no RSS keys

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import { auth } from '$lib/stores/auth.svelte';
+  import { appManager } from '$lib/stores/app.svelte';
   import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
@@ -102,6 +103,16 @@
         }
       });
     });
+  });
+
+  // Initialize app data (cache-first hydrate + background refresh).
+  // Lives in the layout so that reloading on any authenticated route
+  // (e.g. /sources, /activity) still triggers initialization. The
+  // appManager has an internal phase guard so re-entry is a no-op.
+  $effect(() => {
+    if (browser && auth.isAuthenticated) {
+      appManager.initialize();
+    }
   });
 
   // Register global keyboard shortcuts on mount

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -54,19 +54,22 @@
   let filterSheetInitialTab = $state<'filters' | 'channel'>('filters');
   let editingChannelId = $state<number | null>(null);
   let channelCreateMode = $state(false);
+  let channelCreateInitialType = $state<'feed' | 'saved' | null>(null);
 
   function handleEditChannel(id: number) {
     feedSwitcherOpen = false;
     editingChannelId = id;
     channelCreateMode = false;
+    channelCreateInitialType = null;
     filterSheetInitialTab = 'channel';
     filterSheetOpen = true;
   }
 
-  function handleCreateChannel() {
+  function handleCreateChannel(type: 'feed' | 'saved' = 'feed') {
     feedSwitcherOpen = false;
     editingChannelId = null;
     channelCreateMode = true;
+    channelCreateInitialType = type;
     filterSheetInitialTab = 'channel';
     filterSheetOpen = true;
   }
@@ -755,6 +758,7 @@
           initialTab={filterSheetInitialTab}
           {editingChannelId}
           {channelCreateMode}
+          initialChannelType={channelCreateInitialType}
           oncreated={(id) => {
             filterSheetOpen = false;
             goto(`/?view=${id}`);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -202,6 +202,7 @@
       feeds: null,
       contentType,
       view: url.searchParams.get('view'),
+      category: url.searchParams.get('category'),
     };
     untrack(() => feedViewStore.setFilters(filters));
   });
@@ -255,6 +256,9 @@
     if (feedViewStore.viewFilter) {
       const fv = feedViewStore.activeFilteredView;
       return fv?.name || 'Channel';
+    }
+    if (feedViewStore.categoryFilter) {
+      return feedViewStore.categoryFilter;
     }
     if (feedViewStore.feedFilter) {
       const sub = subscriptionsStore.subscriptions.find(

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -33,6 +33,7 @@
   import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import { useScrollDirection } from '$lib/hooks/useScrollDirection.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { toastStore } from '$lib/stores/toast.svelte';
   import { syncStore } from '$lib/stores/sync.svelte';
   import type { Subscription, BlueskyProfile } from '$lib/types';
@@ -50,6 +51,25 @@
   let feedSwitcherOpen = $state(false);
   let filterSheetOpen = $state(false);
   let readerOpen = $state(false);
+  let filterSheetInitialTab = $state<'filters' | 'channel'>('filters');
+  let editingChannelId = $state<number | null>(null);
+  let channelCreateMode = $state(false);
+
+  function handleEditChannel(id: number) {
+    feedSwitcherOpen = false;
+    editingChannelId = id;
+    channelCreateMode = false;
+    filterSheetInitialTab = 'channel';
+    filterSheetOpen = true;
+  }
+
+  function handleCreateChannel() {
+    feedSwitcherOpen = false;
+    editingChannelId = null;
+    channelCreateMode = true;
+    filterSheetInitialTab = 'channel';
+    filterSheetOpen = true;
+  }
 
   // Integration collection picker state
   let collectionPickerOpen = $state(false);
@@ -234,7 +254,7 @@
   let pageTitle = $derived.by(() => {
     if (feedViewStore.viewFilter) {
       const fv = feedViewStore.activeFilteredView;
-      return fv?.name || 'View';
+      return fv?.name || 'Channel';
     }
     if (feedViewStore.feedFilter) {
       const sub = subscriptionsStore.subscriptions.find(
@@ -255,7 +275,7 @@
       }
       return baseName;
     }
-    return 'All';
+    return 'Everything';
   });
 
   // Get unread count for the current view
@@ -576,6 +596,7 @@
           !feedViewStore.sharedFilter &&
           !feedViewStore.sharerFilter &&
           !feedViewStore.followingFilter}
+        onEditChannel={(id) => sidebarStore.openChannelModal(id)}
       />
     {/if}
 
@@ -682,7 +703,13 @@
         currentTitle={pageTitle}
         onScrollToTop={scrollToTop}
         onOpenFeedSwitcher={() => (feedSwitcherOpen = true)}
-        onOpenFilterSheet={() => (filterSheetOpen = true)}
+        onOpenFilterSheet={() => {
+          filterSheetInitialTab = 'filters';
+          const currentView = feedViewStore.viewFilter;
+          editingChannelId = currentView ? parseInt(currentView) : null;
+          channelCreateMode = false;
+          filterSheetOpen = true;
+        }}
         {hasActiveFilters}
       />
 
@@ -691,20 +718,24 @@
         onclose={() => (feedSwitcherOpen = false)}
         title="Switch Feed"
       >
-        <MobileFeedSwitcher onclose={() => (feedSwitcherOpen = false)} currentTitle={pageTitle} />
+        <MobileFeedSwitcher
+          onclose={() => (feedSwitcherOpen = false)}
+          currentTitle={pageTitle}
+          onEditChannel={handleEditChannel}
+          onCreateChannel={handleCreateChannel}
+        />
       </BottomSheet>
 
       <BottomSheet
         open={filterSheetOpen}
         onclose={() => (filterSheetOpen = false)}
-        title="Filters & Style"
+        title={filterSheetInitialTab === 'channel'
+          ? editingChannelId != null
+            ? 'Edit Channel'
+            : 'New Channel'
+          : 'Filters & Style'}
       >
         <MobileFilterSheet
-          showSourceFilter={!feedViewStore.feedFilter &&
-            !feedViewStore.savedFilter &&
-            !feedViewStore.sharedFilter &&
-            !feedViewStore.sharerFilter &&
-            !feedViewStore.followingFilter}
           expandAllItems={preferences.expandAllItems}
           onToggleExpandAll={(value) => {
             preferences.setExpandAllItems(value);
@@ -717,6 +748,17 @@
             ? markAllAsReadInCurrentView
             : undefined}
           onclose={() => (filterSheetOpen = false)}
+          initialTab={filterSheetInitialTab}
+          {editingChannelId}
+          {channelCreateMode}
+          oncreated={(id) => {
+            filterSheetOpen = false;
+            goto(`/?view=${id}`);
+          }}
+          ondeleted={() => {
+            filterSheetOpen = false;
+            goto('/');
+          }}
         />
       </BottomSheet>
     {/if}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -214,7 +214,7 @@
   let feedListView = $state<ReturnType<typeof FeedListView> | null>(null);
   let savedListView = $state<ReturnType<typeof SavedListView> | null>(null);
 
-  let isSavedView = $derived(Boolean(feedViewStore.savedFilter));
+  let isSavedView = $derived(feedViewStore.isSavedView);
 
   function getArticleElements(): HTMLElement[] {
     if (isSavedView) {

--- a/frontend/src/routes/activity/+page.svelte
+++ b/frontend/src/routes/activity/+page.svelte
@@ -5,8 +5,12 @@
   import { activityStore } from '$lib/stores/activity.svelte';
   import { profileService } from '$lib/services/profiles';
   import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';
-  import PageHeader from '$lib/components/common/PageHeader.svelte';
+  import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
+  import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
+  import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import StateView from '$lib/components/common/StateView.svelte';
+  import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { formatRelativeDate } from '$lib/utils/date';
   import type { BlueskyProfile, ReshareActivity } from '$lib/types';
   import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
@@ -65,14 +69,16 @@
     return `${first} and ${othersCount} others`;
   }
 
+  let feedSwitcherOpen = $state(false);
+
   async function loadMore() {
     await activityStore.loadReshareActivity(true);
   }
 </script>
 
-<div class="activity-page">
-  <PageHeader title="Activity" subtitle="See who reshared your articles" />
+<FeedPageHeader title="Activity" hideControls />
 
+<div class="activity-page">
   <StateView
     isLoading={activityStore.isLoading && activityStore.reshareActivity.length === 0}
     isEmpty={activityStore.reshareActivity.length === 0}
@@ -103,6 +109,26 @@
       onLoadMore={loadMore}
     />
   </StateView>
+
+  {#if mobileStore.isMobile}
+    <MobileBottomBar
+      controlsVisible={true}
+      currentTitle="Activity"
+      onScrollToTop={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onOpenFeedSwitcher={() => (feedSwitcherOpen = true)}
+      onOpenFilterSheet={() => {}}
+      hasActiveFilters={false}
+      hideFilterButton
+    />
+
+    <BottomSheet
+      open={feedSwitcherOpen}
+      onclose={() => (feedSwitcherOpen = false)}
+      title="Switch Feed"
+    >
+      <MobileFeedSwitcher onclose={() => (feedSwitcherOpen = false)} currentTitle="Activity" />
+    </BottomSheet>
+  {/if}
 </div>
 
 <style>
@@ -111,8 +137,15 @@
     flex-direction: column;
     max-width: 600px;
     margin: 0 auto;
-    padding: 0 1rem;
+    padding: 3.5rem 1rem 1rem;
     gap: 1rem;
+  }
+
+  @media (max-width: 1000px) {
+    .activity-page {
+      padding-top: 0.5rem;
+      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
+    }
   }
 
   .activity-list {

--- a/frontend/src/routes/channels/discover/+page.svelte
+++ b/frontend/src/routes/channels/discover/+page.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { channelSuggestions } from '$lib/stores/channelSuggestions.svelte';
+  import {
+    savedChannelSuggestions,
+    type SavedChannelSuggestion,
+  } from '$lib/stores/savedChannelSuggestions.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import { DOMAIN_CLUSTERS } from '$lib/utils/channelLogic';
   import Icon from '$lib/components/Icon.svelte';
   import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
   import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import type { ChannelSuggestion } from '$lib/stores/channelSuggestions.svelte';
+  import type {
+    ChannelAutoRule,
+    SavedSourceType,
+    ReadingLengthFilter,
+    SortOrder,
+  } from '$lib/types';
 
   let feedSwitcherOpen = $state(false);
 
@@ -24,87 +35,201 @@
     goto(`/?view=${id}`);
   }
 
-  // All possible channel types with descriptions, even when they don't currently match
-  const CHANNEL_TYPES = [
+  async function acceptSavedSuggestion(suggestion: SavedChannelSuggestion) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      mode: 'saved',
+      savedSourceFilter: suggestion.savedSourceFilter,
+      savedDomainFilter: suggestion.savedDomainFilter,
+      savedReadingLength: suggestion.savedReadingLength,
+      savedDateFilter: suggestion.savedDateFilter,
+      readFilter: suggestion.readFilter ?? 'all',
+      sortOrder: suggestion.sortOrder ?? 'newest',
+    });
+    goto(`/?view=${id}`);
+  }
+
+  async function createChannelFromType(type: ChannelTypeConfig) {
+    const id = await filteredViewsStore.create({
+      name: type.name,
+      sourceMode: type.sourceMode,
+      sourceKeys: [],
+      typeFilter: type.typeFilter,
+      autoRule: type.autoRule,
+      readFilter: 'unread',
+      sortOrder: 'newest',
+    });
+    goto(`/?view=${id}`);
+  }
+
+  async function createSavedChannelFromType(type: SavedChannelTypeConfig) {
+    const id = await filteredViewsStore.create({
+      name: type.name,
+      mode: 'saved',
+      savedSourceFilter: type.savedSourceFilter,
+      savedReadingLength: type.savedReadingLength,
+      readFilter: 'all',
+      sortOrder: type.sortOrder ?? 'newest',
+    });
+    goto(`/?view=${id}`);
+  }
+
+  // All possible channel types with descriptions and default creation config
+  interface ChannelTypeConfig {
+    id: string;
+    name: string;
+    icon: 'inbox' | 'bookmark' | 'file-text' | 'users' | 'rss' | 'share' | 'plus' | 'newspaper';
+    description: string;
+    sourceMode: 'all' | 'include';
+    typeFilter?: ('rss' | 'atproto.shares' | 'atproto.documents')[];
+    autoRule?: ChannelAutoRule;
+  }
+
+  const CHANNEL_TYPES: ChannelTypeConfig[] = [
     {
       id: 'frequency:high',
       name: 'Daily Digest',
-      icon: 'inbox' as const,
+      icon: 'inbox',
       description:
         'Groups high-volume feeds that publish multiple times per day. Helps you skim the firehose without it drowning out quieter sources.',
+      sourceMode: 'include',
+      autoRule: { type: 'frequency', threshold: 'high' },
     },
     {
       id: 'frequency:low',
       name: "Don't Miss",
-      icon: 'bookmark' as const,
+      icon: 'bookmark',
       description:
         "Collects feeds that publish infrequently — personal blogs, monthly newsletters, and thoughtful writers where every post matters. You won't lose them in the noise.",
+      sourceMode: 'include',
+      autoRule: { type: 'frequency', threshold: 'low' },
     },
     {
       id: 'content:longreads',
       name: 'Long Reads',
-      icon: 'file-text' as const,
+      icon: 'file-text',
       description:
         'Feeds with in-depth, long-form articles (1000+ words on average). Perfect for weekend reading or deep dives.',
+      sourceMode: 'include',
+      autoRule: { type: 'longReads', minLength: 5000 },
     },
     {
       id: 'people:all',
       name: 'People I Follow',
-      icon: 'users' as const,
+      icon: 'users',
       description:
         'Everything from the people you follow on Bluesky — their shared articles and published documents in one place.',
+      sourceMode: 'include',
+      autoRule: { type: 'people' },
     },
     {
       id: 'type:articles',
       name: 'Articles',
-      icon: 'rss' as const,
+      icon: 'rss',
       description:
         'Only RSS feed articles, with social content filtered out. A clean reading experience for traditional blog and news content.',
+      sourceMode: 'all',
+      typeFilter: ['rss'],
     },
     {
       id: 'type:social',
       name: 'Social',
-      icon: 'share' as const,
+      icon: 'share',
       description:
         'Only content from people you follow — shares and published documents, without RSS articles mixed in.',
+      sourceMode: 'all',
+      typeFilter: ['atproto.shares', 'atproto.documents'],
     },
     {
       id: 'recent:new',
       name: 'New Sources',
-      icon: 'plus' as const,
+      icon: 'plus',
       description:
         "Sources you've added in the last 2 weeks. A temporary channel to help you get to know new subscriptions before they blend into the mix.",
+      sourceMode: 'include',
+      autoRule: { type: 'recent', withinDays: 14 },
     },
-    {
-      id: 'domain:newsletters',
-      name: 'Newsletters',
+    ...DOMAIN_CLUSTERS.map((cluster) => ({
+      id: cluster.id,
+      name: cluster.name,
       icon: 'newspaper' as const,
+      description: cluster.description,
+      sourceMode: 'include' as const,
+      autoRule: { type: 'domain' as const, patterns: [...cluster.patterns] },
+    })),
+  ];
+
+  // Saved channel types with descriptions and default creation config
+  interface SavedChannelTypeConfig {
+    id: string;
+    name: string;
+    icon: 'rss' | 'link' | 'file-text' | 'clock' | 'share' | 'newspaper';
+    description: string;
+    savedSourceFilter?: SavedSourceType[];
+    savedReadingLength?: ReadingLengthFilter[];
+    sortOrder?: SortOrder;
+  }
+
+  const SAVED_CHANNEL_TYPES: SavedChannelTypeConfig[] = [
+    {
+      id: 'saved:source-feed',
+      name: 'Saved from Feeds',
+      icon: 'rss',
       description:
-        'Groups feeds from newsletter platforms like Substack, Buttondown, Ghost, and Beehiiv.',
+        'Articles you saved from your RSS feeds. Keep feed bookmarks separate from web saves.',
+      savedSourceFilter: ['feed'],
     },
     {
-      id: 'domain:podcasts',
-      name: 'Podcasts',
-      icon: 'newspaper' as const,
-      description: 'Groups podcast feeds from platforms like Transistor, Buzzsprout, and Libsyn.',
+      id: 'saved:source-url',
+      name: 'Saved from Web',
+      icon: 'link',
+      description:
+        'Pages you saved by URL. A dedicated channel for articles and pages you found outside your feeds.',
+      savedSourceFilter: ['url'],
     },
     {
-      id: 'domain:reddit',
-      name: 'Reddit',
-      icon: 'newspaper' as const,
-      description: 'Groups all your Reddit RSS feeds into one channel.',
+      id: 'saved:long-reads',
+      name: 'Saved Long Reads',
+      icon: 'file-text',
+      description:
+        'Saved items with 15+ minute read time. Queue up your long-form reading for when you have the time.',
+      savedReadingLength: ['long'],
+      sortOrder: 'longest',
     },
     {
-      id: 'domain:github',
-      name: 'GitHub',
-      icon: 'newspaper' as const,
-      description: 'Groups GitHub release feeds and activity feeds.',
+      id: 'saved:quick-reads',
+      name: 'Saved Quick Reads',
+      icon: 'clock',
+      description: 'Saved items you can finish in under 5 minutes. Perfect for short breaks.',
+      savedReadingLength: ['quick'],
+      sortOrder: 'shortest',
+    },
+    {
+      id: 'saved:source-share',
+      name: 'Saved Shares',
+      icon: 'share',
+      description:
+        'Shared articles you bookmarked. Keep track of the best content from people you follow.',
+      savedSourceFilter: ['share'],
+    },
+    {
+      id: 'saved:source-document',
+      name: 'Saved Documents',
+      icon: 'newspaper',
+      description:
+        'Published documents you bookmarked. Long-form writing from the people you follow.',
+      savedSourceFilter: ['document'],
     },
   ];
 
   // Map active suggestions by ID for quick lookup
   let activeSuggestionMap = $derived(
     new Map(channelSuggestions.allSuggestions.map((s) => [s.id, s]))
+  );
+
+  // Map active saved suggestions by ID for quick lookup
+  let activeSavedSuggestionMap = $derived(
+    new Map(savedChannelSuggestions.allSuggestions.map((s) => [s.id, s]))
   );
 
   // IDs of channels that already exist
@@ -128,11 +253,12 @@
   </header>
 
   <!-- Active suggestions -->
-  {#if channelSuggestions.allSuggestions.length > 0}
+  {#if channelSuggestions.allSuggestions.length > 0 || savedChannelSuggestions.allSuggestions.length > 0}
     <section class="section">
       <h2 class="section-title">Suggested for you</h2>
       <p class="section-desc">
-        Based on your current sources, these channels would help organize your reading.
+        Based on your current sources and saved items, these channels would help organize your
+        reading.
       </p>
       <div class="channel-grid">
         {#each channelSuggestions.allSuggestions as suggestion (suggestion.id)}
@@ -156,6 +282,30 @@
             </div>
           </div>
         {/each}
+        {#each savedChannelSuggestions.allSuggestions as suggestion (suggestion.id)}
+          {@const type = SAVED_CHANNEL_TYPES.find((t) => t.id === suggestion.id)}
+          <div class="channel-card active">
+            <div class="card-header">
+              <span class="card-icon">
+                <Icon name={type?.icon ?? 'bookmark'} size={18} />
+              </span>
+              <h3>{suggestion.name}</h3>
+            </div>
+            <p class="card-desc">{suggestion.description}</p>
+            <div class="card-actions">
+              <button class="create-btn" onclick={() => acceptSavedSuggestion(suggestion)}>
+                <Icon name="plus" size={14} />
+                Create channel
+              </button>
+              <button
+                class="dismiss-btn"
+                onclick={() => savedChannelSuggestions.dismiss(suggestion.id)}
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        {/each}
       </div>
     </section>
   {/if}
@@ -164,8 +314,8 @@
   <section class="section">
     <h2 class="section-title">All channel types</h2>
     <p class="section-desc">
-      These are all the kinds of channels Skyreader can suggest. Channels that match your sources
-      can be created instantly. Others will appear as suggestions when you add the right sources.
+      These are all the kinds of channels Skyreader can create. Channels with matching sources are
+      highlighted, but you can create any channel — it will populate as you add matching sources.
     </p>
     <div class="channel-grid">
       {#each CHANNEL_TYPES as type (type.id)}
@@ -188,9 +338,15 @@
             {/if}
           </div>
           <p class="card-desc">{type.description}</p>
-          {#if activeSuggestion && !alreadyCreated}
+          {#if !alreadyCreated}
             <div class="card-actions">
-              <button class="create-btn" onclick={() => acceptSuggestion(activeSuggestion)}>
+              <button
+                class="create-btn"
+                onclick={() =>
+                  activeSuggestion
+                    ? acceptSuggestion(activeSuggestion)
+                    : createChannelFromType(type)}
+              >
                 <Icon name="plus" size={14} />
                 Create channel
               </button>
@@ -213,6 +369,73 @@
           <p class="card-desc">{suggestion.description}</p>
           <div class="card-actions">
             <button class="create-btn" onclick={() => acceptSuggestion(suggestion)}>
+              <Icon name="plus" size={14} />
+              Create channel
+            </button>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Saved channel types -->
+  <section class="section">
+    <h2 class="section-title">Saved item channels</h2>
+    <p class="section-desc">
+      Create channels from your saved items to organize bookmarks by source, reading time, or
+      domain.
+    </p>
+    <div class="channel-grid">
+      {#each SAVED_CHANNEL_TYPES as type (type.id)}
+        {@const activeSuggestion = activeSavedSuggestionMap.get(type.id)}
+        {@const alreadyCreated = existingChannelNames.has(type.name.toLowerCase())}
+        <div
+          class="channel-card"
+          class:available={!!activeSuggestion}
+          class:created={alreadyCreated}
+        >
+          <div class="card-header">
+            <span class="card-icon">
+              <Icon name={type.icon} size={18} />
+            </span>
+            <h3>{type.name}</h3>
+            {#if alreadyCreated}
+              <span class="card-badge created-badge">Created</span>
+            {:else if activeSuggestion}
+              <span class="card-badge available-badge">Available</span>
+            {/if}
+          </div>
+          <p class="card-desc">{type.description}</p>
+          {#if !alreadyCreated}
+            <div class="card-actions">
+              <button
+                class="create-btn"
+                onclick={() =>
+                  activeSuggestion
+                    ? acceptSavedSuggestion(activeSuggestion)
+                    : createSavedChannelFromType(type)}
+              >
+                <Icon name="plus" size={14} />
+                Create channel
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/each}
+
+      <!-- Dynamic types: domain-based saved channels -->
+      {#each savedChannelSuggestions.allSuggestions.filter( (s) => s.id.startsWith('saved:domain-') ) as suggestion (suggestion.id)}
+        <div class="channel-card available">
+          <div class="card-header">
+            <span class="card-icon">
+              <Icon name="globe" size={18} />
+            </span>
+            <h3>{suggestion.name}</h3>
+            <span class="card-badge available-badge">Available</span>
+          </div>
+          <p class="card-desc">{suggestion.description}</p>
+          <div class="card-actions">
+            <button class="create-btn" onclick={() => acceptSavedSuggestion(suggestion)}>
               <Icon name="plus" size={14} />
               Create channel
             </button>

--- a/frontend/src/routes/channels/discover/+page.svelte
+++ b/frontend/src/routes/channels/discover/+page.svelte
@@ -1,0 +1,512 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { channelSuggestions } from '$lib/stores/channelSuggestions.svelte';
+  import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
+  import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+  import type { ChannelSuggestion } from '$lib/stores/channelSuggestions.svelte';
+
+  let feedSwitcherOpen = $state(false);
+
+  async function acceptSuggestion(suggestion: ChannelSuggestion) {
+    const id = await filteredViewsStore.create({
+      name: suggestion.name,
+      sourceMode: suggestion.sourceMode,
+      sourceKeys: suggestion.sourceKeys,
+      typeFilter: suggestion.typeFilter.length > 0 ? suggestion.typeFilter : undefined,
+      autoRule: suggestion.autoRule,
+      readFilter: 'unread',
+      sortOrder: 'newest',
+    });
+    goto(`/?view=${id}`);
+  }
+
+  // All possible channel types with descriptions, even when they don't currently match
+  const CHANNEL_TYPES = [
+    {
+      id: 'frequency:high',
+      name: 'Daily Digest',
+      icon: 'inbox' as const,
+      description:
+        'Groups high-volume feeds that publish multiple times per day. Helps you skim the firehose without it drowning out quieter sources.',
+    },
+    {
+      id: 'frequency:low',
+      name: "Don't Miss",
+      icon: 'bookmark' as const,
+      description:
+        "Collects feeds that publish infrequently — personal blogs, monthly newsletters, and thoughtful writers where every post matters. You won't lose them in the noise.",
+    },
+    {
+      id: 'content:longreads',
+      name: 'Long Reads',
+      icon: 'file-text' as const,
+      description:
+        'Feeds with in-depth, long-form articles (1000+ words on average). Perfect for weekend reading or deep dives.',
+    },
+    {
+      id: 'people:all',
+      name: 'People I Follow',
+      icon: 'users' as const,
+      description:
+        'Everything from the people you follow on Bluesky — their shared articles and published documents in one place.',
+    },
+    {
+      id: 'type:articles',
+      name: 'Articles',
+      icon: 'rss' as const,
+      description:
+        'Only RSS feed articles, with social content filtered out. A clean reading experience for traditional blog and news content.',
+    },
+    {
+      id: 'type:social',
+      name: 'Social',
+      icon: 'share' as const,
+      description:
+        'Only content from people you follow — shares and published documents, without RSS articles mixed in.',
+    },
+    {
+      id: 'recent:new',
+      name: 'New Sources',
+      icon: 'plus' as const,
+      description:
+        "Sources you've added in the last 2 weeks. A temporary channel to help you get to know new subscriptions before they blend into the mix.",
+    },
+    {
+      id: 'domain:newsletters',
+      name: 'Newsletters',
+      icon: 'newspaper' as const,
+      description:
+        'Groups feeds from newsletter platforms like Substack, Buttondown, Ghost, and Beehiiv.',
+    },
+    {
+      id: 'domain:podcasts',
+      name: 'Podcasts',
+      icon: 'newspaper' as const,
+      description: 'Groups podcast feeds from platforms like Transistor, Buzzsprout, and Libsyn.',
+    },
+    {
+      id: 'domain:reddit',
+      name: 'Reddit',
+      icon: 'newspaper' as const,
+      description: 'Groups all your Reddit RSS feeds into one channel.',
+    },
+    {
+      id: 'domain:github',
+      name: 'GitHub',
+      icon: 'newspaper' as const,
+      description: 'Groups GitHub release feeds and activity feeds.',
+    },
+  ];
+
+  // Map active suggestions by ID for quick lookup
+  let activeSuggestionMap = $derived(
+    new Map(channelSuggestions.allSuggestions.map((s) => [s.id, s]))
+  );
+
+  // IDs of channels that already exist
+  let existingChannelNames = $derived(
+    new Set(filteredViewsStore.views.map((v) => v.name.toLowerCase()))
+  );
+</script>
+
+<svelte:head>
+  <title>Discover Channels - Skyreader</title>
+</svelte:head>
+
+<div class="discover-page">
+  <header class="discover-header">
+    <h1>Discover Channels</h1>
+    <p class="header-desc">
+      Channels are smart filtered views of your content. They automatically group your sources by
+      topic, frequency, content type, or other patterns. Create one with a single tap — and they
+      stay up to date as you add new sources.
+    </p>
+  </header>
+
+  <!-- Active suggestions -->
+  {#if channelSuggestions.allSuggestions.length > 0}
+    <section class="section">
+      <h2 class="section-title">Suggested for you</h2>
+      <p class="section-desc">
+        Based on your current sources, these channels would help organize your reading.
+      </p>
+      <div class="channel-grid">
+        {#each channelSuggestions.allSuggestions as suggestion (suggestion.id)}
+          {@const type = CHANNEL_TYPES.find((t) => t.id === suggestion.id)}
+          <div class="channel-card active">
+            <div class="card-header">
+              <span class="card-icon">
+                <Icon name={type?.icon ?? 'newspaper'} size={18} />
+              </span>
+              <h3>{suggestion.name}</h3>
+            </div>
+            <p class="card-desc">{suggestion.description}</p>
+            <div class="card-actions">
+              <button class="create-btn" onclick={() => acceptSuggestion(suggestion)}>
+                <Icon name="plus" size={14} />
+                Create channel
+              </button>
+              <button class="dismiss-btn" onclick={() => channelSuggestions.dismiss(suggestion.id)}>
+                Dismiss
+              </button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- All channel types -->
+  <section class="section">
+    <h2 class="section-title">All channel types</h2>
+    <p class="section-desc">
+      These are all the kinds of channels Skyreader can suggest. Channels that match your sources
+      can be created instantly. Others will appear as suggestions when you add the right sources.
+    </p>
+    <div class="channel-grid">
+      {#each CHANNEL_TYPES as type (type.id)}
+        {@const activeSuggestion = activeSuggestionMap.get(type.id)}
+        {@const alreadyCreated = existingChannelNames.has(type.name.toLowerCase())}
+        <div
+          class="channel-card"
+          class:available={!!activeSuggestion}
+          class:created={alreadyCreated}
+        >
+          <div class="card-header">
+            <span class="card-icon">
+              <Icon name={type.icon} size={18} />
+            </span>
+            <h3>{type.name}</h3>
+            {#if alreadyCreated}
+              <span class="card-badge created-badge">Created</span>
+            {:else if activeSuggestion}
+              <span class="card-badge available-badge">Available</span>
+            {/if}
+          </div>
+          <p class="card-desc">{type.description}</p>
+          {#if activeSuggestion && !alreadyCreated}
+            <div class="card-actions">
+              <button class="create-btn" onclick={() => acceptSuggestion(activeSuggestion)}>
+                <Icon name="plus" size={14} />
+                Create channel
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/each}
+
+      <!-- Dynamic types: categories and tags -->
+      {#each channelSuggestions.allSuggestions.filter((s) => s.id.startsWith('category:') || s.id.startsWith('tag:')) as suggestion (suggestion.id)}
+        {@const isCategory = suggestion.id.startsWith('category:')}
+        <div class="channel-card available">
+          <div class="card-header">
+            <span class="card-icon">
+              <Icon name={isCategory ? 'layers' : 'tag'} size={18} />
+            </span>
+            <h3>{suggestion.name}</h3>
+            <span class="card-badge available-badge">Available</span>
+          </div>
+          <p class="card-desc">{suggestion.description}</p>
+          <div class="card-actions">
+            <button class="create-btn" onclick={() => acceptSuggestion(suggestion)}>
+              <Icon name="plus" size={14} />
+              Create channel
+            </button>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Custom channels callout -->
+  <section class="section callout">
+    <h2 class="section-title">Create your own</h2>
+    <p class="section-desc">
+      You can always create a custom channel from any view. Set up filters for specific sources,
+      content types, or tags — then save it as a channel. Use the <strong>+</strong> button in the Channels
+      section of the sidebar.
+    </p>
+  </section>
+</div>
+
+{#if mobileStore.isMobile}
+  <div class="mobile-bottom-bar">
+    <button class="switcher-pill" onclick={() => (feedSwitcherOpen = true)}>
+      <span class="pill-icon"><Icon name="layers" size={20} /></span>
+      <span class="pill-label">Discover Channels</span>
+    </button>
+  </div>
+
+  <BottomSheet
+    open={feedSwitcherOpen}
+    onclose={() => (feedSwitcherOpen = false)}
+    title="Switch Feed"
+  >
+    <MobileFeedSwitcher
+      onclose={() => (feedSwitcherOpen = false)}
+      currentTitle="Discover Channels"
+    />
+  </BottomSheet>
+{/if}
+
+<style>
+  .discover-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .discover-header {
+    margin-bottom: 2rem;
+  }
+
+  h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  .header-desc {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .section {
+    margin-bottom: 2rem;
+  }
+
+  .section-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+  }
+
+  .section-desc {
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    margin: 0 0 1rem;
+  }
+
+  .channel-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .channel-card {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 1rem;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .channel-card.available {
+    border-color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.03);
+  }
+
+  .channel-card.created {
+    opacity: 0.6;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .card-icon {
+    display: flex;
+    align-items: center;
+    color: var(--color-text-secondary);
+  }
+
+  .channel-card.available .card-icon {
+    color: var(--color-primary);
+  }
+
+  .card-header h3 {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    margin: 0;
+    flex: 1;
+  }
+
+  .card-badge {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.125rem 0.375rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .available-badge {
+    background: rgba(0, 102, 204, 0.1);
+    color: var(--color-primary);
+  }
+
+  .created-badge {
+    background: rgba(0, 0, 0, 0.06);
+    color: var(--color-text-secondary);
+  }
+
+  .card-desc {
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    line-height: 1.5;
+    margin: 0 0 0.375rem;
+  }
+
+  .card-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .create-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.375rem 0.75rem;
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    transition: opacity 0.15s;
+  }
+
+  .create-btn:hover {
+    opacity: 0.9;
+  }
+
+  .dismiss-btn {
+    padding: 0.375rem 0.75rem;
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+  }
+
+  .dismiss-btn:hover {
+    background: var(--color-bg-hover);
+  }
+
+  .callout {
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
+    border-radius: 12px;
+    padding: 1.25rem;
+  }
+
+  .callout .section-title {
+    margin-bottom: 0.375rem;
+  }
+
+  .callout .section-desc {
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 1000px) {
+    .discover-page {
+      padding-bottom: 5rem;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .channel-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Mobile bottom bar */
+  .mobile-bottom-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 0.75rem 1rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  .switcher-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(8px);
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem 0.25rem 0.5rem;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+    pointer-events: auto;
+    border: none;
+    color: var(--color-text);
+    font-size: 0.875rem;
+    font-weight: 500;
+    max-width: 80%;
+  }
+
+  .switcher-pill:active {
+    background: rgba(240, 240, 240, 0.95);
+  }
+
+  .pill-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem;
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+  }
+
+  .pill-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 1001px) {
+    .mobile-bottom-bar {
+      display: none;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .channel-card.available {
+      background: rgba(0, 102, 204, 0.06);
+    }
+
+    .created-badge {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .callout {
+      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.04));
+    }
+
+    .switcher-pill {
+      background: rgba(40, 40, 40, 0.95);
+    }
+
+    .switcher-pill:active {
+      background: rgba(55, 55, 55, 0.95);
+    }
+  }
+</style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -10,7 +10,11 @@
     type ArticleFontSize,
   } from '$lib/stores/preferences.svelte';
   import ImportOPMLModal from '$lib/components/ImportOPMLModal.svelte';
-  import PageHeader from '$lib/components/common/PageHeader.svelte';
+  import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
+  import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
+  import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+  import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { downloadOPML } from '$lib/utils/opml-exporter';
   import { api, RateLimitError } from '$lib/services/api';
   import { syncStore } from '$lib/stores/sync.svelte';
@@ -36,6 +40,7 @@
   ];
 
   let showImportModal = $state(false);
+  let feedSwitcherOpen = $state(false);
 
   // PDS Sync state
   let pdsSyncEnabled = $state(false);
@@ -226,9 +231,9 @@
   }
 </script>
 
-<div class="settings-page">
-  <PageHeader title="Settings" />
+<FeedPageHeader title="Settings" hideControls />
 
+<div class="settings-page">
   {#if auth.user}
     <section class="card">
       <h2>Account</h2>
@@ -464,6 +469,26 @@
       {/if}
     </button>
   </section>
+
+  {#if mobileStore.isMobile}
+    <MobileBottomBar
+      controlsVisible={true}
+      currentTitle="Settings"
+      onScrollToTop={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onOpenFeedSwitcher={() => (feedSwitcherOpen = true)}
+      onOpenFilterSheet={() => {}}
+      hasActiveFilters={false}
+      hideFilterButton
+    />
+
+    <BottomSheet
+      open={feedSwitcherOpen}
+      onclose={() => (feedSwitcherOpen = false)}
+      title="Switch Feed"
+    >
+      <MobileFeedSwitcher onclose={() => (feedSwitcherOpen = false)} currentTitle="Settings" />
+    </BottomSheet>
+  {/if}
 </div>
 
 <ImportOPMLModal open={showImportModal} onclose={() => (showImportModal = false)} />
@@ -472,6 +497,14 @@
   .settings-page {
     max-width: 600px;
     margin: 0 auto;
+    padding-top: 3.5rem;
+  }
+
+  @media (max-width: 1000px) {
+    .settings-page {
+      padding-top: 0.5rem;
+      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
+    }
   }
 
   section {

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -9,6 +9,7 @@
   import { fetchSingleFeed } from '$lib/services/feedFetcher';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import { profileService } from '$lib/services/profiles';
+  import { api } from '$lib/services/api';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
   import Icon from '$lib/components/Icon.svelte';
@@ -21,6 +22,21 @@
   import AddHandleModal from '$lib/components/AddHandleModal.svelte';
   import type { Subscription, BlueskyProfile } from '$lib/types';
 
+  interface DetectedPublication {
+    uri: string;
+    name: string;
+    url: string;
+    description?: string;
+    iconUrl?: string;
+  }
+
+  interface DetectedContent {
+    publications: DetectedPublication[];
+    shareCount: number;
+    freestandingDocumentCount: number;
+    loading: boolean;
+  }
+
   let feedSwitcherOpen = $state(false);
 
   let searchQuery = $state('');
@@ -29,6 +45,36 @@
   let selectedIds = $state<Set<number>>(new Set());
   let profiles = $state<Map<string, BlueskyProfile>>(new Map());
   let assignChannelOpen = $state(false);
+  let detectedContent = $state<Map<string, DetectedContent>>(new Map());
+
+  const CONTENT_CACHE_KEY = 'skyreader:detected-content';
+
+  type CachedContent = Omit<DetectedContent, 'loading'>;
+
+  function loadContentCache(): Map<string, CachedContent> {
+    try {
+      const raw = localStorage.getItem(CONTENT_CACHE_KEY);
+      if (!raw) return new Map();
+      const obj = JSON.parse(raw) as Record<string, CachedContent>;
+      return new Map(Object.entries(obj));
+    } catch {
+      return new Map();
+    }
+  }
+
+  function saveContentCache(did: string, content: CachedContent) {
+    try {
+      const existing = loadContentCache();
+      existing.set(did, content);
+      const obj: Record<string, CachedContent> = {};
+      for (const [k, v] of existing) {
+        obj[k] = v;
+      }
+      localStorage.setItem(CONTENT_CACHE_KEY, JSON.stringify(obj));
+    } catch {
+      // localStorage full or unavailable
+    }
+  }
 
   // Group AT Protocol subscriptions by person (DID)
   interface PersonGroup {
@@ -163,20 +209,64 @@
     selectedIds = next;
   }
 
-  // Content type toggle for a person
-  async function toggleContentType(
-    group: PersonGroup,
-    type: 'atproto.shares' | 'atproto.documents'
-  ) {
-    const existing = group.subscriptions.find((s) => s.sourceType === type);
-    if (existing && existing.id) {
-      // Remove this content type
+  // Toggle subscription for a specific content stream
+  async function toggleShares(group: PersonGroup) {
+    const existing = group.subscriptions.find((s) => s.sourceType === 'atproto.shares');
+    if (existing?.id) {
       await subscriptionsStore.remove(existing.id);
     } else {
-      // Add this content type - use the AddHandle flow
-      sidebarStore.setAddSourceInitialValue(group.profile?.handle || group.did);
-      sidebarStore.openAddHandleModal();
+      await subscriptionsStore.add(undefined, `Shares from @${getPersonHandle(group)}`, {
+        sourceType: 'atproto.shares',
+        subjectDid: group.did,
+      });
     }
+  }
+
+  async function toggleFreestandingDocs(group: PersonGroup) {
+    const existing = group.subscriptions.find(
+      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === '__freestanding__'
+    );
+    if (existing?.id) {
+      await subscriptionsStore.remove(existing.id);
+    } else {
+      await subscriptionsStore.add(
+        '__freestanding__',
+        `Documents from @${getPersonHandle(group)}`,
+        {
+          sourceType: 'atproto.documents',
+          subjectDid: group.did,
+          feedUrl: '__freestanding__',
+        }
+      );
+    }
+  }
+
+  async function togglePublication(group: PersonGroup, pub: DetectedPublication) {
+    const existing = group.subscriptions.find(
+      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === pub.uri
+    );
+    if (existing?.id) {
+      await subscriptionsStore.remove(existing.id);
+    } else {
+      const subId = await subscriptionsStore.add(pub.uri, pub.name || pub.url, {
+        sourceType: 'atproto.documents',
+        subjectDid: group.did,
+        siteUrl: pub.url,
+        feedUrl: pub.uri,
+      });
+      if (pub.iconUrl) {
+        await subscriptionsStore.updateLocal(subId, { customIconUrl: pub.iconUrl });
+      }
+    }
+  }
+
+  function getSubscriptionForFeedUrl(
+    group: PersonGroup,
+    feedUrl: string
+  ): Subscription | undefined {
+    return group.subscriptions.find(
+      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === feedUrl
+    );
   }
 
   // Bulk operations
@@ -255,16 +345,70 @@
     return group.profile?.handle || group.did;
   }
 
-  // Fetch profiles on mount
+  // Fetch profiles and detected content on mount
   onMount(async () => {
     const dids = [
       ...new Set(
         subscriptionsStore.subscriptions.filter((s) => s.subjectDid).map((s) => s.subjectDid!)
       ),
     ];
-    if (dids.length > 0) {
-      const fetched = await profileService.getProfiles(dids);
-      profiles = fetched;
+    if (dids.length === 0) return;
+
+    // 1. Immediately populate from cache
+    const cache = loadContentCache();
+    const initial = new Map<string, DetectedContent>();
+    for (const did of dids) {
+      const cached = cache.get(did);
+      if (cached) {
+        initial.set(did, { ...cached, loading: false });
+      }
+    }
+    detectedContent = initial;
+
+    // Fetch profiles
+    const fetched = await profileService.getProfiles(dids);
+    profiles = fetched;
+
+    // 2. Refresh from API in background
+    for (const did of dids) {
+      // Mark as loading only if we don't already have cached data
+      if (!detectedContent.has(did)) {
+        const next = new Map(detectedContent);
+        next.set(did, {
+          publications: [],
+          shareCount: 0,
+          freestandingDocumentCount: 0,
+          loading: true,
+        });
+        detectedContent = next;
+      }
+
+      api
+        .detectContent(did)
+        .then((result) => {
+          const content = {
+            publications: result.publications,
+            shareCount: result.shareCount,
+            freestandingDocumentCount: result.freestandingDocumentCount,
+          };
+          saveContentCache(did, content);
+          const updated = new Map(detectedContent);
+          updated.set(did, { ...content, loading: false });
+          detectedContent = updated;
+        })
+        .catch(() => {
+          // On failure, keep cached data if we have it
+          if (!detectedContent.has(did)) {
+            const updated = new Map(detectedContent);
+            updated.set(did, {
+              publications: [],
+              shareCount: 0,
+              freestandingDocumentCount: 0,
+              loading: false,
+            });
+            detectedContent = updated;
+          }
+        });
     }
   });
 </script>
@@ -350,68 +494,186 @@
       </h2>
       <div class="source-list">
         {#each filteredPeople as group (group.did)}
-          {@const personSelected = group.subscriptions.every(
-            (s) => s.id != null && selectedIds.has(s.id)
+          {@const detected = detectedContent.get(group.did)}
+          {@const sharesSub = group.subscriptions.find((s) => s.sourceType === 'atproto.shares')}
+          {@const freestandingSub = group.subscriptions.find(
+            (s) => s.sourceType === 'atproto.documents' && s.feedUrl === '__freestanding__'
           )}
-          <div class="source-row person-row">
-            <label class="row-checkbox">
-              <input
-                type="checkbox"
-                checked={personSelected}
-                onchange={() => togglePersonSelect(group)}
-              />
-            </label>
-            <div class="source-icon">
-              {#if group.profile?.avatar}
-                <img src={group.profile.avatar} alt="" class="avatar" />
+          {@const sharesUnread = sharesSub?.id
+            ? (unreadCounts.feedCounts.get(sharesSub.id) ?? 0)
+            : 0}
+          {@const freestandingUnread = freestandingSub?.id
+            ? (unreadCounts.feedCounts.get(freestandingSub.id) ?? 0)
+            : 0}
+          <div class="person-card">
+            <div class="person-header">
+              <div class="source-icon">
+                {#if group.profile?.avatar}
+                  <img src={group.profile.avatar} alt="" class="avatar" />
+                {:else}
+                  <Icon name="user" size={16} />
+                {/if}
+              </div>
+              <div class="source-info">
+                <span class="source-title">{getPersonName(group)}</span>
+                <span class="source-meta">@{getPersonHandle(group)}</span>
+              </div>
+              <div class="source-actions">
+                <button
+                  class="action-btn danger"
+                  onclick={async () => {
+                    if (confirm(`Remove all subscriptions for ${getPersonName(group)}?`)) {
+                      await Promise.all(
+                        group.subscriptions
+                          .filter((s) => s.id != null)
+                          .map((s) => subscriptionsStore.remove(s.id!))
+                      );
+                    }
+                  }}
+                  title="Remove all"
+                >
+                  <Icon name="trash" size={14} />
+                </button>
+              </div>
+            </div>
+            <div class="person-content-types">
+              {#if detected?.loading}
+                <div class="content-type-loading">
+                  <span class="spinner-small"></span>
+                  <span>Detecting content...</span>
+                </div>
               {:else}
-                <Icon name="user" size={16} />
+                <!-- Shares -->
+                <div class="content-type-row">
+                  <label class="row-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={sharesSub?.id != null && selectedIds.has(sharesSub.id)}
+                      disabled={!sharesSub?.id}
+                      onchange={() => sharesSub?.id && toggleSelect(sharesSub.id)}
+                    />
+                  </label>
+                  <div class="content-type-info">
+                    <div class="content-type-label">
+                      <Icon name="share" size={14} />
+                      <span class="content-type-name">Skyreader Shares</span>
+                      {#if detected && detected.shareCount > 0}
+                        <span class="content-count">({detected.shareCount})</span>
+                      {/if}
+                      {#if sharesUnread > 0}
+                        <span class="unread-badge">{sharesUnread}</span>
+                      {/if}
+                    </div>
+                    <span class="content-type-desc"
+                      >Articles they share and recommend on Skyreader</span
+                    >
+                  </div>
+                  <button
+                    class="subscribed-toggle"
+                    class:active={group.hasShares}
+                    onclick={() => toggleShares(group)}
+                    title={group.hasShares ? 'Unsubscribe from shares' : 'Subscribe to shares'}
+                  >
+                    <span class="toggle-track">
+                      <span class="toggle-thumb"></span>
+                    </span>
+                    <span class="toggle-label">{group.hasShares ? 'Subscribed' : 'Subscribe'}</span>
+                  </button>
+                </div>
+
+                <!-- Freestanding documents -->
+                {#if freestandingSub || (detected && detected.freestandingDocumentCount > 0)}
+                  <div class="content-type-row">
+                    <label class="row-checkbox">
+                      <input
+                        type="checkbox"
+                        checked={freestandingSub?.id != null && selectedIds.has(freestandingSub.id)}
+                        disabled={!freestandingSub?.id}
+                        onchange={() => freestandingSub?.id && toggleSelect(freestandingSub.id)}
+                      />
+                    </label>
+                    <div class="content-type-info">
+                      <div class="content-type-label">
+                        <Icon name="file-text" size={14} />
+                        <span class="content-type-name">Documents</span>
+                        {#if detected && detected.freestandingDocumentCount > 0}
+                          <span class="content-count">({detected.freestandingDocumentCount})</span>
+                        {/if}
+                        {#if freestandingUnread > 0}
+                          <span class="unread-badge">{freestandingUnread}</span>
+                        {/if}
+                      </div>
+                      <span class="content-type-desc"
+                        >Free-standing documents by @{getPersonHandle(group)}</span
+                      >
+                    </div>
+                    <button
+                      class="subscribed-toggle"
+                      class:active={!!freestandingSub}
+                      onclick={() => toggleFreestandingDocs(group)}
+                      title={freestandingSub
+                        ? 'Unsubscribe from documents'
+                        : 'Subscribe to documents'}
+                    >
+                      <span class="toggle-track">
+                        <span class="toggle-thumb"></span>
+                      </span>
+                      <span class="toggle-label"
+                        >{freestandingSub ? 'Subscribed' : 'Subscribe'}</span
+                      >
+                    </button>
+                  </div>
+                {/if}
+
+                <!-- Publications -->
+                {#if detected && detected.publications.length > 0}
+                  {#each detected.publications as pub (pub.uri)}
+                    {@const pubSub = getSubscriptionForFeedUrl(group, pub.uri)}
+                    {@const pubUnread = pubSub?.id
+                      ? (unreadCounts.feedCounts.get(pubSub.id) ?? 0)
+                      : 0}
+                    <div class="content-type-row">
+                      <label class="row-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={pubSub?.id != null && selectedIds.has(pubSub.id)}
+                          disabled={!pubSub?.id}
+                          onchange={() => pubSub?.id && toggleSelect(pubSub.id)}
+                        />
+                      </label>
+                      <div class="content-type-info">
+                        <div class="content-type-label">
+                          {#if pub.iconUrl}
+                            <img src={pub.iconUrl} alt="" class="pub-icon" />
+                          {:else}
+                            <Icon name="newspaper" size={14} />
+                          {/if}
+                          <span class="content-type-name">{pub.name || pub.url}</span>
+                          {#if pubUnread > 0}
+                            <span class="unread-badge">{pubUnread}</span>
+                          {/if}
+                        </div>
+                        {#if pub.description}
+                          <span class="content-type-desc">{pub.description}</span>
+                        {:else if pub.url}
+                          <span class="content-type-desc">{pub.url}</span>
+                        {/if}
+                      </div>
+                      <button
+                        class="subscribed-toggle"
+                        class:active={!!pubSub}
+                        onclick={() => togglePublication(group, pub)}
+                        title={pubSub ? `Unsubscribe from ${pub.name}` : `Subscribe to ${pub.name}`}
+                      >
+                        <span class="toggle-track">
+                          <span class="toggle-thumb"></span>
+                        </span>
+                        <span class="toggle-label">{pubSub ? 'Subscribed' : 'Subscribe'}</span>
+                      </button>
+                    </div>
+                  {/each}
+                {/if}
               {/if}
-            </div>
-            <div class="source-info">
-              <span class="source-title">{getPersonName(group)}</span>
-              <span class="source-meta">@{getPersonHandle(group)}</span>
-            </div>
-            <div class="content-toggles">
-              <button
-                class="type-toggle"
-                class:active={group.hasShares}
-                onclick={() => toggleContentType(group, 'atproto.shares')}
-                title={group.hasShares ? 'Unsubscribe from shares' : 'Subscribe to shares'}
-              >
-                <Icon name="share" size={12} />
-                <span>Shares</span>
-              </button>
-              <button
-                class="type-toggle"
-                class:active={group.hasDocuments}
-                onclick={() => toggleContentType(group, 'atproto.documents')}
-                title={group.hasDocuments ? 'Unsubscribe from articles' : 'Subscribe to articles'}
-              >
-                <Icon name="file-text" size={12} />
-                <span>Articles</span>
-              </button>
-            </div>
-            {#if group.totalUnread > 0}
-              <span class="unread-badge">{group.totalUnread}</span>
-            {/if}
-            <div class="source-actions">
-              <button
-                class="action-btn danger"
-                onclick={async () => {
-                  const names = group.subscriptions.map((s) => s.customTitle || s.title).join(', ');
-                  if (confirm(`Remove all subscriptions for ${getPersonName(group)}?`)) {
-                    await Promise.all(
-                      group.subscriptions
-                        .filter((s) => s.id != null)
-                        .map((s) => subscriptionsStore.remove(s.id!))
-                    );
-                  }
-                }}
-                title="Remove all"
-              >
-                <Icon name="trash" size={14} />
-              </button>
             </div>
           </div>
         {/each}
@@ -808,38 +1070,151 @@
     white-space: nowrap;
   }
 
-  /* Content type toggles for people */
-  .content-toggles {
+  /* Person card layout */
+  .person-card {
+    background: var(--color-bg);
+    padding: 0.75rem;
+  }
+
+  .person-header {
     display: flex;
-    gap: 0.25rem;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.625rem;
+  }
+
+  .person-content-types {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding-left: 2.25rem;
+  }
+
+  .content-type-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 8px;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.02));
+  }
+
+  .content-type-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .content-type-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+
+  .content-type-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .content-type-desc {
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.3;
+  }
+
+  .content-count {
+    font-weight: 400;
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+  }
+
+  .pub-icon {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
     flex-shrink: 0;
   }
 
-  .type-toggle {
+  .content-type-loading {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .spinner-small {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--color-border);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* Subscribe toggle switch */
+  .subscribed-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
     background: none;
+    border: none;
     cursor: pointer;
+    flex-shrink: 0;
+    padding: 0.25rem;
+  }
+
+  .toggle-track {
+    display: block;
+    width: 28px;
+    height: 16px;
+    border-radius: 8px;
+    background: var(--color-border);
+    position: relative;
+    transition: background-color 0.2s;
+  }
+
+  .subscribed-toggle.active .toggle-track {
+    background: var(--color-primary);
+  }
+
+  .toggle-thumb {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: white;
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.2s;
+  }
+
+  .subscribed-toggle.active .toggle-thumb {
+    transform: translateX(12px);
+  }
+
+  .toggle-label {
     font-size: 0.6875rem;
     color: var(--color-text-secondary);
-    transition:
-      background-color 0.15s,
-      color 0.15s,
-      border-color 0.15s;
+    white-space: nowrap;
   }
 
-  .type-toggle.active {
-    background: rgba(0, 102, 204, 0.08);
+  .subscribed-toggle.active .toggle-label {
     color: var(--color-primary);
-    border-color: var(--color-primary);
-  }
-
-  .type-toggle:hover {
-    background: var(--color-bg-hover);
   }
 
   .unread-badge {
@@ -910,13 +1285,26 @@
       display: none;
     }
 
-    .content-toggles {
-      flex-direction: column;
+    .person-content-types {
+      padding-left: 0;
+    }
+
+    .content-type-row {
+      flex-wrap: wrap;
+    }
+
+    .toggle-label {
+      display: none;
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    .source-row:hover {
+    .content-type-row {
+      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.04));
+    }
+
+    .source-row:hover,
+    .person-card:hover {
       background: var(--color-bg-hover, rgba(255, 255, 255, 0.03));
     }
 

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
@@ -12,6 +11,7 @@
   import { api } from '$lib/services/api';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
+  import { getSourceDisplay } from '$lib/utils/sourceDisplay';
   import Icon from '$lib/components/Icon.svelte';
   import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
   import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
@@ -20,6 +20,10 @@
   import EditFeedModal from '$lib/components/EditFeedModal.svelte';
   import AddFeedModal from '$lib/components/AddFeedModal.svelte';
   import AddHandleModal from '$lib/components/AddHandleModal.svelte';
+  import SourceRow from '$lib/components/sources/SourceRow.svelte';
+  import SourceGroupHeader from '$lib/components/sources/SourceGroupHeader.svelte';
+  import SourcesToolbar from '$lib/components/sources/SourcesToolbar.svelte';
+  import BulkActionBar from '$lib/components/sources/BulkActionBar.svelte';
   import type { Subscription, BlueskyProfile } from '$lib/types';
 
   interface DetectedPublication {
@@ -37,18 +41,16 @@
     loading: boolean;
   }
 
+  // -- State --
   let feedSwitcherOpen = $state(false);
-
   let searchQuery = $state('');
   let editingSubscription = $state<Subscription | null>(null);
   let editModalOpen = $state(false);
   let selectedIds = $state<Set<number>>(new Set());
   let profiles = $state<Map<string, BlueskyProfile>>(new Map());
-  let assignChannelOpen = $state(false);
   let detectedContent = $state<Map<string, DetectedContent>>(new Map());
 
   const CONTENT_CACHE_KEY = 'skyreader:detected-content';
-
   type CachedContent = Omit<DetectedContent, 'loading'>;
 
   function loadContentCache(): Map<string, CachedContent> {
@@ -76,7 +78,7 @@
     }
   }
 
-  // Group AT Protocol subscriptions by person (DID)
+  // -- Person groups --
   interface PersonGroup {
     did: string;
     profile: BlueskyProfile | null;
@@ -88,7 +90,6 @@
 
   let peopleGroups = $derived.by((): PersonGroup[] => {
     const byDid = new Map<string, Subscription[]>();
-
     for (const sub of subscriptionsStore.subscriptions) {
       if (!sub.subjectDid) continue;
       if (
@@ -125,7 +126,6 @@
       const nameB = b.profile?.displayName || b.profile?.handle || b.did;
       return nameA.localeCompare(nameB);
     });
-
     return groups;
   });
 
@@ -135,7 +135,7 @@
       .sort((a, b) => (a.customTitle || a.title).localeCompare(b.customTitle || b.title));
   });
 
-  // Filtering
+  // -- Filtering --
   let filteredPeople = $derived(
     searchQuery
       ? peopleGroups.filter((g) => {
@@ -159,7 +159,7 @@
       : websites
   );
 
-  // Selection helpers
+  // -- Selection --
   let allVisibleIds = $derived.by(() => {
     const ids: number[] = [];
     for (const g of filteredPeople) {
@@ -176,112 +176,103 @@
   let allSelected = $derived(
     allVisibleIds.length > 0 && allVisibleIds.every((id) => selectedIds.has(id))
   );
-
   let selectionCount = $derived(selectedIds.size);
 
   function toggleSelectAll() {
-    if (allSelected) {
-      selectedIds = new Set();
-    } else {
-      selectedIds = new Set(allVisibleIds);
-    }
+    selectedIds = allSelected ? new Set() : new Set(allVisibleIds);
   }
 
   function toggleSelect(id: number) {
     const next = new Set(selectedIds);
-    if (next.has(id)) {
-      next.delete(id);
-    } else {
-      next.add(id);
-    }
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
     selectedIds = next;
   }
 
-  function togglePersonSelect(group: PersonGroup) {
-    const ids = group.subscriptions.map((s) => s.id!).filter(Boolean);
-    const allIn = ids.every((id) => selectedIds.has(id));
-    const next = new Set(selectedIds);
-    if (allIn) {
-      ids.forEach((id) => next.delete(id));
-    } else {
-      ids.forEach((id) => next.add(id));
-    }
-    selectedIds = next;
+  // -- Subscribe/unsubscribe for AT Proto content streams --
+  function getPersonHandle(group: PersonGroup): string {
+    return group.profile?.handle || group.did;
   }
 
-  // Toggle subscription for a specific content stream
-  async function toggleShares(group: PersonGroup) {
-    const existing = group.subscriptions.find((s) => s.sourceType === 'atproto.shares');
-    if (existing?.id) {
-      await subscriptionsStore.remove(existing.id);
-    } else {
-      await subscriptionsStore.add(undefined, `Shares from @${getPersonHandle(group)}`, {
-        sourceType: 'atproto.shares',
-        subjectDid: group.did,
-      });
-    }
+  function getPersonName(group: PersonGroup): string {
+    return group.profile?.displayName || group.profile?.handle || group.did;
   }
 
-  async function toggleFreestandingDocs(group: PersonGroup) {
-    const existing = group.subscriptions.find(
-      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === '__freestanding__'
-    );
-    if (existing?.id) {
-      await subscriptionsStore.remove(existing.id);
-    } else {
-      await subscriptionsStore.add(
-        '__freestanding__',
-        `Documents from @${getPersonHandle(group)}`,
-        {
-          sourceType: 'atproto.documents',
-          subjectDid: group.did,
-          feedUrl: '__freestanding__',
-        }
-      );
+  async function subscribeShares(did: string, handle: string) {
+    await subscriptionsStore.add(undefined, `Shares from @${handle}`, {
+      sourceType: 'atproto.shares',
+      subjectDid: did,
+    });
+  }
+
+  async function subscribeFreestandingDocs(did: string, handle: string) {
+    await subscriptionsStore.add('__freestanding__', `Documents from @${handle}`, {
+      sourceType: 'atproto.documents',
+      subjectDid: did,
+      feedUrl: '__freestanding__',
+    });
+  }
+
+  async function subscribePublication(did: string, pub: DetectedPublication) {
+    const subId = await subscriptionsStore.add(pub.uri, pub.name || pub.url, {
+      sourceType: 'atproto.documents',
+      subjectDid: did,
+      siteUrl: pub.url,
+      feedUrl: pub.uri,
+    });
+    if (pub.iconUrl) {
+      await subscriptionsStore.updateLocal(subId, { customIconUrl: pub.iconUrl });
     }
   }
 
-  async function togglePublication(group: PersonGroup, pub: DetectedPublication) {
-    const existing = group.subscriptions.find(
-      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === pub.uri
-    );
-    if (existing?.id) {
-      await subscriptionsStore.remove(existing.id);
-    } else {
-      const subId = await subscriptionsStore.add(pub.uri, pub.name || pub.url, {
-        sourceType: 'atproto.documents',
-        subjectDid: group.did,
-        siteUrl: pub.url,
-        feedUrl: pub.uri,
-      });
-      if (pub.iconUrl) {
-        await subscriptionsStore.updateLocal(subId, { customIconUrl: pub.iconUrl });
+  // -- Actions --
+  function handleEdit(sub: Subscription) {
+    editingSubscription = sub;
+    editModalOpen = true;
+  }
+
+  async function handleRemove(sub: Subscription) {
+    if (sub.id && confirm(`Remove "${sub.customTitle || sub.title}"?`)) {
+      await subscriptionsStore.remove(sub.id);
+    }
+  }
+
+  function closeEditModal() {
+    editModalOpen = false;
+    editingSubscription = null;
+  }
+
+  function getFaviconUrl(sub: Subscription): string | null {
+    if (sub.customIconUrl) return sub.customIconUrl;
+    const url = sub.siteUrl || sub.feedUrl;
+    if (!url || url === '__freestanding__') return null;
+    try {
+      const host = new URL(url).hostname;
+      return `https://icons.duckduckgo.com/ip3/${host}.ico`;
+    } catch {
+      return null;
+    }
+  }
+
+  function getSubtitle(sub: Subscription): string {
+    if (!sub.sourceType || sub.sourceType === 'rss') {
+      try {
+        return new URL(sub.siteUrl || sub.feedUrl || '').hostname;
+      } catch {
+        return '';
       }
     }
+    return '';
   }
 
-  function getSubscriptionForFeedUrl(
-    group: PersonGroup,
-    feedUrl: string
-  ): Subscription | undefined {
-    return group.subscriptions.find(
-      (s) => s.sourceType === 'atproto.documents' && s.feedUrl === feedUrl
-    );
-  }
-
-  // Bulk operations
+  // -- Bulk operations --
   async function bulkDelete() {
     const count = selectionCount;
     if (!confirm(`Remove ${count} source${count > 1 ? 's' : ''}?`)) return;
-    const ids = [...selectedIds];
-    for (const id of ids) {
+    for (const id of [...selectedIds]) {
       await subscriptionsStore.remove(id);
     }
     selectedIds = new Set();
-  }
-
-  function bulkAssignToChannel() {
-    assignChannelOpen = !assignChannelOpen;
   }
 
   async function assignToChannel(channelId: number) {
@@ -305,47 +296,10 @@
       sourceMode: 'include',
       sourceKeys: [...currentKeys],
     });
-    assignChannelOpen = false;
     selectedIds = new Set();
   }
 
-  function handleEdit(sub: Subscription) {
-    editingSubscription = sub;
-    editModalOpen = true;
-  }
-
-  async function handleRemove(sub: Subscription) {
-    if (sub.id && confirm(`Remove "${sub.customTitle || sub.title}"?`)) {
-      await subscriptionsStore.remove(sub.id);
-    }
-  }
-
-  function closeEditModal() {
-    editModalOpen = false;
-    editingSubscription = null;
-  }
-
-  function getFaviconUrl(sub: Subscription): string | null {
-    if (sub.customIconUrl) return sub.customIconUrl;
-    const url = sub.siteUrl || sub.feedUrl;
-    if (!url) return null;
-    try {
-      const host = new URL(url).hostname;
-      return `https://icons.duckduckgo.com/ip3/${host}.ico`;
-    } catch {
-      return null;
-    }
-  }
-
-  function getPersonName(group: PersonGroup): string {
-    return group.profile?.displayName || group.profile?.handle || group.did;
-  }
-
-  function getPersonHandle(group: PersonGroup): string {
-    return group.profile?.handle || group.did;
-  }
-
-  // Fetch profiles and detected content on mount
+  // -- Fetch profiles and detected content on mount --
   onMount(async () => {
     const dids = [
       ...new Set(
@@ -354,7 +308,6 @@
     ];
     if (dids.length === 0) return;
 
-    // 1. Immediately populate from cache
     const cache = loadContentCache();
     const initial = new Map<string, DetectedContent>();
     for (const did of dids) {
@@ -365,13 +318,10 @@
     }
     detectedContent = initial;
 
-    // Fetch profiles
     const fetched = await profileService.getProfiles(dids);
     profiles = fetched;
 
-    // 2. Refresh from API in background
     for (const did of dids) {
-      // Mark as loading only if we don't already have cached data
       if (!detectedContent.has(did)) {
         const next = new Map(detectedContent);
         next.set(did, {
@@ -397,7 +347,6 @@
           detectedContent = updated;
         })
         .catch(() => {
-          // On failure, keep cached data if we have it
           if (!detectedContent.has(did)) {
             const updated = new Map(detectedContent);
             updated.set(did, {
@@ -420,61 +369,23 @@
 <FeedPageHeader title="Manage Sources" hideControls />
 
 <div class="sources-page">
-  <div class="sources-toolbar">
-    <div class="search-wrapper">
-      <Icon name="search" size={16} />
-      <input
-        type="text"
-        bind:value={searchQuery}
-        placeholder="Search sources..."
-        class="search-input"
-      />
-    </div>
-    <button class="add-btn" onclick={() => sidebarStore.openAddFeedModal()}>
-      <Icon name="plus" size={16} />
-      <span>Add RSS</span>
-    </button>
-    <button class="add-btn" onclick={() => sidebarStore.openAddHandleModal()}>
-      <Icon name="at-sign" size={16} />
-      <span>Add @handle</span>
-    </button>
-  </div>
+  <SourcesToolbar
+    {searchQuery}
+    onSearchChange={(v) => (searchQuery = v)}
+    onAddRss={() => sidebarStore.openAddFeedModal()}
+    onAddHandle={() => sidebarStore.openAddHandleModal()}
+  />
 
-  <!-- Bulk action bar -->
   {#if selectionCount > 0}
-    <div class="bulk-bar">
-      <span class="bulk-count">{selectionCount} selected</span>
-      <div class="bulk-actions">
-        <div class="assign-wrapper">
-          <button class="bulk-btn" onclick={bulkAssignToChannel}>
-            <Icon name="filter" size={14} />
-            Add to channel
-          </button>
-          {#if assignChannelOpen && filteredViewsStore.views.length > 0}
-            <div class="assign-dropdown">
-              {#each filteredViewsStore.views as view (view.id)}
-                <button
-                  class="assign-item"
-                  onclick={() => view.id != null && assignToChannel(view.id)}
-                >
-                  {view.name}
-                </button>
-              {/each}
-            </div>
-          {/if}
-        </div>
-        <button class="bulk-btn danger" onclick={bulkDelete}>
-          <Icon name="trash" size={14} />
-          Remove
-        </button>
-      </div>
-      <button class="bulk-clear" onclick={() => (selectedIds = new Set())}>
-        <Icon name="x" size={14} />
-      </button>
-    </div>
+    <BulkActionBar
+      {selectionCount}
+      channels={filteredViewsStore.views}
+      onAssignToChannel={assignToChannel}
+      onBulkDelete={bulkDelete}
+      onClearSelection={() => (selectedIds = new Set())}
+    />
   {/if}
 
-  <!-- Select all -->
   {#if filteredPeople.length > 0 || filteredWebsites.length > 0}
     <div class="select-all-row">
       <label class="checkbox-label">
@@ -495,187 +406,103 @@
       <div class="source-list">
         {#each filteredPeople as group (group.did)}
           {@const detected = detectedContent.get(group.did)}
-          {@const sharesSub = group.subscriptions.find((s) => s.sourceType === 'atproto.shares')}
-          {@const freestandingSub = group.subscriptions.find(
-            (s) => s.sourceType === 'atproto.documents' && s.feedUrl === '__freestanding__'
-          )}
-          {@const sharesUnread = sharesSub?.id
-            ? (unreadCounts.feedCounts.get(sharesSub.id) ?? 0)
-            : 0}
-          {@const freestandingUnread = freestandingSub?.id
-            ? (unreadCounts.feedCounts.get(freestandingSub.id) ?? 0)
-            : 0}
-          <div class="person-card">
-            <div class="person-header">
-              <div class="source-icon">
-                {#if group.profile?.avatar}
-                  <img src={group.profile.avatar} alt="" class="avatar" />
-                {:else}
-                  <Icon name="user" size={16} />
-                {/if}
-              </div>
-              <div class="source-info">
-                <span class="source-title">{getPersonName(group)}</span>
-                <span class="source-meta">@{getPersonHandle(group)}</span>
-              </div>
-              <div class="source-actions">
-                <button
-                  class="action-btn danger"
-                  onclick={async () => {
-                    if (confirm(`Remove all subscriptions for ${getPersonName(group)}?`)) {
-                      await Promise.all(
-                        group.subscriptions
-                          .filter((s) => s.id != null)
-                          .map((s) => subscriptionsStore.remove(s.id!))
-                      );
-                    }
-                  }}
-                  title="Remove all"
-                >
-                  <Icon name="trash" size={14} />
-                </button>
-              </div>
-            </div>
-            <div class="person-content-types">
-              {#if detected?.loading}
-                <div class="content-type-loading">
-                  <span class="spinner-small"></span>
-                  <span>Detecting content...</span>
-                </div>
-              {:else}
-                <!-- Shares -->
-                <div class="content-type-row">
-                  <label class="row-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={sharesSub?.id != null && selectedIds.has(sharesSub.id)}
-                      disabled={!sharesSub?.id}
-                      onchange={() => sharesSub?.id && toggleSelect(sharesSub.id)}
-                    />
-                  </label>
-                  <div class="content-type-info">
-                    <div class="content-type-label">
-                      <Icon name="share" size={14} />
-                      <span class="content-type-name">Skyreader Shares</span>
-                      {#if detected && detected.shareCount > 0}
-                        <span class="content-count">({detected.shareCount})</span>
-                      {/if}
-                      {#if sharesUnread > 0}
-                        <span class="unread-badge">{sharesUnread}</span>
-                      {/if}
-                    </div>
-                    <span class="content-type-desc"
-                      >Articles they share and recommend on Skyreader</span
-                    >
-                  </div>
-                  <button
-                    class="subscribed-toggle"
-                    class:active={group.hasShares}
-                    onclick={() => toggleShares(group)}
-                    title={group.hasShares ? 'Unsubscribe from shares' : 'Subscribe to shares'}
-                  >
-                    <span class="toggle-track">
-                      <span class="toggle-thumb"></span>
-                    </span>
-                    <span class="toggle-label">{group.hasShares ? 'Subscribed' : 'Subscribe'}</span>
-                  </button>
-                </div>
+          {@const handle = getPersonHandle(group)}
+          {@const avatarUrl = group.profile?.avatar ?? null}
 
-                <!-- Freestanding documents -->
-                {#if freestandingSub || (detected && detected.freestandingDocumentCount > 0)}
-                  <div class="content-type-row">
-                    <label class="row-checkbox">
-                      <input
-                        type="checkbox"
-                        checked={freestandingSub?.id != null && selectedIds.has(freestandingSub.id)}
-                        disabled={!freestandingSub?.id}
-                        onchange={() => freestandingSub?.id && toggleSelect(freestandingSub.id)}
-                      />
-                    </label>
-                    <div class="content-type-info">
-                      <div class="content-type-label">
-                        <Icon name="file-text" size={14} />
-                        <span class="content-type-name">Documents</span>
-                        {#if detected && detected.freestandingDocumentCount > 0}
-                          <span class="content-count">({detected.freestandingDocumentCount})</span>
-                        {/if}
-                        {#if freestandingUnread > 0}
-                          <span class="unread-badge">{freestandingUnread}</span>
-                        {/if}
-                      </div>
-                      <span class="content-type-desc"
-                        >Free-standing documents by @{getPersonHandle(group)}</span
-                      >
-                    </div>
-                    <button
-                      class="subscribed-toggle"
-                      class:active={!!freestandingSub}
-                      onclick={() => toggleFreestandingDocs(group)}
-                      title={freestandingSub
-                        ? 'Unsubscribe from documents'
-                        : 'Subscribe to documents'}
-                    >
-                      <span class="toggle-track">
-                        <span class="toggle-thumb"></span>
-                      </span>
-                      <span class="toggle-label"
-                        >{freestandingSub ? 'Subscribed' : 'Subscribe'}</span
-                      >
-                    </button>
-                  </div>
-                {/if}
+          <SourceGroupHeader
+            {avatarUrl}
+            displayName={getPersonName(group)}
+            {handle}
+            totalUnread={group.totalUnread}
+            onRemoveAll={async () => {
+              if (confirm(`Remove all subscriptions for ${getPersonName(group)}?`)) {
+                await Promise.all(
+                  group.subscriptions
+                    .filter((s) => s.id != null)
+                    .map((s) => subscriptionsStore.remove(s.id!))
+                );
+              }
+            }}
+          />
 
-                <!-- Publications -->
-                {#if detected && detected.publications.length > 0}
-                  {#each detected.publications as pub (pub.uri)}
-                    {@const pubSub = getSubscriptionForFeedUrl(group, pub.uri)}
-                    {@const pubUnread = pubSub?.id
-                      ? (unreadCounts.feedCounts.get(pubSub.id) ?? 0)
-                      : 0}
-                    <div class="content-type-row">
-                      <label class="row-checkbox">
-                        <input
-                          type="checkbox"
-                          checked={pubSub?.id != null && selectedIds.has(pubSub.id)}
-                          disabled={!pubSub?.id}
-                          onchange={() => pubSub?.id && toggleSelect(pubSub.id)}
-                        />
-                      </label>
-                      <div class="content-type-info">
-                        <div class="content-type-label">
-                          {#if pub.iconUrl}
-                            <img src={pub.iconUrl} alt="" class="pub-icon" />
-                          {:else}
-                            <Icon name="newspaper" size={14} />
-                          {/if}
-                          <span class="content-type-name">{pub.name || pub.url}</span>
-                          {#if pubUnread > 0}
-                            <span class="unread-badge">{pubUnread}</span>
-                          {/if}
-                        </div>
-                        {#if pub.description}
-                          <span class="content-type-desc">{pub.description}</span>
-                        {:else if pub.url}
-                          <span class="content-type-desc">{pub.url}</span>
-                        {/if}
-                      </div>
-                      <button
-                        class="subscribed-toggle"
-                        class:active={!!pubSub}
-                        onclick={() => togglePublication(group, pub)}
-                        title={pubSub ? `Unsubscribe from ${pub.name}` : `Subscribe to ${pub.name}`}
-                      >
-                        <span class="toggle-track">
-                          <span class="toggle-thumb"></span>
-                        </span>
-                        <span class="toggle-label">{pubSub ? 'Subscribed' : 'Subscribe'}</span>
-                      </button>
-                    </div>
-                  {/each}
-                {/if}
+          <!-- Subscribed content streams -->
+          {#each group.subscriptions as sub (sub.rkey)}
+            {@const display = getSourceDisplay(sub.sourceType, sub.feedUrl)}
+            {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+            <SourceRow
+              iconUrl={sub.customIconUrl || avatarUrl}
+              iconRound={!sub.customIconUrl}
+              title={sub.customTitle || sub.title}
+              subtitle={'@' + handle}
+              sourceLabel={display.label}
+              pillClass={display.pillClass}
+              unreadCount={subUnread}
+              subscribed={true}
+              selected={sub.id != null && selectedIds.has(sub.id)}
+              fallbackIcon={display.iconName}
+              onToggleSelect={() => sub.id && toggleSelect(sub.id)}
+              onRemove={() => handleRemove(sub)}
+              onEdit={sub.sourceType === 'atproto.documents' && sub.feedUrl !== '__freestanding__'
+                ? () => handleEdit(sub)
+                : null}
+            />
+          {/each}
+
+          <!-- Unsubscribed content streams -->
+          {#if !group.hasShares}
+            <SourceRow
+              iconUrl={avatarUrl}
+              iconRound={true}
+              title="Skyreader Shares"
+              subtitle={detected && !detected.loading && detected.shareCount > 0
+                ? `Articles they share and recommend (${detected.shareCount})`
+                : 'Articles they share and recommend on Skyreader'}
+              sourceLabel="Shares"
+              pillClass="pill-shares"
+              subscribed={false}
+              fallbackIcon="share"
+              onSubscribe={() => subscribeShares(group.did, handle)}
+            />
+          {/if}
+
+          {#if detected && !detected.loading}
+            {#if !group.subscriptions.some((s) => s.sourceType === 'atproto.documents' && s.feedUrl === '__freestanding__') && detected.freestandingDocumentCount > 0}
+              <SourceRow
+                iconUrl={avatarUrl}
+                iconRound={true}
+                title="Documents"
+                subtitle="Free-standing documents by @{handle} ({detected.freestandingDocumentCount})"
+                sourceLabel="Documents"
+                pillClass="pill-documents"
+                subscribed={false}
+                fallbackIcon="file-text"
+                onSubscribe={() => subscribeFreestandingDocs(group.did, handle)}
+              />
+            {/if}
+
+            {#each detected.publications as pub (pub.uri)}
+              {#if !group.subscriptions.some((s) => s.sourceType === 'atproto.documents' && s.feedUrl === pub.uri)}
+                <SourceRow
+                  iconUrl={pub.iconUrl || avatarUrl}
+                  iconRound={!pub.iconUrl}
+                  title={pub.name || pub.url}
+                  subtitle={pub.description || pub.url}
+                  sourceLabel="Publication"
+                  pillClass="pill-publication"
+                  subscribed={false}
+                  fallbackIcon="newspaper"
+                  onSubscribe={() => subscribePublication(group.did, pub)}
+                />
               {/if}
+            {/each}
+          {/if}
+
+          {#if detected?.loading}
+            <div class="content-type-loading">
+              <span class="spinner-small"></span>
+              <span>Detecting content...</span>
             </div>
-          </div>
+          {/if}
         {/each}
       </div>
     </section>
@@ -691,58 +518,25 @@
       </h2>
       <div class="source-list">
         {#each filteredWebsites as sub (sub.id)}
-          {@const favicon = getFaviconUrl(sub)}
+          {@const display = getSourceDisplay(sub.sourceType, sub.feedUrl)}
           {@const feedCount = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
           {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
-          <div class="source-row">
-            <label class="row-checkbox">
-              <input
-                type="checkbox"
-                checked={sub.id != null && selectedIds.has(sub.id)}
-                onchange={() => sub.id && toggleSelect(sub.id)}
-              />
-            </label>
-            <div class="source-icon">
-              {#if favicon}
-                <img src={favicon} alt="" class="favicon" />
-              {:else}
-                <Icon name="rss" size={16} />
-              {/if}
-            </div>
-            <div class="source-info">
-              <span class="source-title">{sub.customTitle || sub.title}</span>
-              <span class="source-meta">
-                {#if sub.siteUrl}
-                  {new URL(sub.siteUrl).hostname}
-                {:else if sub.feedUrl}
-                  {new URL(sub.feedUrl).hostname}
-                {/if}
-              </span>
-            </div>
-            {#if status?.status === 'error' || status?.status === 'circuit-open'}
-              <span class="error-badge" title="Feed error">
-                <Icon name="alert-triangle" size={14} />
-              </span>
-            {/if}
-            {#if feedCount > 0}
-              <span class="unread-badge">{feedCount}</span>
-            {/if}
-            <div class="source-actions">
-              <button class="action-btn" onclick={() => handleEdit(sub)} title="Edit">
-                <Icon name="edit" size={14} />
-              </button>
-              <button
-                class="action-btn"
-                onclick={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-                title="Refresh"
-              >
-                <Icon name="refresh-cw" size={14} />
-              </button>
-              <button class="action-btn danger" onclick={() => handleRemove(sub)} title="Remove">
-                <Icon name="trash" size={14} />
-              </button>
-            </div>
-          </div>
+          <SourceRow
+            iconUrl={getFaviconUrl(sub)}
+            title={sub.customTitle || sub.title}
+            subtitle={getSubtitle(sub)}
+            sourceLabel={display.label}
+            pillClass={display.pillClass}
+            unreadCount={feedCount}
+            hasError={status?.status === 'error' || status?.status === 'circuit-open'}
+            subscribed={true}
+            selected={sub.id != null && selectedIds.has(sub.id)}
+            fallbackIcon="rss"
+            onToggleSelect={() => sub.id && toggleSelect(sub.id)}
+            onEdit={() => handleEdit(sub)}
+            onRefresh={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+            onRemove={() => handleRemove(sub)}
+          />
         {/each}
       </div>
     </section>
@@ -801,155 +595,11 @@
     padding: 3.5rem 1rem 1.5rem;
   }
 
-  .sources-toolbar {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    margin-bottom: 1rem;
-  }
-
   @media (max-width: 1000px) {
     .sources-page {
       padding-top: 0.5rem;
       padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
     }
-  }
-
-  .search-wrapper {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
-    border-radius: 8px;
-    padding: 0.5rem 0.75rem;
-    color: var(--color-text-secondary);
-  }
-
-  .search-input {
-    flex: 1;
-    border: none;
-    background: none;
-    font: inherit;
-    font-size: 0.875rem;
-    color: var(--color-text);
-    outline: none;
-  }
-
-  .search-input::placeholder {
-    color: var(--color-text-secondary);
-  }
-
-  .add-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    background: none;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    color: var(--color-text);
-    white-space: nowrap;
-  }
-
-  .add-btn:hover {
-    background: var(--color-bg-hover);
-  }
-
-  /* Bulk action bar */
-  .bulk-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
-    background: var(--color-primary);
-    color: #fff;
-    border-radius: 10px;
-    margin-bottom: 1rem;
-    font-size: 0.8125rem;
-  }
-
-  .bulk-count {
-    font-weight: 500;
-  }
-
-  .bulk-actions {
-    display: flex;
-    gap: 0.375rem;
-    flex: 1;
-  }
-
-  .bulk-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    background: none;
-    color: #fff;
-    cursor: pointer;
-    font-size: 0.75rem;
-  }
-
-  .bulk-btn:hover {
-    background: rgba(255, 255, 255, 0.15);
-  }
-
-  .bulk-btn.danger:hover {
-    background: rgba(220, 38, 38, 0.3);
-  }
-
-  .bulk-clear {
-    background: none;
-    border: none;
-    color: rgba(255, 255, 255, 0.7);
-    cursor: pointer;
-    padding: 0.25rem;
-    display: flex;
-    align-items: center;
-    border-radius: 4px;
-  }
-
-  .bulk-clear:hover {
-    color: #fff;
-  }
-
-  .assign-wrapper {
-    position: relative;
-  }
-
-  .assign-dropdown {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    margin-top: 0.25rem;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    padding: 0.25rem;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    z-index: 100;
-    min-width: 160px;
-  }
-
-  .assign-item {
-    display: block;
-    width: 100%;
-    padding: 0.375rem 0.5rem;
-    border: none;
-    background: none;
-    text-align: left;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    color: var(--color-text);
-    border-radius: 4px;
-  }
-
-  .assign-item:hover {
-    background: var(--color-bg-hover);
   }
 
   .select-all-row {
@@ -969,7 +619,6 @@
     user-select: none;
   }
 
-  /* Source groups */
   .source-group {
     margin-bottom: 1.5rem;
   }
@@ -997,157 +646,28 @@
     gap: 1px;
     background: var(--color-border);
     border-radius: 12px;
-    overflow: hidden;
   }
 
-  .source-row {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.75rem;
-    background: var(--color-bg);
-    transition: background-color 0.15s;
+  .source-list > :global(:first-child) {
+    border-radius: 12px 12px 0 0;
   }
 
-  .source-row:hover {
-    background: var(--color-bg-hover, rgba(0, 0, 0, 0.02));
+  .source-list > :global(:last-child) {
+    border-radius: 0 0 12px 12px;
   }
 
-  .row-checkbox {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-  }
-
-  .row-checkbox input {
-    cursor: pointer;
-  }
-
-  .source-icon {
-    flex-shrink: 0;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--color-text-secondary);
-  }
-
-  .favicon {
-    width: 20px;
-    height: 20px;
-    border-radius: 4px;
-  }
-
-  .avatar {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-  }
-
-  .source-info {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-  }
-
-  .source-title {
-    font-size: 0.875rem;
-    font-weight: 500;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .source-meta {
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Person card layout */
-  .person-card {
-    background: var(--color-bg);
-    padding: 0.75rem;
-  }
-
-  .person-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 0.625rem;
-  }
-
-  .person-content-types {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    padding-left: 2.25rem;
-  }
-
-  .content-type-row {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-    padding: 0.375rem 0.5rem;
-    border-radius: 8px;
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.02));
-  }
-
-  .content-type-info {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-  }
-
-  .content-type-label {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--color-text);
-  }
-
-  .content-type-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .content-type-desc {
-    font-size: 0.6875rem;
-    color: var(--color-text-secondary);
-    line-height: 1.3;
-  }
-
-  .content-count {
-    font-weight: 400;
-    color: var(--color-text-secondary);
-    font-size: 0.75rem;
-  }
-
-  .pub-icon {
-    width: 14px;
-    height: 14px;
-    border-radius: 3px;
-    flex-shrink: 0;
+  .source-list > :global(:only-child) {
+    border-radius: 12px;
   }
 
   .content-type-loading {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem;
+    padding: 0.5rem 0.75rem;
     font-size: 0.75rem;
     color: var(--color-text-secondary);
+    background: var(--color-bg);
   }
 
   .spinner-small {
@@ -1165,155 +685,10 @@
     }
   }
 
-  /* Subscribe toggle switch */
-  .subscribed-toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    background: none;
-    border: none;
-    cursor: pointer;
-    flex-shrink: 0;
-    padding: 0.25rem;
-  }
-
-  .toggle-track {
-    display: block;
-    width: 28px;
-    height: 16px;
-    border-radius: 8px;
-    background: var(--color-border);
-    position: relative;
-    transition: background-color 0.2s;
-  }
-
-  .subscribed-toggle.active .toggle-track {
-    background: var(--color-primary);
-  }
-
-  .toggle-thumb {
-    display: block;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background: white;
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    transition: transform 0.2s;
-  }
-
-  .subscribed-toggle.active .toggle-thumb {
-    transform: translateX(12px);
-  }
-
-  .toggle-label {
-    font-size: 0.6875rem;
-    color: var(--color-text-secondary);
-    white-space: nowrap;
-  }
-
-  .subscribed-toggle.active .toggle-label {
-    color: var(--color-primary);
-  }
-
-  .unread-badge {
-    flex-shrink: 0;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--color-primary);
-    background: rgba(0, 102, 204, 0.1);
-    padding: 0.125rem 0.375rem;
-    border-radius: 10px;
-  }
-
-  .error-badge {
-    flex-shrink: 0;
-    color: var(--color-error, #dc2626);
-    display: flex;
-    align-items: center;
-  }
-
-  .source-actions {
-    display: flex;
-    gap: 0.25rem;
-    opacity: 0;
-    transition: opacity 0.15s;
-  }
-
-  .source-row:hover .source-actions {
-    opacity: 1;
-  }
-
-  .action-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0.25rem;
-    border-radius: 4px;
-    color: var(--color-text-secondary);
-    display: flex;
-    align-items: center;
-  }
-
-  .action-btn:hover {
-    background: var(--color-bg-hover);
-    color: var(--color-text);
-  }
-
-  .action-btn.danger:hover {
-    color: var(--color-error, #dc2626);
-  }
-
   .empty-state {
     text-align: center;
     padding: 3rem 1rem;
     color: var(--color-text-secondary);
     font-size: 0.875rem;
-  }
-
-  @media (max-width: 640px) {
-    .source-actions {
-      opacity: 1;
-    }
-
-    .sources-toolbar {
-      flex-wrap: wrap;
-    }
-
-    .add-btn span {
-      display: none;
-    }
-
-    .person-content-types {
-      padding-left: 0;
-    }
-
-    .content-type-row {
-      flex-wrap: wrap;
-    }
-
-    .toggle-label {
-      display: none;
-    }
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .content-type-row {
-      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.04));
-    }
-
-    .source-row:hover,
-    .person-card:hover {
-      background: var(--color-bg-hover, rgba(255, 255, 255, 0.03));
-    }
-
-    .search-wrapper {
-      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.06));
-    }
-
-    .assign-dropdown {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    }
   }
 </style>

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -4,13 +4,11 @@
   import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
-  import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { fetchSingleFeed } from '$lib/services/feedFetcher';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import { profileService } from '$lib/services/profiles';
   import { api } from '$lib/services/api';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
-  import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
   import { getSourceDisplay } from '$lib/utils/sourceDisplay';
   import Icon from '$lib/components/Icon.svelte';
   import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
@@ -49,6 +47,12 @@
   let selectedIds = $state<Set<number>>(new Set());
   let profiles = $state<Map<string, BlueskyProfile>>(new Map());
   let detectedContent = $state<Map<string, DetectedContent>>(new Map());
+  let activeTab = $state<'people' | 'websites'>('people');
+
+  function switchTab(tab: 'people' | 'websites') {
+    activeTab = tab;
+    selectedIds = new Set();
+  }
 
   const CONTENT_CACHE_KEY = 'skyreader:detected-content';
   type CachedContent = Omit<DetectedContent, 'loading'>;
@@ -135,6 +139,28 @@
       .sort((a, b) => (a.customTitle || a.title).localeCompare(b.customTitle || b.title));
   });
 
+  // Group websites by category
+  interface WebsiteCategoryGroup {
+    name: string;
+    websites: Subscription[];
+  }
+
+  let websiteCategories = $derived.by((): WebsiteCategoryGroup[] => {
+    const byCategory = new Map<string, Subscription[]>();
+    for (const sub of websites) {
+      if (sub.category) {
+        const existing = byCategory.get(sub.category) || [];
+        existing.push(sub);
+        byCategory.set(sub.category, existing);
+      }
+    }
+    return [...byCategory.entries()]
+      .map(([name, subs]) => ({ name, websites: subs }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  let uncategorizedWebsites = $derived(websites.filter((s) => !s.category));
+
   // -- Filtering --
   let filteredPeople = $derived(
     searchQuery
@@ -159,16 +185,38 @@
       : websites
   );
 
+  function filterWebsitesBySearch(subs: Subscription[]): Subscription[] {
+    if (!searchQuery) return subs;
+    const q = searchQuery.toLowerCase();
+    return subs.filter(
+      (s) =>
+        (s.customTitle || s.title).toLowerCase().includes(q) ||
+        (s.feedUrl || '').toLowerCase().includes(q) ||
+        (s.siteUrl || '').toLowerCase().includes(q)
+    );
+  }
+
+  let filteredWebsiteCategories = $derived(
+    websiteCategories
+      .map((cat) => ({ ...cat, websites: filterWebsitesBySearch(cat.websites) }))
+      .filter((cat) => cat.websites.length > 0)
+  );
+
+  let filteredUncategorizedWebsites = $derived(filterWebsitesBySearch(uncategorizedWebsites));
+
   // -- Selection --
   let allVisibleIds = $derived.by(() => {
     const ids: number[] = [];
-    for (const g of filteredPeople) {
-      for (const s of g.subscriptions) {
+    if (activeTab === 'people') {
+      for (const g of filteredPeople) {
+        for (const s of g.subscriptions) {
+          if (s.id) ids.push(s.id);
+        }
+      }
+    } else {
+      for (const s of filteredWebsites) {
         if (s.id) ids.push(s.id);
       }
-    }
-    for (const s of filteredWebsites) {
-      if (s.id) ids.push(s.id);
     }
     return ids;
   });
@@ -275,27 +323,29 @@
     selectedIds = new Set();
   }
 
-  async function assignToChannel(channelId: number) {
-    const channel = filteredViewsStore.getById(channelId);
-    if (!channel) return;
+  let folders = $derived.by(() => {
+    const cats = new Set<string>();
+    for (const sub of subscriptionsStore.subscriptions) {
+      if (sub.category) cats.add(sub.category);
+    }
+    return [...cats].sort((a, b) => a.localeCompare(b));
+  });
 
-    const currentKeys = new Set(channel.sourceKeys || []);
+  let selectedHasCategory = $derived.by(() => {
     for (const id of selectedIds) {
       const sub = subscriptionsStore.getById(id);
-      if (!sub?.rkey) continue;
-      if (!sub.sourceType || sub.sourceType === 'rss') {
-        currentKeys.add(rssSourceKey(sub.rkey));
-      } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
-        currentKeys.add(sharesSourceKey(sub.subjectDid));
-      } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
-        currentKeys.add(documentsSourceKey(sub.subjectDid));
-      }
+      if (sub?.category) return true;
     }
+    return false;
+  });
 
-    await filteredViewsStore.update(channelId, {
-      sourceMode: 'include',
-      sourceKeys: [...currentKeys],
-    });
+  async function assignToFolder(folderName: string) {
+    await subscriptionsStore.bulkUpdateLocal([...selectedIds], { category: folderName });
+    selectedIds = new Set();
+  }
+
+  async function removeFromFolder() {
+    await subscriptionsStore.bulkUpdateLocal([...selectedIds], { category: null });
     selectedIds = new Set();
   }
 
@@ -379,30 +429,47 @@
   {#if selectionCount > 0}
     <BulkActionBar
       {selectionCount}
-      channels={filteredViewsStore.views}
-      onAssignToChannel={assignToChannel}
+      {folders}
+      hasCategory={selectedHasCategory}
+      onAssignToFolder={assignToFolder}
+      onRemoveFromFolder={removeFromFolder}
       onBulkDelete={bulkDelete}
       onClearSelection={() => (selectedIds = new Set())}
     />
   {/if}
 
-  {#if filteredPeople.length > 0 || filteredWebsites.length > 0}
-    <div class="select-all-row">
-      <label class="checkbox-label">
-        <input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
-        <span class="select-all-text">Select all</span>
-      </label>
-    </div>
-  {/if}
+  <!-- Tab bar -->
+  <div class="tab-bar">
+    <button class="tab" class:active={activeTab === 'people'} onclick={() => switchTab('people')}>
+      <Icon name="users" size={16} />
+      People
+      {#if peopleGroups.length > 0}
+        <span class="tab-count">{peopleGroups.length}</span>
+      {/if}
+    </button>
+    <button
+      class="tab"
+      class:active={activeTab === 'websites'}
+      onclick={() => switchTab('websites')}
+    >
+      <Icon name="globe" size={16} />
+      Websites
+      {#if websites.length > 0}
+        <span class="tab-count">{websites.length}</span>
+      {/if}
+    </button>
+  </div>
 
-  <!-- People section -->
-  {#if filteredPeople.length > 0}
-    <section class="source-group">
-      <h2 class="group-title">
-        <Icon name="users" size={16} />
-        People
-        <span class="group-count">{filteredPeople.length}</span>
-      </h2>
+  <!-- People tab -->
+  {#if activeTab === 'people'}
+    {#if filteredPeople.length > 0}
+      <div class="select-all-row">
+        <label class="checkbox-label">
+          <input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+          <span class="select-all-text">Select all</span>
+        </label>
+      </div>
+
       <div class="source-list">
         {#each filteredPeople as group (group.did)}
           {@const detected = detectedContent.get(group.did)}
@@ -505,51 +572,100 @@
           {/if}
         {/each}
       </div>
-    </section>
-  {/if}
-
-  <!-- Websites section -->
-  {#if filteredWebsites.length > 0}
-    <section class="source-group">
-      <h2 class="group-title">
-        <Icon name="globe" size={16} />
-        Websites
-        <span class="group-count">{filteredWebsites.length}</span>
-      </h2>
-      <div class="source-list">
-        {#each filteredWebsites as sub (sub.id)}
-          {@const display = getSourceDisplay(sub.sourceType, sub.feedUrl)}
-          {@const feedCount = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
-          {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
-          <SourceRow
-            iconUrl={getFaviconUrl(sub)}
-            title={sub.customTitle || sub.title}
-            subtitle={getSubtitle(sub)}
-            sourceLabel={display.label}
-            pillClass={display.pillClass}
-            unreadCount={feedCount}
-            hasError={status?.status === 'error' || status?.status === 'circuit-open'}
-            subscribed={true}
-            selected={sub.id != null && selectedIds.has(sub.id)}
-            fallbackIcon="rss"
-            onToggleSelect={() => sub.id && toggleSelect(sub.id)}
-            onEdit={() => handleEdit(sub)}
-            onRefresh={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
-            onRemove={() => handleRemove(sub)}
-          />
-        {/each}
+    {:else}
+      <div class="empty-state">
+        {#if searchQuery}
+          <p>No people match "{searchQuery}"</p>
+        {:else}
+          <p>No people yet. Follow a @handle to get started.</p>
+        {/if}
       </div>
-    </section>
+    {/if}
   {/if}
 
-  {#if filteredPeople.length === 0 && filteredWebsites.length === 0}
-    <div class="empty-state">
-      {#if searchQuery}
-        <p>No sources match "{searchQuery}"</p>
-      {:else}
-        <p>No sources yet. Add an RSS feed or follow a @handle to get started.</p>
+  <!-- Websites tab -->
+  {#if activeTab === 'websites'}
+    {#if filteredWebsites.length > 0}
+      <div class="select-all-row">
+        <label class="checkbox-label">
+          <input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+          <span class="select-all-text">Select all</span>
+        </label>
+      </div>
+
+      {#each filteredWebsiteCategories as cat (cat.name)}
+        <div class="category-section">
+          <h3 class="category-title">
+            <Icon name="folder" size={14} />
+            {cat.name}
+            <span class="group-count">{cat.websites.length}</span>
+          </h3>
+          <div class="source-list">
+            {#each cat.websites as sub (sub.id)}
+              {@const display = getSourceDisplay(sub.sourceType, sub.feedUrl)}
+              {@const feedCount = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+              {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
+              <SourceRow
+                iconUrl={getFaviconUrl(sub)}
+                title={sub.customTitle || sub.title}
+                subtitle={getSubtitle(sub)}
+                sourceLabel={display.label}
+                pillClass={display.pillClass}
+                unreadCount={feedCount}
+                hasError={status?.status === 'error' || status?.status === 'circuit-open'}
+                subscribed={true}
+                selected={sub.id != null && selectedIds.has(sub.id)}
+                fallbackIcon="rss"
+                onToggleSelect={() => sub.id && toggleSelect(sub.id)}
+                onEdit={() => handleEdit(sub)}
+                onRefresh={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+                onRemove={() => handleRemove(sub)}
+              />
+            {/each}
+          </div>
+        </div>
+      {/each}
+
+      {#if filteredUncategorizedWebsites.length > 0}
+        {#if filteredWebsiteCategories.length > 0}
+          <h3 class="category-title uncategorized-title">
+            Uncategorized
+            <span class="group-count">{filteredUncategorizedWebsites.length}</span>
+          </h3>
+        {/if}
+        <div class="source-list">
+          {#each filteredUncategorizedWebsites as sub (sub.id)}
+            {@const display = getSourceDisplay(sub.sourceType, sub.feedUrl)}
+            {@const feedCount = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+            {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
+            <SourceRow
+              iconUrl={getFaviconUrl(sub)}
+              title={sub.customTitle || sub.title}
+              subtitle={getSubtitle(sub)}
+              sourceLabel={display.label}
+              pillClass={display.pillClass}
+              unreadCount={feedCount}
+              hasError={status?.status === 'error' || status?.status === 'circuit-open'}
+              subscribed={true}
+              selected={sub.id != null && selectedIds.has(sub.id)}
+              fallbackIcon="rss"
+              onToggleSelect={() => sub.id && toggleSelect(sub.id)}
+              onEdit={() => handleEdit(sub)}
+              onRefresh={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+              onRemove={() => handleRemove(sub)}
+            />
+          {/each}
+        </div>
       {/if}
-    </div>
+    {:else}
+      <div class="empty-state">
+        {#if searchQuery}
+          <p>No websites match "{searchQuery}"</p>
+        {:else}
+          <p>No websites yet. Add an RSS feed to get started.</p>
+        {/if}
+      </div>
+    {/if}
   {/if}
 
   {#if mobileStore.isMobile}
@@ -592,14 +708,59 @@
   .sources-page {
     max-width: 640px;
     margin: 0 auto;
-    padding: 3.5rem 1rem 1.5rem;
+    padding: 3.5rem 1rem 5rem;
   }
 
   @media (max-width: 1000px) {
     .sources-page {
       padding-top: 0.5rem;
-      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
+      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 5rem);
     }
+  }
+
+  .tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 1rem;
+  }
+
+  .tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition:
+      color 0.15s,
+      border-color 0.15s;
+  }
+
+  .tab:hover {
+    color: var(--color-text-primary);
+  }
+
+  .tab.active {
+    color: var(--color-primary);
+    border-bottom-color: var(--color-primary);
+  }
+
+  .tab-count {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-secondary);
+  }
+
+  .tab.active .tab-count {
+    color: var(--color-primary);
   }
 
   .select-all-row {
@@ -617,23 +778,6 @@
 
   .select-all-text {
     user-select: none;
-  }
-
-  .source-group {
-    margin-bottom: 1.5rem;
-  }
-
-  .group-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    color: var(--color-text-secondary);
-    margin: 0 0 0.5rem;
-    padding: 0 0.25rem;
   }
 
   .group-count {
@@ -658,6 +802,25 @@
 
   .source-list > :global(:only-child) {
     border-radius: 12px;
+  }
+
+  .category-section {
+    margin-bottom: 1rem;
+  }
+
+  .category-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    margin: 0.75rem 0 0.375rem;
+    padding: 0 0.25rem;
+  }
+
+  .uncategorized-title {
+    margin-top: 1rem;
   }
 
   .content-type-loading {

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -1,0 +1,931 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
+  import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
+  import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
+  import { sidebarStore } from '$lib/stores/sidebar.svelte';
+  import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
+  import { fetchSingleFeed } from '$lib/services/feedFetcher';
+  import { articlesStore } from '$lib/stores/articles.svelte';
+  import { profileService } from '$lib/services/profiles';
+  import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import { rssSourceKey, sharesSourceKey, documentsSourceKey } from '$lib/utils/sourceKeys';
+  import Icon from '$lib/components/Icon.svelte';
+  import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
+  import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
+  import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+  import EditFeedModal from '$lib/components/EditFeedModal.svelte';
+  import AddFeedModal from '$lib/components/AddFeedModal.svelte';
+  import AddHandleModal from '$lib/components/AddHandleModal.svelte';
+  import type { Subscription, BlueskyProfile } from '$lib/types';
+
+  let feedSwitcherOpen = $state(false);
+
+  let searchQuery = $state('');
+  let editingSubscription = $state<Subscription | null>(null);
+  let editModalOpen = $state(false);
+  let selectedIds = $state<Set<number>>(new Set());
+  let profiles = $state<Map<string, BlueskyProfile>>(new Map());
+  let assignChannelOpen = $state(false);
+
+  // Group AT Protocol subscriptions by person (DID)
+  interface PersonGroup {
+    did: string;
+    profile: BlueskyProfile | null;
+    subscriptions: Subscription[];
+    hasShares: boolean;
+    hasDocuments: boolean;
+    totalUnread: number;
+  }
+
+  let peopleGroups = $derived.by((): PersonGroup[] => {
+    const byDid = new Map<string, Subscription[]>();
+
+    for (const sub of subscriptionsStore.subscriptions) {
+      if (!sub.subjectDid) continue;
+      if (
+        sub.sourceType === 'atproto.shares' ||
+        sub.sourceType === 'atproto.documents' ||
+        sub.sourceType === 'atproto.collection'
+      ) {
+        const existing = byDid.get(sub.subjectDid) || [];
+        existing.push(sub);
+        byDid.set(sub.subjectDid, existing);
+      }
+    }
+
+    const groups: PersonGroup[] = [];
+    for (const [did, subs] of byDid) {
+      const hasShares = subs.some((s) => s.sourceType === 'atproto.shares');
+      const hasDocuments = subs.some((s) => s.sourceType === 'atproto.documents');
+      const totalUnread = subs.reduce(
+        (sum, s) => sum + (s.id ? (unreadCounts.feedCounts.get(s.id) ?? 0) : 0),
+        0
+      );
+      groups.push({
+        did,
+        profile: profiles.get(did) || null,
+        subscriptions: subs,
+        hasShares,
+        hasDocuments,
+        totalUnread,
+      });
+    }
+
+    groups.sort((a, b) => {
+      const nameA = a.profile?.displayName || a.profile?.handle || a.did;
+      const nameB = b.profile?.displayName || b.profile?.handle || b.did;
+      return nameA.localeCompare(nameB);
+    });
+
+    return groups;
+  });
+
+  let websites = $derived.by(() => {
+    return [...subscriptionsStore.subscriptions]
+      .filter((s) => !s.sourceType || s.sourceType === 'rss')
+      .sort((a, b) => (a.customTitle || a.title).localeCompare(b.customTitle || b.title));
+  });
+
+  // Filtering
+  let filteredPeople = $derived(
+    searchQuery
+      ? peopleGroups.filter((g) => {
+          const q = searchQuery.toLowerCase();
+          const name = g.profile?.displayName || g.profile?.handle || g.did;
+          return name.toLowerCase().includes(q) || g.did.toLowerCase().includes(q);
+        })
+      : peopleGroups
+  );
+
+  let filteredWebsites = $derived(
+    searchQuery
+      ? websites.filter((s) => {
+          const q = searchQuery.toLowerCase();
+          return (
+            (s.customTitle || s.title).toLowerCase().includes(q) ||
+            (s.feedUrl || '').toLowerCase().includes(q) ||
+            (s.siteUrl || '').toLowerCase().includes(q)
+          );
+        })
+      : websites
+  );
+
+  // Selection helpers
+  let allVisibleIds = $derived.by(() => {
+    const ids: number[] = [];
+    for (const g of filteredPeople) {
+      for (const s of g.subscriptions) {
+        if (s.id) ids.push(s.id);
+      }
+    }
+    for (const s of filteredWebsites) {
+      if (s.id) ids.push(s.id);
+    }
+    return ids;
+  });
+
+  let allSelected = $derived(
+    allVisibleIds.length > 0 && allVisibleIds.every((id) => selectedIds.has(id))
+  );
+
+  let selectionCount = $derived(selectedIds.size);
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      selectedIds = new Set();
+    } else {
+      selectedIds = new Set(allVisibleIds);
+    }
+  }
+
+  function toggleSelect(id: number) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    selectedIds = next;
+  }
+
+  function togglePersonSelect(group: PersonGroup) {
+    const ids = group.subscriptions.map((s) => s.id!).filter(Boolean);
+    const allIn = ids.every((id) => selectedIds.has(id));
+    const next = new Set(selectedIds);
+    if (allIn) {
+      ids.forEach((id) => next.delete(id));
+    } else {
+      ids.forEach((id) => next.add(id));
+    }
+    selectedIds = next;
+  }
+
+  // Content type toggle for a person
+  async function toggleContentType(
+    group: PersonGroup,
+    type: 'atproto.shares' | 'atproto.documents'
+  ) {
+    const existing = group.subscriptions.find((s) => s.sourceType === type);
+    if (existing && existing.id) {
+      // Remove this content type
+      await subscriptionsStore.remove(existing.id);
+    } else {
+      // Add this content type - use the AddHandle flow
+      sidebarStore.setAddSourceInitialValue(group.profile?.handle || group.did);
+      sidebarStore.openAddHandleModal();
+    }
+  }
+
+  // Bulk operations
+  async function bulkDelete() {
+    const count = selectionCount;
+    if (!confirm(`Remove ${count} source${count > 1 ? 's' : ''}?`)) return;
+    const ids = [...selectedIds];
+    for (const id of ids) {
+      await subscriptionsStore.remove(id);
+    }
+    selectedIds = new Set();
+  }
+
+  function bulkAssignToChannel() {
+    assignChannelOpen = !assignChannelOpen;
+  }
+
+  async function assignToChannel(channelId: number) {
+    const channel = filteredViewsStore.getById(channelId);
+    if (!channel) return;
+
+    const currentKeys = new Set(channel.sourceKeys || []);
+    for (const id of selectedIds) {
+      const sub = subscriptionsStore.getById(id);
+      if (!sub) continue;
+      if (!sub.sourceType || sub.sourceType === 'rss') {
+        currentKeys.add(rssSourceKey(id));
+      } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
+        currentKeys.add(sharesSourceKey(sub.subjectDid));
+      } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {
+        currentKeys.add(documentsSourceKey(sub.subjectDid));
+      }
+    }
+
+    await filteredViewsStore.update(channelId, {
+      sourceMode: 'include',
+      sourceKeys: [...currentKeys],
+    });
+    assignChannelOpen = false;
+    selectedIds = new Set();
+  }
+
+  function handleEdit(sub: Subscription) {
+    editingSubscription = sub;
+    editModalOpen = true;
+  }
+
+  async function handleRemove(sub: Subscription) {
+    if (sub.id && confirm(`Remove "${sub.customTitle || sub.title}"?`)) {
+      await subscriptionsStore.remove(sub.id);
+    }
+  }
+
+  function closeEditModal() {
+    editModalOpen = false;
+    editingSubscription = null;
+  }
+
+  function getFaviconUrl(sub: Subscription): string | null {
+    if (sub.customIconUrl) return sub.customIconUrl;
+    const url = sub.siteUrl || sub.feedUrl;
+    if (!url) return null;
+    try {
+      const host = new URL(url).hostname;
+      return `https://icons.duckduckgo.com/ip3/${host}.ico`;
+    } catch {
+      return null;
+    }
+  }
+
+  function getPersonName(group: PersonGroup): string {
+    return group.profile?.displayName || group.profile?.handle || group.did;
+  }
+
+  function getPersonHandle(group: PersonGroup): string {
+    return group.profile?.handle || group.did;
+  }
+
+  // Fetch profiles on mount
+  onMount(async () => {
+    const dids = [
+      ...new Set(
+        subscriptionsStore.subscriptions.filter((s) => s.subjectDid).map((s) => s.subjectDid!)
+      ),
+    ];
+    if (dids.length > 0) {
+      const fetched = await profileService.getProfiles(dids);
+      profiles = fetched;
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Sources - Skyreader</title>
+</svelte:head>
+
+<FeedPageHeader title="Manage Sources" hideControls />
+
+<div class="sources-page">
+  <div class="sources-toolbar">
+    <div class="search-wrapper">
+      <Icon name="search" size={16} />
+      <input
+        type="text"
+        bind:value={searchQuery}
+        placeholder="Search sources..."
+        class="search-input"
+      />
+    </div>
+    <button class="add-btn" onclick={() => sidebarStore.openAddFeedModal()}>
+      <Icon name="plus" size={16} />
+      <span>Add RSS</span>
+    </button>
+    <button class="add-btn" onclick={() => sidebarStore.openAddHandleModal()}>
+      <Icon name="at-sign" size={16} />
+      <span>Add @handle</span>
+    </button>
+  </div>
+
+  <!-- Bulk action bar -->
+  {#if selectionCount > 0}
+    <div class="bulk-bar">
+      <span class="bulk-count">{selectionCount} selected</span>
+      <div class="bulk-actions">
+        <div class="assign-wrapper">
+          <button class="bulk-btn" onclick={bulkAssignToChannel}>
+            <Icon name="filter" size={14} />
+            Add to channel
+          </button>
+          {#if assignChannelOpen && filteredViewsStore.views.length > 0}
+            <div class="assign-dropdown">
+              {#each filteredViewsStore.views as view (view.id)}
+                <button
+                  class="assign-item"
+                  onclick={() => view.id != null && assignToChannel(view.id)}
+                >
+                  {view.name}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+        <button class="bulk-btn danger" onclick={bulkDelete}>
+          <Icon name="trash" size={14} />
+          Remove
+        </button>
+      </div>
+      <button class="bulk-clear" onclick={() => (selectedIds = new Set())}>
+        <Icon name="x" size={14} />
+      </button>
+    </div>
+  {/if}
+
+  <!-- Select all -->
+  {#if filteredPeople.length > 0 || filteredWebsites.length > 0}
+    <div class="select-all-row">
+      <label class="checkbox-label">
+        <input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+        <span class="select-all-text">Select all</span>
+      </label>
+    </div>
+  {/if}
+
+  <!-- People section -->
+  {#if filteredPeople.length > 0}
+    <section class="source-group">
+      <h2 class="group-title">
+        <Icon name="users" size={16} />
+        People
+        <span class="group-count">{filteredPeople.length}</span>
+      </h2>
+      <div class="source-list">
+        {#each filteredPeople as group (group.did)}
+          {@const personSelected = group.subscriptions.every(
+            (s) => s.id != null && selectedIds.has(s.id)
+          )}
+          <div class="source-row person-row">
+            <label class="row-checkbox">
+              <input
+                type="checkbox"
+                checked={personSelected}
+                onchange={() => togglePersonSelect(group)}
+              />
+            </label>
+            <div class="source-icon">
+              {#if group.profile?.avatar}
+                <img src={group.profile.avatar} alt="" class="avatar" />
+              {:else}
+                <Icon name="user" size={16} />
+              {/if}
+            </div>
+            <div class="source-info">
+              <span class="source-title">{getPersonName(group)}</span>
+              <span class="source-meta">@{getPersonHandle(group)}</span>
+            </div>
+            <div class="content-toggles">
+              <button
+                class="type-toggle"
+                class:active={group.hasShares}
+                onclick={() => toggleContentType(group, 'atproto.shares')}
+                title={group.hasShares ? 'Unsubscribe from shares' : 'Subscribe to shares'}
+              >
+                <Icon name="share" size={12} />
+                <span>Shares</span>
+              </button>
+              <button
+                class="type-toggle"
+                class:active={group.hasDocuments}
+                onclick={() => toggleContentType(group, 'atproto.documents')}
+                title={group.hasDocuments ? 'Unsubscribe from articles' : 'Subscribe to articles'}
+              >
+                <Icon name="file-text" size={12} />
+                <span>Articles</span>
+              </button>
+            </div>
+            {#if group.totalUnread > 0}
+              <span class="unread-badge">{group.totalUnread}</span>
+            {/if}
+            <div class="source-actions">
+              <button
+                class="action-btn danger"
+                onclick={async () => {
+                  const names = group.subscriptions.map((s) => s.customTitle || s.title).join(', ');
+                  if (confirm(`Remove all subscriptions for ${getPersonName(group)}?`)) {
+                    await Promise.all(
+                      group.subscriptions
+                        .filter((s) => s.id != null)
+                        .map((s) => subscriptionsStore.remove(s.id!))
+                    );
+                  }
+                }}
+                title="Remove all"
+              >
+                <Icon name="trash" size={14} />
+              </button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Websites section -->
+  {#if filteredWebsites.length > 0}
+    <section class="source-group">
+      <h2 class="group-title">
+        <Icon name="globe" size={16} />
+        Websites
+        <span class="group-count">{filteredWebsites.length}</span>
+      </h2>
+      <div class="source-list">
+        {#each filteredWebsites as sub (sub.id)}
+          {@const favicon = getFaviconUrl(sub)}
+          {@const feedCount = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
+          {@const status = sub.feedUrl ? feedStatusStore.getStatus(sub.feedUrl) : undefined}
+          <div class="source-row">
+            <label class="row-checkbox">
+              <input
+                type="checkbox"
+                checked={sub.id != null && selectedIds.has(sub.id)}
+                onchange={() => sub.id && toggleSelect(sub.id)}
+              />
+            </label>
+            <div class="source-icon">
+              {#if favicon}
+                <img src={favicon} alt="" class="favicon" />
+              {:else}
+                <Icon name="rss" size={16} />
+              {/if}
+            </div>
+            <div class="source-info">
+              <span class="source-title">{sub.customTitle || sub.title}</span>
+              <span class="source-meta">
+                {#if sub.siteUrl}
+                  {new URL(sub.siteUrl).hostname}
+                {:else if sub.feedUrl}
+                  {new URL(sub.feedUrl).hostname}
+                {/if}
+              </span>
+            </div>
+            {#if status?.status === 'error' || status?.status === 'circuit-open'}
+              <span class="error-badge" title="Feed error">
+                <Icon name="alert-triangle" size={14} />
+              </span>
+            {/if}
+            {#if feedCount > 0}
+              <span class="unread-badge">{feedCount}</span>
+            {/if}
+            <div class="source-actions">
+              <button class="action-btn" onclick={() => handleEdit(sub)} title="Edit">
+                <Icon name="edit" size={14} />
+              </button>
+              <button
+                class="action-btn"
+                onclick={() => fetchSingleFeed(sub, true, articlesStore.savedGuids)}
+                title="Refresh"
+              >
+                <Icon name="refresh-cw" size={14} />
+              </button>
+              <button class="action-btn danger" onclick={() => handleRemove(sub)} title="Remove">
+                <Icon name="trash" size={14} />
+              </button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  {#if filteredPeople.length === 0 && filteredWebsites.length === 0}
+    <div class="empty-state">
+      {#if searchQuery}
+        <p>No sources match "{searchQuery}"</p>
+      {:else}
+        <p>No sources yet. Add an RSS feed or follow a @handle to get started.</p>
+      {/if}
+    </div>
+  {/if}
+
+  {#if mobileStore.isMobile}
+    <MobileBottomBar
+      controlsVisible={true}
+      currentTitle="Manage Sources"
+      onScrollToTop={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onOpenFeedSwitcher={() => (feedSwitcherOpen = true)}
+      onOpenFilterSheet={() => {}}
+      hasActiveFilters={false}
+      hideFilterButton
+    />
+
+    <BottomSheet
+      open={feedSwitcherOpen}
+      onclose={() => (feedSwitcherOpen = false)}
+      title="Switch Feed"
+    >
+      <MobileFeedSwitcher
+        onclose={() => (feedSwitcherOpen = false)}
+        currentTitle="Manage Sources"
+      />
+    </BottomSheet>
+  {/if}
+</div>
+
+<AddFeedModal
+  open={sidebarStore.addFeedModalOpen}
+  onclose={() => sidebarStore.closeAddFeedModal()}
+/>
+
+<AddHandleModal
+  open={sidebarStore.addHandleModalOpen}
+  onclose={() => sidebarStore.closeAddHandleModal()}
+/>
+
+<EditFeedModal open={editModalOpen} subscription={editingSubscription} onclose={closeEditModal} />
+
+<style>
+  .sources-page {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 3.5rem 1rem 1.5rem;
+  }
+
+  .sources-toolbar {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  @media (max-width: 1000px) {
+    .sources-page {
+      padding-top: 0.5rem;
+      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
+    }
+  }
+
+  .search-wrapper {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .search-input {
+    flex: 1;
+    border: none;
+    background: none;
+    font: inherit;
+    font-size: 0.875rem;
+    color: var(--color-text);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .add-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: none;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    white-space: nowrap;
+  }
+
+  .add-btn:hover {
+    background: var(--color-bg-hover);
+  }
+
+  /* Bulk action bar */
+  .bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-primary);
+    color: #fff;
+    border-radius: 10px;
+    margin-bottom: 1rem;
+    font-size: 0.8125rem;
+  }
+
+  .bulk-count {
+    font-weight: 500;
+  }
+
+  .bulk-actions {
+    display: flex;
+    gap: 0.375rem;
+    flex: 1;
+  }
+
+  .bulk-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 6px;
+    background: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  .bulk-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .bulk-btn.danger:hover {
+    background: rgba(220, 38, 38, 0.3);
+  }
+
+  .bulk-clear {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+  }
+
+  .bulk-clear:hover {
+    color: #fff;
+  }
+
+  .assign-wrapper {
+    position: relative;
+  }
+
+  .assign-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 0.25rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 0.25rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    min-width: 160px;
+  }
+
+  .assign-item {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    border-radius: 4px;
+  }
+
+  .assign-item:hover {
+    background: var(--color-bg-hover);
+  }
+
+  .select-all-row {
+    padding: 0 0.25rem 0.5rem;
+  }
+
+  .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .select-all-text {
+    user-select: none;
+  }
+
+  /* Source groups */
+  .source-group {
+    margin-bottom: 1.5rem;
+  }
+
+  .group-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--color-text-secondary);
+    margin: 0 0 0.5rem;
+    padding: 0 0.25rem;
+  }
+
+  .group-count {
+    font-weight: 400;
+  }
+
+  .source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    background: var(--color-border);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .source-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    background: var(--color-bg);
+    transition: background-color 0.15s;
+  }
+
+  .source-row:hover {
+    background: var(--color-bg-hover, rgba(0, 0, 0, 0.02));
+  }
+
+  .row-checkbox {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .row-checkbox input {
+    cursor: pointer;
+  }
+
+  .source-icon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-secondary);
+  }
+
+  .favicon {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+  }
+
+  .avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+
+  .source-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .source-title {
+    font-size: 0.875rem;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .source-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Content type toggles for people */
+  .content-toggles {
+    display: flex;
+    gap: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  .type-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.375rem;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: none;
+    cursor: pointer;
+    font-size: 0.6875rem;
+    color: var(--color-text-secondary);
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+
+  .type-toggle.active {
+    background: rgba(0, 102, 204, 0.08);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  .type-toggle:hover {
+    background: var(--color-bg-hover);
+  }
+
+  .unread-badge {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: rgba(0, 102, 204, 0.1);
+    padding: 0.125rem 0.375rem;
+    border-radius: 10px;
+  }
+
+  .error-badge {
+    flex-shrink: 0;
+    color: var(--color-error, #dc2626);
+    display: flex;
+    align-items: center;
+  }
+
+  .source-actions {
+    display: flex;
+    gap: 0.25rem;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .source-row:hover .source-actions {
+    opacity: 1;
+  }
+
+  .action-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 4px;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+  }
+
+  .action-btn:hover {
+    background: var(--color-bg-hover);
+    color: var(--color-text);
+  }
+
+  .action-btn.danger:hover {
+    color: var(--color-error, #dc2626);
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+  }
+
+  @media (max-width: 640px) {
+    .source-actions {
+      opacity: 1;
+    }
+
+    .sources-toolbar {
+      flex-wrap: wrap;
+    }
+
+    .add-btn span {
+      display: none;
+    }
+
+    .content-toggles {
+      flex-direction: column;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .source-row:hover {
+      background: var(--color-bg-hover, rgba(255, 255, 255, 0.03));
+    }
+
+    .search-wrapper {
+      background: var(--color-bg-secondary, rgba(255, 255, 255, 0.06));
+    }
+
+    .assign-dropdown {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+  }
+</style>

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -282,9 +282,9 @@
     const currentKeys = new Set(channel.sourceKeys || []);
     for (const id of selectedIds) {
       const sub = subscriptionsStore.getById(id);
-      if (!sub) continue;
+      if (!sub?.rkey) continue;
       if (!sub.sourceType || sub.sourceType === 'rss') {
-        currentKeys.add(rssSourceKey(id));
+        currentKeys.add(rssSourceKey(sub.rkey));
       } else if (sub.sourceType === 'atproto.shares' && sub.subjectDid) {
         currentKeys.add(sharesSourceKey(sub.subjectDid));
       } else if (sub.sourceType === 'atproto.documents' && sub.subjectDid) {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, 'src/lib'),
+    },
+  },
+});


### PR DESCRIPTION
Major UX redesign that replaces "filtered views" with channels as the primary organizing
concept, adds a dedicated sources management page, and introduces folders/categories for
subscriptions.

Highlights

Channels (replaces filtered views)
- Renamed/reworked filtered views into channels, with backend persistence (new channels table
and /channels routes) and bidirectional sync via channelSync.ts
- Channels split into "everything" vs "saved" variants; can be auto-generated as suggestions
from saved items
- New channel discover page (/channels/discover) and reworked channel editor
- Pure, tested sync/logic modules: channelLogic.ts, channelSync.ts, sourceKeys.ts (~1100 lines
of new tests)
- Extracted shared option constants into constants/channelOptions.ts

Sources management
- New /sources page with bulk actions, grouping, and toolbar
- New components: SourceRow, SourceGroupHeader, SourcesToolbar, BulkActionBar, AddSourceInput,
DomainPatternInput
- Sources returned to the sidebar with context menus
- Folders/categories support via 0050_subscription_category.sql

Sidebar / navigation
- Significant sidebar rework (~900 lines changed) with collapsible sources
- Reworked FilterToolbar, MobileFilterSheet, MobileFeedSwitcher, NavigationDropdown,
FeedPageHeader
- New unreadCounts.svelte.ts store with optimized per-channel counts (reuses precomputed totals,
fixes dup counts)

Backend
- New migrations: 0049_channels.sql, 0050_subscription_category.sql
- New routes/channels.ts with validation (UUID, size limits, JSON config), atomic soft-delete
via INSERT ... ON CONFLICT
- Updates to subscriptions.ts, jetstream-poller.ts, subscription-sync.ts