### PR TITLE
Auto-recover subscription sync after a PDS migration

### DIFF
--- a/backend/src/routes/sync.ts
+++ b/backend/src/routes/sync.ts
@@ -1,5 +1,5 @@
 import type { Env } from '../types';
-import { getSessionFromRequest } from '../services/oauth';
+import { getSessionFromRequest, getSessionIdFromRequest } from '../services/oauth';
 import { getUserSettings, updateSyncTimestamp } from './settings';
 import {
   syncSubscriptions,
@@ -18,6 +18,11 @@ export interface FullSyncResult {
   error?: string;
   /** If true, there's more work to do - call sync again */
   hasMore?: boolean;
+  /**
+   * Set when the user's PDS moved (migration) and their tokens no longer work
+   * against the new host — they must reconnect their account to resume sync.
+   */
+  needsReauth?: boolean;
 }
 
 export interface SyncStatusResponse {
@@ -64,8 +69,10 @@ export async function handleFullSync(
   const result: FullSyncResult = { success: true };
 
   try {
-    // Sync subscriptions
-    const subResult = await syncSubscriptions(session, env);
+    // Sync subscriptions. Pass the session id so the PDS client can self-heal a
+    // stale host after a PDS migration (re-resolve + persist + retry).
+    const sessionId = getSessionIdFromRequest(request) ?? undefined;
+    const subResult = await syncSubscriptions(session, env, sessionId);
     result.subscriptions = subResult;
 
     if (subResult.success) {
@@ -74,6 +81,10 @@ export async function handleFullSync(
 
     if (subResult.hasMore) {
       result.hasMore = true;
+    }
+
+    if (subResult.needsReauth) {
+      result.needsReauth = true;
     }
 
     result.success = subResult.success;
@@ -141,7 +152,8 @@ export async function handleSyncSubscriptions(request: Request, env: Env): Promi
   }
 
   try {
-    const result = await syncSubscriptions(session, env);
+    const sessionId = getSessionIdFromRequest(request) ?? undefined;
+    const result = await syncSubscriptions(session, env, sessionId);
 
     if (result.success) {
       await updateSyncTimestamp(env, session.did, 'subscriptions');

--- a/backend/src/services/oauth.ts
+++ b/backend/src/services/oauth.ts
@@ -488,6 +488,36 @@ export async function storeSession(env: Env, sessionId: string, session: Session
     .run();
 }
 
+// Persist a re-resolved PDS host onto an existing session. storeSession's
+// ON CONFLICT clause deliberately only refreshes tokens/expiry and does NOT
+// touch pds_url, so a host that moved after a PDS migration must be written
+// explicitly here (see PDSClient's stale-endpoint recovery).
+export async function updateSessionPdsUrl(
+  env: Env,
+  sessionId: string,
+  pdsUrl: string
+): Promise<void> {
+  await env.DB.prepare('UPDATE sessions SET pds_url = ? WHERE session_id = ?')
+    .bind(pdsUrl, sessionId)
+    .run();
+}
+
+// Extract the session id from a request's cookie or Authorization header, using
+// the same precedence as resolveSessionFromRequest. Returns null if neither is
+// present. Useful when a caller needs the id itself (not just the session) to
+// persist a migrated PDS host back to the row.
+export function getSessionIdFromRequest(request: Request): string | null {
+  const cookies = parseCookies(request.headers.get('Cookie'));
+  const fromCookie = cookies.get(SESSION_COOKIE_NAME);
+  if (fromCookie) return fromCookie;
+
+  const authHeader = request.headers.get('Authorization');
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7);
+  }
+  return null;
+}
+
 // Get session from D1 (returns session even if expired, to allow refresh)
 async function getSessionWithRefreshState(
   env: Env,

--- a/backend/src/services/pds-client.ts
+++ b/backend/src/services/pds-client.ts
@@ -1,5 +1,11 @@
-import type { Session } from '../types';
-import { importPrivateKey, createDPoPProof } from './oauth';
+import type { Env, Session } from '../types';
+import {
+  importPrivateKey,
+  createDPoPProof,
+  getPdsFromDid,
+  invalidatePdsCache,
+  updateSessionPdsUrl,
+} from './oauth';
 
 /**
  * Response type for listRecords API
@@ -70,7 +76,21 @@ export interface PDSError {
  */
 export type PDSResult<T> =
   | { success: true; data: T; truncated?: boolean }
-  | { success: false; error: string; retryable: boolean };
+  // `needsReauth` is set when the PDS host was re-resolved after a migration but
+  // the existing OAuth tokens were still rejected — the user must re-authenticate
+  // against the new PDS's auth server. Callers should surface this, not retry.
+  | { success: false; error: string; retryable: boolean; needsReauth?: boolean };
+
+/**
+ * Optional context that lets a PDSClient self-heal a stale PDS endpoint.
+ * When present, a request that fails because the cached host moved (PDS
+ * migration) re-resolves the host from the DID document, persists it back to
+ * the session, and retries once.
+ */
+export interface PDSRecoveryContext {
+  env: Env;
+  sessionId: string;
+}
 
 /**
  * Client for interacting with the user's Personal Data Server (PDS)
@@ -79,19 +99,102 @@ export type PDSResult<T> =
 export class PDSClient {
   private session: Session;
   private dpopNonce: string | null = null;
+  private readonly recovery?: PDSRecoveryContext;
+  // One-shot guard: only attempt endpoint re-resolution once per client, so a
+  // genuinely broken host (or a transient blip misread as a migration) can't
+  // spin into a re-resolve loop.
+  private recoveryAttempted = false;
 
-  constructor(session: Session) {
+  constructor(session: Session, recovery?: PDSRecoveryContext) {
     this.session = session;
+    this.recovery = recovery;
   }
 
   /**
-   * Make an authenticated request to the PDS
+   * Make an authenticated request to the PDS, with one-shot recovery from a
+   * stale PDS endpoint (e.g. after the user migrated their PDS). If the first
+   * attempt fails in a way that looks like the host moved and a recovery
+   * context is available, re-resolve the host from the DID document, persist
+   * it, and retry once.
    */
   private async request<T>(
     method: string,
     endpoint: string,
     body?: unknown
   ): Promise<PDSResult<T>> {
+    const first = await this.attemptRequest<T>(method, endpoint, body);
+    if (!first.staleEndpoint || !this.recovery || this.recoveryAttempted) {
+      return first.result;
+    }
+
+    this.recoveryAttempted = true;
+    const moved = await this.recoverEndpoint();
+    if (!moved) {
+      // Host didn't actually change (or re-resolution failed) — the original
+      // failure stands; don't mask it.
+      return first.result;
+    }
+
+    const second = await this.attemptRequest<T>(method, endpoint, body);
+    if (second.staleEndpoint && !second.result.success) {
+      // New host resolved but auth still rejected: the tokens were minted by
+      // the old PDS's auth server and don't carry over. Signal re-auth.
+      console.warn(
+        `[PDSClient] Auth still rejected after migrating to ${this.session.pdsUrl}; re-auth required`
+      );
+      return { ...second.result, needsReauth: true };
+    }
+    return second.result;
+  }
+
+  /**
+   * Re-resolve this session's PDS host from the DID document, bypassing the
+   * cache. If the host genuinely moved, persist it to the session and reset
+   * per-host DPoP state so the retry binds proofs to the new host. Returns true
+   * only when the host changed (a real migration).
+   */
+  private async recoverEndpoint(): Promise<boolean> {
+    if (!this.recovery) return false;
+    const { env, sessionId } = this.recovery;
+    const did = this.session.did;
+    const oldUrl = this.session.pdsUrl;
+
+    try {
+      await invalidatePdsCache(did, env);
+      const { pdsUrl } = await getPdsFromDid(did, env);
+
+      if (pdsUrl === oldUrl) {
+        // Same host — the failure wasn't a migration (transient error, expired
+        // token, etc.). Nothing to recover.
+        console.warn(
+          `[PDSClient] Re-resolved PDS for ${did} unchanged (${pdsUrl}); not a migration`
+        );
+        return false;
+      }
+
+      console.warn(`[PDSClient] PDS host moved for ${did}: ${oldUrl} -> ${pdsUrl}; persisting`);
+      await updateSessionPdsUrl(env, sessionId, pdsUrl);
+      this.session = { ...this.session, pdsUrl };
+      // DPoP nonces are issued per-host; a nonce from the old host is invalid
+      // against the new one.
+      this.dpopNonce = null;
+      return true;
+    } catch (err) {
+      console.error(`[PDSClient] Endpoint recovery failed for ${did}:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Perform a single authenticated PDS request (including the in-band
+   * use_dpop_nonce retry). Reports whether the failure looks like a stale
+   * endpoint so the caller can decide whether to re-resolve + retry.
+   */
+  private async attemptRequest<T>(
+    method: string,
+    endpoint: string,
+    body?: unknown
+  ): Promise<{ result: PDSResult<T>; staleEndpoint: boolean }> {
     const url = `${this.session.pdsUrl}/xrpc/${endpoint}`;
     console.log(`[PDSClient] ${method} ${url}`);
 
@@ -212,16 +315,33 @@ export class PDSClient {
           });
         }
 
-        return { success: false, error: errorMessage, retryable };
+        // A stale/migrated endpoint shows up as an auth rejection: the request
+        // reached *a* server but the credentials/host no longer line up. We
+        // exclude not-found (a normal outcome), rate limits, and 5xx (transient,
+        // the host is fine) so a re-resolve only fires on real host drift.
+        const staleEndpoint =
+          !isNotFound &&
+          (response.status === 401 ||
+            response.status === 403 ||
+            errorData?.error === 'invalid_token');
+
+        return { result: { success: false, error: errorMessage, retryable }, staleEndpoint };
       }
 
       const data = (await response.json()) as T;
       console.log(`[PDSClient] ${method} ${endpoint} succeeded`);
-      return { success: true, data };
+      return { result: { success: true, data }, staleEndpoint: false };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Network error';
       console.error(`[PDSClient] Request error: ${method} ${endpoint}`, error);
-      return { success: false, error: errorMessage, retryable: true };
+      // A network throw can mean the old host is unreachable after a migration.
+      // Treat it as a stale-endpoint candidate; recoverEndpoint() only retries
+      // if the DID doc actually points somewhere new, so a transient blip with
+      // an unchanged host is a no-op.
+      return {
+        result: { success: false, error: errorMessage, retryable: true },
+        staleEndpoint: true,
+      };
     }
   }
 
@@ -427,8 +547,9 @@ export class PDSClient {
 }
 
 /**
- * Create a PDS client for the given session
+ * Create a PDS client for the given session. Pass a recovery context to enable
+ * one-shot self-healing of a stale PDS endpoint after a PDS migration.
  */
-export function createPDSClient(session: Session): PDSClient {
-  return new PDSClient(session);
+export function createPDSClient(session: Session, recovery?: PDSRecoveryContext): PDSClient {
+  return new PDSClient(session, recovery);
 }

--- a/backend/src/services/subscription-sync.ts
+++ b/backend/src/services/subscription-sync.ts
@@ -51,6 +51,11 @@ export interface SyncResult {
   warnings: string[];
   /** If true, there are more records to push - call sync again */
   hasMore?: boolean;
+  /**
+   * Set when the PDS host moved (migration) but the existing tokens were
+   * rejected by the new host — the user must reconnect their account.
+   */
+  needsReauth?: boolean;
 }
 
 // Batch size for applyWrites - 200 is the documented limit but large batches
@@ -85,7 +90,11 @@ function buildRecordUri(did: string, collection: string, rkey: string): string {
  * 4. For each local record not in PDS: push to PDS
  * 5. For conflicts: keep both (merge by feedUrl)
  */
-export async function syncSubscriptions(session: Session, env: Env): Promise<SyncResult> {
+export async function syncSubscriptions(
+  session: Session,
+  env: Env,
+  sessionId?: string
+): Promise<SyncResult> {
   const result: SyncResult = {
     success: true,
     pulledFromPds: 0,
@@ -95,7 +104,9 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
     warnings: [],
   };
 
-  const pdsClient = createPDSClient(session);
+  // With a sessionId, the client can self-heal a stale PDS host (PDS migration)
+  // by re-resolving from the DID doc and persisting the new host to the session.
+  const pdsClient = createPDSClient(session, sessionId ? { env, sessionId } : undefined);
 
   try {
     // Step 1: Fetch records from PDS (limited to avoid subrequest limit)
@@ -109,6 +120,7 @@ export async function syncSubscriptions(session: Session, env: Env): Promise<Syn
         ...result,
         success: false,
         error: `Failed to fetch from PDS: ${pdsResult.error}`,
+        needsReauth: pdsResult.needsReauth,
       };
     }
 

--- a/backend/test/pds-client.spec.ts
+++ b/backend/test/pds-client.spec.ts
@@ -1,3 +1,4 @@
+import { env } from 'cloudflare:test';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PDSClient, createPDSClient } from '../src/services/pds-client';
 import type { Session } from '../src/types';
@@ -480,6 +481,235 @@ describe('PDSClient', () => {
       const session = createTestSession();
       const client = createPDSClient(session);
       expect(client).toBeInstanceOf(PDSClient);
+    });
+  });
+
+  // Regression coverage for the PDS-migration bug: a session whose pds_url no
+  // longer matches the DID document must recover automatically (re-resolve the
+  // host from the DID doc, persist it, and retry) with no manual sync toggle.
+  describe('stale endpoint recovery (PDS migration)', () => {
+    const RECOVERY_DID = 'did:plc:migrationuser';
+    const OLD_PDS = 'https://old.pds.example';
+    const NEW_PDS = 'https://new.pds.example';
+    const SESSION_ID = 'recovery-session-1';
+
+    function plcDoc(did: string, pds: string) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({
+          id: did,
+          service: [
+            { id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: pds },
+          ],
+        }),
+        text: async () => '',
+      };
+    }
+
+    function authRejected() {
+      return {
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        text: async () => JSON.stringify({ error: 'invalid_token', message: 'Token invalid' }),
+      };
+    }
+
+    function emptyRecords() {
+      return {
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ records: [] }),
+      };
+    }
+
+    async function seedSession(pdsUrl: string) {
+      await env.DB.prepare(
+        `INSERT OR IGNORE INTO users (did, handle, pds_url, created_at)
+         VALUES (?, ?, ?, unixepoch())`
+      )
+        .bind(RECOVERY_DID, 'migration.bsky.social', pdsUrl)
+        .run();
+      await env.DB.prepare(
+        `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+        .bind(
+          SESSION_ID,
+          RECOVERY_DID,
+          'migration.bsky.social',
+          pdsUrl,
+          'tok',
+          'refresh',
+          JSON.stringify(TEST_DPOP_KEY),
+          Date.now() + 3600000
+        )
+        .run();
+    }
+
+    beforeEach(async () => {
+      await env.DB.prepare('DELETE FROM sessions WHERE session_id = ?').bind(SESSION_ID).run();
+      await env.DB.prepare('DELETE FROM did_pds_cache WHERE did = ?').bind(RECOVERY_DID).run();
+      await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(RECOVERY_DID).run();
+    });
+
+    function recoverySession(): Session {
+      return createTestSession({ did: RECOVERY_DID, pdsUrl: OLD_PDS });
+    }
+
+    it('re-resolves, persists, and retries when the host moved and tokens still work', async () => {
+      await seedSession(OLD_PDS);
+
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        calls.push(u);
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) return authRejected();
+        if (u.startsWith('https://plc.directory/')) return plcDoc(RECOVERY_DID, NEW_PDS);
+        if (u.startsWith(`${NEW_PDS}/xrpc/`)) return emptyRecords();
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession(), { env, sessionId: SESSION_ID });
+      const result = await client.listRecords('app.skyreader.feed.subscription');
+
+      expect(result.success).toBe(true);
+
+      // Old host hit, DID re-resolved, new host hit — in that order.
+      expect(calls.some((c) => c.startsWith(`${OLD_PDS}/xrpc/`))).toBe(true);
+      expect(calls.some((c) => c.startsWith('https://plc.directory/'))).toBe(true);
+      expect(calls.some((c) => c.startsWith(`${NEW_PDS}/xrpc/`))).toBe(true);
+
+      // New host persisted to the session row.
+      const row = await env.DB.prepare('SELECT pds_url FROM sessions WHERE session_id = ?')
+        .bind(SESSION_ID)
+        .first<{ pds_url: string }>();
+      expect(row?.pds_url).toBe(NEW_PDS);
+
+      // And to the DID cache.
+      const cache = await env.DB.prepare('SELECT pds_url FROM did_pds_cache WHERE did = ?')
+        .bind(RECOVERY_DID)
+        .first<{ pds_url: string }>();
+      expect(cache?.pds_url).toBe(NEW_PDS);
+    });
+
+    it('signals needsReauth (and does not loop) when the new host still rejects tokens', async () => {
+      await seedSession(OLD_PDS);
+
+      let newHostCalls = 0;
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) return authRejected();
+        if (u.startsWith('https://plc.directory/')) return plcDoc(RECOVERY_DID, NEW_PDS);
+        if (u.startsWith(`${NEW_PDS}/xrpc/`)) {
+          newHostCalls++;
+          return authRejected();
+        }
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession(), { env, sessionId: SESSION_ID });
+      const result = await client.listRecords('app.skyreader.feed.subscription');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.needsReauth).toBe(true);
+      }
+      // Exactly one retry against the new host — no re-resolve loop.
+      expect(newHostCalls).toBe(1);
+    });
+
+    it('does not re-resolve on a transient 5xx (host is fine)', async () => {
+      await seedSession(OLD_PDS);
+
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        calls.push(u);
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) {
+          return { ok: false, status: 503, headers: new Headers(), text: async () => 'down' };
+        }
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession(), { env, sessionId: SESSION_ID });
+      const result = await client.listRecords('app.skyreader.feed.subscription');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.retryable).toBe(true);
+      // No DID re-resolution attempted.
+      expect(calls.some((c) => c.startsWith('https://plc.directory/'))).toBe(false);
+      const row = await env.DB.prepare('SELECT pds_url FROM sessions WHERE session_id = ?')
+        .bind(SESSION_ID)
+        .first<{ pds_url: string }>();
+      expect(row?.pds_url).toBe(OLD_PDS);
+    });
+
+    it('does not re-resolve on a not-found (RecordNotFound)', async () => {
+      await seedSession(OLD_PDS);
+
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        calls.push(u);
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) {
+          return {
+            ok: false,
+            status: 400,
+            headers: new Headers(),
+            text: async () => JSON.stringify({ error: 'RecordNotFound' }),
+          };
+        }
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession(), { env, sessionId: SESSION_ID });
+      const result = await client.getRecord('app.skyreader.feed.subscription', 'rkey');
+
+      expect(result.success).toBe(false);
+      expect(calls.some((c) => c.startsWith('https://plc.directory/'))).toBe(false);
+    });
+
+    it('does not retry when the re-resolved host is unchanged', async () => {
+      await seedSession(OLD_PDS);
+
+      let oldHostCalls = 0;
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) {
+          oldHostCalls++;
+          return authRejected();
+        }
+        // DID doc still points at the OLD host (not actually a migration).
+        if (u.startsWith('https://plc.directory/')) return plcDoc(RECOVERY_DID, OLD_PDS);
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession(), { env, sessionId: SESSION_ID });
+      const result = await client.listRecords('app.skyreader.feed.subscription');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.needsReauth).toBeFalsy();
+      // Only the original attempt — no pointless retry against the same host.
+      expect(oldHostCalls).toBe(1);
+    });
+
+    it('leaves failures untouched when no recovery context is supplied', async () => {
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        calls.push(u);
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) return authRejected();
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const client = createPDSClient(recoverySession()); // no recovery context
+      const result = await client.listRecords('app.skyreader.feed.subscription');
+
+      expect(result.success).toBe(false);
+      expect(calls.some((c) => c.startsWith('https://plc.directory/'))).toBe(false);
     });
   });
 });

