### PR TITLE
Use native Leaflet blockquotes for shared articles

### DIFF
--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -32,14 +32,14 @@ const MAX_NOTE_SCAN_CHARS = 4000;
 // for ANY resolvable handle — interop is universal. Surfacing it in-app is fully
 // client-side: the recipient's browser discovers it via Constellation's backlink
 // index (see frontend services/mentions.ts); there is no server-side notifier.
-async function resolveNoteMentions(note: string | undefined): Promise<MentionFacet[]> {
+async function resolveNoteMentionHandles(note: string | undefined): Promise<Map<string, string>> {
   const text = note?.trim();
-  if (!text) return [];
+  if (!text) return new Map();
   // Bound the regex input (see MAX_NOTE_SCAN_CHARS). Byte offsets stay valid
   // because we only ever slice off the tail, never shift the prefix.
   const scanText = text.length > MAX_NOTE_SCAN_CHARS ? text.slice(0, MAX_NOTE_SCAN_CHARS) : text;
   const tokens = parseHandleTokens(scanText);
-  if (tokens.length === 0) return [];
+  if (tokens.length === 0) return new Map();
 
   const uniqueHandles = [...new Set(tokens.map((t) => t.handle))].slice(0, MAX_RESOLVED_HANDLES);
   const resolved = new Map<string, string>();
@@ -54,12 +54,7 @@ async function resolveNoteMentions(note: string | undefined): Promise<MentionFac
     })
   );
 
-  const facets: MentionFacet[] = [];
-  for (const t of tokens) {
-    const did = resolved.get(t.handle);
-    if (did) facets.push(buildMentionFacet(t.byteStart, t.byteEnd, did));
-  }
-  return facets;
+  return resolved;
 }
 
 export const PUBLICATION_COLLECTION = 'site.standard.publication';
@@ -324,25 +319,91 @@ function websiteCardExcerpt(content: unknown): string {
   return '';
 }
 
-// Build the rich, interoperable body: the user's note as a text block, then the
-// shared article as a website link-card. The card carries the external URL so
+// Build the rich, interoperable body: the user's note as native text/blockquote
+// blocks, then the shared article as a website link-card. The card carries the external URL so
 // any pub.leaflet-aware reader (incl. Skyreader's own renderer in Phase 2) can
 // render and open it; the top-level `links` field is the machine-readable ref.
