### PR TITLE
Mark documents as read on scroll

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -343,6 +343,17 @@
         share.itemUrl,
         share.itemTitle
       );
+    } else if (item.type === 'document') {
+      const doc = item.item;
+      if (itemLabelsStore.isSocialRead(doc.recordUri)) return;
+
+      itemLabelsStore.markSocialAsRead(
+        'document',
+        doc.recordUri,
+        doc.authorDid,
+        doc.canonicalUrl || '',
+        doc.title
+      );
     }
     // userShare items don't auto-mark as read from scroll
   }


### PR DESCRIPTION
## Summary
- The scroll-to-mark-as-read handler in \`+page.svelte\` only handled \`article\` and \`share\` items, so non-RSS items like standard.site documents were never marked as read when scrolled past.
- Added a \`document\` branch to \`markItemAsReadByKey\` that calls \`itemLabelsStore.markSocialAsRead('document', ...)\`, mirroring the existing keyboard-shortcut and click-to-mark paths in \`useFeedKeyboardShortcuts\` and \`FeedListView\`.

## Test plan
- [ ] With "Mark as read on scroll" enabled, scroll a document item (e.g. a standard.site doc) past the top of the viewport and confirm it becomes read.
- [ ] Confirm article and share items continue to be marked as read on scroll.
- [ ] Confirm \`userShare\` items still don't auto-mark on scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)