### PR TITLE
Add note controls to the Highlights view

### DIFF
--- a/frontend/src/lib/components/feed/HighlightPopover.svelte
+++ b/frontend/src/lib/components/feed/HighlightPopover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy, tick } from 'svelte';
+  import { onMount, onDestroy, tick, untrack } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { tooltip } from '$lib/actions/tooltip';
   import { positionFloating } from '$lib/utils/floating';
@@ -14,6 +14,10 @@
     onSaveNote?: (note: string) => void;
     existingNote?: string;
     marginSaved?: boolean;
+    // Which sub-view to open into: 'toolbar' (action buttons, the default) or
+    // 'note' (jump straight into the note editor — used by callers that have a
+    // dedicated "add a note" control).
+    initialView?: 'toolbar' | 'note';
     onClose: () => void;
   }
 
@@ -27,14 +31,17 @@
     onSaveNote,
     existingNote = '',
     marginSaved = false,
+    initialView = 'toolbar',
     onClose,
   }: Props = $props();
 
   let menuEl = $state<HTMLDivElement | null>(null);
   let textareaEl = $state<HTMLTextAreaElement | null>(null);
   // 'toolbar' shows the action buttons; 'note' shows the floating text box.
-  let view = $state<'toolbar' | 'note'>('toolbar');
-  let noteText = $state('');
+  // These seed from props once at mount; later prop changes shouldn't reset the
+  // open view or clobber what the user is typing, so the reads are untracked.
+  let view = $state<'toolbar' | 'note'>(untrack(() => initialView));
+  let noteText = $state(untrack(() => (initialView === 'note' ? (existingNote ?? '') : '')));
   let scrollArmed = false;
   let scrollArmTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -78,6 +85,15 @@
     document.addEventListener('touchstart', handleClickOutside, true);
     document.addEventListener('scroll', handleScroll, true);
     requestAnimationFrame(positionMenu);
+    // When opened straight into the note editor, focus the textarea once it has
+    // rendered so the user can type immediately.
+    if (view === 'note') {
+      tick().then(() => {
+        positionMenu();
+        textareaEl?.focus();
+        textareaEl?.select();
+      });
+    }
     // Delay arming the scroll-to-close so residual scroll momentum
     // (e.g. from trackpad inertia) doesn't immediately dismiss the popover
     scrollArmTimer = setTimeout(() => {

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -9,6 +9,7 @@
   import SavedReader from '$lib/components/feed/SavedReader.svelte';
   import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
   import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
   import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import NotificationList from '$lib/components/NotificationList.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
@@ -20,7 +21,11 @@
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { useScrollDirection } from '$lib/hooks/useScrollDirection.svelte';
-  import { saveHighlightToMargin, deleteHighlight } from '$lib/services/marginHighlights';
+  import {
+    saveHighlightToMargin,
+    deleteHighlight,
+    updateHighlightNoteOnMargin,
+  } from '$lib/services/marginHighlights';
   import { formatRelativeTime } from '$lib/utils/date';
   import { decodeEntities } from '$lib/utils/entities';
   import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
@@ -208,6 +213,33 @@
     void saveHighlightToMargin(group.itemKey, row.highlight, group.url, group.title);
   }
 
+  // Note editor — a floating popover anchored to the "add a note" button, opened
+  // straight into its note view. Mirrors the reader's note-editing UX.
+  let noteEditor = $state<{
+    group: HighlightGroup;
+    row: HighlightRow;
+    anchorRect: DOMRect;
+  } | null>(null);
+
+  function openNoteEditor(event: MouseEvent, group: HighlightGroup, row: HighlightRow) {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    noteEditor = { group, row, anchorRect: rect };
+  }
+
+  function handleSaveNote(note: string) {
+    if (!noteEditor) return;
+    const { group, row } = noteEditor;
+    noteEditor = null;
+    void (async () => {
+      await itemLabelsStore.setHighlightNote(group.itemKey, row.id, note);
+      // Re-read so we act on the persisted note + current Margin linkage.
+      const updated = itemLabelsStore.getHighlights(group.itemKey).find((h) => h.id === row.id);
+      if (updated?.marginRkey) {
+        await updateHighlightNoteOnMargin(group.itemKey, updated, group.url, group.title);
+      }
+    })();
+  }
+
   // --- Mobile chrome (floating bottom bar + sheets), matching the feed page ---
   const scrollDirection = useScrollDirection();
   let feedSwitcherOpen = $state(false);
@@ -283,6 +315,14 @@
                       {/if}
                     </span>
                     <span class="row-actions">
+                      <button
+                        class="action-btn"
+                        onclick={(e) => openNoteEditor(e, group, row)}
+                        title={row.note ? 'Edit note' : 'Add a note'}
+                        aria-label={row.note ? 'Edit note' : 'Add a note'}
+                      >
+                        <Icon name="message-circle" size={15} />
+                      </button>
                       {#if !row.isMargin}
                         <button
                           class="action-btn"
@@ -361,6 +401,17 @@
 
 {#if readerItem}
   <SavedReader {readerItem} onClose={closeReader} />
+{/if}
+
+{#if noteEditor}
+  <HighlightPopover
+    mode="view"
+    initialView="note"
+    anchorRect={noteEditor.anchorRect}
+    existingNote={noteEditor.row.note ?? ''}
+    onSaveNote={handleSaveNote}
+    onClose={() => (noteEditor = null)}
+  />
 {/if}
 
 <style>


### PR DESCRIPTION
## What

Adds an **Add a note** / **Edit note** control to each highlight row in the Highlights view. Previously the only row actions were *Save to Margin* and *Remove* — there was no way to attach a note from this surface, even though the note infrastructure (lexicon field, store persistence + sync, read-only rendering, and the reader's note editor) already existed end-to-end.

## How

- **`HighlightPopover.svelte`** — new optional `initialView: 'toolbar' | 'note'` prop (default `'toolbar'`, so existing callers are unchanged). When `'note'`, the popover opens straight into its note editor and focuses the textarea on mount. The state seeds from props once via `untrack` so later prop changes don't reset the open view or clobber in-progress typing. The existing scroll-to-close guard already skips dismissal while the note view is open.
- **`HighlightsPage.svelte`** — a third per-row action button (`message-circle` icon, labeled *Add a note* or *Edit note* based on `row.note`). Clicking captures the button's `getBoundingClientRect()` and opens `HighlightPopover` anchored to it with `initialView="note"` and the existing note prefilled. The save handler mirrors the reader's `saveNoteFromPopover`: `itemLabelsStore.setHighlightNote(...)`, then re-reads the highlight and calls `updateHighlightNoteOnMargin(...)` if it's Margin-synced.

This reuses the floating popover the reader already uses, rather than building a new inline editor, so the two note-editing surfaces stay in lockstep.

## Notes / tradeoffs

- If a Margin-synced highlight's source URL has aged out (`group.url == null`), the local note still saves but the Margin copy can't update — matches existing behavior in the service layer.
- Clearing a note (saving empty) drops the `note` field and removes the marker, per `setHighlightNote`'s existing trim-to-empty handling.

## Validation

- `npm run check` — 0 errors; warning count unchanged from baseline (the 3 transient `state_referenced_locally` warnings were resolved with `untrack`).
- Manual checks remaining for reviewer: add/edit/clear a private note, edit a Margin-synced note (verify Margin update fires), offline edit (queues), mobile touch targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)