### PR TITLE
Render numbered Leaflet footnotes in the reader and cards

### DIFF
--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -9,6 +9,7 @@
   import { overlapShadow } from '$lib/actions/overlap-shadow';
   import type { ArticleCardViewProps } from './articleCardView.types';
   import { safeHref } from '$lib/utils/sanitize';
+  import { handleFootnoteClick } from '$lib/utils/footnoteNav';
 
   let {
     // data
@@ -105,6 +106,9 @@
   // The content tap: keep the pure DOM guards here (let real links / media play),
   // then hand off the expand-vs-select decision to the container via onContentTap.
   function handleContentClick(e: MouseEvent) {
+    // Footnote markers jump within this card's own content (scoped lookup, so
+    // other cards' footnotes on the same page don't interfere).
+    if (handleFootnoteClick(e, e.currentTarget as HTMLElement)) return;
     // A @mention opens the add-feed dialog for that account (to subscribe to their
     // publications) instead of following its bsky-profile href fallback.
     const mention = (e.target as HTMLElement).closest<HTMLElement>('a[data-mention-did]');
@@ -1407,6 +1411,36 @@
 
   .article-body :global(mark.highlight:hover) {
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
+  }
+
+  /* Leaflet footnotes: a numbered reference in the text and the bodies in a
+     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
+  .article-body :global(sup.footnote-ref) {
+    font-size: 0.7em;
+    line-height: 0;
+    padding: 0 0.1em;
+  }
+
+  .article-body :global(sup.footnote-ref a) {
+    text-decoration: none;
+  }
+
+  .article-body :global(section.footnotes) {
+    margin-top: 1.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+    font-size: 0.875em;
+    color: var(--color-text-secondary);
+  }
+
+  .article-body :global(a.footnote-backref) {
+    text-decoration: none;
+    margin-left: 0.25rem;
+  }
+
+  .article-body :global(.footnote-flash) {
+    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
+    transition: background-color 0.4s ease;
   }
 
   .article-actions-container {

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -1552,6 +1552,37 @@
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
   }
 
+  /* Leaflet footnotes: a numbered reference in the text, the bodies in a
+     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
+  .reader-body :global(sup.footnote-ref) {
+    font-size: 0.7em;
+    line-height: 0;
+    padding: 0 0.1em;
+  }
+
+  .reader-body :global(sup.footnote-ref a) {
+    text-decoration: none;
+  }
+
+  .reader-body :global(section.footnotes) {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+    font-size: 0.875em;
+    color: var(--color-text-secondary);
+  }
+
+  .reader-body :global(a.footnote-backref) {
+    text-decoration: none;
+    margin-left: 0.25rem;
+  }
+
+  /* Brief arrival highlight so the jump is legible. */
+  .reader-body :global(.footnote-flash) {
+    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
+    transition: background-color 0.4s ease;
+  }
+
   /* On narrower desktops, drop the action labels to icons — matches the feed
      header's 1100px breakpoint so both collapse at the same width. */
   @media (max-width: 1100px) {

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -1,4 +1,5 @@
 import { onDestroy } from 'svelte';
+import { handleFootnoteClick } from '$lib/utils/footnoteNav';
 
 export interface LinkMenuState {
   url: string;
@@ -24,6 +25,11 @@ export function useLinkInterception(params: LinkInterceptionParams) {
 
     const target = e.target as HTMLElement;
     if (target.closest(INTERACTIVE_MEDIA_SELECTOR)) return;
+
+    // Footnote markers are placeholder links that jump within this content, so
+    // they're resolved here rather than offered as an external link. This runs
+    // in the capture phase, ahead of any handler on the content itself.
+    if (handleFootnoteClick(e, currentEl ?? params.contentEl())) return;
 
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
     if (!link) return;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -93,6 +93,12 @@ export interface LeafletFacetFeature {
   $type: string;
   uri?: string; // for links
   did?: string; // for mentions
+  // Footnotes travel inside the facet rather than as a block: the reference
+  // point is a facet over a marker character in the block's plaintext, and the
+  // footnote body rides along in contentPlaintext/contentFacets.
+  footnoteId?: string;
+  contentPlaintext?: string;
+  contentFacets?: LeafletFacet[];
 }
 
 export interface LeafletFacet {

--- a/frontend/src/lib/utils/footnoteNav.ts
+++ b/frontend/src/lib/utils/footnoteNav.ts
@@ -1,0 +1,58 @@
+/**
+ * In-page navigation for the footnotes rendered by `leaflet-renderer.ts`.
+ *
+ * The markers are anchors with `data-footnote-ref` / `data-footnote-backref`
+ * rather than real hash links: `sanitizeHtml` rewrites `href="#…"` to the
+ * source article and forces `target="_blank"` on every anchor (it also
+ * processes untrusted feed HTML, so it isn't loosened for our own output).
+ * Lookups are scoped to the clicked content container, so several Leaflet
+ * cards on one page can't collide the way document-global `id`s would.
+ */
+
+/** How long the arrival highlight stays on the jumped-to element. */
+const FLASH_MS = 1200;
+
+function scrollTo(el: Element | null): void {
+  if (!el) return;
+
+  const reduceMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+
+  el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+
+  el.classList.add('footnote-flash');
+  setTimeout(() => el.classList.remove('footnote-flash'), FLASH_MS);
+}
+
+/**
+ * Handle a click inside rendered content. Returns true when the click was a
+ * footnote jump (already prevented and stopped), so callers can bail out of
+ * their own content-click behavior.
+ */
+export function handleFootnoteClick(
+  e: MouseEvent,
+  container: HTMLElement | null | undefined
+): boolean {
+  const target = e.target as HTMLElement | null;
+  if (!target) return false;
+
+  const ref = target.closest<HTMLElement>('a[data-footnote-ref]');
+  const backref = ref ? null : target.closest<HTMLElement>('a[data-footnote-backref]');
+  if (!ref && !backref) return false;
+
+  // The marker is a placeholder link; never follow it.
+  e.preventDefault();
+  e.stopPropagation();
+
+  // Numbers are renderer-generated, but keep the selector well-formed regardless.
+  const number = (ref?.dataset.footnoteRef ?? backref?.dataset.footnoteBackref ?? '').trim();
+  if (!container || !/^\d+$/.test(number)) return true;
+
+  scrollTo(
+    ref
+      ? container.querySelector(`[data-footnote-id="${number}"]`)
+      : container.querySelector(`a[data-footnote-ref="${number}"]`)
+  );
+  return true;
+}

--- a/frontend/src/lib/utils/leaflet-renderer.test.ts
+++ b/frontend/src/lib/utils/leaflet-renderer.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderLeafletContent } from './leaflet-renderer';
+import { sanitizeHtml } from './sanitize';
+import type {
+  LeafletBlockWrapper,
+  LeafletContent,
+  LeafletFacet,
+  LeafletListItemBlock,
+} from '$lib/types';
+
+const AUTHOR_DID = 'did:plc:example';
+
+function doc(...blocks: LeafletBlockWrapper[]): LeafletContent {
+  return {
+    $type: 'pub.leaflet.content',
+    pages: [{ $type: 'pub.leaflet.pages.linearDocument', blocks }],
+  };
+}
+
+function text(plaintext: string, facets?: LeafletFacet[]): LeafletBlockWrapper {
+  return { block: { $type: 'pub.leaflet.blocks.text', plaintext, facets } };
+}
+
+function list(...items: LeafletListItemBlock[]): LeafletBlockWrapper {
+  return { block: { $type: 'pub.leaflet.blocks.unorderedList', children: items } };
+}
+
+function listItem(plaintext: string, facets?: LeafletFacet[]): LeafletListItemBlock {
+  return {
+    $type: 'pub.leaflet.blocks.unorderedList#listItem',
+    content: { $type: 'pub.leaflet.blocks.text', plaintext, facets },
+  };
+}
+
+/** A footnote facet over the marker character Leaflet leaves in the plaintext. */
+function footnote(
+  byteStart: number,
+  footnoteId: string,
+  contentPlaintext: string,
+  contentFacets?: LeafletFacet[]
+): LeafletFacet {
+  return {
+    index: { byteStart, byteEnd: byteStart + 1 },
+    features: [
+      {
+        $type: 'pub.leaflet.richtext.facet#footnote',
+        footnoteId,
+        contentPlaintext,
+        ...(contentFacets ? { contentFacets } : {}),
+      },
+    ],
+  };
+}
+
+function link(byteStart: number, byteEnd: number, uri: string): LeafletFacet {
+  return {
+    index: { byteStart, byteEnd },
+    features: [{ $type: 'pub.leaflet.richtext.facet#link', uri }],
+  };
+}
+
+/** Parse rendered HTML so assertions read against the DOM, not the string. */
+function parse(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  return el;
+}
+
+describe('renderLeafletContent footnotes', () => {
+  it('replaces the marker with a numbered reference and lists the body at the end', () => {
+    const html = renderLeafletContent(
+      doc(text('The claim*', [footnote(9, 'fn-a', 'The evidence.')])),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    // The bare "*" the user saw is gone, replaced by an identifiable number.
+    expect(el.querySelector('p')?.textContent).toBe('The claim1');
+    const ref = el.querySelector('sup.footnote-ref a');
+    expect(ref?.getAttribute('data-footnote-ref')).toBe('1');
+    expect(ref?.getAttribute('aria-label')).toBe('Footnote 1');
+
+    const entry = el.querySelector('section.footnotes li[data-footnote-id="1"]');
+    expect(entry?.textContent).toContain('The evidence.');
+    expect(entry?.querySelector('a.footnote-backref')?.getAttribute('data-footnote-backref')).toBe(
+      '1'
+    );
+    expect(el.querySelector('section.footnotes')?.getAttribute('role')).toBe('doc-endnotes');
+  });
+
+  it('numbers footnotes in document order across blocks, including list items', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('First*', [footnote(5, 'fn-a', 'Note A')]),
+        list(listItem('Item*', [footnote(4, 'fn-b', 'Note B')])),
+        text('Last*', [footnote(4, 'fn-c', 'Note C')])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect([...el.querySelectorAll('sup.footnote-ref a')].map((a) => a.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+    expect([...el.querySelectorAll('section.footnotes li')].map((li) => li.textContent)).toEqual([
+      expect.stringContaining('Note A'),
+      expect.stringContaining('Note B'),
+      expect.stringContaining('Note C'),
+    ]);
+  });
+
+  it('numbers by reading order even when facets are stored out of order', () => {
+    // applyFacets walks facets from the end backwards; numbering must not follow.
+    const html = renderLeafletContent(
+      doc(
+        text('one* two*', [
+          footnote(8, 'fn-second', 'Second note'),
+          footnote(3, 'fn-first', 'First note'),
+        ])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect(el.querySelector('p')?.textContent).toBe('one1 two2');
+    expect(el.querySelector('li[data-footnote-id="1"]')?.textContent).toContain('First note');
+    expect(el.querySelector('li[data-footnote-id="2"]')?.textContent).toContain('Second note');
+  });
+
+  it('reuses one number and one entry for a repeated footnoteId', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('here*', [footnote(4, 'fn-a', 'Note A')]),
+        text('again*', [footnote(5, 'fn-a', 'Note A')])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect([...el.querySelectorAll('sup.footnote-ref a')].map((a) => a.textContent)).toEqual([
+      '1',
+      '1',
+    ]);
+    expect(el.querySelectorAll('section.footnotes li')).toHaveLength(1);
+  });
+
+  it('renders formatting inside a footnote body', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('cited*', [
+          footnote(5, 'fn-a', 'See source here', [link(11, 15, 'https://example.com/paper')]),
+        ])
+      ),
+      AUTHOR_DID
+    );
+    const entry = parse(html).querySelector('section.footnotes li');
+
+    const anchor = entry?.querySelector('a:not(.footnote-backref)');
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/paper');
+    expect(anchor?.textContent).toBe('here');
+  });
+
+  it('renders a footnote nested inside a footnote body as plain text', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('outer*', [footnote(5, 'fn-a', 'inner*', [footnote(5, 'fn-b', 'should not recurse')])])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect(el.querySelectorAll('sup.footnote-ref')).toHaveLength(1);
+    expect(el.querySelectorAll('section.footnotes li')).toHaveLength(1);
+    expect(el.querySelector('section.footnotes li')?.textContent).toContain('inner*');
+    expect(html).not.toContain('should not recurse');
+  });
+
+  it('places the reference correctly after multi-byte text', () => {
+    // "Héllo" is 6 bytes, so the marker facet starts at byte 6, not index 5.
+    const html = renderLeafletContent(
+      doc(text('Héllo* world', [footnote(6, 'fn-a', 'Note A')])),
+      AUTHOR_DID
+    );
+
+    expect(parse(html).querySelector('p')?.textContent).toBe('Héllo1 world');
+  });
+
+  it('escapes HTML in a footnote body', () => {
+    const html = renderLeafletContent(
+      doc(text('x*', [footnote(1, 'fn-a', '<img src=x onerror=alert(1)>')])),
+      AUTHOR_DID
+    );
+
+    expect(html).not.toContain('<img');
+    expect(parse(html).querySelector('section.footnotes li')?.textContent).toContain(
+      '<img src=x onerror=alert(1)>'
+    );
+  });
+
+  it('leaves a malformed footnote feature as plain text', () => {
+    const malformed: LeafletFacet = {
+      index: { byteStart: 4, byteEnd: 5 },
+      features: [{ $type: 'pub.leaflet.richtext.facet#footnote', contentPlaintext: 'orphan' }],
+    };
+    const html = renderLeafletContent(doc(text('here*', [malformed])), AUTHOR_DID);
+
+    expect(parse(html).querySelector('p')?.textContent).toBe('here*');
+    expect(html).not.toContain('section class="footnotes"');
+  });
+
+  it('renders no footnotes section for a document without footnotes', () => {
+    const html = renderLeafletContent(doc(text('Just prose.')), AUTHOR_DID);
+
+    expect(html).toBe('<p>Just prose.</p>');
+  });
+});
+
+describe('footnote markup survives sanitizeHtml', () => {
+  // The markup deliberately routes around the sanitizer (classes + data-* instead
+  // of inline styles and hash hrefs). Pin those assumptions so a future tightening
+  // of sanitize.ts fails here rather than silently breaking footnote navigation.
+  const rendered = renderLeafletContent(
+    doc(text('claim*', [footnote(5, 'fn-a', 'The evidence.')])),
+    AUTHOR_DID
+  );
+
+  it('keeps the reference, the section, and every data attribute', () => {
+    const el = parse(sanitizeHtml(rendered, 'https://example.com/post'));
+
+    expect(el.querySelector('sup.footnote-ref a[data-footnote-ref="1"]')?.textContent).toBe('1');
+    expect(el.querySelector('section.footnotes[role="doc-endnotes"]')).not.toBeNull();
+    expect(el.querySelector('li[data-footnote-id="1"]')).not.toBeNull();
+    expect(el.querySelector('a.footnote-backref[data-footnote-backref="1"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/leaflet-renderer.ts
+++ b/frontend/src/lib/utils/leaflet-renderer.ts
@@ -52,11 +52,131 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;');
 }
 
+const FOOTNOTE_FEATURE = 'pub.leaflet.richtext.facet#footnote';
+
+/** A footnote collected in document order, keyed by its footnoteId. */
+interface FootnoteEntry {
+  /** 1-based number shown in the marker and in the list at the end. */
+  number: number;
+  contentPlaintext: string;
+  contentFacets?: LeafletFacet[];
+}
+
+type FootnoteIndex = Map<string, FootnoteEntry>;
+
+/**
+ * Visit every facet-bearing block in document order.
+ * Used to number footnotes by reading order (applyFacets walks facets in
+ * reverse, so numbers can't be assigned while wrapping).
+ */
+function forEachFacetList(
+  content: LeafletContent,
+  visit: (facets: LeafletFacet[] | undefined) => void
+): void {
+  const visitItems = (items: LeafletListItemBlock[] | undefined) => {
+    for (const item of items || []) {
+      visit(item.content?.facets);
+      visitItems(item.children);
+    }
+  };
+
+  for (const page of content.pages || []) {
+    if (page.$type !== 'pub.leaflet.pages.linearDocument' || !page.blocks) {
+      continue;
+    }
+    for (const wrapper of page.blocks) {
+      const block = wrapper.block;
+      switch (block.$type) {
+        case 'pub.leaflet.blocks.text':
+        case 'pub.leaflet.blocks.header':
+        case 'pub.leaflet.blocks.blockquote':
+          visit(block.facets);
+          break;
+        case 'pub.leaflet.blocks.unorderedList':
+        case 'pub.leaflet.blocks.orderedList':
+          visitItems(block.children);
+          break;
+      }
+    }
+  }
+}
+
+/**
+ * Number every footnote in the document by reading order.
+ * A footnoteId that appears more than once reuses its first number.
+ */
+function buildFootnoteIndex(content: LeafletContent): FootnoteIndex {
+  const index: FootnoteIndex = new Map();
+
+  forEachFacetList(content, (facets) => {
+    if (!facets || facets.length === 0) return;
+    const inOrder = [...facets].sort(
+      (a, b) => (a.index?.byteStart ?? 0) - (b.index?.byteStart ?? 0)
+    );
+    for (const facet of inOrder) {
+      for (const feature of facet.features || []) {
+        if (feature.$type !== FOOTNOTE_FEATURE) continue;
+        const id = feature.footnoteId;
+        if (!id || index.has(id)) continue;
+        index.set(id, {
+          number: index.size + 1,
+          contentPlaintext: feature.contentPlaintext || '',
+          contentFacets: feature.contentFacets,
+        });
+      }
+    }
+  });
+
+  return index;
+}
+
+/**
+ * The inline reference. Leaflet puts a bare marker character (a `*`) at the
+ * reference position, so we replace the faceted span rather than wrap it —
+ * the number is what makes each reference identifiable.
+ *
+ * `href="#"` is a placeholder: the sanitizer rewrites real hash hrefs to the
+ * source article and forces target="_blank", so the jump is handled by the
+ * delegated click handler in `footnoteNav.ts` instead.
+ */
+function renderFootnoteRef(number: number): string {
+  return `<sup class="footnote-ref"><a href="#" data-footnote-ref="${number}" aria-label="Footnote ${number}">${number}</a></sup>`;
+}
+
+/**
+ * The list of footnote bodies, appended once at the end of the document.
+ */
+function renderFootnotesSection(footnotes: FootnoteIndex): string {
+  if (footnotes.size === 0) {
+    return '';
+  }
+
+  const items = [...footnotes.values()]
+    .sort((a, b) => a.number - b.number)
+    .map((footnote) => {
+      // No footnote index passed down: a footnote nested inside a footnote body
+      // (the lexicon allows it) renders as plain text rather than recursing.
+      const body = applyFacets(footnote.contentPlaintext, footnote.contentFacets);
+      const backref = `<a class="footnote-backref" href="#" data-footnote-backref="${footnote.number}" aria-label="Back to reference ${footnote.number}">↩</a>`;
+      return `<li data-footnote-id="${footnote.number}">${body} ${backref}</li>`;
+    })
+    .join('');
+
+  return `<section class="footnotes" role="doc-endnotes" aria-label="Footnotes"><ol>${items}</ol></section>`;
+}
+
 /**
  * Apply facets (rich text formatting) to plaintext
  * Facets use byte ranges, so we need to handle UTF-8 encoding properly
+ *
+ * @param footnotes - Document footnote numbering; omitted inside footnote
+ *   bodies so nested footnotes degrade to plain text.
  */
-function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
+function applyFacets(
+  plaintext: string,
+  facets?: LeafletFacet[],
+  footnotes?: FootnoteIndex
+): string {
   if (!facets || facets.length === 0) {
     return escapeHtml(plaintext);
   }
@@ -85,7 +205,16 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
     // Build the wrapped text based on facet features
     let wrappedText = facetText;
 
-    for (const feature of facet.features) {
+    // A footnote replaces the marker outright, so the other features on that
+    // facet don't apply (a bold footnote number means nothing). A malformed
+    // feature — no footnoteId, or one the pre-pass never saw — falls through
+    // to the normal wrapping below.
+    const footnoteId = footnotes
+      ? facet.features?.find((f) => f.$type === FOOTNOTE_FEATURE && f.footnoteId)?.footnoteId
+      : undefined;
+    const footnote = footnoteId ? footnotes?.get(footnoteId) : undefined;
+
+    for (const feature of footnote ? [] : facet.features) {
       switch (feature.$type) {
         case 'pub.leaflet.richtext.facet#bold':
         case 'app.bsky.richtext.facet#bold':
@@ -127,6 +256,10 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
       }
     }
 
+    if (footnote) {
+      wrappedText = renderFootnoteRef(footnote.number);
+    }
+
     // Reconstruct the byte array with the HTML-wrapped text
     const wrappedBytes = encoder.encode(wrappedText);
     const newResult = new Uint8Array(beforeBytes.length + wrappedBytes.length + afterBytes.length);
@@ -142,11 +275,11 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
 /**
  * Render a text block
  */
-function renderTextBlock(block: LeafletTextBlock): string {
+function renderTextBlock(block: LeafletTextBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
 
   // Apply text size styling
   let sizeClass = '';
@@ -162,11 +295,11 @@ function renderTextBlock(block: LeafletTextBlock): string {
 /**
  * Render a header block
  */
-function renderHeaderBlock(block: LeafletHeaderBlock): string {
+function renderHeaderBlock(block: LeafletHeaderBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
   const level = block.level || 2; // Default to h2
   const tag = `h${Math.min(Math.max(level, 1), 6)}`;
   return `<${tag}>${content}</${tag}>`;
@@ -187,11 +320,11 @@ function renderCodeBlock(block: LeafletCodeBlock): string {
 /**
  * Render a blockquote block
  */
-function renderBlockquoteBlock(block: LeafletBlockquoteBlock): string {
+function renderBlockquoteBlock(block: LeafletBlockquoteBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
   return `<blockquote>${content}</blockquote>`;
 }
 
@@ -209,7 +342,8 @@ function renderHorizontalRuleBlock(): string {
  */
 function renderListItems(
   children: LeafletListItemBlock[] | undefined,
-  listTag: 'ul' | 'ol' = 'ul'
+  listTag: 'ul' | 'ol' = 'ul',
+  footnotes?: FootnoteIndex
 ): string {
   if (!children || children.length === 0) {
     return '';
@@ -220,12 +354,12 @@ function renderListItems(
       // Extract plaintext and facets from the content block
       const plaintext = item.content?.plaintext || '';
       const facets = item.content?.facets;
-      const content = applyFacets(plaintext, facets);
+      const content = applyFacets(plaintext, facets, footnotes);
       let html = `<li>${content}`;
 
       // Handle nested lists (inherit parent list type)
       if (item.children && item.children.length > 0) {
-        html += `<${listTag}>${renderListItems(item.children, listTag)}</${listTag}>`;
+        html += `<${listTag}>${renderListItems(item.children, listTag, footnotes)}</${listTag}>`;
       }
 
       html += '</li>';
@@ -237,8 +371,11 @@ function renderListItems(
 /**
  * Render an unordered list block
  */
-function renderUnorderedListBlock(block: LeafletUnorderedListBlock): string {
-  const itemsHtml = renderListItems(block.children, 'ul');
+function renderUnorderedListBlock(
+  block: LeafletUnorderedListBlock,
+  footnotes?: FootnoteIndex
+): string {
+  const itemsHtml = renderListItems(block.children, 'ul', footnotes);
   if (!itemsHtml) {
     return '';
   }
@@ -248,8 +385,8 @@ function renderUnorderedListBlock(block: LeafletUnorderedListBlock): string {
 /**
  * Render an ordered list block
  */
-function renderOrderedListBlock(block: LeafletOrderedListBlock): string {
-  const itemsHtml = renderListItems(block.children, 'ol');
+function renderOrderedListBlock(block: LeafletOrderedListBlock, footnotes?: FootnoteIndex): string {
+  const itemsHtml = renderListItems(block.children, 'ol', footnotes);
   if (!itemsHtml) {
     return '';
   }
@@ -344,22 +481,22 @@ function renderPageBlock(block: LeafletPageBlock): string {
 /**
  * Render a single block based on its type
  */
-function renderBlock(block: LeafletBlock, authorDid: string): string {
+function renderBlock(block: LeafletBlock, authorDid: string, footnotes?: FootnoteIndex): string {
   switch (block.$type) {
     case 'pub.leaflet.blocks.text':
-      return renderTextBlock(block as LeafletTextBlock);
+      return renderTextBlock(block as LeafletTextBlock, footnotes);
     case 'pub.leaflet.blocks.header':
-      return renderHeaderBlock(block as LeafletHeaderBlock);
+      return renderHeaderBlock(block as LeafletHeaderBlock, footnotes);
     case 'pub.leaflet.blocks.code':
       return renderCodeBlock(block as LeafletCodeBlock);
     case 'pub.leaflet.blocks.blockquote':
-      return renderBlockquoteBlock(block as LeafletBlockquoteBlock);
+      return renderBlockquoteBlock(block as LeafletBlockquoteBlock, footnotes);
     case 'pub.leaflet.blocks.horizontalRule':
       return renderHorizontalRuleBlock();
     case 'pub.leaflet.blocks.unorderedList':
-      return renderUnorderedListBlock(block as LeafletUnorderedListBlock);
+      return renderUnorderedListBlock(block as LeafletUnorderedListBlock, footnotes);
     case 'pub.leaflet.blocks.orderedList':
-      return renderOrderedListBlock(block as LeafletOrderedListBlock);
+      return renderOrderedListBlock(block as LeafletOrderedListBlock, footnotes);
     case 'pub.leaflet.blocks.image':
       return renderImageBlock(block as LeafletImageBlock, authorDid);
     case 'pub.leaflet.blocks.website':
@@ -389,13 +526,16 @@ export function renderLeafletContent(content: LeafletContent, authorDid: string)
 
   const htmlParts: string[] = [];
 
+  // Numbered up front, in reading order, so markers and the list at the end agree.
+  const footnotes = buildFootnoteIndex(content);
+
   for (const page of content.pages) {
     if (page.$type !== 'pub.leaflet.pages.linearDocument' || !page.blocks) {
       continue;
     }
 
     for (const wrapper of page.blocks) {
-      const blockHtml = renderBlock(wrapper.block, authorDid);
+      const blockHtml = renderBlock(wrapper.block, authorDid, footnotes);
       if (blockHtml) {
         // Apply alignment if specified
         if (wrapper.alignment && wrapper.alignment !== 'left') {
@@ -407,6 +547,11 @@ export function renderLeafletContent(content: LeafletContent, authorDid: string)
         }
       }
     }
+  }
+
+  const footnotesHtml = renderFootnotesSection(footnotes);
+  if (footnotesHtml) {
+    htmlParts.push(footnotesHtml);
   }
 
   return htmlParts.join('\n');

--- a/frontend/src/routes/dev/cards/fixtures.ts
+++ b/frontend/src/routes/dev/cards/fixtures.ts
@@ -1,4 +1,5 @@
 import type { ArticleCardViewProps } from '$lib/components/articleCardView.types';
+import { renderLeafletContent } from '$lib/utils/leaflet-renderer';
 
 /**
  * Mock view-models for ArticleCardView — one per visual state. These are plain
@@ -40,6 +41,75 @@ const BODY_HTML_LONG =
       `shadow while this text scrolls beneath it, then settles flat once the ` +
       `card's end comes into view.</p>`
   ).join('\n');
+
+// A Leaflet document whose footnotes are facets over a `*` marker — the shape a
+// leaflet.pub post arrives in. Rendered here (not hand-written HTML) so the dev
+// page exercises the real renderer: numbered references, the list at the end,
+// and the click-to-jump wiring.
+const LEAFLET_FOOTNOTES_HTML = renderLeafletContent(
+  {
+    $type: 'pub.leaflet.content',
+    pages: [
+      {
+        $type: 'pub.leaflet.pages.linearDocument',
+        blocks: [
+          {
+            block: {
+              $type: 'pub.leaflet.blocks.text',
+              plaintext:
+                'Reading in public used to mean a blogroll and a feed reader.* The tools got quieter; the habit did not.',
+              facets: [
+                {
+                  index: { byteStart: 60, byteEnd: 61 },
+                  features: [
+                    {
+                      $type: 'pub.leaflet.richtext.facet#footnote',
+                      footnoteId: 'fn-blogroll',
+                      contentPlaintext:
+                        'Both are still around, and both are better than they were. See the archive.',
+                      contentFacets: [
+                        {
+                          index: { byteStart: 67, byteEnd: 74 },
+                          features: [
+                            {
+                              $type: 'pub.leaflet.richtext.facet#link',
+                              uri: 'https://example.com/archive',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            block: {
+              $type: 'pub.leaflet.blocks.text',
+              plaintext:
+                'What changed is where the record lives.* A reading life that outlives one app is worth the small friction of owning it.',
+              facets: [
+                {
+                  index: { byteStart: 39, byteEnd: 40 },
+                  features: [
+                    {
+                      $type: 'pub.leaflet.richtext.facet#footnote',
+                      footnoteId: 'fn-record',
+                      contentPlaintext:
+                        'Portability is the foundation here, not the pitch — it only matters because it keeps the reading.',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  'did:plc:example'
+);
 
 const base: ArticleCardViewProps = {
   itemUrl: 'https://arstechnica.com/example-article',
@@ -675,6 +745,24 @@ export const fixtures: CardFixture[] = [
           },
         ],
       },
+    },
+  },
+  {
+    name: 'Leaflet · footnotes',
+    note: 'A Leaflet post with footnote facets: each reference renders as a numbered superscript instead of a bare "*", and the bodies collect in a ruled list at the end. Tap a number to jump down, ↩ to come back.',
+    props: {
+      ...base,
+      itemTitle: 'Notes on reading in public',
+      displayFeedTitle: 'leaflet.pub',
+      feedTitle: 'A Quiet Publication',
+      isDocumentMode: true,
+      selected: true,
+      isOpen: true,
+      expanded: true,
+      hasContent: true,
+      readTimeMinutes: 2,
+      sanitizedContent: LEAFLET_FOOTNOTES_HTML,
+      hasOpenFullscreen: true,
     },
   },
   {


### PR DESCRIPTION
Leaflet models footnotes as a rich-text facet (`pub.leaflet.richtext.facet#footnote`) over a bare `*` marker in the block plaintext, with the footnote body carried inside the facet. The renderer had no case for it, so a Leaflet post in the reader showed an unexplained `*` and the footnote text was dropped entirely.

**What changed**

- `leaflet-renderer.ts`: a document-order pre-pass numbers every footnote by `footnoteId` (`applyFacets` walks facets backwards, so numbers can't be assigned while wrapping). Each marker is replaced by `<sup class="footnote-ref"><a data-footnote-ref="N">N</a></sup>`, and the bodies are appended once as `<section class="footnotes"><ol>` at the end. Footnote bodies render their own `contentFacets` (links, bold, …); a footnote nested inside a body degrades to plain text.
- Navigation: `footnoteNav.ts` resolves a marker click within the clicked content container (`data-` attributes, not document-global `id`s, so several Leaflet cards on one page don't collide), with a brief arrival highlight and `↩` back-references. It is wired into `useLinkInterception`, whose capture-phase listener already intercepts every anchor in rendered prose — handling it there covers the reader, the feed cards, and the daily magazine from one place instead of losing footnote clicks to the link context menu.
- Styling: hairline rule, smaller type, secondary color in both `SavedReader` and `ArticleCardView`. No new colors, no boxes.
- Tests: `leaflet-renderer.test.ts` covers numbering order, repeated ids, list items, nested/malformed features, multi-byte offsets and escaping, plus a `sanitizeHtml` round-trip that pins the DOMPurify assumptions this markup relies on.
- A `Leaflet · footnotes` fixture on `/dev/cards` renders through the real renderer for visual checking.

**Checks:** `npm run test` (247 passing, 16 files) and `npm run check` (svelte-check 0 errors, prettier clean) in `frontend/`.

**Known limits:** in paged reader mode the jump scrolls but does not turn the page (footnotes sit at the end and remain reachable by paging); server-built card summaries in `feed-proxy` still extract raw plaintext, so a `*` can persist in previews.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-thsghnbsxadtnfy5elcxtfde)
