### PR TITLE
Add favicon link tags so Safari renders an icon

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <link rel="icon" type="image/svg+xml" href="/icons/icon-512.svg" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icons/icon-512.png" />
+    <link rel="apple-touch-icon" href="/icons/icon-512.png" />
+    <link rel="mask-icon" href="/icons/icon-512.svg" color="#4A9FD4" />
+    <meta name="theme-color" content="#4A9FD4" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary
- Adds explicit `<link rel="icon">` (SVG + PNG fallback), `apple-touch-icon`, `mask-icon`, and `theme-color` to `frontend/src/app.html` so Safari has a discoverable favicon on first paint.
- Previously `app.html` had zero icon tags; the only favicon link came from `+layout.svelte`'s `<svelte:head>` and was SVG-only, which Safari ≤15 and iOS share/home-screen flows don't pick up.
- Reuses existing `/icons/icon-512.{svg,png}` assets — no new image files.

## Notes
- The plan's "no other place injects favicon links" assumption was slightly off: `frontend/src/routes/+layout.svelte:267` already declares `<link rel="icon" type="image/svg+xml" href={Logo} />`. That layout-injected tag still wins for the SVG icon (it renders after `%sveltekit.head%`), so the SVG line in `app.html` is a redundant baseline. The PNG, apple-touch-icon, and mask-icon entries are net-new and are what actually unblock Safari ≤15 and iOS.
- Safari aggressively caches favicons. Users who already loaded the old page may need a hard reload (Cmd+Opt+R) or to clear `~/Library/Safari/Favicon Cache/` before they see the icon.

## Test plan
- [x] `npm run check` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run build` — succeeds; `build/icons/icon-512.{svg,png}` emitted and the new link tags appear in `build/index.html`
- [ ] Open in Safari desktop, confirm tab favicon (hard-refresh)
- [ ] iOS Safari → Share → Add to Home Screen, confirm icon renders
- [ ] Chrome + Firefox: confirm no regression

## Out of scope (follow-ups)
- Dedicated 180×180 `apple-touch-icon.png` and 32×32 favicon to avoid sending the 21 KB 512 PNG.
- `static/favicon.ico` to quiet bare `/favicon.ico` 404s.
- Monochrome SVG for `mask-icon` (current SVG is multi-color; Safari flattens it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)