### PR TITLE
Fix saved items showing wrong reading time ("1 min")

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,6 +53,7 @@ import {
 import {
   handleCreateSaved,
   handleGetSaved,
+  handleUpdateSaved,
   handleDeleteSaved,
   handleDeleteSavedByGuid,
 } from './routes/saved';
@@ -387,7 +388,11 @@ export default {
           break;
         case url.pathname.startsWith('/api/saved/'):
           if (!session) return unauthorizedResponse(headers);
-          response = await handleDeleteSaved(request, env, ctx);
+          if (request.method === 'PATCH') {
+            response = await handleUpdateSaved(request, env);
+          } else {
+            response = await handleDeleteSaved(request, env, ctx);
+          }
           break;
 
         // Settings routes

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -412,6 +412,82 @@ export async function handleGetSaved(request: Request, env: Env): Promise<Respon
   }
 }
 
+// PATCH /api/saved/:rkey — update mutable fields on a saved item.
+// Currently only the precomputed word count, used by the frontend to backfill
+// old saves that were stored without one (so the read time stops falling back
+// to the short description and showing a misleading "1 min"). D1-only: the
+// word count is a derived display value and isn't part of the PDS record's
+// canonical data, so there's no PDS write here.
+export async function handleUpdateSaved(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'PATCH') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const url = new URL(request.url);
+  const rkey = url.pathname.split('/').pop();
+  if (!rkey || !isValidRkey(rkey)) {
+    return invalidRkeyResponse();
+  }
+
+  let body: { wordCount?: number };
+  try {
+    body = (await request.json()) as { wordCount?: number };
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (
+    body.wordCount == null ||
+    typeof body.wordCount !== 'number' ||
+    !Number.isFinite(body.wordCount) ||
+    body.wordCount < 0
+  ) {
+    return new Response(JSON.stringify({ error: 'Missing or invalid wordCount' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const result = await env.DB.prepare(
+      'UPDATE saved_articles SET word_count = ? WHERE user_did = ? AND rkey = ?'
+    )
+      .bind(Math.round(body.wordCount), session.did, rkey)
+      .run();
+
+    if (!result.meta.changes) {
+      return new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to update saved item:', error);
+    return new Response(JSON.stringify({ error: 'Failed to update saved item' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
 // DELETE /api/saved/:rkey — delete a saved item
 export async function handleDeleteSaved(
   request: Request,

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -106,22 +106,63 @@
   let isArchived = $derived(itemLabelsStore.isArchived(itemKey));
   let tags = $derived(itemLabelsStore.getTagsForItem(itemKey));
 
-  // Estimate read time from content (~200 words/min)
-  let readTimeMinutes = $derived.by(() => {
-    let content = '';
-    if (displayItem.type === 'article') {
-      content = displayItem.item.content || displayItem.item.summary || '';
-    } else if (displayItem.type === 'document') {
-      if (displayItem.item.wordCount)
-        return Math.max(1, Math.round(displayItem.item.wordCount / 200));
-      content = displayItem.item.textContent || displayItem.item.description || '';
-    } else if (displayItem.type === 'saved') {
-      if (displayItem.item.wordCount)
-        return Math.max(1, Math.round(displayItem.item.wordCount / 200));
-      content = displayItem.item.content || displayItem.item.description || '';
+  // Saved "light" items carry `content: null` in memory, so when their stored
+  // wordCount is missing we pull the body back from IndexedDB to count it rather
+  // than falling back to the short RSS `description` (which produced a misleading
+  // "1 min"). Only runs for saved items that lack a precomputed wordCount; most
+  // self-heal via the store's backfill before this is ever needed.
+  let lazyWordCount = $state<number | null>(null);
+  $effect(() => {
+    if (displayItem.type !== 'saved' || displayItem.item.wordCount) {
+      lazyWordCount = null;
+      return;
     }
-    const text = content.replace(/<[^>]*>/g, '');
-    const wordCount = text.split(/\s+/).filter(Boolean).length;
+    const rkey = displayItem.item.rkey;
+    let cancelled = false;
+    (async () => {
+      let body = '';
+      try {
+        body = (await savesStore.getContent(rkey)) || '';
+      } catch {
+        // Best effort — leave the count unknown and hide the chip.
+      }
+      if (cancelled) return;
+      const text = body.replace(/<[^>]*>/g, '');
+      const count = text.split(/\s+/).filter(Boolean).length;
+      lazyWordCount = count || null;
+    })();
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // Estimate read time from word count (~200 words/min). Returns null — and the
+  // chip is hidden — when there's genuinely no text to estimate from, which beats
+  // showing a misleading "1 min".
+  let readTimeMinutes = $derived.by((): number | null => {
+    let wordCount: number | null = null;
+    if (displayItem.type === 'article') {
+      wordCount = displayItem.item.wordCount ?? null;
+      if (wordCount == null) {
+        const text = (displayItem.item.content || displayItem.item.summary || '').replace(
+          /<[^>]*>/g,
+          ''
+        );
+        wordCount = text.split(/\s+/).filter(Boolean).length || null;
+      }
+    } else if (displayItem.type === 'document') {
+      wordCount = displayItem.item.wordCount ?? null;
+      if (wordCount == null) {
+        const text = (displayItem.item.textContent || displayItem.item.description || '').replace(
+          /<[^>]*>/g,
+          ''
+        );
+        wordCount = text.split(/\s+/).filter(Boolean).length || null;
+      }
+    } else if (displayItem.type === 'saved') {
+      wordCount = displayItem.item.wordCount ?? lazyWordCount;
+    }
+    if (wordCount == null) return null;
     return Math.max(1, Math.round(wordCount / 200));
   });
 
@@ -468,10 +509,12 @@
           {#if displayItem.type === 'article' && displayItem.item.author}
             <span class="meta-author">{displayItem.item.author}</span>
           {/if}
-          <span class="meta-read-time">
-            <Icon name="clock" size={12} />
-            {readTimeMinutes} min
-          </span>
+          {#if readTimeMinutes}
+            <span class="meta-read-time">
+              <Icon name="clock" size={12} />
+              {readTimeMinutes} min
+            </span>
+          {/if}
           <span class="meta-date">{formatRelativeDate(publishedAt)}</span>
           {#each tags as tag, i}
             {#if i === 0}<span class="meta-dot" aria-hidden="true">·</span>{/if}

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -909,6 +909,15 @@ class ApiClient {
     return this.fetch('/api/saved');
   }
 
+  // Patch mutable fields on an existing saved item (currently just the
+  // precomputed word count, used to backfill old saves that lack one).
+  async updateSaved(rkey: string, fields: { wordCount?: number }): Promise<{ success: boolean }> {
+    return this.fetch(`/api/saved/${rkey}`, {
+      method: 'PATCH',
+      body: JSON.stringify(fields),
+    });
+  }
+
   async deleteSaved(rkey: string): Promise<{ success: boolean }> {
     return this.fetch(`/api/saved/${rkey}`, {
       method: 'DELETE',

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -40,6 +40,7 @@ export interface SavedPayload {
   author?: string;
   description?: string;
   content?: string;
+  wordCount?: number;
   image?: string;
   publishedAt?: string;
   domain?: string;
@@ -453,6 +454,7 @@ class SyncQueue {
           author: payload.author,
           description: payload.description,
           content: payload.content,
+          wordCount: payload.wordCount,
           image: payload.image,
           publishedAt: payload.publishedAt,
           domain: payload.domain,

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -5,7 +5,18 @@ import { generateTid } from '$lib/utils/tid';
 import { syncQueue, type SavedPayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
 import { extractArticle } from '$lib/services/extract';
+import { computeContentStats } from '$lib/services/articleMerge';
 import type { SavedItem } from '$lib/types';
+
+// Derive a word count from the best available body text, returning null when
+// there's nothing to count. Used so a saved item's read time never silently
+// falls back to "1 min" from the short RSS description — every save path that
+// has any body computes a real count locally even when the extractor/proxy
+// didn't supply one.
+function wordCountFrom(...texts: (string | null | undefined)[]): number | null {
+  const body = texts.find((t) => t && t.trim().length > 0) || undefined;
+  return computeContentStats(body).wordCount || null;
+}
 
 // The extracted webpage body is the largest field on a saved item and is only
 // read in the fullscreen reader (the card preview uses `description`; read time
@@ -57,6 +68,23 @@ function createSavesStore() {
 
       // Then fetch from backend
       const response = await api.getSaved();
+
+      // Self-heal old saves that have a body but no stored word count (pre-fix
+      // saves, failed extractions, offline replays). Without this they fall back
+      // to counting the short RSS description and show a misleading "1 min".
+      // Compute locally, persist to IndexedDB, and PATCH the backend so the fix
+      // sticks across reloads and devices instead of recomputing every load.
+      const backfilled: SavedItem[] = [];
+      for (const a of response.articles) {
+        if (a.wordCount == null && a.content) {
+          const wc = wordCountFrom(a.content);
+          if (wc != null) {
+            a.wordCount = wc;
+            backfilled.push(a);
+          }
+        }
+      }
+
       articles = response.articles.map(toLightSaved);
       rebuildMaps();
 
@@ -65,6 +93,16 @@ function createSavesStore() {
       await db.saved.clear();
       if (response.articles.length > 0) {
         await safeBulkPut(db.saved, response.articles);
+      }
+
+      if (backfilled.length > 0 && syncStore.isOnline) {
+        void Promise.all(
+          backfilled.map((a) =>
+            api.updateSaved(a.rkey, { wordCount: a.wordCount! }).catch((err) => {
+              console.warn('Failed to backfill saved word count:', err);
+            })
+          )
+        );
       }
     } catch (err) {
       console.error('Failed to load saved items:', err);
@@ -83,6 +121,11 @@ function createSavesStore() {
       // Fetch HTML via proxy and extract content client-side
       const extracted = await extractArticle(url);
 
+      // Prefer the extractor's word count, but never leave it null when a body
+      // exists — count locally so the read time is right even if the proxy
+      // omitted it.
+      const wordCount = extracted.wordCount || wordCountFrom(extracted.content);
+
       const result = await api.saveFromUrl(url, rkey, {
         title: extracted.title || undefined,
         author: extracted.author || undefined,
@@ -91,7 +134,7 @@ function createSavesStore() {
         domain: extracted.domain || undefined,
         image: extracted.image || undefined,
         publishedAt: extracted.published || undefined,
-        wordCount: extracted.wordCount || undefined,
+        wordCount: wordCount || undefined,
       });
 
       const savedItem: SavedItem = {
@@ -105,7 +148,7 @@ function createSavesStore() {
         contentType: 'webpage',
         domain: extracted.domain,
         image: extracted.image,
-        wordCount: extracted.wordCount,
+        wordCount,
         publishedAt: extracted.published,
         savedAt: result.savedAt,
         source: 'url',
@@ -177,7 +220,10 @@ function createSavesStore() {
         contentType: 'article',
         domain: null,
         image: article.imageUrl || null,
-        wordCount: null,
+        // Count the RSS body up-front so the read time is right immediately —
+        // including offline, where extraction never runs. Upgraded below with
+        // the extracted body's count when online.
+        wordCount: wordCountFrom(rssBody),
         publishedAt: article.publishedAt || null,
         savedAt: now,
         source: 'feed',
@@ -206,6 +252,11 @@ function createSavesStore() {
           } catch (err) {
             console.warn('Article extraction failed, using feed body:', err);
           }
+
+          // Never leave the count null when a body exists: extraction may have
+          // failed (content stayed the RSS body) or returned a body with no
+          // count. Count whatever body we ended up with.
+          if (wordCount == null) wordCount = wordCountFrom(content);
 
           const result = await api.saveFromUrl(article.url, rkey, {
             fromFeed: true,
@@ -246,6 +297,7 @@ function createSavesStore() {
             author: article.author,
             description: article.summary,
             content: rssBody ?? undefined,
+            wordCount: wordCountFrom(rssBody) ?? undefined,
             image: article.imageUrl,
             publishedAt: article.publishedAt,
           } as SavedPayload);
@@ -264,6 +316,7 @@ function createSavesStore() {
           author: article.author,
           description: article.summary,
           content: rssBody ?? undefined,
+          wordCount: wordCountFrom(rssBody) ?? undefined,
           image: article.imageUrl,
           publishedAt: article.publishedAt,
         } as SavedPayload);


### PR DESCRIPTION
## Problem

Saved items sometimes show **"1 min"** read time even when the article is long.

**Root cause:** saved list items are memory-light copies with `content: null` (the body is stripped by `toLightSaved` and kept only in IndexedDB). `SavedCard`'s read-time derivation used `wordCount` when set, else fell back to `content || description` — but `content` is always null in memory, so it counted the short RSS `description` → "1 min". And `wordCount` was left `null` in several common save paths (extraction failure, proxy returning content with no count, offline saves, sync-queue replays, and pre-`339cbcd` saves).

## Fix (three layers)

1. **Save paths** (`saves.svelte.ts`) — always compute `wordCount` locally from the best available body via `computeContentStats` when the extractor/proxy didn't supply one. Covers URL saves, feed saves (online), the optimistic/offline body, and the sync-queue replay (added `wordCount` to `SavedPayload` and threaded it through `executeSavedOperation`).
2. **Backfill on load** (`saves.svelte.ts` `load()`) — for rows that have a `content` body but `wordCount == null`, compute the count, persist it to IndexedDB, and `PATCH` the backend so old saves self-heal and the fix sticks across reloads/devices (rather than recomputing every load).
3. **Display** (`SavedCard.svelte`) — drop the dead `content ||` branch. When `wordCount` is genuinely unknown, lazy-load the body via `getContent()` to count it; if there's no text at all, hide the chip rather than show a misleading estimate from the description.

## Backend

New `PATCH /api/saved/:rkey` (`handleUpdateSaved`) updates `word_count` in D1 only — the word count is a derived display value, not part of the PDS record's canonical data, so there's no PDS write. Routed in `index.ts` alongside the existing `DELETE`.

## Verification

- `frontend: npm run check` — 0 errors (pre-existing warnings only)
- `backend: npm run check` — clean
- `articleMerge.test.ts` (`computeContentStats`) — 19 passing

Manual validation to do on a running instance: save a long article online, offline, and from an extraction-failing URL; confirm correct minutes on the card and reader; confirm an old null-`wordCount` save self-heals after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)