### PR TITLE
Hide desktop reader header on scroll-down

### DIFF
--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -55,12 +55,15 @@
   let styleMenuOpen = $state(false);
   let styleSheetOpen = $state(false);
   let tagMenuOpen = $state(false);
+  let overflowMenuOpen = $state(false);
   let overflowRef = $state<HTMLDivElement | null>(null);
   let tagBtnRef = $state<HTMLButtonElement | null>(null);
   let controlsVisible = $state(true);
   // Desktop header hides on scroll-down, but stays put while a header-anchored
-  // menu (Style/Tag) is open so its popover doesn't slide off-screen.
-  let headerHidden = $derived(!controlsVisible && !styleMenuOpen && !tagMenuOpen);
+  // menu (Style/Tag/overflow ⋯) is open so its popover doesn't slide off-screen.
+  let headerHidden = $derived(
+    !controlsVisible && !styleMenuOpen && !tagMenuOpen && !overflowMenuOpen
+  );
   let scrolled = $state(false);
   let lastScrollY = $state(0);
   let suppressScrollHide = $state(false);
@@ -701,7 +704,7 @@
         </button>
 
         <div class="overflow-menu-wrapper" bind:this={overflowRef}>
-          <PopoverMenu items={overflowItems} />
+          <PopoverMenu items={overflowItems} bind:open={overflowMenuOpen} />
         </div>
       </div>
     </div>

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -58,6 +58,9 @@
   let overflowRef = $state<HTMLDivElement | null>(null);
   let tagBtnRef = $state<HTMLButtonElement | null>(null);
   let controlsVisible = $state(true);
+  // Desktop header hides on scroll-down, but stays put while a header-anchored
+  // menu (Style/Tag) is open so its popover doesn't slide off-screen.
+  let headerHidden = $derived(!controlsVisible && !styleMenuOpen && !tagMenuOpen);
   let scrolled = $state(false);
   let lastScrollY = $state(0);
   let suppressScrollHide = $state(false);
@@ -636,7 +639,12 @@
   <!-- Desktop: top header — a full-width flat bar (matches the feed header's
        800px band) so the chrome doesn't shift when opening the reader. The
        article below lives in its own narrower reading column. -->
-  <header class="reader-header desktop-only" class:scrolled bind:this={headerRef}>
+  <header
+    class="reader-header desktop-only"
+    class:scrolled
+    class:hidden={headerHidden}
+    bind:this={headerRef}
+  >
     <div class="reader-header-bar">
       <div class="reader-actions-left">
         <button class="action-btn" onclick={onClose} title="Back (Escape)">
@@ -1060,6 +1068,14 @@
     flex-direction: column;
     background: var(--color-bg, #ffffff);
     margin-bottom: 0.5rem;
+    /* Hide on scroll-down / reveal on scroll-up — matches the mobile bottom
+       bar's motion. The header is position:sticky overlaying content, so
+       translating it off-screen reclaims vertical space without reflow. */
+    transition: transform 0.25s ease;
+  }
+
+  .reader-header.hidden {
+    transform: translateY(-100%);
   }
 
   /* The divider spans only the 800px control band, centered — matching the feed
@@ -1084,6 +1100,10 @@
 
   @media (prefers-reduced-motion: reduce) {
     .reader-header::after {
+      transition: none;
+    }
+
+    .reader-header {
       transition: none;
     }
   }


### PR DESCRIPTION
## Hide desktop reader header on scroll

In the full-screen reader on **desktop**, the top page-navigation header now hides when scrolling down into the article and returns on scroll-up — a quieter, text-first reading surface that reclaims vertical space. Mobile is untouched.

### How it works
The named `useScrollDirection` hook keys off `window.scrollY`, but the reader scrolls inside `overlayEl` (a fixed `overflow-y:auto` container), so that hook can't track it. The reader already has the right mechanism: the inline `handleScroll` computes `controlsVisible` from `overlayEl.scrollTop` (60px threshold, immediate reveal-on-up, `suppressScrollHide` guard protecting scroll-position-restore). It previously drove only the mobile bottom bar; this PR reuses it for the desktop header — no new listener, no hook change.

- `headerHidden` derived → `!controlsVisible` plus guards for any open header-anchored menu.
- `.reader-header.hidden { transform: translateY(-100%); }` with a `transform 0.25s ease` transition matching the mobile bottom bar; disabled under `prefers-reduced-motion`.
- Header is `position: sticky` overlaying content, so translating it off-screen reveals content beneath with no reflow/jump.
- Cross-platform-safe: on desktop the mobile bar is `display:none`; on mobile the header is `display:none`. Each platform toggles only its visible element from the shared `controlsVisible`.

### Acceptance criteria
1. Scroll down past 60px → header slides up. ✅
2. Scroll up → header returns immediately. ✅
3. Header always visible at scroll position 0. ✅
4. Content reflows into reclaimed space with no jump/clip; scroll-position restore still works (`suppressScrollHide` freezes the hide during restore). ✅
5. Mobile unchanged. ✅

### Revised in response to review (round 2)
The header also hosts the overflow `⋯` `PopoverMenu`, whose open state was **not** part of `headerHidden`. Opening it then scrolling down hid the header and slid the open menu off-screen — the exact header-anchored-menu failure the Style/Tag guard exists to prevent.

Fix: bound the `PopoverMenu`'s `open` (`bind:open={overflowMenuOpen}`, the component already exposes a `$bindable` `open`) and added it to the `headerHidden` derived alongside the existing Style/Tag guards. Now the header stays pinned while **any** of its anchored menus is open.

### Verification
- `cd frontend && npm run check` → 0 errors (pre-existing warnings only), Prettier clean.
- Manual desktop verification per plan (scroll-hide/reveal, scroll-0 always-visible, open-menu-then-scroll no longer orphans, scroll-restore, reduced-motion).

### Caveats
No automated test added — there's no existing coverage for this overlay's scroll chrome; relies on manual desktop verification.