### PR TITLE
Fix double-tap on sidebar items on touchscreen devices

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -767,8 +767,10 @@
     transition: background-color 0.15s;
   }
 
-  .user-info:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .user-info:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .avatar {
@@ -856,8 +858,10 @@
     transition: background-color 0.15s;
   }
 
-  .nav-row:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .nav-row:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .nav-row.active {
@@ -901,21 +905,27 @@
   }
 
   .row-add-btn {
-    opacity: 0;
+    opacity: 0.6;
     transition: opacity 0.15s;
   }
 
-  .nav-row:hover .row-add-btn {
-    opacity: 0.6;
-  }
+  @media (hover: hover) {
+    .row-add-btn {
+      opacity: 0;
+    }
 
-  .row-add-btn:hover {
-    opacity: 1 !important;
-    color: var(--color-primary);
-  }
+    .nav-row:hover .row-add-btn {
+      opacity: 0.6;
+    }
 
-  .row-disclosure-btn:hover {
-    color: var(--color-text);
+    .row-add-btn:hover {
+      opacity: 1 !important;
+      color: var(--color-primary);
+    }
+
+    .row-disclosure-btn:hover {
+      color: var(--color-text);
+    }
   }
 
   .nav-row.active .row-disclosure-btn {
@@ -929,8 +939,10 @@
     gap: 2px;
   }
 
-  .nav-item:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .nav-item:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .nav-link {
@@ -1005,8 +1017,10 @@
     transition: color 0.15s;
   }
 
-  .suggestion-accept:hover {
-    color: var(--color-primary);
+  @media (hover: hover) {
+    .suggestion-accept:hover {
+      color: var(--color-primary);
+    }
   }
 
   .suggestion-icon {
@@ -1040,8 +1054,10 @@
     transition: color 0.15s;
   }
 
-  .more-suggestions-link:hover {
-    color: var(--color-primary);
+  @media (hover: hover) {
+    .more-suggestions-link:hover {
+      color: var(--color-primary);
+    }
   }
 
   .suggestion-dismiss {
@@ -1056,18 +1072,24 @@
     cursor: pointer;
     color: var(--color-text-secondary);
     padding: 0;
-    opacity: 0;
+    opacity: 0.6;
     transition: opacity 0.15s;
     border-radius: 4px;
   }
 
-  .suggestion-item:hover .suggestion-dismiss {
-    opacity: 0.6;
-  }
+  @media (hover: hover) {
+    .suggestion-dismiss {
+      opacity: 0;
+    }
 
-  .suggestion-dismiss:hover {
-    opacity: 1 !important;
-    color: var(--color-text);
+    .suggestion-item:hover .suggestion-dismiss {
+      opacity: 0.6;
+    }
+
+    .suggestion-dismiss:hover {
+      opacity: 1 !important;
+      color: var(--color-text);
+    }
   }
 
   .category-group {
@@ -1118,9 +1140,11 @@
       background-color 0.15s;
   }
 
-  .category-name-btn:hover {
-    color: var(--color-text);
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .category-name-btn:hover {
+      color: var(--color-text);
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .category-name-btn.active {
@@ -1166,7 +1190,7 @@
     }
   }
 
-  @media (prefers-color-scheme: dark) {
+  @media (hover: hover) and (prefers-color-scheme: dark) {
     .nav-item:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
     }
@@ -1174,7 +1198,9 @@
     .nav-row:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
     }
+  }
 
+  @media (prefers-color-scheme: dark) {
     .nav-group.expanded {
       background-color: rgba(255, 255, 255, 0.025);
     }

--- a/frontend/src/lib/components/sidebar/FeedItem.svelte
+++ b/frontend/src/lib/components/sidebar/FeedItem.svelte
@@ -233,8 +233,10 @@
     transition: background-color 0.15s;
   }
 
-  .nav-item:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .nav-item:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .nav-item.active {
@@ -407,8 +409,10 @@
     animation: spin 0.8s linear infinite;
   }
 
-  .retry-btn:hover {
-    color: var(--color-primary);
+  @media (hover: hover) {
+    .retry-btn:hover {
+      color: var(--color-primary);
+    }
   }
 
   .more-btn {
@@ -424,25 +428,31 @@
     font-size: var(--text-base);
     padding: 0;
     line-height: var(--leading-none);
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.15s;
     flex-shrink: 0;
     -webkit-tap-highlight-color: transparent;
     touch-action: manipulation;
   }
 
-  .feed-item:hover .more-btn,
-  .more-btn:focus {
-    opacity: 1;
+  @media (hover: hover) {
+    .more-btn {
+      opacity: 0;
+    }
+
+    .feed-item:hover .more-btn,
+    .more-btn:focus {
+      opacity: 1;
+    }
+
+    .more-btn:hover {
+      color: var(--color-text);
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.1));
+      border-radius: 4px;
+    }
   }
 
-  .more-btn:hover {
-    color: var(--color-text);
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.1));
-    border-radius: 4px;
-  }
-
-  @media (prefers-color-scheme: dark) {
+  @media (hover: hover) and (prefers-color-scheme: dark) {
     .nav-item:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
     }

--- a/frontend/src/lib/components/sidebar/NavSection.svelte
+++ b/frontend/src/lib/components/sidebar/NavSection.svelte
@@ -96,8 +96,10 @@
     transition: background-color 0.15s;
   }
 
-  .section-header:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .section-header:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .section-header.active {
@@ -152,18 +154,24 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 0;
+    opacity: 0.6;
     transition: opacity 0.15s;
     border-radius: 4px;
   }
 
-  .section-header:hover .add-btn {
-    opacity: 0.6;
-  }
+  @media (hover: hover) {
+    .add-btn {
+      opacity: 0;
+    }
 
-  .add-btn:hover {
-    opacity: 1 !important;
-    color: var(--color-primary);
+    .section-header:hover .add-btn {
+      opacity: 0.6;
+    }
+
+    .add-btn:hover {
+      opacity: 1 !important;
+      color: var(--color-primary);
+    }
   }
 
   .disclosure-btn {
@@ -177,8 +185,10 @@
     justify-content: center;
   }
 
-  .disclosure-btn:hover {
-    color: var(--color-text);
+  @media (hover: hover) {
+    .disclosure-btn:hover {
+      color: var(--color-text);
+    }
   }
 
   .section-header.active .disclosure-btn {
@@ -194,16 +204,22 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 0;
+    opacity: 0.6;
     transition: opacity 0.15s;
   }
 
-  .section-header:hover .filter-toggle {
-    opacity: 0.6;
-  }
+  @media (hover: hover) {
+    .filter-toggle {
+      opacity: 0;
+    }
 
-  .filter-toggle:hover {
-    opacity: 1 !important;
+    .section-header:hover .filter-toggle {
+      opacity: 0.6;
+    }
+
+    .filter-toggle:hover {
+      opacity: 1 !important;
+    }
   }
 
   .filter-toggle.active {
@@ -218,11 +234,13 @@
     gap: 2px;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @media (hover: hover) and (prefers-color-scheme: dark) {
     .section-header:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
     }
+  }
 
+  @media (prefers-color-scheme: dark) {
     .nav-section.expanded {
       background-color: rgba(255, 255, 255, 0.025);
     }

--- a/frontend/src/lib/components/sidebar/ViewItem.svelte
+++ b/frontend/src/lib/components/sidebar/ViewItem.svelte
@@ -130,8 +130,10 @@
     transition: background-color 0.15s;
   }
 
-  .nav-item:hover {
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+  @media (hover: hover) {
+    .nav-item:hover {
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.05));
+    }
   }
 
   .nav-item.active {
@@ -190,28 +192,28 @@
     font-size: var(--text-base);
     padding: 0;
     line-height: var(--leading-none);
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.15s;
     flex-shrink: 0;
     -webkit-tap-highlight-color: transparent;
     touch-action: manipulation;
   }
 
-  .view-item:hover .more-btn,
-  .more-btn:focus {
-    opacity: 1;
-  }
-
-  @media (max-width: 1000px) {
+  @media (hover: hover) {
     .more-btn {
+      opacity: 0;
+    }
+
+    .view-item:hover .more-btn,
+    .more-btn:focus {
       opacity: 1;
     }
-  }
 
-  .more-btn:hover {
-    color: var(--color-text);
-    background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.1));
-    border-radius: 4px;
+    .more-btn:hover {
+      color: var(--color-text);
+      background-color: var(--color-bg-hover, rgba(0, 0, 0, 0.1));
+      border-radius: 4px;
+    }
   }
 
   .rename-input {
@@ -227,7 +229,7 @@
     outline: none;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @media (hover: hover) and (prefers-color-scheme: dark) {
     .nav-item:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
     }


### PR DESCRIPTION
## Problem

On touchscreen devices, the first tap on a sidebar item triggered the CSS `:hover` state instead of the item's action, forcing a second tap (classic tap-as-hover bug). The frontend had **no** `@media (hover: hover)` guards, so every sidebar `:hover` rule fired on touch. The worst offenders were the hover-revealed controls (three-dot more button, section add/filter buttons, row add button, suggestion dismiss) that are `opacity: 0` until hover — effectively unreachable on touch without the sticky-hover tap.

## Fix

CSS-only change across the four in-scope sidebar components. Two patterns:

- **Pattern B (plain hover styling — background/color feedback):** wrap the `:hover` rule in `@media (hover: hover)`. Active/selection/focus/`favicon-loaded` states stay **unguarded** so selection still highlights on touch.
- **Pattern A (hover-reveal controls):** make the control visible by default (touch + keyboard) and move the `opacity: 0` + `:hover` reveal **inside** `@media (hover: hover)`. Controls whose revealed resting opacity is `0.6` use `0.6` as the touch default. The now-redundant `@media (max-width: 1000px) { .more-btn { opacity: 1 } }` override in `ViewItem` was deleted.

Dark-mode `:hover` overrides were split: the hover-dependent rules combine to `@media (hover: hover) and (prefers-color-scheme: dark)`, while pointer-independent dark rules (`.nav-group.expanded`, `.nav-section.expanded` backgrounds) stay in a plain `prefers-color-scheme: dark` block.

### Design decision

Hover-revealed controls become **always-visible on coarse/no-hover pointers** (not tap-to-reveal) — simplest, most discoverable, zero new interaction state, and matches the existing mobile `opacity: 1` intent. Slightly busier touch sidebar; reversible CSS-only choice. Desktop/mouse hover behavior is unchanged.

## Files

- `frontend/src/lib/components/sidebar/ViewItem.svelte`
- `frontend/src/lib/components/sidebar/FeedItem.svelte` — newly reveals `.more-btn` on touch (the primary bug)
- `frontend/src/lib/components/sidebar/NavSection.svelte`
- `frontend/src/lib/components/Sidebar.svelte`

`.feed-favicon` opacity (favicon load fade) was explicitly left untouched.

## Acceptance criteria

- ✅ Single tap on any sidebar item performs its action immediately on touch — no second tap.
- ✅ Hover background/reveal no longer sticks after a tap on coarse-pointer devices (guarded behind `@media (hover: hover)`).
- ✅ Hover-revealed controls stay reachable on touch (always-visible on touch).
- ✅ Desktop/mouse hover behavior unchanged.
- ✅ Bottom-nav `<a>` links (`nav-item nav-link`) and the settings `.user-info` link — sticky-hover background guarded; all within declared scope (no 5th component).

## Verification

- `npm run check` — svelte-check **0 errors**, prettier clean (24 pre-existing unrelated warnings).
- Manual touch-emulation smoke test recommended (no automated test covers hover-on-touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)