### PR TITLE
Render numbered Leaflet footnotes, navigable on every reading surface

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -326,9 +326,9 @@ body.sidebar-open-mobile {
    into four surfaces now (the saved reader, article cards, the daily magazine,
    and curated editions), so the rules live here rather than being copied into
    each component's scoped styles. Sized in `em` so they track the reader's
-   chosen article size; muted with `opacity` and a `currentColor` rule rather
-   than the app's text tokens, so they stay legible on a curated edition's own
-   themed background too. Text-first — no boxes, no backgrounds. */
+   chosen article size; muted off `currentColor` rather than the app's text
+   tokens, so they stay legible on a curated edition's own themed background
+   too. Text-first — no boxes, no backgrounds. */
 sup.footnote-ref {
   font-size: 0.7em;
   line-height: 0;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -321,6 +321,57 @@ body.sidebar-open-mobile {
    px value on the document root by AppShell (see preferences store), so there
    are no discrete size selectors here. */
 
+/* Leaflet footnotes — a numbered reference in the text and the bodies in a
+   hairline-ruled list at the end (see lib/utils/leaflet-renderer.ts). Rendered
+   into four surfaces now (the saved reader, article cards, the daily magazine,
+   and curated editions), so the rules live here rather than being copied into
+   each component's scoped styles. Sized in `em` so they track the reader's
+   chosen article size; muted with `opacity` and a `currentColor` rule rather
+   than the app's text tokens, so they stay legible on a curated edition's own
+   themed background too. Text-first — no boxes, no backgrounds. */
+sup.footnote-ref {
+  font-size: 0.7em;
+  line-height: 0;
+  padding: 0 0.1em;
+}
+
+sup.footnote-ref a,
+a.footnote-backref {
+  text-decoration: none;
+}
+
+a.footnote-backref {
+  margin-left: 0.25rem;
+}
+
+section.footnotes {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  font-size: 0.875em;
+  /* Muted off the surrounding text rather than off a token, so the section reads
+     as secondary on the app's body and on a curated edition's themed page alike.
+     On `color` (not `opacity`) so links inside a note keep their own color and
+     the arrival highlight keeps its strength. */
+  color: color-mix(in srgb, currentColor 72%, transparent);
+}
+
+/* Brief arrival highlight so the jump is legible. */
+.footnote-flash {
+  background-color: color-mix(
+    in srgb,
+    var(--mag-accent, var(--color-primary, #0066cc)) 12%,
+    transparent
+  );
+  transition: background-color 0.4s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footnote-flash {
+    transition: none;
+  }
+}
+
 /* Inline note marker — a small comment glyph appended after a highlight that
    carries a note. Injected as raw DOM into the reader body (in both the saved
    reader and the article card), so it's styled globally here rather than in a

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -754,6 +754,10 @@
   const linkInterception = useLinkInterception({
     contentEl: () => bodyEl,
     enabled: () => true,
+    // While the preview is clamped, a footnote number is visible but its list
+    // entry is below the clamp: let the tap expand the card instead of jumping
+    // to something the reader can't see.
+    footnoteJump: () => !(selected && !expanded),
   });
 
   // Highlights hook

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -754,10 +754,12 @@
   const linkInterception = useLinkInterception({
     contentEl: () => bodyEl,
     enabled: () => true,
-    // While the preview is clamped, a footnote number is visible but its list
-    // entry is below the clamp: let the tap expand the card instead of jumping
-    // to something the reader can't see.
-    footnoteJump: () => !(selected && !expanded),
+    // While the preview is clamped *and overflowing* (`isTruncated`), a footnote
+    // number is visible but its list entry is below the clamp: let the tap expand
+    // the card instead of jumping to something the reader can't see. A preview
+    // that fits keeps the jump — handleContentTap deliberately does nothing in
+    // that state, so suppressing it there would leave a dead tap.
+    footnoteJump: () => !(selected && !expanded && isTruncated),
   });
 
   // Highlights hook

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -9,6 +9,7 @@
   import { overlapShadow } from '$lib/actions/overlap-shadow';
   import type { ArticleCardViewProps } from './articleCardView.types';
   import { safeHref } from '$lib/utils/sanitize';
+  import { handleFootnoteClick } from '$lib/utils/footnoteNav';
 
   let {
     // data
@@ -105,6 +106,9 @@
   // The content tap: keep the pure DOM guards here (let real links / media play),
   // then hand off the expand-vs-select decision to the container via onContentTap.
   function handleContentClick(e: MouseEvent) {
+    // Footnote markers jump within this card's own content (scoped lookup, so
+    // other cards' footnotes on the same page don't interfere).
+    if (handleFootnoteClick(e, e.currentTarget as HTMLElement)) return;
     // A @mention opens the add-feed dialog for that account (to subscribe to their
     // publications) instead of following its bsky-profile href fallback.
     const mention = (e.target as HTMLElement).closest<HTMLElement>('a[data-mention-did]');
@@ -1407,6 +1411,36 @@
 
   .article-body :global(mark.highlight:hover) {
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
+  }
+
+  /* Leaflet footnotes: a numbered reference in the text and the bodies in a
+     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
+  .article-body :global(sup.footnote-ref) {
+    font-size: 0.7em;
+    line-height: 0;
+    padding: 0 0.1em;
+  }
+
+  .article-body :global(sup.footnote-ref a) {
+    text-decoration: none;
+  }
+
+  .article-body :global(section.footnotes) {
+    margin-top: 1.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+    font-size: 0.875em;
+    color: var(--color-text-secondary);
+  }
+
+  .article-body :global(a.footnote-backref) {
+    text-decoration: none;
+    margin-left: 0.25rem;
+  }
+
+  .article-body :global(.footnote-flash) {
+    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
+    transition: background-color 0.4s ease;
   }
 
   .article-actions-container {

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -103,12 +103,24 @@
   // any trailing slash so it reads as a clean address rather than a raw href.
   const linkDisplayUrl = $derived((itemUrl ?? '').replace(/^https?:\/\//, '').replace(/\/+$/, ''));
 
+  // The collapsed preview line-clamps the body, so anything below the clamp
+  // (notably the footnotes list) can't be jumped to — the card has to expand
+  // first. Mirrors the `class:truncated` condition on the body below.
+  const bodyClamped = $derived(selected && !expanded);
+
   // The content tap: keep the pure DOM guards here (let real links / media play),
   // then hand off the expand-vs-select decision to the container via onContentTap.
   function handleContentClick(e: MouseEvent) {
     // Footnote markers jump within this card's own content (scoped lookup, so
-    // other cards' footnotes on the same page don't interfere).
-    if (handleFootnoteClick(e, e.currentTarget as HTMLElement)) return;
+    // other cards' footnotes on the same page don't interfere) — except while
+    // the preview is clamped, where the footnotes list is below the clamp: there
+    // the tap is only kept from following its href and falls through to the
+    // ordinary expand tap below (skipping the anchor guard, since the marker is
+    // an anchor).
+    const footnote = handleFootnoteClick(e, e.currentTarget as HTMLElement, {
+      jump: !bodyClamped,
+    });
+    if (footnote === 'handled') return;
     // A @mention opens the add-feed dialog for that account (to subscribe to their
     // publications) instead of following its bsky-profile href fallback.
     const mention = (e.target as HTMLElement).closest<HTMLElement>('a[data-mention-did]');
@@ -121,7 +133,7 @@
         return;
       }
     }
-    if ((e.target as HTMLElement).closest('a')) return;
+    if (footnote !== 'suppressed' && (e.target as HTMLElement).closest('a')) return;
     if ((e.target as HTMLElement).closest('video, audio, iframe')) return;
     // A click that ends a drag-select shouldn't expand/collapse the card — let
     // the text selection stand so it can be highlighted (matters most for short
@@ -1413,34 +1425,12 @@
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
   }
 
-  /* Leaflet footnotes: a numbered reference in the text and the bodies in a
-     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
-  .article-body :global(sup.footnote-ref) {
-    font-size: 0.7em;
-    line-height: 0;
-    padding: 0 0.1em;
-  }
-
-  .article-body :global(sup.footnote-ref a) {
-    text-decoration: none;
-  }
-
+  /* Leaflet footnote styling is shared by every surface that renders leaflet
+     content, so it lives in app.css rather than here. The card's tighter
+     rhythm for the trailing list is the one local override. */
   .article-body :global(section.footnotes) {
     margin-top: 1.5rem;
     padding-top: 0.75rem;
-    border-top: 1px solid var(--color-border);
-    font-size: 0.875em;
-    color: var(--color-text-secondary);
-  }
-
-  .article-body :global(a.footnote-backref) {
-    text-decoration: none;
-    margin-left: 0.25rem;
-  }
-
-  .article-body :global(.footnote-flash) {
-    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
-    transition: background-color 0.4s ease;
   }
 
   .article-actions-container {

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -105,8 +105,12 @@
 
   // The collapsed preview line-clamps the body, so anything below the clamp
   // (notably the footnotes list) can't be jumped to — the card has to expand
-  // first. Mirrors the `class:truncated` condition on the body below.
-  const bodyClamped = $derived(selected && !expanded);
+  // first. `class:truncated` is set on every selected, unexpanded body, but it
+  // only *hides* anything when the body actually overflows the clamp, which is
+  // what `isTruncated` measures. A short Leaflet post that fits shows its
+  // footnotes on screen, so there the jump stays live (and the container's
+  // content tap would do nothing anyway).
+  const bodyClamped = $derived(selected && !expanded && isTruncated);
 
   // The content tap: keep the pure DOM guards here (let real links / media play),
   // then hand off the expand-vs-select decision to the container via onContentTap.

--- a/frontend/src/lib/components/feed/CollectionMagazine.svelte
+++ b/frontend/src/lib/components/feed/CollectionMagazine.svelte
@@ -6,7 +6,7 @@
   import { decodeEntities } from '$lib/utils/entities';
   import { fetchCollectionDoc } from '$lib/utils/collectionPiece';
   import { magazineThemeVars, magazineFontHref } from '$lib/utils/magazineTheme';
-  import { footnoteNav } from '$lib/utils/footnoteNav';
+  import { footnoteNav, type FootnotePagedController } from '$lib/utils/footnoteNav';
   import { bskyEmbed } from '$lib/actions/bsky-embed';
   import Icon from '$lib/components/Icon.svelte';
   import type { ReaderCollection, ReaderCollectionItem, SocialDocument } from '$lib/types';
@@ -16,6 +16,7 @@
     title,
     onSavePiece,
     isPieceSaved,
+    pagedController,
   }: {
     collection: ReaderCollection;
     // The edition's title (the document title, e.g. "Inflection points"), shown as
@@ -26,6 +27,12 @@
     onSavePiece?: (item: ReaderCollectionItem) => void | Promise<void>;
     // Reactive saved-state predicate for a piece.
     isPieceSaved?: (item: ReaderCollectionItem) => boolean;
+    // The paginator when the host renders this edition in paged reading mode
+    // (SavedReader puts it inside PagedView, so an edition can sit in a paged
+    // flow). A getter, not the controller itself: it's bound late and swapped on
+    // re-measure, and the action's `update` only runs when its parameter object
+    // changes.
+    pagedController?: () => FootnotePagedController | null | undefined;
   } = $props();
 
   let savingUri = $state<string | null>(null);
@@ -241,8 +248,9 @@
           <!-- Each piece is its own render, so footnote numbering restarts at 1
                per piece — scope the jump to this body. Without this the marker's
                href (rewritten by sanitizeHtml to the source article) would open
-               the original in a new tab. -->
-          <div class="piece-content" use:footnoteNav>{@html st.html}</div>
+               the original in a new tab. In paged mode the jump turns the page
+               rather than scrolling the paged viewport out of sync. -->
+          <div class="piece-content" use:footnoteNav={{ pagedController }}>{@html st.html}</div>
         {/if}
       </article>
     {/each}

--- a/frontend/src/lib/components/feed/CollectionMagazine.svelte
+++ b/frontend/src/lib/components/feed/CollectionMagazine.svelte
@@ -6,6 +6,7 @@
   import { decodeEntities } from '$lib/utils/entities';
   import { fetchCollectionDoc } from '$lib/utils/collectionPiece';
   import { magazineThemeVars, magazineFontHref } from '$lib/utils/magazineTheme';
+  import { footnoteNav } from '$lib/utils/footnoteNav';
   import { bskyEmbed } from '$lib/actions/bsky-embed';
   import Icon from '$lib/components/Icon.svelte';
   import type { ReaderCollection, ReaderCollectionItem, SocialDocument } from '$lib/types';
@@ -237,7 +238,11 @@
             {/if}
           </p>
         {:else}
-          <div class="piece-content">{@html st.html}</div>
+          <!-- Each piece is its own render, so footnote numbering restarts at 1
+               per piece — scope the jump to this body. Without this the marker's
+               href (rewritten by sanitizeHtml to the source article) would open
+               the original in a new tab. -->
+          <div class="piece-content" use:footnoteNav>{@html st.html}</div>
         {/if}
       </article>
     {/each}

--- a/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
+++ b/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
@@ -81,7 +81,13 @@
     itemType: () => 'saved',
     enabled: () => active,
   });
-  const linkInterception = useLinkInterception({ contentEl: () => bodyEl, enabled: () => true });
+  const linkInterception = useLinkInterception({
+    contentEl: () => bodyEl,
+    enabled: () => true,
+    // Paged mode: turn to the footnote's page rather than scrolling the paged
+    // viewport (which the transform-driven paginator never resets).
+    pagedController: () => pagedController,
+  });
   const highlightsHook = useHighlights({
     contentEl: () => bodyEl,
     itemKey: () => itemKey,

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -546,6 +546,9 @@
   const linkInterception = useLinkInterception({
     contentEl: () => readerBodyEl,
     enabled: () => true,
+    // Paged mode: a footnote jump turns to the target's page (scrolling would
+    // slide the paged viewport sideways and desync every later page turn).
+    pagedController: () => pagedController,
   });
 
   // Highlights hook
@@ -1552,36 +1555,8 @@
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
   }
 
-  /* Leaflet footnotes: a numbered reference in the text, the bodies in a
-     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
-  .reader-body :global(sup.footnote-ref) {
-    font-size: 0.7em;
-    line-height: 0;
-    padding: 0 0.1em;
-  }
-
-  .reader-body :global(sup.footnote-ref a) {
-    text-decoration: none;
-  }
-
-  .reader-body :global(section.footnotes) {
-    margin-top: 2rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--color-border);
-    font-size: 0.875em;
-    color: var(--color-text-secondary);
-  }
-
-  .reader-body :global(a.footnote-backref) {
-    text-decoration: none;
-    margin-left: 0.25rem;
-  }
-
-  /* Brief arrival highlight so the jump is legible. */
-  .reader-body :global(.footnote-flash) {
-    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
-    transition: background-color 0.4s ease;
-  }
+  /* Leaflet footnote styling is shared by every surface that renders leaflet
+     content, so it lives in app.css rather than here. */
 
   /* On narrower desktops, drop the action labels to icons — matches the feed
      header's 1100px breakpoint so both collapse at the same width. */

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -974,6 +974,7 @@
               title={collectionTitle}
               onSavePiece={saveCollectionPiece}
               isPieceSaved={isCollectionPieceSaved}
+              pagedController={() => pagedController}
             />
           </div>
         {:else}

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -1552,6 +1552,37 @@
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
   }
 
+  /* Leaflet footnotes: a numbered reference in the text, the bodies in a
+     hairline-ruled list at the end. Text-first — no boxes, no backgrounds. */
+  .reader-body :global(sup.footnote-ref) {
+    font-size: 0.7em;
+    line-height: 0;
+    padding: 0 0.1em;
+  }
+
+  .reader-body :global(sup.footnote-ref a) {
+    text-decoration: none;
+  }
+
+  .reader-body :global(section.footnotes) {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+    font-size: 0.875em;
+    color: var(--color-text-secondary);
+  }
+
+  .reader-body :global(a.footnote-backref) {
+    text-decoration: none;
+    margin-left: 0.25rem;
+  }
+
+  /* Brief arrival highlight so the jump is legible. */
+  .reader-body :global(.footnote-flash) {
+    background-color: color-mix(in srgb, var(--color-primary, #0066cc) 12%, transparent);
+    transition: background-color 0.4s ease;
+  }
+
   /* On narrower desktops, drop the action labels to icons — matches the feed
      header's 1100px breakpoint so both collapse at the same width. */
   @media (max-width: 1100px) {

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -1,4 +1,5 @@
 import { onDestroy } from 'svelte';
+import { handleFootnoteClick } from '$lib/utils/footnoteNav';
 
 export interface LinkMenuState {
   url: string;
@@ -24,6 +25,11 @@ export function useLinkInterception(params: LinkInterceptionParams) {
 
     const target = e.target as HTMLElement;
     if (target.closest(INTERACTIVE_MEDIA_SELECTOR)) return;
+
+    // Footnote markers are placeholder links that jump within this content, so
+    // they're resolved here rather than offered as an external link. This runs
+    // in the capture phase, ahead of any handler on the content itself.
+    if (handleFootnoteClick(e, currentEl ?? params.contentEl())) return;
 
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
     if (!link) return;

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -1,5 +1,5 @@
 import { onDestroy } from 'svelte';
-import { handleFootnoteClick } from '$lib/utils/footnoteNav';
+import { handleFootnoteClick, type FootnotePagedController } from '$lib/utils/footnoteNav';
 
 export interface LinkMenuState {
   url: string;
@@ -12,6 +12,13 @@ const INTERACTIVE_MEDIA_SELECTOR = 'video, audio, iframe, embed, object';
 interface LinkInterceptionParams {
   contentEl: () => HTMLElement | undefined;
   enabled: () => boolean;
+  // Footnote markers jump within the content. False while the surface can't
+  // honor a jump (the clamped card preview, whose footnotes list sits below the
+  // line clamp) — the click is then left to the host's own tap handling.
+  footnoteJump?: () => boolean;
+  // The paginator when this content is laid out in paged mode, so a footnote
+  // jump turns the page instead of scrolling (which would desync the columns).
+  pagedController?: () => FootnotePagedController | null | undefined;
 }
 
 export function useLinkInterception(params: LinkInterceptionParams) {
@@ -28,8 +35,14 @@ export function useLinkInterception(params: LinkInterceptionParams) {
 
     // Footnote markers are placeholder links that jump within this content, so
     // they're resolved here rather than offered as an external link. This runs
-    // in the capture phase, ahead of any handler on the content itself.
-    if (handleFootnoteClick(e, currentEl ?? params.contentEl())) return;
+    // in the capture phase, ahead of any handler on the content itself. A
+    // 'suppressed' result already blocked the (rewritten) href but deliberately
+    // left propagation alone, so the host's content tap still runs.
+    const footnote = handleFootnoteClick(e, currentEl ?? params.contentEl(), {
+      jump: params.footnoteJump?.() ?? true,
+      pagedController: params.pagedController,
+    });
+    if (footnote !== 'none') return;
 
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
     if (!link) return;

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -27,22 +27,26 @@ export function useLinkInterception(params: LinkInterceptionParams) {
   let currentEl: HTMLElement | null = null;
 
   function handleClick(e: MouseEvent) {
-    // Let modifier clicks (cmd/ctrl/shift/middle-click) use default browser behavior
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-
     const target = e.target as HTMLElement;
     if (target.closest(INTERACTIVE_MEDIA_SELECTOR)) return;
 
     // Footnote markers are placeholder links that jump within this content, so
     // they're resolved here rather than offered as an external link. This runs
-    // in the capture phase, ahead of any handler on the content itself. A
-    // 'suppressed' result already blocked the (rewritten) href but deliberately
-    // left propagation alone, so the host's content tap still runs.
+    // in the capture phase, ahead of any handler on the content itself, and
+    // ahead of the modifier-click bail below: the marker's href is the
+    // sanitizer's rewrite to the source article, so a cmd/middle-click must not
+    // be handed to the browser (the helper consumes those). A 'suppressed'
+    // result already blocked the href but deliberately left propagation alone,
+    // so the host's content tap still runs.
     const footnote = handleFootnoteClick(e, currentEl ?? params.contentEl(), {
       jump: params.footnoteJump?.() ?? true,
       pagedController: params.pagedController,
     });
     if (footnote !== 'none') return;
+
+    // Let modifier clicks (cmd/ctrl/shift/middle-click) on real links use default
+    // browser behavior
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
 
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
     if (!link) return;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -93,6 +93,12 @@ export interface LeafletFacetFeature {
   $type: string;
   uri?: string; // for links
   did?: string; // for mentions
+  // Footnotes travel inside the facet rather than as a block: the reference
+  // point is a facet over a marker character in the block's plaintext, and the
+  // footnote body rides along in contentPlaintext/contentFacets.
+  footnoteId?: string;
+  contentPlaintext?: string;
+  contentFacets?: LeafletFacet[];
 }
 
 export interface LeafletFacet {

--- a/frontend/src/lib/utils/footnoteNav.test.ts
+++ b/frontend/src/lib/utils/footnoteNav.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleFootnoteClick } from './footnoteNav';
+
+/**
+ * A content container holding one footnote reference and its list entry, the
+ * shape `leaflet-renderer.ts` emits.
+ */
+function content(paged = false): {
+  container: HTMLElement;
+  ref: HTMLAnchorElement;
+  backref: HTMLAnchorElement;
+  entry: HTMLElement;
+} {
+  const host = document.createElement('div');
+  if (paged) host.className = 'paged-content';
+  host.innerHTML = `
+    <div class="body">
+      <p>Text<sup class="footnote-ref"><a href="#" data-footnote-ref="1">1</a></sup></p>
+      <section class="footnotes">
+        <ol>
+          <li data-footnote-id="1">The note
+            <a href="#" class="footnote-backref" data-footnote-backref="1">↩</a>
+          </li>
+        </ol>
+      </section>
+    </div>`;
+  document.body.appendChild(host);
+  return {
+    container: host.querySelector('.body') as HTMLElement,
+    ref: host.querySelector('a[data-footnote-ref]') as HTMLAnchorElement,
+    backref: host.querySelector('a[data-footnote-backref]') as HTMLAnchorElement,
+    entry: host.querySelector('[data-footnote-id]') as HTMLElement,
+  };
+}
+
+/**
+ * Dispatch a real click on `el` and run the helper from a listener on it, so
+ * `preventDefault` / `stopPropagation` can be observed the way a caller sees
+ * them. `reachedAncestor` reports whether the click still bubbled out of the
+ * container (i.e. whether a host's own tap handler would have run).
+ */
+function click(
+  el: HTMLElement,
+  container: HTMLElement,
+  options?: Parameters<typeof handleFootnoteClick>[2]
+): { result: string; prevented: boolean; reachedAncestor: boolean } {
+  let result = 'none';
+  let reachedAncestor = false;
+  const onEl = (e: Event) => {
+    result = handleFootnoteClick(e as MouseEvent, container, options);
+  };
+  const onAncestor = () => {
+    reachedAncestor = true;
+  };
+  el.addEventListener('click', onEl);
+  document.body.addEventListener('click', onAncestor);
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+  el.dispatchEvent(event);
+  el.removeEventListener('click', onEl);
+  document.body.removeEventListener('click', onAncestor);
+  return { result, prevented: event.defaultPrevented, reachedAncestor };
+}
+
+let scrollIntoView: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  // jsdom has no layout, so scrollIntoView isn't implemented.
+  scrollIntoView = vi.fn();
+  Element.prototype.scrollIntoView = scrollIntoView as unknown as Element['scrollIntoView'];
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('handleFootnoteClick', () => {
+  it('ignores clicks that are not on a footnote marker', () => {
+    const { container } = content();
+    const p = container.querySelector('p') as HTMLElement;
+    const { result, prevented } = click(p, container);
+    expect(result).toBe('none');
+    expect(prevented).toBe(false);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to the entry, stops the event, and flashes the target', () => {
+    vi.useFakeTimers();
+    const { container, ref, entry } = content();
+    const { result, prevented, reachedAncestor } = click(ref, container);
+    expect(result).toBe('handled');
+    expect(prevented).toBe(true);
+    expect(reachedAncestor).toBe(false);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(entry.classList.contains('footnote-flash')).toBe(true);
+    vi.advanceTimersByTime(1500);
+    expect(entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('sends a back-reference click to its marker', () => {
+    const { container, ref, backref } = content();
+    const { result } = click(backref, container);
+    expect(result).toBe('handled');
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(ref.classList.contains('footnote-flash')).toBe(true);
+  });
+
+  it('resolves within the given container, not across the page', () => {
+    const first = content();
+    const second = content();
+    click(second.ref, second.container);
+    expect(second.entry.classList.contains('footnote-flash')).toBe(true);
+    expect(first.entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('suppresses the link but leaves the click alone when jumping is off', () => {
+    const { container, ref, entry } = content();
+    const { result, prevented, reachedAncestor } = click(ref, container, { jump: false });
+    // Prevented (the sanitizer rewrote the href to the source article) but still
+    // bubbling, so the card's own tap handler expands it.
+    expect(result).toBe('suppressed');
+    expect(prevented).toBe(true);
+    expect(reachedAncestor).toBe(true);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('turns the page instead of scrolling inside a paged flow', () => {
+    const { container, ref, entry } = content(true);
+    const goToElement = vi.fn();
+    const { result } = click(ref, container, { pagedController: () => ({ goToElement }) });
+    expect(result).toBe('handled');
+    // Scrolling would slide the overflow-hidden paged viewport sideways, and the
+    // paginator (which positions pages with a transform) never resets that.
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(goToElement).toHaveBeenCalledWith(entry);
+  });
+
+  it('does nothing in a paged flow without a paginator', () => {
+    const { container, ref, entry } = content(true);
+    const { result } = click(ref, container, { pagedController: () => null });
+    expect(result).toBe('handled');
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('is inert for a malformed marker', () => {
+    const { container, ref } = content();
+    ref.dataset.footnoteRef = 'not-a-number';
+    const { result, prevented } = click(ref, container);
+    expect(result).toBe('handled');
+    expect(prevented).toBe(true);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/utils/footnoteNav.test.ts
+++ b/frontend/src/lib/utils/footnoteNav.test.ts
@@ -43,7 +43,8 @@ function content(paged = false): {
 function click(
   el: HTMLElement,
   container: HTMLElement,
-  options?: Parameters<typeof handleFootnoteClick>[2]
+  options?: Parameters<typeof handleFootnoteClick>[2],
+  init: MouseEventInit = {}
 ): { result: string; prevented: boolean; reachedAncestor: boolean } {
   let result = 'none';
   let reachedAncestor = false;
@@ -55,7 +56,7 @@ function click(
   };
   el.addEventListener('click', onEl);
   document.body.addEventListener('click', onAncestor);
-  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
   el.dispatchEvent(event);
   el.removeEventListener('click', onEl);
   document.body.removeEventListener('click', onAncestor);
@@ -143,6 +144,31 @@ describe('handleFootnoteClick', () => {
     expect(result).toBe('handled');
     expect(scrollIntoView).not.toHaveBeenCalled();
     expect(entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('consumes a modifier click instead of opening the rewritten href', () => {
+    const { container, ref, entry } = content();
+    const { result, prevented, reachedAncestor } = click(ref, container, undefined, {
+      metaKey: true,
+    });
+    // sanitizeHtml rewrote the placeholder href to the source article, so letting
+    // the browser have this would open the whole post in a new tab. No jump
+    // either — "open elsewhere" has no in-page meaning.
+    expect(result).toBe('handled');
+    expect(prevented).toBe(true);
+    expect(reachedAncestor).toBe(false);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(entry.classList.contains('footnote-flash')).toBe(false);
+  });
+
+  it('consumes a modifier click even where jumping is off', () => {
+    // The clamped card preview: an ordinary tap falls through to expand the card,
+    // but a cmd-click still shouldn't leave the app.
+    const { container, ref } = content();
+    const { result, prevented } = click(ref, container, { jump: false }, { ctrlKey: true });
+    expect(result).toBe('handled');
+    expect(prevented).toBe(true);
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
   it('is inert for a malformed marker', () => {

--- a/frontend/src/lib/utils/footnoteNav.ts
+++ b/frontend/src/lib/utils/footnoteNav.ts
@@ -92,6 +92,17 @@ export function handleFootnoteClick(
   // The marker is a placeholder link; never follow it.
   e.preventDefault();
 
+  // A modifier / non-primary click on a real link means "open a copy elsewhere",
+  // but this href is the sanitizer's rewrite to the source article, so honoring
+  // it would open the whole post in a new tab. An in-page jump has no
+  // open-elsewhere form either, so consume the gesture and do nothing — the same
+  // outcome on every surface, rather than one that depends on which entry point
+  // sees the click first.
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+    e.stopPropagation();
+    return 'handled';
+  }
+
   // The surface can't jump right now — leave the click to the caller.
   if (options.jump === false) return 'suppressed';
 

--- a/frontend/src/lib/utils/footnoteNav.ts
+++ b/frontend/src/lib/utils/footnoteNav.ts
@@ -1,0 +1,58 @@
+/**
+ * In-page navigation for the footnotes rendered by `leaflet-renderer.ts`.
+ *
+ * The markers are anchors with `data-footnote-ref` / `data-footnote-backref`
+ * rather than real hash links: `sanitizeHtml` rewrites `href="#…"` to the
+ * source article and forces `target="_blank"` on every anchor (it also
+ * processes untrusted feed HTML, so it isn't loosened for our own output).
+ * Lookups are scoped to the clicked content container, so several Leaflet
+ * cards on one page can't collide the way document-global `id`s would.
+ */
+
+/** How long the arrival highlight stays on the jumped-to element. */
+const FLASH_MS = 1200;
+
+function scrollTo(el: Element | null): void {
+  if (!el) return;
+
+  const reduceMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+
+  el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+
+  el.classList.add('footnote-flash');
+  setTimeout(() => el.classList.remove('footnote-flash'), FLASH_MS);
+}
+
+/**
+ * Handle a click inside rendered content. Returns true when the click was a
+ * footnote jump (already prevented and stopped), so callers can bail out of
+ * their own content-click behavior.
+ */
+export function handleFootnoteClick(
+  e: MouseEvent,
+  container: HTMLElement | null | undefined
+): boolean {
+  const target = e.target as HTMLElement | null;
+  if (!target) return false;
+
+  const ref = target.closest<HTMLElement>('a[data-footnote-ref]');
+  const backref = ref ? null : target.closest<HTMLElement>('a[data-footnote-backref]');
+  if (!ref && !backref) return false;
+
+  // The marker is a placeholder link; never follow it.
+  e.preventDefault();
+  e.stopPropagation();
+
+  // Numbers are renderer-generated, but keep the selector well-formed regardless.
+  const number = (ref?.dataset.footnoteRef ?? backref?.dataset.footnoteBackref ?? '').trim();
+  if (!container || !/^\d+$/.test(number)) return true;
+
+  scrollTo(
+    ref
+      ? container.querySelector(`[data-footnote-id="${number}"]`)
+      : container.querySelector(`a[data-footnote-ref="${number}"]`)
+  );
+  return true;
+}

--- a/frontend/src/lib/utils/footnoteNav.ts
+++ b/frontend/src/lib/utils/footnoteNav.ts
@@ -12,47 +12,121 @@
 /** How long the arrival highlight stays on the jumped-to element. */
 const FLASH_MS = 1200;
 
-function scrollTo(el: Element | null): void {
+/**
+ * The slice of `PagedController` this needs. Structural, so the helper doesn't
+ * have to import a type out of a `.svelte` module.
+ */
+export interface FootnotePagedController {
+  goToElement: (el: HTMLElement) => void;
+}
+
+export interface FootnoteNavOptions {
+  /**
+   * False when the surface can't honor a jump — today the clamped card preview,
+   * where the footnotes list is below the line clamp. The click is still kept
+   * from following its (rewritten) href, but propagation is left alone so the
+   * caller's ordinary content tap runs and expands the card.
+   */
+  jump?: boolean;
+  /**
+   * Paged reading: the paginator for the flow this content sits in. Paged mode
+   * lays the body out in horizontally overflowing columns inside an
+   * `overflow: hidden` viewport and positions pages with a transform, so
+   * `scrollIntoView` would scroll that viewport sideways and desync every
+   * subsequent page turn. Inside a paged flow we turn the page instead.
+   */
+  pagedController?: () => FootnotePagedController | null | undefined;
+}
+
+/**
+ * - `none` — not a footnote click; the caller's own handling applies.
+ * - `handled` — jumped; the event is prevented *and* stopped, so callers bail.
+ * - `suppressed` — a footnote click the surface can't jump for: prevented only,
+ *   and the caller should treat it as a tap on ordinary text (not on a link).
+ */
+export type FootnoteClickResult = 'none' | 'handled' | 'suppressed';
+
+function flash(el: Element): void {
+  el.classList.add('footnote-flash');
+  setTimeout(() => el.classList.remove('footnote-flash'), FLASH_MS);
+}
+
+function jumpTo(el: Element | null, options: FootnoteNavOptions): void {
   if (!el) return;
+
+  // Paged mode: never scroll (see `pagedController` above) — turn to the page the
+  // target sits on. Without a paginator to ask, do nothing rather than scroll the
+  // paged viewport out of sync.
+  if (el.closest('.paged-content')) {
+    const controller = options.pagedController?.();
+    if (!controller) return;
+    controller.goToElement(el as HTMLElement);
+    flash(el);
+    return;
+  }
 
   const reduceMotion =
     typeof window !== 'undefined' &&
     window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
   el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
-
-  el.classList.add('footnote-flash');
-  setTimeout(() => el.classList.remove('footnote-flash'), FLASH_MS);
+  flash(el);
 }
 
 /**
- * Handle a click inside rendered content. Returns true when the click was a
- * footnote jump (already prevented and stopped), so callers can bail out of
- * their own content-click behavior.
+ * Handle a click inside rendered content. See `FootnoteClickResult` for what the
+ * caller should do with each outcome.
  */
 export function handleFootnoteClick(
   e: MouseEvent,
-  container: HTMLElement | null | undefined
-): boolean {
+  container: HTMLElement | null | undefined,
+  options: FootnoteNavOptions = {}
+): FootnoteClickResult {
   const target = e.target as HTMLElement | null;
-  if (!target) return false;
+  if (!target) return 'none';
 
   const ref = target.closest<HTMLElement>('a[data-footnote-ref]');
   const backref = ref ? null : target.closest<HTMLElement>('a[data-footnote-backref]');
-  if (!ref && !backref) return false;
+  if (!ref && !backref) return 'none';
 
   // The marker is a placeholder link; never follow it.
   e.preventDefault();
+
+  // The surface can't jump right now — leave the click to the caller.
+  if (options.jump === false) return 'suppressed';
+
   e.stopPropagation();
 
   // Numbers are renderer-generated, but keep the selector well-formed regardless.
   const number = (ref?.dataset.footnoteRef ?? backref?.dataset.footnoteBackref ?? '').trim();
-  if (!container || !/^\d+$/.test(number)) return true;
+  if (!container || !/^\d+$/.test(number)) return 'handled';
 
-  scrollTo(
+  jumpTo(
     ref
       ? container.querySelector(`[data-footnote-id="${number}"]`)
-      : container.querySelector(`a[data-footnote-ref="${number}"]`)
+      : container.querySelector(`a[data-footnote-ref="${number}"]`),
+    options
   );
-  return true;
+  return 'handled';
+}
+
+/**
+ * Svelte action: delegate footnote clicks for a block of rendered content that
+ * has no click handling of its own (the curated-edition pieces). Capture phase,
+ * so it wins over anything the content itself attaches.
+ */
+export function footnoteNav(node: HTMLElement, options: FootnoteNavOptions = {}) {
+  let current = options;
+  const onClick = (e: MouseEvent) => {
+    handleFootnoteClick(e, node, current);
+  };
+  node.addEventListener('click', onClick, true);
+  return {
+    update(next: FootnoteNavOptions = {}) {
+      current = next;
+    },
+    destroy() {
+      node.removeEventListener('click', onClick, true);
+    },
+  };
 }

--- a/frontend/src/lib/utils/leaflet-renderer.test.ts
+++ b/frontend/src/lib/utils/leaflet-renderer.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderLeafletContent } from './leaflet-renderer';
+import { sanitizeHtml } from './sanitize';
+import type {
+  LeafletBlockWrapper,
+  LeafletContent,
+  LeafletFacet,
+  LeafletListItemBlock,
+} from '$lib/types';
+
+const AUTHOR_DID = 'did:plc:example';
+
+function doc(...blocks: LeafletBlockWrapper[]): LeafletContent {
+  return {
+    $type: 'pub.leaflet.content',
+    pages: [{ $type: 'pub.leaflet.pages.linearDocument', blocks }],
+  };
+}
+
+function text(plaintext: string, facets?: LeafletFacet[]): LeafletBlockWrapper {
+  return { block: { $type: 'pub.leaflet.blocks.text', plaintext, facets } };
+}
+
+function list(...items: LeafletListItemBlock[]): LeafletBlockWrapper {
+  return { block: { $type: 'pub.leaflet.blocks.unorderedList', children: items } };
+}
+
+function listItem(plaintext: string, facets?: LeafletFacet[]): LeafletListItemBlock {
+  return {
+    $type: 'pub.leaflet.blocks.unorderedList#listItem',
+    content: { $type: 'pub.leaflet.blocks.text', plaintext, facets },
+  };
+}
+
+/** A footnote facet over the marker character Leaflet leaves in the plaintext. */
+function footnote(
+  byteStart: number,
+  footnoteId: string,
+  contentPlaintext: string,
+  contentFacets?: LeafletFacet[]
+): LeafletFacet {
+  return {
+    index: { byteStart, byteEnd: byteStart + 1 },
+    features: [
+      {
+        $type: 'pub.leaflet.richtext.facet#footnote',
+        footnoteId,
+        contentPlaintext,
+        ...(contentFacets ? { contentFacets } : {}),
+      },
+    ],
+  };
+}
+
+function link(byteStart: number, byteEnd: number, uri: string): LeafletFacet {
+  return {
+    index: { byteStart, byteEnd },
+    features: [{ $type: 'pub.leaflet.richtext.facet#link', uri }],
+  };
+}
+
+/** Parse rendered HTML so assertions read against the DOM, not the string. */
+function parse(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  return el;
+}
+
+describe('renderLeafletContent footnotes', () => {
+  it('replaces the marker with a numbered reference and lists the body at the end', () => {
+    const html = renderLeafletContent(
+      doc(text('The claim*', [footnote(9, 'fn-a', 'The evidence.')])),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    // The bare "*" the user saw is gone, replaced by an identifiable number.
+    expect(el.querySelector('p')?.textContent).toBe('The claim1');
+    const ref = el.querySelector('sup.footnote-ref a');
+    expect(ref?.getAttribute('data-footnote-ref')).toBe('1');
+    expect(ref?.getAttribute('aria-label')).toBe('Footnote 1');
+
+    const entry = el.querySelector('section.footnotes li[data-footnote-id="1"]');
+    expect(entry?.textContent).toContain('The evidence.');
+    expect(entry?.querySelector('a.footnote-backref')?.getAttribute('data-footnote-backref')).toBe(
+      '1'
+    );
+    expect(el.querySelector('section.footnotes')?.getAttribute('role')).toBe('doc-endnotes');
+  });
+
+  it('numbers footnotes in document order across blocks, including list items', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('First*', [footnote(5, 'fn-a', 'Note A')]),
+        list(listItem('Item*', [footnote(4, 'fn-b', 'Note B')])),
+        text('Last*', [footnote(4, 'fn-c', 'Note C')])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect([...el.querySelectorAll('sup.footnote-ref a')].map((a) => a.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+    expect([...el.querySelectorAll('section.footnotes li')].map((li) => li.textContent)).toEqual([
+      expect.stringContaining('Note A'),
+      expect.stringContaining('Note B'),
+      expect.stringContaining('Note C'),
+    ]);
+  });
+
+  it('numbers by reading order even when facets are stored out of order', () => {
+    // applyFacets walks facets from the end backwards; numbering must not follow.
+    const html = renderLeafletContent(
+      doc(
+        text('one* two*', [
+          footnote(8, 'fn-second', 'Second note'),
+          footnote(3, 'fn-first', 'First note'),
+        ])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect(el.querySelector('p')?.textContent).toBe('one1 two2');
+    expect(el.querySelector('li[data-footnote-id="1"]')?.textContent).toContain('First note');
+    expect(el.querySelector('li[data-footnote-id="2"]')?.textContent).toContain('Second note');
+  });
+
+  it('reuses one number and one entry for a repeated footnoteId', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('here*', [footnote(4, 'fn-a', 'Note A')]),
+        text('again*', [footnote(5, 'fn-a', 'Note A')])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect([...el.querySelectorAll('sup.footnote-ref a')].map((a) => a.textContent)).toEqual([
+      '1',
+      '1',
+    ]);
+    expect(el.querySelectorAll('section.footnotes li')).toHaveLength(1);
+  });
+
+  it('renders formatting inside a footnote body', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('cited*', [
+          footnote(5, 'fn-a', 'See source here', [link(11, 15, 'https://example.com/paper')]),
+        ])
+      ),
+      AUTHOR_DID
+    );
+    const entry = parse(html).querySelector('section.footnotes li');
+
+    const anchor = entry?.querySelector('a:not(.footnote-backref)');
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/paper');
+    expect(anchor?.textContent).toBe('here');
+  });
+
+  it('renders a footnote nested inside a footnote body as plain text', () => {
+    const html = renderLeafletContent(
+      doc(
+        text('outer*', [footnote(5, 'fn-a', 'inner*', [footnote(5, 'fn-b', 'should not recurse')])])
+      ),
+      AUTHOR_DID
+    );
+    const el = parse(html);
+
+    expect(el.querySelectorAll('sup.footnote-ref')).toHaveLength(1);
+    expect(el.querySelectorAll('section.footnotes li')).toHaveLength(1);
+    expect(el.querySelector('section.footnotes li')?.textContent).toContain('inner*');
+    expect(html).not.toContain('should not recurse');
+  });
+
+  it('places the reference correctly after multi-byte text', () => {
+    // "Héllo" is 6 bytes, so the marker facet starts at byte 6, not index 5.
+    const html = renderLeafletContent(
+      doc(text('Héllo* world', [footnote(6, 'fn-a', 'Note A')])),
+      AUTHOR_DID
+    );
+
+    expect(parse(html).querySelector('p')?.textContent).toBe('Héllo1 world');
+  });
+
+  it('escapes HTML in a footnote body', () => {
+    const html = renderLeafletContent(
+      doc(text('x*', [footnote(1, 'fn-a', '<img src=x onerror=alert(1)>')])),
+      AUTHOR_DID
+    );
+
+    expect(html).not.toContain('<img');
+    expect(parse(html).querySelector('section.footnotes li')?.textContent).toContain(
+      '<img src=x onerror=alert(1)>'
+    );
+  });
+
+  it('leaves a malformed footnote feature as plain text', () => {
+    const malformed: LeafletFacet = {
+      index: { byteStart: 4, byteEnd: 5 },
+      features: [{ $type: 'pub.leaflet.richtext.facet#footnote', contentPlaintext: 'orphan' }],
+    };
+    const html = renderLeafletContent(doc(text('here*', [malformed])), AUTHOR_DID);
+
+    expect(parse(html).querySelector('p')?.textContent).toBe('here*');
+    expect(html).not.toContain('section class="footnotes"');
+  });
+
+  it('renders no footnotes section for a document without footnotes', () => {
+    const html = renderLeafletContent(doc(text('Just prose.')), AUTHOR_DID);
+
+    expect(html).toBe('<p>Just prose.</p>');
+  });
+});
+
+describe('footnote markup survives sanitizeHtml', () => {
+  // The markup deliberately routes around the sanitizer (classes + data-* instead
+  // of inline styles and hash hrefs). Pin those assumptions so a future tightening
+  // of sanitize.ts fails here rather than silently breaking footnote navigation.
+  const rendered = renderLeafletContent(
+    doc(text('claim*', [footnote(5, 'fn-a', 'The evidence.')])),
+    AUTHOR_DID
+  );
+
+  it('keeps the reference, the section, and every data attribute', () => {
+    const el = parse(sanitizeHtml(rendered, 'https://example.com/post'));
+
+    expect(el.querySelector('sup.footnote-ref a[data-footnote-ref="1"]')?.textContent).toBe('1');
+    expect(el.querySelector('section.footnotes[role="doc-endnotes"]')).not.toBeNull();
+    expect(el.querySelector('li[data-footnote-id="1"]')).not.toBeNull();
+    expect(el.querySelector('a.footnote-backref[data-footnote-backref="1"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/leaflet-renderer.ts
+++ b/frontend/src/lib/utils/leaflet-renderer.ts
@@ -52,11 +52,131 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;');
 }
 
+const FOOTNOTE_FEATURE = 'pub.leaflet.richtext.facet#footnote';
+
+/** A footnote collected in document order, keyed by its footnoteId. */
+interface FootnoteEntry {
+  /** 1-based number shown in the marker and in the list at the end. */
+  number: number;
+  contentPlaintext: string;
+  contentFacets?: LeafletFacet[];
+}
+
+type FootnoteIndex = Map<string, FootnoteEntry>;
+
+/**
+ * Visit every facet-bearing block in document order.
+ * Used to number footnotes by reading order (applyFacets walks facets in
+ * reverse, so numbers can't be assigned while wrapping).
+ */
+function forEachFacetList(
+  content: LeafletContent,
+  visit: (facets: LeafletFacet[] | undefined) => void
+): void {
+  const visitItems = (items: LeafletListItemBlock[] | undefined) => {
+    for (const item of items || []) {
+      visit(item.content?.facets);
+      visitItems(item.children);
+    }
+  };
+
+  for (const page of content.pages || []) {
+    if (page.$type !== 'pub.leaflet.pages.linearDocument' || !page.blocks) {
+      continue;
+    }
+    for (const wrapper of page.blocks) {
+      const block = wrapper.block;
+      switch (block.$type) {
+        case 'pub.leaflet.blocks.text':
+        case 'pub.leaflet.blocks.header':
+        case 'pub.leaflet.blocks.blockquote':
+          visit(block.facets);
+          break;
+        case 'pub.leaflet.blocks.unorderedList':
+        case 'pub.leaflet.blocks.orderedList':
+          visitItems(block.children);
+          break;
+      }
+    }
+  }
+}
+
+/**
+ * Number every footnote in the document by reading order.
+ * A footnoteId that appears more than once reuses its first number.
+ */
+function buildFootnoteIndex(content: LeafletContent): FootnoteIndex {
+  const index: FootnoteIndex = new Map();
+
+  forEachFacetList(content, (facets) => {
+    if (!facets || facets.length === 0) return;
+    const inOrder = [...facets].sort(
+      (a, b) => (a.index?.byteStart ?? 0) - (b.index?.byteStart ?? 0)
+    );
+    for (const facet of inOrder) {
+      for (const feature of facet.features || []) {
+        if (feature.$type !== FOOTNOTE_FEATURE) continue;
+        const id = feature.footnoteId;
+        if (!id || index.has(id)) continue;
+        index.set(id, {
+          number: index.size + 1,
+          contentPlaintext: feature.contentPlaintext || '',
+          contentFacets: feature.contentFacets,
+        });
+      }
+    }
+  });
+
+  return index;
+}
+
+/**
+ * The inline reference. Leaflet puts a bare marker character (a `*`) at the
+ * reference position, so we replace the faceted span rather than wrap it —
+ * the number is what makes each reference identifiable.
+ *
+ * `href="#"` is a placeholder: the sanitizer rewrites real hash hrefs to the
+ * source article and forces target="_blank", so the jump is handled by the
+ * delegated click handler in `footnoteNav.ts` instead.
+ */
+function renderFootnoteRef(number: number): string {
+  return `<sup class="footnote-ref"><a href="#" data-footnote-ref="${number}" aria-label="Footnote ${number}">${number}</a></sup>`;
+}
+
+/**
+ * The list of footnote bodies, appended once at the end of the document.
+ */
+function renderFootnotesSection(footnotes: FootnoteIndex): string {
+  if (footnotes.size === 0) {
+    return '';
+  }
+
+  const items = [...footnotes.values()]
+    .sort((a, b) => a.number - b.number)
+    .map((footnote) => {
+      // No footnote index passed down: a footnote nested inside a footnote body
+      // (the lexicon allows it) renders as plain text rather than recursing.
+      const body = applyFacets(footnote.contentPlaintext, footnote.contentFacets);
+      const backref = `<a class="footnote-backref" href="#" data-footnote-backref="${footnote.number}" aria-label="Back to reference ${footnote.number}">↩</a>`;
+      return `<li data-footnote-id="${footnote.number}">${body} ${backref}</li>`;
+    })
+    .join('');
+
+  return `<section class="footnotes" role="doc-endnotes" aria-label="Footnotes"><ol>${items}</ol></section>`;
+}
+
 /**
  * Apply facets (rich text formatting) to plaintext
  * Facets use byte ranges, so we need to handle UTF-8 encoding properly
+ *
+ * @param footnotes - Document footnote numbering; omitted inside footnote
+ *   bodies so nested footnotes degrade to plain text.
  */
-function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
+function applyFacets(
+  plaintext: string,
+  facets?: LeafletFacet[],
+  footnotes?: FootnoteIndex
+): string {
   if (!facets || facets.length === 0) {
     return escapeHtml(plaintext);
   }
@@ -85,7 +205,16 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
     // Build the wrapped text based on facet features
     let wrappedText = facetText;
 
-    for (const feature of facet.features) {
+    // A footnote replaces the marker outright, so the other features on that
+    // facet don't apply (a bold footnote number means nothing). A malformed
+    // feature — no footnoteId, or one the pre-pass never saw — falls through
+    // to the normal wrapping below.
+    const footnoteId = footnotes
+      ? facet.features?.find((f) => f.$type === FOOTNOTE_FEATURE && f.footnoteId)?.footnoteId
+      : undefined;
+    const footnote = footnoteId ? footnotes?.get(footnoteId) : undefined;
+
+    for (const feature of footnote ? [] : facet.features) {
       switch (feature.$type) {
         case 'pub.leaflet.richtext.facet#bold':
         case 'app.bsky.richtext.facet#bold':
@@ -127,6 +256,10 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
       }
     }
 
+    if (footnote) {
+      wrappedText = renderFootnoteRef(footnote.number);
+    }
+
     // Reconstruct the byte array with the HTML-wrapped text
     const wrappedBytes = encoder.encode(wrappedText);
     const newResult = new Uint8Array(beforeBytes.length + wrappedBytes.length + afterBytes.length);
@@ -142,11 +275,11 @@ function applyFacets(plaintext: string, facets?: LeafletFacet[]): string {
 /**
  * Render a text block
  */
-function renderTextBlock(block: LeafletTextBlock): string {
+function renderTextBlock(block: LeafletTextBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
 
   // Apply text size styling
   let sizeClass = '';
@@ -162,11 +295,11 @@ function renderTextBlock(block: LeafletTextBlock): string {
 /**
  * Render a header block
  */
-function renderHeaderBlock(block: LeafletHeaderBlock): string {
+function renderHeaderBlock(block: LeafletHeaderBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
   const level = block.level || 2; // Default to h2
   const tag = `h${Math.min(Math.max(level, 1), 6)}`;
   return `<${tag}>${content}</${tag}>`;
@@ -187,11 +320,11 @@ function renderCodeBlock(block: LeafletCodeBlock): string {
 /**
  * Render a blockquote block
  */
-function renderBlockquoteBlock(block: LeafletBlockquoteBlock): string {
+function renderBlockquoteBlock(block: LeafletBlockquoteBlock, footnotes?: FootnoteIndex): string {
   if (!block.plaintext) {
     return '';
   }
-  const content = applyFacets(block.plaintext, block.facets);
+  const content = applyFacets(block.plaintext, block.facets, footnotes);
   return `<blockquote>${content}</blockquote>`;
 }
 
@@ -209,7 +342,8 @@ function renderHorizontalRuleBlock(): string {
  */
 function renderListItems(
   children: LeafletListItemBlock[] | undefined,
-  listTag: 'ul' | 'ol' = 'ul'
+  listTag: 'ul' | 'ol' = 'ul',
+  footnotes?: FootnoteIndex
 ): string {
   if (!children || children.length === 0) {
     return '';
@@ -220,12 +354,12 @@ function renderListItems(
       // Extract plaintext and facets from the content block
       const plaintext = item.content?.plaintext || '';
       const facets = item.content?.facets;
-      const content = applyFacets(plaintext, facets);
+      const content = applyFacets(plaintext, facets, footnotes);
       let html = `<li>${content}`;
 
       // Handle nested lists (inherit parent list type)
       if (item.children && item.children.length > 0) {
-        html += `<${listTag}>${renderListItems(item.children, listTag)}</${listTag}>`;
+        html += `<${listTag}>${renderListItems(item.children, listTag, footnotes)}</${listTag}>`;
       }
 
       html += '</li>';
@@ -237,8 +371,11 @@ function renderListItems(
 /**
  * Render an unordered list block
  */
-function renderUnorderedListBlock(block: LeafletUnorderedListBlock): string {
-  const itemsHtml = renderListItems(block.children, 'ul');
+function renderUnorderedListBlock(
+  block: LeafletUnorderedListBlock,
+  footnotes?: FootnoteIndex
+): string {
+  const itemsHtml = renderListItems(block.children, 'ul', footnotes);
   if (!itemsHtml) {
     return '';
   }
@@ -248,8 +385,8 @@ function renderUnorderedListBlock(block: LeafletUnorderedListBlock): string {
 /**
  * Render an ordered list block
  */
-function renderOrderedListBlock(block: LeafletOrderedListBlock): string {
-  const itemsHtml = renderListItems(block.children, 'ol');
+function renderOrderedListBlock(block: LeafletOrderedListBlock, footnotes?: FootnoteIndex): string {
+  const itemsHtml = renderListItems(block.children, 'ol', footnotes);
   if (!itemsHtml) {
     return '';
   }
@@ -344,22 +481,22 @@ function renderPageBlock(block: LeafletPageBlock): string {
 /**
  * Render a single block based on its type
  */
-function renderBlock(block: LeafletBlock, authorDid: string): string {
+function renderBlock(block: LeafletBlock, authorDid: string, footnotes?: FootnoteIndex): string {
   switch (block.$type) {
     case 'pub.leaflet.blocks.text':
-      return renderTextBlock(block as LeafletTextBlock);
+      return renderTextBlock(block as LeafletTextBlock, footnotes);
     case 'pub.leaflet.blocks.header':
-      return renderHeaderBlock(block as LeafletHeaderBlock);
+      return renderHeaderBlock(block as LeafletHeaderBlock, footnotes);
     case 'pub.leaflet.blocks.code':
       return renderCodeBlock(block as LeafletCodeBlock);
     case 'pub.leaflet.blocks.blockquote':
-      return renderBlockquoteBlock(block as LeafletBlockquoteBlock);
+      return renderBlockquoteBlock(block as LeafletBlockquoteBlock, footnotes);
     case 'pub.leaflet.blocks.horizontalRule':
       return renderHorizontalRuleBlock();
     case 'pub.leaflet.blocks.unorderedList':
-      return renderUnorderedListBlock(block as LeafletUnorderedListBlock);
+      return renderUnorderedListBlock(block as LeafletUnorderedListBlock, footnotes);
     case 'pub.leaflet.blocks.orderedList':
-      return renderOrderedListBlock(block as LeafletOrderedListBlock);
+      return renderOrderedListBlock(block as LeafletOrderedListBlock, footnotes);
     case 'pub.leaflet.blocks.image':
       return renderImageBlock(block as LeafletImageBlock, authorDid);
     case 'pub.leaflet.blocks.website':
@@ -389,13 +526,16 @@ export function renderLeafletContent(content: LeafletContent, authorDid: string)
 
   const htmlParts: string[] = [];
 
+  // Numbered up front, in reading order, so markers and the list at the end agree.
+  const footnotes = buildFootnoteIndex(content);
+
   for (const page of content.pages) {
     if (page.$type !== 'pub.leaflet.pages.linearDocument' || !page.blocks) {
       continue;
     }
 
     for (const wrapper of page.blocks) {
-      const blockHtml = renderBlock(wrapper.block, authorDid);
+      const blockHtml = renderBlock(wrapper.block, authorDid, footnotes);
       if (blockHtml) {
         // Apply alignment if specified
         if (wrapper.alignment && wrapper.alignment !== 'left') {
@@ -407,6 +547,11 @@ export function renderLeafletContent(content: LeafletContent, authorDid: string)
         }
       }
     }
+  }
+
+  const footnotesHtml = renderFootnotesSection(footnotes);
+  if (footnotesHtml) {
+    htmlParts.push(footnotesHtml);
   }
 
   return htmlParts.join('\n');

--- a/frontend/src/routes/dev/cards/fixtures.ts
+++ b/frontend/src/routes/dev/cards/fixtures.ts
@@ -1,4 +1,5 @@
 import type { ArticleCardViewProps } from '$lib/components/articleCardView.types';
+import { renderLeafletContent } from '$lib/utils/leaflet-renderer';
 
 /**
  * Mock view-models for ArticleCardView — one per visual state. These are plain
@@ -40,6 +41,75 @@ const BODY_HTML_LONG =
       `shadow while this text scrolls beneath it, then settles flat once the ` +
       `card's end comes into view.</p>`
   ).join('\n');
+
+// A Leaflet document whose footnotes are facets over a `*` marker — the shape a
+// leaflet.pub post arrives in. Rendered here (not hand-written HTML) so the dev
+// page exercises the real renderer: numbered references, the list at the end,
+// and the click-to-jump wiring.
+const LEAFLET_FOOTNOTES_HTML = renderLeafletContent(
+  {
+    $type: 'pub.leaflet.content',
+    pages: [
+      {
+        $type: 'pub.leaflet.pages.linearDocument',
+        blocks: [
+          {
+            block: {
+              $type: 'pub.leaflet.blocks.text',
+              plaintext:
+                'Reading in public used to mean a blogroll and a feed reader.* The tools got quieter; the habit did not.',
+              facets: [
+                {
+                  index: { byteStart: 60, byteEnd: 61 },
+                  features: [
+                    {
+                      $type: 'pub.leaflet.richtext.facet#footnote',
+                      footnoteId: 'fn-blogroll',
+                      contentPlaintext:
+                        'Both are still around, and both are better than they were. See the archive.',
+                      contentFacets: [
+                        {
+                          index: { byteStart: 67, byteEnd: 74 },
+                          features: [
+                            {
+                              $type: 'pub.leaflet.richtext.facet#link',
+                              uri: 'https://example.com/archive',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            block: {
+              $type: 'pub.leaflet.blocks.text',
+              plaintext:
+                'What changed is where the record lives.* A reading life that outlives one app is worth the small friction of owning it.',
+              facets: [
+                {
+                  index: { byteStart: 39, byteEnd: 40 },
+                  features: [
+                    {
+                      $type: 'pub.leaflet.richtext.facet#footnote',
+                      footnoteId: 'fn-record',
+                      contentPlaintext:
+                        'Portability is the foundation here, not the pitch — it only matters because it keeps the reading.',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  'did:plc:example'
+);
 
 const base: ArticleCardViewProps = {
   itemUrl: 'https://arstechnica.com/example-article',
@@ -675,6 +745,24 @@ export const fixtures: CardFixture[] = [
           },
         ],
       },
+    },
+  },
+  {
+    name: 'Leaflet · footnotes',
+    note: 'A Leaflet post with footnote facets: each reference renders as a numbered superscript instead of a bare "*", and the bodies collect in a ruled list at the end. Tap a number to jump down, ↩ to come back.',
+    props: {
+      ...base,
+      itemTitle: 'Notes on reading in public',
+      displayFeedTitle: 'leaflet.pub',
+      feedTitle: 'A Quiet Publication',
+      isDocumentMode: true,
+      selected: true,
+      isOpen: true,
+      expanded: true,
+      hasContent: true,
+      readTimeMinutes: 2,
+      sanitizedContent: LEAFLET_FOOTNOTES_HTML,
+      hasOpenFullscreen: true,
     },
   },
   {


### PR DESCRIPTION
Renders Leaflet footnotes as numbered references with their bodies at the end of the document, and makes those references navigable on every surface that renders Leaflet content.

Supersedes #338 (and #337 before it): this branch carries both earlier commits plus a third addressing the latest review.

## The fix

Leaflet carries footnotes as a rich-text facet (`pub.leaflet.richtext.facet#footnote`) over a bare `*` in the block plaintext, with the body inside the facet. `leaflet-renderer.ts` had no case for it, so readers saw an unexplained `*` and the footnote text was dropped. A document-order pre-pass numbers the footnotes, each marker becomes `<sup class="footnote-ref">`, and the bodies render in one `<section class="footnotes">` at the end. Taps on a number jump to the entry (and back), scoped to the clicked content container so several Leaflet cards on one page can't collide.

## Latest review follow-up (third commit)

- **Short previews keep a live footnote tap.** Clamp suppression was keyed on `selected && !expanded`, which holds for *every* collapsed preview — including one whose body fits inside the 8-line clamp with its footnotes on screen. There the tap was prevented and `handleContentTap` deliberately does nothing for a non-truncated preview, so the number became a dead tap (and `expandAllItems` made every card that state). Both conditions now also require the measured `isTruncated`.
- **Curated editions are navigable in paged mode.** `SavedReader` renders `CollectionMagazine` from the same snippet it puts inside `PagedView`, so with paged reading on the action's paged branch found no controller and did nothing. `CollectionMagazine` now takes a `pagedController` getter and forwards it into `use:footnoteNav`.
- **Modifier clicks behave the same everywhere.** A cmd/middle-click on a marker followed the sanitizer-rewritten href into a new tab in the reader, and was silently dropped on a card. The helper now consumes those clicks itself; `useLinkInterception` runs the footnote check ahead of its modifier bail so real links keep their default behavior.
- Comment fix in `app.css` (the muting is on `color`, not `opacity`).

## Checks

In `frontend/`: `npm run test` — 257 passed, 17 files (2 new modifier-click cases); `svelte-check` — 0 errors, 25 pre-existing warnings, none in touched files; `prettier --check .` — clean; `npm run build` — succeeds.

## Not done

- **CI still doesn't run vitest.** The `test` job was written again and again rejected on push: this token has no `workflow` scope, so the commit was dropped. The renderer, sanitizer round-trip, and footnote-nav suites remain local-only guards. The job to add, after the `typecheck` job in `.github/workflows/frontend-ci.yml`:

  ```yaml
    test:
      name: Unit Tests
      runs-on: ubuntu-latest
      steps:
        - name: Checkout
          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

        - name: Setup Node.js
          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
          with:
            node-version: '20'
            cache: 'npm'
            cache-dependency-path: frontend/package-lock.json

        - name: Install dependencies
          run: npm ci

        - name: Run unit tests
          run: npm run test
  ```

- **No browser verification.** Paged mode, the clamped/short-preview split, and the modifier-click path are reasoned from the pagination and clamp code and covered by unit tests, but no app was run here.
- A footnote whose `contentPlaintext` is empty still renders as a bare `<li> ↩</li>`, left as-is so list numbering stays aligned with the reference numbers.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-izk7lqbqflnh447j3dfu3tre)
