### PR TITLE
Clear read-this-session items on refresh

### DIFF
--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -1111,6 +1111,12 @@ function createFeedViewStore() {
     readDocumentUrisThisSession = new Set();
   }
 
+  function clearReadThisSession() {
+    readArticleGuidsThisSession = new Set();
+    readShareUrisThisSession = new Set();
+    readDocumentUrisThisSession = new Set();
+  }
+
   // Derived: all unique domains from saved items (for domain filter picker)
   let availableSavedDomains = $derived.by((): string[] => {
     if (!isSavedView) return [];
@@ -1339,6 +1345,7 @@ function createFeedViewStore() {
     expand,
     collapse,
     resetSelection,
+    clearReadThisSession,
     toggleUnreadFilter,
     trackSeenThisSession,
     trackItemsAsReadThisSession,

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -519,6 +519,7 @@
       if (appManager.isStale(STALE_THRESHOLD_MS)) {
         console.log('Data is stale, refreshing...');
         await appManager.refreshFromBackend();
+        feedViewStore.clearReadThisSession();
       }
     }
     lastVisibleTime = Date.now();
@@ -526,6 +527,7 @@
 
   async function handleRefreshWithToast() {
     const newArticles = await appManager.refreshFromBackend();
+    feedViewStore.clearReadThisSession();
     if (newArticles > 0) {
       const id = toastStore.add(`${newArticles} new article${newArticles === 1 ? '' : 's'}`);
       toastStore.update(id, 'success');


### PR DESCRIPTION
## Summary
- Add `clearReadThisSession()` to `feedViewStore` that resets the three `*ThisSession` Sets without disturbing keyboard selection / expansion state.
- Call it from `handleRefreshWithToast()` (pull-to-refresh + refresh button) and from the visibility-change auto-refresh in `+page.svelte`.

When the unread filter is on, items the user has just read stay visible (via the `*ThisSession` Sets) so the list doesn't reshuffle out from under them. After a user-triggered refresh, those items should drop off — that's what people expect of a refresh. This wires that up without touching the cursor or expanded card.

## Test plan
- [x] `npm run check` in `frontend/` (0 errors, prettier clean).
- [ ] Manual: unread-only on, mark a few items read, hit refresh — read items disappear, keyboard cursor / expanded card preserved.
- [ ] Manual: unread-only off, refresh — list unchanged.
- [ ] Manual: hide tab >5 min, return — visibility-change refresh also clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)