+type NoteBlock = { block: Record<string, unknown> };
+
+// Parse the editor's deliberately small Markdown subset into native Leaflet
+// blocks. Only a `>` at the beginning of a line is special; all other Markdown
+// remains plaintext for Leaflet-aware clients to interpret as they choose.
+export function noteToLeafletBlocks(
+  note: string | undefined,
+  resolvedHandles: Map<string, string> = new Map()
+): NoteBlock[] {
+  const text = note?.trim();
+  if (!text) return [];
+
+  const blocks: NoteBlock[] = [];
+  let kind: 'text' | 'blockquote' | undefined;
+  let lines: string[] = [];
+  const flush = () => {
+    if (!kind || lines.length === 0) return;
+    const plaintext = lines.join('\n');
+    const block: Record<string, unknown> = {
+      $type: `pub.leaflet.blocks.${kind}`,
+      plaintext,
+    };
+    const facets = parseHandleTokens(plaintext).flatMap((token) => {
+      const did = resolvedHandles.get(token.handle);
+      return did ? [buildMentionFacet(token.byteStart, token.byteEnd, did)] : [];
+    });
+    if (facets.length > 0) block.facets = facets;
+    blocks.push({ block });
+    kind = undefined;
+    lines = [];
+  };
+
+  for (const line of text.split('\n')) {
+    const quote = line.match(/^> ?(.*)$/);
+    if (!quote && line.trim() === '') {
+      flush();
+      continue;
+    }
+    const nextKind = quote ? 'blockquote' : 'text';
+    if (kind && kind !== nextKind) flush();
+    kind = nextKind;
+    lines.push(quote ? quote[1] : line);
+  }
+  flush();
+  return blocks;
+}
+
+export function replaceLeafletNoteRegion(
+  existing: unknown,
+  note: string,
+  resolvedHandles: Map<string, string> = new Map()
+): unknown {
+  const oldContent = existing as {
+    $type?: string;
+    pages?: Array<{ $type?: string; blocks?: Array<{ block?: Record<string, unknown> }> }>;
+  };
+  const oldBlocks = oldContent?.pages?.[0]?.blocks ?? [];
+  const firstPreserved = oldBlocks.findIndex(
+    (wrapper) =>
+      wrapper.block?.$type !== 'pub.leaflet.blocks.text' &&
+      wrapper.block?.$type !== 'pub.leaflet.blocks.blockquote'
+  );
+  const preserved = firstPreserved < 0 ? [] : oldBlocks.slice(firstPreserved);
+  return {
+    $type: oldContent?.$type || 'pub.leaflet.content',
+    pages: [
+      {
+        $type: oldContent?.pages?.[0]?.$type || 'pub.leaflet.pages.linearDocument',
+        blocks: [...noteToLeafletBlocks(note, resolvedHandles), ...preserved],
+      },
+      ...(oldContent?.pages?.slice(1) ?? []),
+    ],
+  };
+}
+
 function buildLeafletContent(
   input: LinkblogShareInput,
   excerpt: string,
-  noteFacets?: MentionFacet[]
+  resolvedHandles?: Map<string, string>
 ): unknown {
-  const blocks: Array<{ block: unknown }> = [];
-
-  const note = input.note?.trim();
-  if (note) {
-    const block: Record<string, unknown> = { $type: 'pub.leaflet.blocks.text', plaintext: note };
-    // Attach didMention facets so the note's @mentions are legible to any
-    // pub.leaflet-aware reader/notifier (Leaflet incl.) and to Constellation.
-    if (noteFacets && noteFacets.length > 0) block.facets = noteFacets;
-    blocks.push({ block });
-  }
+  const blocks: Array<{ block: unknown }> = noteToLeafletBlocks(input.note, resolvedHandles);
 
   const website: Record<string, unknown> = {
     $type: 'pub.leaflet.blocks.website',
@@ -362,7 +423,7 @@ export function buildLinkblogDocument(
   did: string,
   rkey: string,
   input: LinkblogShareInput,
-  mentionFacets?: MentionFacet[]
+  resolvedHandles?: Map<string, string>
 ): DocumentRecord {
   const now = new Date().toISOString();
   const excerpt = input.excerpt ? truncate(input.excerpt, MAX_EXCERPT_CHARS) : '';
@@ -379,7 +440,7 @@ export function buildLinkblogDocument(
     path: `/${rkey}`,
     publishedAt: input.articlePublishedAt || now,
     createdAt: now,
-    // The quote now lives inside the editable note (the leading text block), so
+    // The quote now lives inside the editable note (as a native blockquote), so
     // new shares no longer write a top-level `description`. Its presence is the
     // legacy marker the renderers use to keep showing the old standalone quote;
     // an absent description means "the note owns the body." The excerpt still
@@ -389,7 +450,7 @@ export function buildLinkblogDocument(
     textContent,
     tags: input.tags && input.tags.length > 0 ? input.tags : undefined,
     links,
-    content: buildLeafletContent(input, excerpt, mentionFacets),
+    content: buildLeafletContent(input, excerpt, resolvedHandles),
   };
 }
 
@@ -404,8 +465,8 @@ export async function writeLinkblogShare(
   const ensured = await ensureLinkblogPublication(session, env);
   if (!ensured.success) return ensured;
 
-  const mentionFacets = await resolveNoteMentions(input.note);
-  const record = buildLinkblogDocument(session.did, rkey, input, mentionFacets);
+  const resolvedHandles = await resolveNoteMentionHandles(input.note);
+  const record = buildLinkblogDocument(session.did, rkey, input, resolvedHandles);
   return createPDSClient(session).putRecord(DOCUMENT_COLLECTION, rkey, record);
 }
 
@@ -419,7 +480,7 @@ export async function deleteLinkblogShare(
 // Update just the note on an existing share document, leaving everything else
 // (createdAt, publishedAt, path, links/provenance, tags, the article link-card)
 // intact. We read the record back, swap the note-derived parts — the leaflet
-// text block and the flattened `textContent` — and putRecord under the same rkey.
+// note region and the flattened `textContent` — and putRecord under the same rkey.
 export async function updateLinkblogShareNote(
   session: Session,
   rkey: string,
@@ -435,22 +496,17 @@ export async function updateLinkblogShareNote(
   // comes from the website card (its durable home); `rec.description` is the
   // fallback for legacy records that still carry it at the top level. `...rec`
   // preserves that legacy `description` as-is — we never add one to a new record.
-  const articleUrl = rec.links?.find((l) => l.rel === 'related')?.uri || '';
   const excerpt = websiteCardExcerpt(rec.content) || rec.description || '';
   const trimmedNote = note.trim();
   // Re-resolve mentions on edit so added/removed @handles re-encode; recipients
   // pick up the change on their next Constellation poll.
-  const mentionFacets = await resolveNoteMentions(trimmedNote);
+  const resolvedHandles = await resolveNoteMentionHandles(trimmedNote);
 
   const updated: DocumentRecord = {
     ...rec,
     $type: DOCUMENT_COLLECTION,
     textContent: [trimmedNote, excerpt].filter(Boolean).join('\n\n') || undefined,
-    content: buildLeafletContent(
-      { articleUrl, articleTitle: rec.title, excerpt, note: trimmedNote },
-      excerpt,
-      mentionFacets
-    ),
+    content: replaceLeafletNoteRegion(rec.content, trimmedNote, resolvedHandles),
   };
 
   return pdsClient.putRecord(DOCUMENT_COLLECTION, rkey, updated);

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildLinkblogDocument,
+  noteToLeafletBlocks,
+  replaceLeafletNoteRegion,
   publicationUri,
   LINKBLOG_RKEY,
 } from '../src/services/linkblog-sync';
@@ -74,5 +76,79 @@ describe('buildLinkblogDocument', () => {
     const types = content.pages[0].blocks.map((b) => b.block.$type);
     expect(types).not.toContain('pub.leaflet.blocks.text');
     expect(types).toContain('pub.leaflet.blocks.website');
+  });
+});
+
+describe('noteToLeafletBlocks', () => {
+  it('converts mixed commentary and multiline quotes into ordered native blocks', () => {
+    const blocks = noteToLeafletBlocks('Before\n\n> first\n> second\n>\n> fourth\n\nAfter');
+    expect(blocks.map(({ block }) => [block.$type, block.plaintext])).toEqual([
+      ['pub.leaflet.blocks.text', 'Before'],
+      ['pub.leaflet.blocks.blockquote', 'first\nsecond\n\nfourth'],
+      ['pub.leaflet.blocks.text', 'After'],
+    ]);
+  });
+
+  it('supports quote-only and multiple separated quote runs without empty blocks', () => {
+    const blocks = noteToLeafletBlocks('  \n> one\n\nComment\n\n>two\n  ');
+    expect(blocks.map(({ block }) => [block.$type, block.plaintext])).toEqual([
+      ['pub.leaflet.blocks.blockquote', 'one'],
+      ['pub.leaflet.blocks.text', 'Comment'],
+      ['pub.leaflet.blocks.blockquote', 'two'],
+    ]);
+  });
+
+  it('does not interpret greater-than characters away from line start', () => {
+    expect(noteToLeafletBlocks('one > two')[0].block).toMatchObject({
+      $type: 'pub.leaflet.blocks.text',
+      plaintext: 'one > two',
+    });
+  });
+
+  it('rebases Unicode mention facets to each marker-stripped block', () => {
+    const blocks = noteToLeafletBlocks(
+      'é @text.test\n> ü @quote.test',
+      new Map([
+        ['text.test', 'did:plc:text'],
+        ['quote.test', 'did:plc:quote'],
+      ])
+    );
+    expect(blocks[0].block.facets).toMatchObject([{ index: { byteStart: 3, byteEnd: 13 } }]);
+    expect(blocks[1].block.facets).toMatchObject([{ index: { byteStart: 3, byteEnd: 14 } }]);
+  });
+});
+
+describe('replaceLeafletNoteRegion', () => {
+  const existing = {
+    $type: 'pub.leaflet.content',
+    pages: [
+      {
+        $type: 'pub.leaflet.pages.linearDocument',
+        blocks: [
+          { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'old' } },
+          { block: { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'old quote' } },
+          { block: { $type: 'pub.leaflet.blocks.website', url: 'https://example.com' } },
+          { block: { $type: 'pub.leaflet.blocks.image', image: { ref: { $link: 'cid' } } } },
+        ],
+      },
+    ],
+  };
+
+  it('replaces every leading note block and preserves the website and trailing blocks', () => {
+    const content = replaceLeafletNoteRegion(existing, 'new\n> quote') as typeof existing;
+    expect(content.pages[0].blocks.map(({ block }) => block.$type)).toEqual([
+      'pub.leaflet.blocks.text',
+      'pub.leaflet.blocks.blockquote',
+      'pub.leaflet.blocks.website',
+      'pub.leaflet.blocks.image',
+    ]);
+  });
+
+  it('clearing a note removes both old note block types', () => {
+    const content = replaceLeafletNoteRegion(existing, '') as typeof existing;
+    expect(content.pages[0].blocks.map(({ block }) => block.$type)).toEqual([
+      'pub.leaflet.blocks.website',
+      'pub.leaflet.blocks.image',
+    ]);
   });
 });

--- a/backend/test/mention-facets.spec.ts
+++ b/backend/test/mention-facets.spec.ts
@@ -51,7 +51,7 @@ describe('buildLinkblogDocument with mention facets', () => {
       'did:plc:author',
       '3kabcdefghijk',
       { articleUrl: 'https://example.com/a', note: '@a.com hi' },
-      [facet]
+      new Map([['a.com', 'did:plc:xyz']])
     );
     const content = doc.content as {
       pages: Array<{ blocks: Array<{ block: Record<string, unknown> }> }>;
@@ -66,7 +66,7 @@ describe('buildLinkblogDocument with mention facets', () => {
       'did:plc:author',
       '3kabcdefghijk',
       { articleUrl: 'https://example.com/a', note: 'no mentions' },
-      []
+      new Map()
     );
     const content = doc.content as {
       pages: Array<{ blocks: Array<{ block: Record<string, unknown> }> }>;

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -10,6 +10,7 @@
 import { api } from '$lib/services/api';
 import { auth } from '$lib/stores/auth.svelte';
 import { getExternalArticleLink } from '$lib/utils/linkPost';
+import { noteToLeafletBlocks } from '$lib/utils/linkPostNote';
 import { loadDigests, saveDigests, scopeKey } from '$lib/services/documentDigests';
 import type { LinkblogPublication, SocialDocument } from '$lib/types';
 
@@ -106,7 +107,7 @@ function createMyLinkblogStore() {
   // Front-insert a just-shared link so it shows on the user's own linkblog
   // immediately, ahead of the PDS → indexer → proxy round-trip. Built to match
   // what the link-post card reads: the external URL in `links`, the note as the
-  // leading leaflet text block. Deduped by article URL.
+  // leading native Leaflet note blocks. Deduped by article URL.
   function addOptimistic(input: {
     recordUri: string;
     siteUri: string;
@@ -137,7 +138,7 @@ function createMyLinkblogStore() {
             pages: [
               {
                 $type: 'pub.leaflet.pages.linearDocument',
-                blocks: [{ block: { $type: 'pub.leaflet.blocks.text', plaintext: note } }],
+                blocks: noteToLeafletBlocks(note),
               },
             ],
           }
@@ -147,23 +148,23 @@ function createMyLinkblogStore() {
     documents = [doc, ...documents.filter((d) => getExternalArticleLink(d) !== input.articleUrl)];
   }
 
-  // Rebuild a document's pub.leaflet body with a new note as the leading text
-  // block, preserving any other blocks (the website link-card). Mirrors the shape
-  // getLinkPostNote reads. Returns undefined when the note is empty AND there are
-  // no other blocks (a bare share).
+  // Rebuild a document's pub.leaflet body with new leading text/blockquote
+  // blocks, preserving the website card and everything after it.
   function rebuildContentWithNote(existing: unknown, note: string): unknown {
     const pages =
       (existing as { pages?: Array<{ blocks?: Array<{ block?: { $type?: string } }> }> })?.pages ??
       [];
     const blocks: Array<{ block: unknown }> = [];
-    if (note) blocks.push({ block: { $type: 'pub.leaflet.blocks.text', plaintext: note } });
-    for (const page of pages) {
-      for (const wrapper of page.blocks ?? []) {
-        // Preserve every non-text block (the website link-card); the note above
-        // replaces the original leading text block.
-        if (wrapper.block && wrapper.block.$type !== 'pub.leaflet.blocks.text') {
-          blocks.push({ block: wrapper.block });
-        }
+    blocks.push(...noteToLeafletBlocks(note));
+    const oldBlocks = pages[0]?.blocks ?? [];
+    const firstPreserved = oldBlocks.findIndex(
+      (wrapper) =>
+        wrapper.block?.$type !== 'pub.leaflet.blocks.text' &&
+        wrapper.block?.$type !== 'pub.leaflet.blocks.blockquote'
+    );
+    if (firstPreserved >= 0) {
+      for (const wrapper of oldBlocks.slice(firstPreserved)) {
+        if (wrapper.block) blocks.push({ block: wrapper.block });
       }
     }
     if (blocks.length === 0) return undefined;

--- a/frontend/src/lib/utils/linkPost.ts
+++ b/frontend/src/lib/utils/linkPost.ts
@@ -1,5 +1,6 @@
 import type { LeafletContent, SocialDocument } from '$lib/types';
 import { isLeafletContent } from '$lib/utils/leaflet-renderer';
+import { reconstructLinkPostNote } from '$lib/utils/linkPostNote';
 
 /**
  * Link-post helpers (Linkblog Phase 2).
@@ -8,7 +9,7 @@ import { isLeafletContent } from '$lib/utils/leaflet-renderer';
  * rather than being the thing you read itself — the shape Skyreader writes when a
  * user shares an article to their `skyreader-links` publication (Phase 1). The
  * external URL lives in the document's `links` field; the user's commentary is the
- * leading text block of the `pub.leaflet.content` body.
+ * leading text and blockquote blocks of the `pub.leaflet.content` body.
  *
  * The rule lives here so the feed card, the reader, save/Semble/Margin metadata,
  * and content normalization all agree on "is this a link post, and what's its URL".
@@ -37,20 +38,15 @@ export function getDocumentEffectiveUrl(doc: SocialDocument): string {
 }
 
 /**
- * The user's commentary on a link post: the plaintext of the first
- * `pub.leaflet.blocks.text` block (Skyreader writes the note as the leading text
- * block, before the website card). Returns undefined when there's no note.
+ * The user's commentary on a link post, reconstructed from the native text and
+ * blockquote blocks before the website card. Returns undefined when there's no note.
  */
 export function getLinkPostNote(doc: SocialDocument): string | undefined {
   if (!doc.content || !isLeafletContent(doc.content)) return undefined;
   const content = doc.content as LeafletContent;
   for (const page of content.pages ?? []) {
-    for (const wrapper of page.blocks ?? []) {
-      if (wrapper.block?.$type === 'pub.leaflet.blocks.text') {
-        const text = wrapper.block.plaintext?.trim();
-        if (text) return text;
-      }
-    }
+    const note = reconstructLinkPostNote(page.blocks ?? []).note;
+    if (note) return note;
   }
   return undefined;
 }
@@ -65,42 +61,17 @@ export interface MentionFacet {
 
 // Facet $types we treat as an @mention. Skyreader's writer emits `#didMention`; the
 // others are accepted for interop with bsky/leaflet-native records.
-const MENTION_FACET_TYPES = new Set([
-  'pub.leaflet.richtext.facet#didMention',
-  'pub.leaflet.richtext.facet#mention',
-  'app.bsky.richtext.facet#mention',
-]);
-
 /**
  * The resolved @mention facets on a link post's note, byte-indexed into
- * getLinkPostNote(doc). Pulled from the same leading text block, so the offsets line
- * up with that string (the backend stores the note plaintext already trimmed).
+ * getLinkPostNote(doc). Block-local offsets are rebased over the reconstructed
+ * Markdown, including the inserted `> ` markers and blank-line separators.
  */
 export function getLinkPostNoteMentions(doc: SocialDocument): MentionFacet[] {
   if (!doc.content || !isLeafletContent(doc.content)) return [];
   const content = doc.content as LeafletContent;
   for (const page of content.pages ?? []) {
-    for (const wrapper of page.blocks ?? []) {
-      if (wrapper.block?.$type === 'pub.leaflet.blocks.text' && wrapper.block.plaintext?.trim()) {
-        const out: MentionFacet[] = [];
-        for (const f of wrapper.block.facets ?? []) {
-          const byteStart = f?.index?.byteStart;
-          const byteEnd = f?.index?.byteEnd;
-          if (
-            typeof byteStart !== 'number' ||
-            typeof byteEnd !== 'number' ||
-            byteEnd <= byteStart
-          ) {
-            continue;
-          }
-          const did = (f.features ?? []).find(
-            (ft) => ft && MENTION_FACET_TYPES.has(ft.$type ?? '') && ft.did?.startsWith('did:')
-          )?.did;
-          if (did) out.push({ byteStart, byteEnd, did });
-        }
-        return out;
-      }
-    }
+    const result = reconstructLinkPostNote(page.blocks ?? []);
+    if (result.note) return result.mentions;
   }
   return [];
 }

--- a/frontend/src/lib/utils/linkPostNote.test.ts
+++ b/frontend/src/lib/utils/linkPostNote.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { LeafletBlockWrapper } from '$lib/types';
+import { noteToLeafletBlocks, reconstructLinkPostNote } from './linkPostNote';
+
+describe('link post note conversion', () => {
+  it('round-trips mixed commentary and native blockquotes', () => {
+    const note = 'Before\n\n> first\n> second\n\nAfter';
+    const blocks = noteToLeafletBlocks(note);
+    expect(
+      blocks.map(({ block }) => [block.$type, 'plaintext' in block && block.plaintext])
+    ).toEqual([
+      ['pub.leaflet.blocks.text', 'Before'],
+      ['pub.leaflet.blocks.blockquote', 'first\nsecond'],
+      ['pub.leaflet.blocks.text', 'After'],
+    ]);
+    expect(reconstructLinkPostNote(blocks).note).toBe(note);
+  });
+
+  it('leaves legacy Markdown in a text block unchanged', () => {
+    const blocks = noteToLeafletBlocks('placeholder');
+    blocks[0] = { block: { $type: 'pub.leaflet.blocks.text', plaintext: '> legacy quote' } };
+    expect(reconstructLinkPostNote(blocks).note).toBe('> legacy quote');
+  });
+
+  it('stops the note at the website card and handles website-only shares', () => {
+    const website = {
+      block: { $type: 'pub.leaflet.blocks.website', url: 'https://example.com' },
+    } as LeafletBlockWrapper;
+    expect(reconstructLinkPostNote([website])).toEqual({ note: undefined, mentions: [] });
+    expect(
+      reconstructLinkPostNote([
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'note' } },
+        website,
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'not note' } },
+      ]).note
+    ).toBe('note');
+  });
+
+  it('rebases block-local Unicode mention offsets into reconstructed Markdown', () => {
+    const feature = { $type: 'pub.leaflet.richtext.facet#didMention', did: 'did:plc:bob' };
+    const result = reconstructLinkPostNote([
+      {
+        block: {
+          $type: 'pub.leaflet.blocks.text',
+          plaintext: 'é @a.test',
+          facets: [{ index: { byteStart: 3, byteEnd: 10 }, features: [feature] }],
+        },
+      },
+      {
+        block: {
+          $type: 'pub.leaflet.blocks.blockquote',
+          plaintext: 'ü @b.test',
+          facets: [{ index: { byteStart: 3, byteEnd: 10 }, features: [feature] }],
+        },
+      },
+    ]);
+    expect(result.note).toBe('é @a.test\n\n> ü @b.test');
+    expect(result.mentions.map(({ byteStart, byteEnd }) => [byteStart, byteEnd])).toEqual([
+      [3, 10],
+      [17, 24],
+    ]);
+  });
+});

--- a/frontend/src/lib/utils/linkPostNote.ts
+++ b/frontend/src/lib/utils/linkPostNote.ts
@@ -1,0 +1,99 @@
+import type { LeafletBlockWrapper, LeafletFacet } from '$lib/types';
+
+export function noteToLeafletBlocks(note: string | null | undefined): LeafletBlockWrapper[] {
+  const text = note?.trim();
+  if (!text) return [];
+  const blocks: LeafletBlockWrapper[] = [];
+  let kind: 'text' | 'blockquote' | undefined;
+  let lines: string[] = [];
+  const flush = () => {
+    if (!kind || lines.length === 0) return;
+    blocks.push({
+      block: {
+        $type: `pub.leaflet.blocks.${kind}`,
+        plaintext: lines.join('\n'),
+      } as LeafletBlockWrapper['block'],
+    });
+    kind = undefined;
+    lines = [];
+  };
+  for (const line of text.split('\n')) {
+    const quote = line.match(/^> ?(.*)$/);
+    if (!quote && line.trim() === '') {
+      flush();
+      continue;
+    }
+    const nextKind = quote ? 'blockquote' : 'text';
+    if (kind && kind !== nextKind) flush();
+    kind = nextKind;
+    lines.push(quote ? quote[1] : line);
+  }
+  flush();
+  return blocks;
+}
+
+export interface ReconstructedMention {
+  byteStart: number;
+  byteEnd: number;
+  did: string;
+}
+
+const MENTION_TYPES = new Set([
+  'pub.leaflet.richtext.facet#didMention',
+  'pub.leaflet.richtext.facet#mention',
+  'app.bsky.richtext.facet#mention',
+]);
+
+function mentionDid(facet: LeafletFacet): string | undefined {
+  return facet.features?.find(
+    (feature) => MENTION_TYPES.has(feature.$type) && feature.did?.startsWith('did:')
+  )?.did;
+}
+
+function quoteOffset(plaintext: string, byteOffset: number): number {
+  const prefix = new TextEncoder().encode(plaintext).slice(0, byteOffset);
+  let newlines = 0;
+  for (const byte of prefix) if (byte === 10) newlines++;
+  return byteOffset + 2 * (newlines + 1);
+}
+
+export function reconstructLinkPostNote(blocks: LeafletBlockWrapper[]): {
+  note?: string;
+  mentions: ReconstructedMention[];
+} {
+  const parts: string[] = [];
+  const mentions: ReconstructedMention[] = [];
+  let outputBytes = 0;
+
+  for (const wrapper of blocks) {
+    const block = wrapper.block;
+    if (
+      block.$type !== 'pub.leaflet.blocks.text' &&
+      block.$type !== 'pub.leaflet.blocks.blockquote'
+    )
+      break;
+    if (!('plaintext' in block) || !block.plaintext.trim()) continue;
+    const isQuote = block.$type === 'pub.leaflet.blocks.blockquote';
+    const rendered = isQuote
+      ? block.plaintext
+          .split('\n')
+          .map((line) => `> ${line}`)
+          .join('\n')
+      : block.plaintext;
+    if (parts.length > 0) outputBytes += 2;
+    for (const facet of block.facets ?? []) {
+      const did = mentionDid(facet);
+      const { byteStart, byteEnd } = facet.index ?? {};
+      if (!did || typeof byteStart !== 'number' || typeof byteEnd !== 'number') continue;
+      mentions.push({
+        byteStart: outputBytes + (isQuote ? quoteOffset(block.plaintext, byteStart) : byteStart),
+        byteEnd: outputBytes + (isQuote ? quoteOffset(block.plaintext, byteEnd) : byteEnd),
+        did,
+      });
+    }
+    parts.push(rendered);
+    outputBytes += new TextEncoder().encode(rendered).length;
+  }
+  const note = parts.join('\n\n').trim();
+  return { note: note || undefined, mentions };
+}

--- a/frontend/src/routes/dev/cards/fixtures.ts
+++ b/frontend/src/routes/dev/cards/fixtures.ts
@@ -511,7 +511,7 @@ export const fixtures: CardFixture[] = [
   },
   {
     name: 'Link post · in-note quote',
-    note: 'The new model: the article quote lives inside the note as a Markdown blockquote (seeded at share time, editable). No separate excerpt quote — the note owns the body.',
+    note: 'The article quote is authored with Markdown markers, stored as a native Leaflet blockquote, and remains editable. No separate excerpt quote — the note owns the body.',
     props: {
       ...base,
       itemTitle: 'The Web We Lost',


### PR DESCRIPTION
## Summary

- Serialize editor blockquote markers as native Leaflet blockquote blocks on create, update, and optimistic UI paths.

- Reconstruct native blocks back into editable Markdown with block-relative mention facets rebased safely.


## Verification

- Backend focused tests and check pass.
- Frontend full tests and check pass.



[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-3i3fbko3eyaink45azihxhr5)