--- a/backend/test/subscription-sync.spec.ts
+++ b/backend/test/subscription-sync.spec.ts
@@ -563,4 +563,132 @@ describe('Subscription Sync', () => {
       );
     });
   });
+
+  // The reported bug: after a PDS migration the session's pds_url is stale and
+  // sync silently stops. Syncing (the same call the Settings toggle makes) must
+  // recover on its own — no off/on toggle required.
+  describe('PDS migration recovery', () => {
+    const OLD_PDS = 'https://old.pds.example';
+    const NEW_PDS = 'https://new.pds.example';
+    const MIGRATE_SESSION = 'migrate-session-1';
+
+    function plcDoc(pds: string) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({
+          id: TEST_DID,
+          service: [
+            { id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: pds },
+          ],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('recovers a stale endpoint and syncs without a manual toggle', async () => {
+      // Session still points at the old PDS host.
+      await env.DB.prepare(
+        `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+        .bind(
+          MIGRATE_SESSION,
+          TEST_DID,
+          'test.bsky.social',
+          OLD_PDS,
+          'tok',
+          'refresh',
+          JSON.stringify(TEST_DPOP_KEY),
+          Date.now() + 3600000
+        )
+        .run();
+      await env.DB.prepare('DELETE FROM did_pds_cache WHERE did = ?').bind(TEST_DID).run();
+
+      const pdsRecords = [
+        createPdsSubscriptionRecord('rkey1', 'https://example.com/feed1.xml', 'Feed 1'),
+      ];
+
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        // Old host rejects the now-stale credentials/host.
+        if (u.startsWith(`${OLD_PDS}/xrpc/`)) {
+          return {
+            ok: false,
+            status: 403,
+            headers: new Headers(),
+            text: async () => JSON.stringify({ error: 'AccountDeactivated' }),
+          };
+        }
+        // DID doc now points at the new host.
+        if (u.startsWith('https://plc.directory/')) return plcDoc(NEW_PDS);
+        // New host serves the user's records.
+        if (u.startsWith(`${NEW_PDS}/xrpc/`)) {
+          return { ok: true, headers: new Headers(), json: async () => ({ records: pdsRecords }) };
+        }
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const session = createTestSession({ pdsUrl: OLD_PDS });
+      const result = await syncSubscriptions(session, env, MIGRATE_SESSION);
+
+      expect(result.success).toBe(true);
+      expect(result.needsReauth).toBeFalsy();
+      expect(result.pulledFromPds).toBe(1);
+
+      // Session host was migrated and persisted.
+      const row = await env.DB.prepare('SELECT pds_url FROM sessions WHERE session_id = ?')
+        .bind(MIGRATE_SESSION)
+        .first<{ pds_url: string }>();
+      expect(row?.pds_url).toBe(NEW_PDS);
+
+      // The pulled record landed locally.
+      const local = await env.DB.prepare(
+        'SELECT feed_url FROM subscriptions_cache WHERE user_did = ?'
+      )
+        .bind(TEST_DID)
+        .all<{ feed_url: string }>();
+      expect(local.results?.map((r) => r.feed_url)).toContain('https://example.com/feed1.xml');
+    });
+
+    it('reports needsReauth when the migrated host still rejects the tokens', async () => {
+      await env.DB.prepare(
+        `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+        .bind(
+          MIGRATE_SESSION,
+          TEST_DID,
+          'test.bsky.social',
+          OLD_PDS,
+          'tok',
+          'refresh',
+          JSON.stringify(TEST_DPOP_KEY),
+          Date.now() + 3600000
+        )
+        .run();
+      await env.DB.prepare('DELETE FROM did_pds_cache WHERE did = ?').bind(TEST_DID).run();
+
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const u = url.toString();
+        if (u.startsWith(`${OLD_PDS}/xrpc/`) || u.startsWith(`${NEW_PDS}/xrpc/`)) {
+          return {
+            ok: false,
+            status: 401,
+            headers: new Headers(),
+            text: async () => JSON.stringify({ error: 'invalid_token' }),
+          };
+        }
+        if (u.startsWith('https://plc.directory/')) return plcDoc(NEW_PDS);
+        throw new Error(`Unexpected fetch: ${u}`);
+      });
+
+      const session = createTestSession({ pdsUrl: OLD_PDS });
+      const result = await syncSubscriptions(session, env, MIGRATE_SESSION);
+
+      expect(result.success).toBe(false);
+      expect(result.needsReauth).toBe(true);
+    });
+  });
 });

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -970,6 +970,8 @@ class ApiClient {
   // PDS Sync
   async triggerFullSync(): Promise<{
     success: boolean;
+    /** Set when the user's PDS moved and they must reconnect to resume sync. */
+    needsReauth?: boolean;
     subscriptions?: {
       success: boolean;
       pulledFromPds: number;
@@ -977,6 +979,7 @@ class ApiClient {
       skipped: number;
       warnings: string[];
       hasMore?: boolean;
+      needsReauth?: boolean;
     };
     atmosphere?: {
       success: boolean;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -205,6 +205,11 @@
           throw error;
         }
 
+        if (result.needsReauth) {
+          syncError = 'Your data moved to a new PDS. Sign in again to reconnect Atmospheric sync.';
+          return;
+        }
+
         if (!result.success) {
           syncError = result.error || 'Sync failed';
           return;


### PR DESCRIPTION
## Problem

A user migrated their PDS (changed PDS host) and their RSS subscriptions silently stopped syncing. Toggling Atmospheric sync off and back on appeared to fix it.

**Root cause:** the PDS host is resolved once at login into `sessions.pds_url` and `did_pds_cache` (24h TTL) and never re-resolved. `PDSClient.request` binds both the request URL and the DPoP `htu` claim to `session.pdsUrl`. After a migration the DID document's service endpoint changes but the session keeps the old host, so every authenticated PDS request fails (network / 401 / 403) and sync stops. Only the login/callback flow ever evicted + re-resolved the cache — the sync path and `refreshSession` reused the stale host.

On Phase 1 (confirm the toggle's recovery): `/api/sync/full` read `sessions.pds_url` verbatim and never re-resolved, so the toggle alone could **not** repair the host. The fix therefore makes recovery happen in the request path itself, covering both possible migration shapes — host-only (existing tokens still valid → full auto-recovery) and a full account migration (tokens rejected by the new auth server → an explicit re-auth signal).

## Fix

One-shot stale-endpoint recovery centralized in `PDSClient`:

- A new optional `PDSRecoveryContext` (`{ env, sessionId }`) enables self-healing. When a request fails in a way that looks like a moved host — network throw / `401` / `403` / `invalid_token`, **excluding** `RecordNotFound`, `429`, `5xx`, and `use_dpop_nonce` — the client evicts the DID cache, re-resolves the host from the DID doc, and **only if the host actually changed** persists it to the session, resets the per-host DPoP nonce, and retries once.
- New `updateSessionPdsUrl` in `oauth.ts` persists the migrated host (`storeSession`'s `ON CONFLICT` deliberately doesn't touch `pds_url`).
- A one-shot guard + the "host unchanged ⇒ don't retry" check prevent any re-resolve loop and stop transient blips from being misread as migrations.
- If the new host still rejects the tokens, the failure carries `needsReauth`, which flows through `syncSubscriptions` → `/api/sync/full` → the frontend, where Settings shows a calm Atmosphere-voice prompt to sign in again.

Recovery is wired through `syncSubscriptions` / `/api/sync/full` using the request's session id, so the same sync the Settings toggle fires now self-heals automatically — no manual toggle needed.

## Tests

- **`pds-client.spec.ts`** — re-resolve + persist + retry + success; `needsReauth` with no retry loop; `5xx` and `RecordNotFound` don't trigger recovery; unchanged re-resolved host doesn't retry; no recovery context is a no-op.
- **`subscription-sync.spec.ts`** — sync-path migration: a seeded stale session recovers and pulls records without a toggle; new host still rejecting → `needsReauth`.

All affected backend suites pass; `npm run check` is clean on backend and frontend.