### PR TITLE
Fix layout shift when focusing the share comment box

### DIFF
--- a/frontend/src/lib/components/feed/ShareCommentBox.svelte
+++ b/frontend/src/lib/components/feed/ShareCommentBox.svelte
@@ -173,10 +173,13 @@
       }}
     ></textarea>
     <MentionAutocomplete {textareaEl} bind:value />
-    <!-- Always rendered so it reserves its space — focusing (or a saved note at
-         rest) reveals it via opacity/visibility, never a layout shift. -->
-    <div class="actions" class:hidden={!focused && !showSaved}>
-      {#if focused}
+    <!-- The actions slot always reserves the focused controls' footprint: the
+         controls stay mounted and are only hidden via visibility/opacity, never
+         unmounted, so revealing them on focus changes neither the row's width nor
+         its height. The at-rest "Saved" pill overlaps the controls in a single grid
+         cell, so the slot stays sized to the controls in every state — no reflow. -->
+    <div class="actions">
+      <div class="action-controls" class:hidden={!focused}>
         {#if nearLimit}
           <span class="counter" class:over={value.length >= MAX}>{MAX - value.length}</span>
         {/if}
@@ -241,9 +244,13 @@
           <Icon name="check" size={16} />
           <span class="btn-text">Save</span>
         </button>
-      {:else if showSaved}
+      </div>
+      {#if !focused && showSaved}
         <!-- Persistent confirmation: the note landed. Stays until the user edits
-             again, so the feedback doesn't blink out the moment they tap save. -->
+             again, so the feedback doesn't blink out the moment they tap save.
+             Overlaid in the same grid cell as the controls, so mounting it on save
+             never shifts the row. Mounting (rather than toggling visibility) keeps
+             the aria-live announcement firing. -->
         <span class="saved-pill" aria-live="polite">
           <Icon name="check" size={14} />
           <span class="saved-text">Saved</span>
@@ -319,6 +326,19 @@
     /* Stick to the bottom so the button trails the last line as the note wraps,
        while the icon stays aligned to the first line. */
     align-self: flex-end;
+    /* Overlap children in a single cell so the slot is always sized to the
+       controls — whichever state (focused controls or at-rest "Saved" pill) is
+       showing — so focus only toggles visibility and never reflows the row. */
+    display: grid;
+    justify-items: end;
+    align-items: center;
+  }
+
+  .actions > * {
+    grid-area: 1 / 1;
+  }
+
+  .action-controls {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -326,7 +346,7 @@
   }
 
   /* Hidden but still occupying space, so showing it on focus never reflows. */
-  .actions.hidden {
+  .hidden {
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -492,7 +512,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .actions {
+    .action-controls {
       transition: none;
     }
   }


### PR DESCRIPTION
## Problem

Focusing the inline share-comment textarea shifted surrounding layout: the **Save** control popped in on focus, narrowing the textarea and (being taller than a one-line field) growing the row, which pushed the card controls below it down.

## Root cause

`ShareCommentBox.svelte`'s `.actions` slot was meant to reserve its space so revealing the controls on focus wouldn't reflow — but the controls were gated behind `{#if focused}`, so at rest they were **unmounted and reserved nothing**. On focus they mounted and took up width + height for the first time.

## Fix

- Keep the focused controls (`.action-controls`) **mounted at all times**, hidden only via `visibility`/`opacity` — never unmounted.
- Make `.actions` a single-cell grid and overlap the at-rest **"Saved"** pill on top of the controls (`grid-area: 1/1`), so the slot stays sized to the controls in **every** state (empty, focused, saved-at-rest).
- Focus now toggles visibility alone: the textarea and neighboring card controls keep identical geometry before and after focus.

The "Saved" pill is still mounted on save (not just toggled) so its `aria-live` announcement keeps firing; the reserved slot means mounting it causes no reflow.

## ShareNoteComposer (audited, unchanged)

`ShareNoteComposer.svelte`'s `.note-input` keeps a `1px` border at rest and on focus only changes `border-color` (no geometry change), and it renders inside a `position: fixed` popover — so focusing it cannot shift surrounding page layout. No change needed.

## Design

No new colors or shadows introduced — One Blue (`#0066cc` accent) and Flat-By-Default are preserved.

## Verification

- `npm run check` (svelte-check + prettier): **0 errors**, formatting clean. Pre-existing warnings in unrelated files only.
- Manual reasoning across the empty / focused / saved-at-rest states confirms a constant actions footprint on both the desktop card flow and the mobile (≤1000px) collapsed-label layout. Live device sanity-check of desktop and mobile still recommended on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)