### PR TITLE
better linkblog format

### DIFF
--- a/linkblog-site/src/app.css
+++ b/linkblog-site/src/app.css
@@ -301,6 +301,18 @@ img {
 .meta .social {
   color: var(--muted);
 }
+/* The date doubles as the (subtle) permalink to the commentary. It must sit above
+   the headline's stretched ::after overlay to stay clickable, and stays quiet until
+   hovered so the headline keeps the visual weight. */
+.meta a {
+  position: relative;
+  z-index: 1;
+  color: inherit;
+}
+.meta a:hover {
+  color: var(--blue);
+  text-decoration: none;
+}
 
 /* Permalink entry */
 .back {
@@ -322,6 +334,15 @@ img {
   letter-spacing: -0.02em;
   font-weight: 700;
   text-wrap: balance;
+}
+/* The headline links out to the source article (matching the index + RSS). Keep the
+   ink color so it reads as a heading, not a stock link. */
+.entry-page .entry-title-lg a {
+  color: var(--ink);
+}
+.entry-page .entry-title-lg a:hover {
+  color: var(--blue);
+  text-decoration: none;
 }
 .entry-page .entry-note-lg {
   margin: 1.375rem 0 0;

--- a/linkblog-site/src/lib/components/BlogEntry.svelte
+++ b/linkblog-site/src/lib/components/BlogEntry.svelte
@@ -8,6 +8,7 @@
     hostnameOf,
     linkPostNote,
     rkeyFromUri,
+    safeHttpUrl,
     socialCountsText,
   } from '$lib/fields';
   import type { ProxyDocument, SocialContext } from '$lib/types';
@@ -29,17 +30,23 @@
   // when it just repeats the note.
   const note = $derived(linkPostNote(doc).trim());
   const excerpt = $derived(articleExcerpt(doc));
-  const host = $derived(hostnameOf(externalArticleUrl(doc) || doc.canonicalUrl));
+  const articleUrl = $derived(safeHttpUrl(externalArticleUrl(doc) || doc.canonicalUrl));
+  // Daring-Fireball-style: the headline links out to the source article; the date
+  // (in the meta row) is the subtle permalink to the commentary. Note-only posts
+  // with no source fall back to the permalink as the headline link.
+  const headlineHref = $derived(articleUrl ?? permalink);
+  const host = $derived(hostnameOf(articleUrl ?? undefined));
   const date = $derived(formatDate(doc.createdAt || doc.publishedAt));
   const social = $derived(socialCountsText(ctx));
 </script>
 
 <li class="entry">
-  <!-- The title anchor stretches over the whole row (its ::after covers the <li>),
-       so the entire entry is one calm tap target to the permalink. -->
+  <!-- The headline anchor stretches over the whole row (its ::after covers the
+       <li>), so the entire entry is one calm tap target to the source article. The
+       date in the meta row is raised above it as the permalink to the commentary. -->
   <h2 class="entry-title">
-    {#if permalink}
-      <a href={permalink}>{doc.title || 'Untitled'}</a>
+    {#if headlineHref}
+      <a href={headlineHref}>{doc.title || 'Untitled'}</a>
     {:else}
       {doc.title || 'Untitled'}
     {/if}
@@ -50,5 +57,5 @@
   {#if excerpt && excerpt !== note}
     <blockquote class="entry-quote"><p>{clampText(excerpt, 200)}</p></blockquote>
   {/if}
-  <Meta {host} {date} {social} />
+  <Meta {host} {date} {permalink} {social} />
 </li>

--- a/linkblog-site/src/lib/components/Meta.svelte
+++ b/linkblog-site/src/lib/components/Meta.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
   // The quiet meta row beneath an entry: source host · share date · social counts.
-  // Each part is optional; separators only appear between present parts.
+  // Each part is optional; separators only appear between present parts. When a
+  // `permalink` is given, the date doubles as the (subtle) permalink to the entry.
   interface Props {
     host?: string | null;
     date?: string;
+    permalink?: string | null;
     social?: string;
   }
-  let { host = null, date = '', social = '' }: Props = $props();
+  let { host = null, date = '', permalink = null, social = '' }: Props = $props();
 
   const parts = $derived(
     [
-      host ? { cls: 'src', text: host } : null,
-      date ? { cls: '', text: date } : null,
-      social ? { cls: 'social', text: social } : null,
-    ].filter((p): p is { cls: string; text: string } => p !== null)
+      host ? { cls: 'src', text: host, href: null } : null,
+      date ? { cls: '', text: date, href: permalink } : null,
+      social ? { cls: 'social', text: social, href: null } : null,
+    ].filter((p): p is { cls: string; text: string; href: string | null } => p !== null)
   );
 </script>
 
@@ -21,7 +23,11 @@
   <div class="meta">
     {#each parts as p, i (i)}
       {#if i > 0}<span class="sep" aria-hidden="true">·</span>{/if}
-      <span class={p.cls || undefined}>{p.text}</span>
+      {#if p.href}
+        <a class={p.cls || undefined} href={p.href}>{p.text}</a>
+      {:else}
+        <span class={p.cls || undefined}>{p.text}</span>
+      {/if}
     {/each}
   </div>
 {/if}

--- a/linkblog-site/src/lib/server/rss.ts
+++ b/linkblog-site/src/lib/server/rss.ts
@@ -50,10 +50,12 @@ export function toRfc822(iso: string): string {
   return d.toUTCString();
 }
 
-// Each entry's HTML body: the user's note, an article excerpt (when distinct), and
-// a link out to the source. Mirrors the index/permalink pages so a reader sees the
-// same thing whether they visit the page or subscribe.
-function entryHtml(doc: ProxyDocument): string {
+// Each entry's HTML body: the user's note, an article excerpt (when distinct), a
+// link out to the source, and a subtle permalink back to the commentary. Mirrors
+// the index/permalink pages so a reader sees the same thing whether they visit the
+// page or subscribe. The item <link> points at the source (see renderItem), so the
+// permalink is the one thing only the body can carry.
+function entryHtml(doc: ProxyDocument, permalink: string): string {
   const note = linkPostNote(doc).trim();
   const excerpt = articleExcerpt(doc);
   const articleUrl = safeHttpUrl(externalArticleUrl(doc) || doc.canonicalUrl);
@@ -67,22 +69,26 @@ function entryHtml(doc: ProxyDocument): string {
       `<p><a href="${escapeHtml(articleUrl)}">Read the full article${host ? ` on ${escapeHtml(host)}` : ''}</a></p>`
     );
   }
+  parts.push(`<p><a href="${escapeHtml(permalink)}">Permalink</a></p>`);
   return parts.join('\n');
 }
 
 function renderItem(origin: string, did: string, doc: ProxyDocument): string {
   const rkey = rkeyFromUri(doc.recordUri);
-  // The permalink (stable, on this site) is the canonical link for the item; the
-  // source article lives in the body. The guid is the immutable record URI.
+  // Daring-Fireball-style linkblog: the item <link> points at the source article
+  // being commented on (the headline IS the outbound link). A subtle permalink to
+  // the commentary on this site lives in the body, and the guid is the immutable
+  // record URI. Note-only posts (no source) fall back to the permalink.
   const permalink = rkey ? entryUrlFor(origin, did, rkey) : blogUrlFor(origin, did);
+  const itemLink = safeHttpUrl(externalArticleUrl(doc) || doc.canonicalUrl) || permalink;
   const pubDate = toRfc822(doc.createdAt || doc.publishedAt);
 
   const tags = [
     `<title>${escapeXml(doc.title || 'Untitled')}</title>`,
-    `<link>${escapeXml(permalink)}</link>`,
+    `<link>${escapeXml(itemLink)}</link>`,
     `<guid isPermaLink="false">${escapeXml(doc.recordUri)}</guid>`,
     pubDate ? `<pubDate>${escapeXml(pubDate)}</pubDate>` : '',
-    `<description>${cdata(entryHtml(doc))}</description>`,
+    `<description>${cdata(entryHtml(doc, permalink))}</description>`,
   ].filter(Boolean);
 
   return `<item>\n  ${tags.join('\n  ')}\n</item>`;

--- a/linkblog-site/src/routes/[id]/[rkey]/+page.svelte
+++ b/linkblog-site/src/routes/[id]/[rkey]/+page.svelte
@@ -52,7 +52,9 @@
 
 <a class="back" href={backHref}><span aria-hidden="true">←</span> {blogName}</a>
 <article class="entry-page">
-  <h1 class="entry-title-lg">{title}</h1>
+  <h1 class="entry-title-lg">
+    {#if articleUrl}<a href={articleUrl}>{title}</a>{:else}{title}{/if}
+  </h1>
   <Meta {host} {date} {social} />
   {#if note}
     <p class="entry-note-lg">{note}</p>


### PR DESCRIPTION
Boris points out the link should come first in the linkblog: https://blog.bmannconsulting.com/3mnnwcdentk2c

This PR fixes that