### PR TITLE
Remove unread filter from Your Linkblog view

### DIFF
--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -632,14 +632,11 @@
           <LoadingState />
         {:else if !isSavedView && feedViewStore.currentItems.length === 0}
           {#if mode === 'linkblog'}
-            {#if feedViewStore.showOnlyUnread}
-              <EmptyState title="No unread posts" description="You're all caught up." />
-            {:else}
-              <EmptyState
-                title="No shares yet"
-                description="Share an article from your feed and it'll appear here — and on your public page."
-              />
-            {/if}
+            <!-- Linkblog always shows all shares, so there's no "no unread" case. -->
+            <EmptyState
+              title="No shares yet"
+              description="Share an article from your feed and it'll appear here — and on your public page."
+            />
           {:else if feedViewStore.viewFilter}
             <EmptyState
               title="No matching items"

--- a/frontend/src/lib/components/feed/FilterToolbar.svelte
+++ b/frontend/src/lib/components/feed/FilterToolbar.svelte
@@ -289,28 +289,31 @@
       </button>
     {/if}
 
-    <span class="toolbar-divider"></span>
+    <!-- Your own linkblog always shows everything, so no read/unread toggle. -->
+    {#if !feedViewStore.myLinkblogFilter}
+      <span class="toolbar-divider"></span>
 
-    <div class="segment-group" role="group" aria-label="Read filter">
-      <button
-        class="segment-btn"
-        class:active={feedViewStore.showOnlyUnread}
-        onclick={() => feedViewStore.setShowOnlyUnread(true)}
-        title="Unread"
-      >
-        <Icon name="circle-dot" size={16} />
-        <span class="segment-label">Unread</span>
-      </button>
-      <button
-        class="segment-btn"
-        class:active={!feedViewStore.showOnlyUnread}
-        onclick={() => feedViewStore.setShowOnlyUnread(false)}
-        title="All"
-      >
-        <Icon name="inbox" size={16} />
-        <span class="segment-label">All</span>
-      </button>
-    </div>
+      <div class="segment-group" role="group" aria-label="Read filter">
+        <button
+          class="segment-btn"
+          class:active={feedViewStore.showOnlyUnread}
+          onclick={() => feedViewStore.setShowOnlyUnread(true)}
+          title="Unread"
+        >
+          <Icon name="circle-dot" size={16} />
+          <span class="segment-label">Unread</span>
+        </button>
+        <button
+          class="segment-btn"
+          class:active={!feedViewStore.showOnlyUnread}
+          onclick={() => feedViewStore.setShowOnlyUnread(false)}
+          title="All"
+        >
+          <Icon name="inbox" size={16} />
+          <span class="segment-label">All</span>
+        </button>
+      </div>
+    {/if}
   </div>
 
   {#if isEditingView && onEditChannel}

--- a/frontend/src/lib/components/feed/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/feed/MobileFilterSheet.svelte
@@ -507,7 +507,7 @@
       <div class="sheet-section">
         <div class="section-label">
           <Icon name="arrow-down" size={12} />
-          Sort & Read
+          {feedViewStore.myLinkblogFilter ? 'Sort' : 'Sort & Read'}
         </div>
         <div class="toggle-row">
           <button class="toggle-btn" onclick={() => feedViewStore.toggleSortOrder()}>
@@ -517,22 +517,25 @@
             />
             {feedViewStore.currentSortOrder === 'newest' ? 'Newest' : 'Oldest'}
           </button>
-          <button
-            class="toggle-btn"
-            class:active={feedViewStore.showOnlyUnread}
-            onclick={() => feedViewStore.setShowOnlyUnread(true)}
-          >
-            <Icon name="circle-dot" size={16} />
-            Unread
-          </button>
-          <button
-            class="toggle-btn"
-            class:active={!feedViewStore.showOnlyUnread}
-            onclick={() => feedViewStore.setShowOnlyUnread(false)}
-          >
-            <Icon name="inbox" size={16} />
-            All
-          </button>
+          <!-- Your own linkblog always shows everything, so no read/unread toggle. -->
+          {#if !feedViewStore.myLinkblogFilter}
+            <button
+              class="toggle-btn"
+              class:active={feedViewStore.showOnlyUnread}
+              onclick={() => feedViewStore.setShowOnlyUnread(true)}
+            >
+              <Icon name="circle-dot" size={16} />
+              Unread
+            </button>
+            <button
+              class="toggle-btn"
+              class:active={!feedViewStore.showOnlyUnread}
+              onclick={() => feedViewStore.setShowOnlyUnread(false)}
+            >
+              <Icon name="inbox" size={16} />
+              All
+            </button>
+          {/if}
         </div>
       </div>
     {/if}

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -482,19 +482,13 @@ function createFeedViewStore() {
       // publishedAt → createdAt (the record's share time) so both the sort below
       // and the downstream card date reflect when each link was shared. Scoped to
       // this view; the followed-linkblog feed is unaffected.
-      let mine = myLinkblogStore.documents.map((d) => ({
+      // Your own linkblog always shows every share regardless of read state — a
+      // read/unread filter on your own publication is confusing. No readFilter
+      // applied here; the toolbar's read-filter toggle is hidden for this view.
+      const mine = myLinkblogStore.documents.map((d) => ({
         ...d,
         publishedAt: d.createdAt || d.publishedAt,
       }));
-      if (fv.readFilter === 'unread') {
-        mine = mine.filter(
-          (d) =>
-            !itemLabelsStore.isSocialRead(d.recordUri) ||
-            readDocumentUrisThisSession.has(d.recordUri)
-        );
-      } else if (fv.readFilter === 'read') {
-        mine = mine.filter((d) => itemLabelsStore.isSocialRead(d.recordUri));
-      }
       mine.sort((a, b) => {
         const dateA = new Date(a.publishedAt).getTime();
         const dateB = new Date(b.publishedAt).getTime();


### PR DESCRIPTION
## What

In the authenticated **Your Linkblog** view (your own published shares), always show every post regardless of read state, and remove the read/unread filter control from this view's toolbar entirely.

A read/unread toggle on your *own* publication is confusing — you're looking at what you published, not an inbox to triage.

## Scope

- **In scope:** the in-app `myLinkblogFilter` view (`/linkblog`).
- **Not in scope / unchanged:** the public `linkblogs.skyreader.app` site (already shows everything), regular feeds, saved/channels, and the followed-linkblog social feed — all keep their existing unread-filter behavior.

## Changes

- `frontend/src/lib/stores/feedView.svelte.ts` — drop the `readFilter` unread/read branch inside the `myLinkblogFilter` arm of `displayedDocuments`. The share-time `publishedAt → createdAt` remap and sort are unchanged. The global `showOnlyUnread` toggle is untouched.
- `frontend/src/lib/components/feed/FilterToolbar.svelte` — hide the read-filter segment group when `myLinkblogFilter` is active.
- `frontend/src/lib/components/feed/MobileFilterSheet.svelte` — hide the Unread/All toggles in the mobile sheet for this view (section label becomes "Sort").
- `frontend/src/lib/components/feed/FeedPage.svelte` — collapse the now-dead "No unread posts" linkblog empty state to always show "No shares yet".

## Acceptance

1. ✅ Linkblog view shows all shares (read + unread).
2. ✅ The unread/all read-filter toggle is not rendered in this view (desktop toolbar + mobile sheet).
3. ✅ No regression to read filtering in other views — only the `myLinkblogFilter` branch changed; global `showOnlyUnread` and all other view branches are intact.

## Checks

- `npm run check` (frontend): 0 errors, 0 new warnings (24 pre-existing warnings in unrelated files), Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)