### PR TITLE
Connect linkblogs to existing publications

### DIFF
--- a/backend/migrations/0060_linkblog_publication.sql
+++ b/backend/migrations/0060_linkblog_publication.sql
@@ -1,0 +1,4 @@
+-- Optional existing standard.site publication used for new linkblog posts.
+-- NULL means Skyreader's managed skyreader-links publication.
+ALTER TABLE user_settings ADD COLUMN linkblog_publication TEXT;
+ALTER TABLE user_settings ADD COLUMN linkblog_content_format TEXT;

--- a/backend/migrations/0061_subscription_previous_feed_url.sql
+++ b/backend/migrations/0061_subscription_previous_feed_url.sql
@@ -1,0 +1,4 @@
+-- Preserve the prior publication URI while a linkblog follower is being moved.
+-- Atmospheric reconciliation uses it to delete the old portable graph edge
+-- before confirming the replacement edge.
+ALTER TABLE subscriptions_cache ADD COLUMN atmosphere_previous_feed_url TEXT DEFAULT NULL;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,9 @@ import {
   handleUpdatePublication,
   handleDiscover,
   handleDiscoverFriends,
+  handleListPublications,
+  handleConnectPublication,
+  handleResolvePublication,
 } from './routes/linkblog';
 import { handleAtmosphereSubscription } from './routes/atmosphere';
 import {
@@ -288,6 +291,17 @@ export default {
           } else {
             response = await handleUpdatePublication(request, env);
           }
+          break;
+        case url.pathname === '/api/linkblog/publications':
+          if (!session) return unauthorizedResponse(headers);
+          response = await handleListPublications(request, env);
+          break;
+        case url.pathname === '/api/linkblog/publication/connect':
+          if (!session) return unauthorizedResponse(headers);
+          response = await handleConnectPublication(request, env);
+          break;
+        case url.pathname.startsWith('/api/linkblog/resolve/'):
+          response = await handleResolvePublication(request, env);
           break;
 
         // Subscribe via the Atmosphere — writes the portable

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -251,6 +251,47 @@ export async function handleUpdatePublication(request: Request, env: Env): Promi
 
 const FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
 
+export async function migrateLinkblogFollowers(
+  env: Env,
+  subjectDid: string,
+  previousSiteUri: string,
+  nextSiteUri: string
+): Promise<void> {
+  if (previousSiteUri === nextSiteUri) return;
+
+  // A follower may already subscribe to the destination publication. Keep that
+  // row and use it to reconcile the old graph edge, then remove the redundant
+  // source row. Otherwise move the source row in place.
+  await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE subscriptions_cache AS destination
+       SET atmosphere_previous_feed_url = ?, atmosphere_synced = NULL
+       WHERE source_type = 'atproto.documents' AND subject_did = ? AND feed_url = ?
+         AND EXISTS (
+           SELECT 1 FROM subscriptions_cache AS source
+           WHERE source.user_did = destination.user_did
+             AND source.source_type = 'atproto.documents'
+             AND source.subject_did = ? AND source.feed_url = ?
+         )`
+    ).bind(previousSiteUri, subjectDid, nextSiteUri, subjectDid, previousSiteUri),
+    env.DB.prepare(
+      `DELETE FROM subscriptions_cache AS source
+       WHERE source_type = 'atproto.documents' AND subject_did = ? AND feed_url = ?
+         AND EXISTS (
+           SELECT 1 FROM subscriptions_cache AS destination
+           WHERE destination.user_did = source.user_did
+             AND destination.source_type = 'atproto.documents'
+             AND destination.subject_did = ? AND destination.feed_url = ?
+         )`
+    ).bind(subjectDid, previousSiteUri, subjectDid, nextSiteUri),
+    env.DB.prepare(
+      `UPDATE subscriptions_cache
+       SET feed_url = ?, atmosphere_previous_feed_url = ?, atmosphere_synced = NULL
+       WHERE source_type = 'atproto.documents' AND subject_did = ? AND feed_url = ?`
+    ).bind(nextSiteUri, previousSiteUri, subjectDid, previousSiteUri),
+  ]);
+}
+
 export async function handleListPublications(request: Request, env: Env): Promise<Response> {
   if (request.method !== 'GET') return json({ error: 'Method not allowed' }, 405);
   const session = await getSessionFromRequest(request, env);
@@ -276,11 +317,14 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
   if (!session) return json({ error: 'Unauthorized' }, 401);
   const now = Math.floor(Date.now() / 1000);
   if (request.method === 'DELETE') {
+    const previousTarget = await getLinkblogTarget(env, session.did);
+    const nextSiteUri = publicationUri(session.did);
     await env.DB.prepare(
       'UPDATE user_settings SET linkblog_publication = NULL, linkblog_content_format = NULL, updated_at = ? WHERE user_did = ?'
     )
       .bind(now, session.did)
       .run();
+    await migrateLinkblogFollowers(env, session.did, previousTarget.siteUri, nextSiteUri);
     return json(await getPublicationMeta(session, env));
   }
   if (request.method !== 'PUT') return json({ error: 'Method not allowed' }, 405);
@@ -295,24 +339,21 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
   );
   if (!match || match[1] !== session.did)
     return json({ error: 'Choose a publication from your own Atmosphere account' }, 400);
+  const selectedPublicationUri = body.publicationUri!;
   if (body.format && !FORMATS.has(body.format))
     return json({ error: 'Unsupported content format' }, 400);
   const exists = await createPDSClient(session).getRecord('site.standard.publication', match[2]);
   if (!exists.success) return json({ error: 'Publication not found' }, 404);
   const format = body.format || 'leaflet';
+  const previousTarget = await getLinkblogTarget(env, session.did);
   await env.DB.prepare(
     `INSERT INTO user_settings (user_did, linkblog_publication, linkblog_content_format, created_at, updated_at)
     VALUES (?, ?, ?, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_publication=excluded.linkblog_publication,
     linkblog_content_format=excluded.linkblog_content_format, updated_at=excluded.updated_at`
   )
-    .bind(session.did, body.publicationUri, format, now, now)
+    .bind(session.did, selectedPublicationUri, format, now, now)
     .run();
-  await env.DB.prepare(
-    `UPDATE subscriptions_cache SET feed_url = ?, atmosphere_synced = NULL, updated_at = ?
-    WHERE source_type = 'atproto.documents' AND subject_did = ? AND feed_url = ?`
-  )
-    .bind(body.publicationUri, now * 1000, session.did, publicationUri(session.did))
-    .run();
+  await migrateLinkblogFollowers(env, session.did, previousTarget.siteUri, selectedPublicationUri);
   return json(await getPublicationMeta(session, env));
 }
 

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -10,12 +10,15 @@ import { isValidRkey, invalidRkeyResponse } from '../utils/validation';
 import {
   deleteLinkblogShare,
   getPublicationMeta,
+  getLinkblogTarget,
   publicationUri,
   updateLinkblogShareNote,
   updatePublication,
   writeLinkblogShare,
   type LinkblogShareInput,
+  type ContentFormat,
 } from '../services/linkblog-sync';
+import { createPDSClient } from '../services/pds-client';
 import { getLinkblogDiscover, getLinkblogFriends } from '../services/linkblog-discovery';
 
 function json(body: unknown, status = 200): Response {
@@ -106,7 +109,7 @@ export async function handleCreateLinkblogShare(request: Request, env: Env): Pro
     uri: result.data.uri,
     cid: result.data.cid,
     rkey,
-    publication: publicationUri(session.did),
+    publication: (await getLinkblogTarget(env, session.did)).siteUri,
   });
 }
 
@@ -215,6 +218,9 @@ export async function handleUpdatePublication(request: Request, env: Env): Promi
   if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
     return insufficientScopesResponse();
   }
+  if ((await getLinkblogTarget(env, session.did)).external) {
+    return json({ error: 'This publication is managed by its home app' }, 409);
+  }
 
   let body: { name?: string; description?: string };
   try {
@@ -241,4 +247,84 @@ export async function handleUpdatePublication(request: Request, env: Env): Promi
 
   const meta = await getPublicationMeta(session, env);
   return json(meta);
+}
+
+const FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
+
+export async function handleListPublications(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'GET') return json({ error: 'Method not allowed' }, 405);
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return json({ error: 'Unauthorized' }, 401);
+  const result = await createPDSClient(session).listAllRecords<{ name?: string; url?: string }>(
+    'site.standard.publication',
+    { maxPages: 5, maxRecords: 200 }
+  );
+  if (!result.success) return json({ error: result.error }, 502);
+  return json({
+    publications: result.data.map((record) => ({
+      uri: record.uri,
+      rkey: record.uri.split('/').pop(),
+      name: record.value.name || 'Untitled publication',
+      url: record.value.url,
+      isDefault: record.uri === publicationUri(session.did),
+    })),
+  });
+}
+
+export async function handleConnectPublication(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return json({ error: 'Unauthorized' }, 401);
+  const now = Math.floor(Date.now() / 1000);
+  if (request.method === 'DELETE') {
+    await env.DB.prepare(
+      'UPDATE user_settings SET linkblog_publication = NULL, linkblog_content_format = NULL, updated_at = ? WHERE user_did = ?'
+    )
+      .bind(now, session.did)
+      .run();
+    return json(await getPublicationMeta(session, env));
+  }
+  if (request.method !== 'PUT') return json({ error: 'Method not allowed' }, 405);
+  let body: { publicationUri?: string; format?: ContentFormat };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+  const match = body.publicationUri?.match(
+    /^at:\/\/([^/]+)\/site\.standard\.publication\/([^/]+)$/
+  );
+  if (!match || match[1] !== session.did)
+    return json({ error: 'Choose a publication from your own Atmosphere account' }, 400);
+  if (body.format && !FORMATS.has(body.format))
+    return json({ error: 'Unsupported content format' }, 400);
+  const exists = await createPDSClient(session).getRecord('site.standard.publication', match[2]);
+  if (!exists.success) return json({ error: 'Publication not found' }, 404);
+  const format = body.format || 'leaflet';
+  await env.DB.prepare(
+    `INSERT INTO user_settings (user_did, linkblog_publication, linkblog_content_format, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_publication=excluded.linkblog_publication,
+    linkblog_content_format=excluded.linkblog_content_format, updated_at=excluded.updated_at`
+  )
+    .bind(session.did, body.publicationUri, format, now, now)
+    .run();
+  await env.DB.prepare(
+    `UPDATE subscriptions_cache SET feed_url = ?, atmosphere_synced = NULL, updated_at = ?
+    WHERE source_type = 'atproto.documents' AND subject_did = ? AND feed_url = ?`
+  )
+    .bind(body.publicationUri, now * 1000, session.did, publicationUri(session.did))
+    .run();
+  return json(await getPublicationMeta(session, env));
+}
+
+export async function handleResolvePublication(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'GET') return json({ error: 'Method not allowed' }, 405);
+  const did = decodeURIComponent(new URL(request.url).pathname.split('/').pop() || '');
+  if (!did.startsWith('did:')) return json({ error: 'Invalid DID' }, 400);
+  const target = await getLinkblogTarget(env, did);
+  return new Response(
+    JSON.stringify({ siteUri: target.siteUri, defaultSiteUri: publicationUri(did) }),
+    {
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=60' },
+    }
+  );
 }

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -33,6 +33,7 @@ import { resolvePdsUrl } from '../utils/did-resolver';
 import { generateTid } from '../utils/tid';
 import {
   SUBSCRIPTION_COLLECTION,
+  deleteAtmosphereSubscription,
   isPublicationUri,
   writeAtmosphereSubscription,
 } from './atmosphere-subscription';
@@ -75,6 +76,7 @@ interface LocalDocSub {
   record_uri: string;
   feed_url: string;
   atmosphere_synced: number | null;
+  atmosphere_previous_feed_url: string | null;
 }
 
 interface PublicationMeta {
@@ -184,7 +186,7 @@ export async function reconcileAtmosphereSubscriptions(
 
     // Step 2: local atproto.documents subs, keyed by publication URI (feedUrl).
     const localResult = await env.DB.prepare(
-      `SELECT record_uri, feed_url, atmosphere_synced
+      `SELECT record_uri, feed_url, atmosphere_synced, atmosphere_previous_feed_url
          FROM subscriptions_cache
         WHERE user_did = ? AND source_type = 'atproto.documents'`
     )
@@ -192,8 +194,12 @@ export async function reconcileAtmosphereSubscriptions(
       .all<LocalDocSub>();
     const localSubs = localResult.results || [];
     const localByPub = new Map<string, LocalDocSub>();
+    const supersededGraphPubs = new Set<string>();
     for (const sub of localSubs) {
       if (isPublicationUri(sub.feed_url)) localByPub.set(sub.feed_url, sub);
+      if (isPublicationUri(sub.atmosphere_previous_feed_url)) {
+        supersededGraphPubs.add(sub.atmosphere_previous_feed_url);
+      }
     }
 
     // Tier-aware headroom for imports — counts ACTIVE subs only, since the limit
@@ -225,6 +231,10 @@ export async function reconcileAtmosphereSubscriptions(
     let droppedOverCap = 0;
     for (const pubUri of graphPubs) {
       if (localByPub.has(pubUri)) continue;
+      // A publication switch deliberately superseded this edge. Its destination
+      // row below owns deleting it; importing it here would resurrect the old
+      // follower scope and prevent the migration from converging.
+      if (supersededGraphPubs.has(pubUri)) continue;
       if (ops >= MAX_OPS) {
         result.hasMore = true;
         break;
@@ -323,6 +333,51 @@ export async function reconcileAtmosphereSubscriptions(
 
     // Step 4: reconcile each local pub-sub against the graph.
     for (const [pubUri, sub] of localByPub) {
+      if (sub.atmosphere_previous_feed_url) {
+        const previousPubUri = sub.atmosphere_previous_feed_url;
+        if (graphPubs.has(previousPubUri)) {
+          if (ops >= MAX_OPS) {
+            result.hasMore = true;
+            break;
+          }
+          const removeOld = await deleteAtmosphereSubscription(session, previousPubUri);
+          if (!removeOld.success) {
+            result.warnings.push(
+              `Failed to replace old publication follow ${previousPubUri}: ${removeOld.error}`
+            );
+            continue;
+          }
+          graphPubs.delete(previousPubUri);
+          ops++;
+        }
+
+        if (!graphPubs.has(pubUri)) {
+          if (ops >= MAX_OPS) {
+            result.hasMore = true;
+            break;
+          }
+          const writeNew = await writeAtmosphereSubscription(session, pubUri);
+          if (!writeNew.success) {
+            result.warnings.push(
+              `Failed to push replacement edge for ${pubUri}: ${writeNew.error}`
+            );
+            continue;
+          }
+          graphPubs.add(pubUri);
+          result.pushed++;
+          ops++;
+        }
+
+        await env.DB.prepare(
+          `UPDATE subscriptions_cache
+           SET atmosphere_synced = unixepoch(), atmosphere_previous_feed_url = NULL
+           WHERE record_uri = ?`
+        )
+          .bind(sub.record_uri)
+          .run();
+        continue;
+      }
+
       if (graphPubs.has(pubUri)) {
         // Present both places — claim it if not yet marked (e.g. an in-app follow).
         if (sub.atmosphere_synced === null) {

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -78,6 +78,46 @@ export const LINKBLOG_RKEY = 'skyreader-links';
 // See LINKBLOG_PLAN.md Phase 6.
 export const LINKBLOG_MARKER_URL = 'https://skyreader.app/linkblog';
 
+export type ContentFormat = 'leaflet' | 'pckt' | 'offprint' | 'markpub';
+export interface LinkblogTarget {
+  siteUri: string;
+  format: ContentFormat;
+  external: boolean;
+}
+
+const CONTENT_FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
+
+export async function getLinkblogTarget(env: Env, did: string): Promise<LinkblogTarget> {
+  const fallback: LinkblogTarget = {
+    siteUri: publicationUri(did),
+    format: 'leaflet',
+    external: false,
+  };
+  try {
+    const row = await env.DB.prepare(
+      'SELECT linkblog_publication, linkblog_content_format FROM user_settings WHERE user_did = ?'
+    )
+      .bind(did)
+      .first<{ linkblog_publication: string | null; linkblog_content_format: string | null }>();
+    if (!row?.linkblog_publication) return fallback;
+    const match = row.linkblog_publication.match(
+      /^at:\/\/([^/]+)\/site\.standard\.publication\/([^/]+)$/
+    );
+    if (!match || match[1] !== did) return fallback;
+    const format = CONTENT_FORMATS.has(row.linkblog_content_format as ContentFormat)
+      ? (row.linkblog_content_format as ContentFormat)
+      : 'leaflet';
+    return {
+      siteUri: row.linkblog_publication,
+      format,
+      external: row.linkblog_publication !== fallback.siteUri,
+    };
+  } catch {
+    // Deploys remain usable while a migration is rolling out.
+    return fallback;
+  }
+}
+
 // Generous excerpt cap — the excerpt is the only durable copy if the source
 // link-rots or paywalls, so keep it roomy, but bound it so a record can't bloat.
 const MAX_EXCERPT_CHARS = 1500;
@@ -134,6 +174,8 @@ export interface PublicationMeta {
   description?: string;
   iconUrl?: string;
   exists: boolean;
+  external: boolean;
+  format: ContentFormat;
 }
 
 function iconUrlFromBlob(did: string, icon: BlobRef | undefined): string | undefined {
@@ -144,11 +186,10 @@ function iconUrlFromBlob(did: string, icon: BlobRef | undefined): string | undef
 // Read the current linkblog publication, or synthesize sensible defaults when it
 // doesn't exist yet (so the settings UI can render before the first share).
 export async function getPublicationMeta(session: Session, env: Env): Promise<PublicationMeta> {
+  const target = await getLinkblogTarget(env, session.did);
   const pdsClient = createPDSClient(session);
-  const result = await pdsClient.getRecord<PublicationRecord>(
-    PUBLICATION_COLLECTION,
-    LINKBLOG_RKEY
-  );
+  const rkey = target.siteUri.split('/').pop() || LINKBLOG_RKEY;
+  const result = await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, rkey);
 
   const url = linkblogBaseUrl(env, session.did);
   if (!result.success) {
@@ -157,21 +198,25 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
       url,
       name: defaultPublicationName(session),
       exists: false,
+      external: target.external,
+      format: target.format,
     };
   }
 
   const value = result.data.value;
   return {
-    uri: publicationUri(session.did),
+    uri: target.siteUri,
     // Report the current canonical public URL, not the record's stored `value.url`
     // — older records still point at the previous origin (skyreader.app/blogs/…)
     // until lazy-backfilled, and the UI should always show where the linkblog
     // actually lives now (the stored field self-corrects on the user's next share).
-    url,
+    url: target.external ? value.url : url,
     name: value.name || defaultPublicationName(session),
     description: value.description,
     iconUrl: iconUrlFromBlob(session.did, value.icon),
     exists: true,
+    external: target.external,
+    format: target.format,
   };
 }
 
@@ -423,7 +468,9 @@ export function buildLinkblogDocument(
   did: string,
   rkey: string,
   input: LinkblogShareInput,
-  resolvedHandles?: Map<string, string>
+  resolvedHandles?: Map<string, string>,
+  siteUri = publicationUri(did),
+  format: ContentFormat = 'leaflet'
 ): DocumentRecord {
   const now = new Date().toISOString();
   const excerpt = input.excerpt ? truncate(input.excerpt, MAX_EXCERPT_CHARS) : '';
@@ -435,7 +482,7 @@ export function buildLinkblogDocument(
 
   return {
     $type: DOCUMENT_COLLECTION,
-    site: publicationUri(did),
+    site: siteUri,
     title: input.articleTitle?.trim() || input.articleUrl,
     path: `/${rkey}`,
     publishedAt: input.articlePublishedAt || now,
@@ -450,8 +497,53 @@ export function buildLinkblogDocument(
     textContent,
     tags: input.tags && input.tags.length > 0 ? input.tags : undefined,
     links,
-    content: buildLeafletContent(input, excerpt, resolvedHandles),
+    content: buildContent(format, input, excerpt, resolvedHandles),
   };
+}
+
+function buildContent(
+  format: ContentFormat,
+  input: LinkblogShareInput,
+  excerpt: string,
+  handles?: Map<string, string>
+): unknown {
+  if (format === 'leaflet') return buildLeafletContent(input, excerpt, handles);
+  if (format === 'markpub') {
+    const title = (input.articleTitle || input.articleUrl).replace(/([\\[\]()])/g, '\\$1');
+    return {
+      $type: 'at.markpub.markdown',
+      text: {
+        markdown: [input.note?.trim(), `[${title}](${input.articleUrl})`]
+          .filter(Boolean)
+          .join('\n\n'),
+      },
+    };
+  }
+  const prefix = format === 'pckt' ? 'blog.pckt.block.' : 'app.offprint.block.';
+  const items: Array<Record<string, unknown>> = (
+    input.note?.trim() ? input.note.trim().split(/\n\s*\n/) : []
+  ).map((paragraph) => {
+    const quoted = paragraph.startsWith('>');
+    const plaintext = paragraph.replace(/^> ?/gm, '');
+    if (!quoted) return { $type: `${prefix}text`, plaintext };
+    const text = { $type: `${prefix}text`, plaintext };
+    return { $type: `${prefix}blockquote`, content: [text] };
+  });
+  if (format === 'pckt')
+    items.push({
+      $type: 'blog.pckt.block.website',
+      attrs: {
+        src: input.articleUrl,
+        title: input.articleTitle,
+        description: excerpt || undefined,
+      },
+    });
+  else
+    items.push({
+      $type: 'app.offprint.block.text',
+      plaintext: `${input.articleTitle || input.articleUrl} — ${input.articleUrl}`,
+    });
+  return { $type: format === 'pckt' ? 'blog.pckt.content' : 'app.offprint.content', items };
 }
 
 // Ensure the publication exists, then write the share document. The rkey is
@@ -462,11 +554,21 @@ export async function writeLinkblogShare(
   rkey: string,
   input: LinkblogShareInput
 ): Promise<PDSResult<PutRecordResponse>> {
-  const ensured = await ensureLinkblogPublication(session, env);
-  if (!ensured.success) return ensured;
+  const target = await getLinkblogTarget(env, session.did);
+  if (!target.external) {
+    const ensured = await ensureLinkblogPublication(session, env);
+    if (!ensured.success) return ensured;
+  }
 
   const resolvedHandles = await resolveNoteMentionHandles(input.note);
-  const record = buildLinkblogDocument(session.did, rkey, input, resolvedHandles);
+  const record = buildLinkblogDocument(
+    session.did,
+    rkey,
+    input,
+    resolvedHandles,
+    target.siteUri,
+    target.format
+  );
   return createPDSClient(session).putRecord(DOCUMENT_COLLECTION, rkey, record);
 }
 
@@ -491,6 +593,14 @@ export async function updateLinkblogShareNote(
   if (!existing.success) return existing;
 
   const rec = existing.data.value;
+  const contentType = (rec.content as { $type?: string } | undefined)?.$type;
+  if (contentType !== 'pub.leaflet.content') {
+    return {
+      success: false,
+      error: `Editing ${contentType || 'unknown'} linkblog content is not supported yet`,
+      retryable: false,
+    };
+  }
   // Reconstruct the article link-card inputs from the stored record so the
   // rebuilt content keeps the same external link, title, and excerpt. The excerpt
   // comes from the website card (its durable home); `rec.description` is the

--- a/backend/test/linkblog-follower-migration.spec.ts
+++ b/backend/test/linkblog-follower-migration.spec.ts
@@ -1,0 +1,86 @@
+import { env } from 'cloudflare:test';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { migrateLinkblogFollowers } from '../src/routes/linkblog';
+
+const AUTHOR_DID = 'did:plc:linkblog-author';
+const FOLLOWER_DID = 'did:plc:linkblog-follower';
+const DEFAULT_URI = `at://${AUTHOR_DID}/site.standard.publication/skyreader-links`;
+const EXTERNAL_A = `at://${AUTHOR_DID}/site.standard.publication/external-a`;
+const EXTERNAL_B = `at://${AUTHOR_DID}/site.standard.publication/external-b`;
+
+async function insertSubscription(rkey: string, feedUrl: string) {
+  await env.DB.prepare(
+    `INSERT INTO subscriptions_cache
+       (user_did, record_uri, feed_url, title, created_at, source_type, subject_did,
+        atmosphere_synced)
+     VALUES (?, ?, ?, 'Linkblog', unixepoch(), 'atproto.documents', ?, unixepoch())`
+  )
+    .bind(
+      FOLLOWER_DID,
+      `at://${FOLLOWER_DID}/app.skyreader.feed.subscription/${rkey}`,
+      feedUrl,
+      AUTHOR_DID
+    )
+    .run();
+}
+
+async function subscriptions() {
+  const result = await env.DB.prepare(
+    `SELECT feed_url, atmosphere_synced, atmosphere_previous_feed_url
+     FROM subscriptions_cache WHERE user_did = ? ORDER BY feed_url`
+  )
+    .bind(FOLLOWER_DID)
+    .all<{
+      feed_url: string;
+      atmosphere_synced: number | null;
+      atmosphere_previous_feed_url: string | null;
+    }>();
+  return result.results;
+}
+
+describe('linkblog follower target migration', () => {
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM subscriptions_cache WHERE user_did = ?')
+      .bind(FOLLOWER_DID)
+      .run();
+    await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(FOLLOWER_DID).run();
+    await env.DB.prepare(
+      `INSERT INTO users (did, handle, pds_url, created_at) VALUES (?, ?, ?, unixepoch())`
+    )
+      .bind(FOLLOWER_DID, 'follower.test', 'https://test.pds.example')
+      .run();
+  });
+
+  it.each([
+    ['default to external', DEFAULT_URI, EXTERNAL_A],
+    ['external to external', EXTERNAL_A, EXTERNAL_B],
+    ['external to default', EXTERNAL_A, DEFAULT_URI],
+  ])('migrates %s from the actual previous target', async (_label, previous, next) => {
+    await insertSubscription('source', previous);
+
+    await migrateLinkblogFollowers(env, AUTHOR_DID, previous, next);
+
+    expect(await subscriptions()).toEqual([
+      {
+        feed_url: next,
+        atmosphere_synced: null,
+        atmosphere_previous_feed_url: previous,
+      },
+    ]);
+  });
+
+  it('keeps an existing destination row and removes the duplicate source row', async () => {
+    await insertSubscription('source', EXTERNAL_A);
+    await insertSubscription('destination', EXTERNAL_B);
+
+    await migrateLinkblogFollowers(env, AUTHOR_DID, EXTERNAL_A, EXTERNAL_B);
+
+    expect(await subscriptions()).toEqual([
+      {
+        feed_url: EXTERNAL_B,
+        atmosphere_synced: null,
+        atmosphere_previous_feed_url: EXTERNAL_A,
+      },
+    ]);
+  });
+});

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -79,6 +79,33 @@ describe('buildLinkblogDocument', () => {
   });
 });
 
+describe('connected publication formats', () => {
+  const target = `at://${DID}/site.standard.publication/existing`;
+  const input = { articleUrl: 'https://example.com/post', articleTitle: 'Post', note: 'A note' };
+
+  it.each([
+    ['pckt', 'blog.pckt.content'],
+    ['offprint', 'app.offprint.content'],
+    ['markpub', 'at.markpub.markdown'],
+  ] as const)('writes %s content while preserving the selected site URI', (format, type) => {
+    const doc = buildLinkblogDocument(DID, RKEY, input, undefined, target, format);
+    expect(doc.site).toBe(target);
+    expect(doc.content).toMatchObject({ $type: type });
+    expect(doc.links).toEqual([{ uri: input.articleUrl, rel: 'related' }]);
+  });
+
+  it('uses the observed pckt website attrs and markpub text wrapper shapes', () => {
+    const pckt = buildLinkblogDocument(DID, RKEY, input, undefined, target, 'pckt').content as {
+      items: Array<{ $type: string; attrs?: { src?: string } }>;
+    };
+    expect(pckt.items.at(-1)?.attrs?.src).toBe(input.articleUrl);
+    const markpub = buildLinkblogDocument(DID, RKEY, input, undefined, target, 'markpub').content;
+    expect(markpub).toMatchObject({
+      text: { markdown: expect.stringContaining(input.articleUrl) },
+    });
+  });
+});
+
 describe('noteToLeafletBlocks', () => {
   it('converts mixed commentary and multiline quotes into ordered native blocks', () => {
     const blocks = noteToLeafletBlocks('Before\n\n> first\n> second\n>\n> fourth\n\nAfter');

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -597,6 +597,26 @@ class ApiClient {
     });
   }
 
+  async listLinkblogPublications(): Promise<{
+    publications: import('$lib/types').LinkblogPublicationChoice[];
+  }> {
+    return this.fetch('/api/linkblog/publications');
+  }
+
+  async connectLinkblogPublication(
+    publicationUri: string,
+    format: LinkblogPublication['format']
+  ): Promise<LinkblogPublication> {
+    return this.fetch('/api/linkblog/publication/connect', {
+      method: 'PUT',
+      body: JSON.stringify({ publicationUri, format }),
+    });
+  }
+
+  async disconnectLinkblogPublication(): Promise<LinkblogPublication> {
+    return this.fetch('/api/linkblog/publication/connect', { method: 'DELETE' });
+  }
+
   // Subscribe via the Atmosphere — writes/reads/deletes only the portable
   // site.standard.graph.subscription record (no Skyreader subscription).
   async getAtmosphereSubscription(publication: string): Promise<{ subscribed: boolean }> {

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -777,6 +777,16 @@ export interface LinkblogPublication {
   description?: string;
   iconUrl?: string;
   exists: boolean;
+  external: boolean;
+  format: 'leaflet' | 'pckt' | 'offprint' | 'markpub';
+}
+
+export interface LinkblogPublicationChoice {
+  uri: string;
+  rkey: string;
+  name: string;
+  url?: string;
+  isDefault: boolean;
 }
 
 export interface ParsedFeed {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -19,7 +19,7 @@
   import { api, RateLimitError } from '$lib/services/api';
   import { syncStore } from '$lib/stores/sync.svelte';
   import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
-  import type { LinkblogPublication, SaveBacking } from '$lib/types';
+  import type { LinkblogPublication, LinkblogPublicationChoice, SaveBacking } from '$lib/types';
 
   $effect(() => {
     viewTitleStore.set('Settings');
@@ -101,6 +101,9 @@
   let isSavingLinkblog = $state(false);
   let linkblogError = $state<string | null>(null);
   let linkblogSuccess = $state<string | null>(null);
+  let linkblogChoices = $state<LinkblogPublicationChoice[]>([]);
+  let selectedLinkblogUri = $state('');
+  let selectedLinkblogFormat = $state<LinkblogPublication['format']>('leaflet');
 
   onMount(async () => {
     if (!auth.isAuthenticated) {
@@ -121,14 +124,40 @@
     if (!syncStore.isOnline) return;
     isLinkblogLoading = true;
     try {
-      const pub = await api.getLinkblogPublication();
+      const [pub, choices] = await Promise.all([
+        api.getLinkblogPublication(),
+        api.listLinkblogPublications(),
+      ]);
       linkblogPub = pub;
+      linkblogChoices = choices.publications;
+      selectedLinkblogUri = pub.uri;
+      selectedLinkblogFormat = pub.format;
       linkblogName = pub.name;
       linkblogDescription = pub.description ?? '';
     } catch (error) {
       console.error('Failed to load linkblog publication:', error);
     } finally {
       isLinkblogLoading = false;
+    }
+  }
+
+  async function handleConnectLinkblog() {
+    if (!selectedLinkblogUri) return;
+    isSavingLinkblog = true;
+    linkblogError = null;
+    try {
+      const choice = linkblogChoices.find((p) => p.uri === selectedLinkblogUri);
+      const pub = choice?.isDefault
+        ? await api.disconnectLinkblogPublication()
+        : await api.connectLinkblogPublication(selectedLinkblogUri, selectedLinkblogFormat);
+      linkblogPub = pub;
+      linkblogName = pub.name;
+      linkblogDescription = pub.description ?? '';
+      linkblogSuccess = 'Publication connected.';
+    } catch (error) {
+      linkblogError = error instanceof Error ? error.message : 'Failed to connect publication.';
+    } finally {
+      isSavingLinkblog = false;
     }
   }
 
@@ -543,12 +572,42 @@
           >
         </p>
       {/if}
+      {#if linkblogChoices.length > 0}
+        <div class="linkblog-field">
+          <label for="linkblog-publication">Publish new links to</label>
+          <select id="linkblog-publication" bind:value={selectedLinkblogUri}>
+            {#each linkblogChoices as publication}
+              <option value={publication.uri}
+                >{publication.name}{publication.isDefault ? ' (Skyreader)' : ''}</option
+              >
+            {/each}
+          </select>
+        </div>
+        <div class="linkblog-field">
+          <label for="linkblog-format">Content format</label>
+          <select id="linkblog-format" bind:value={selectedLinkblogFormat}>
+            <option value="leaflet">Leaflet</option><option value="pckt">pckt</option>
+            <option value="offprint">Offprint</option><option value="markpub">Markdown</option>
+          </select>
+        </div>
+        <button
+          class="btn btn-secondary"
+          onclick={handleConnectLinkblog}
+          disabled={isSavingLinkblog}>Connect publication</button
+        >
+        <p class="setting-description">
+          New links are public and portable across the Atmosphere. Existing posts stay where they
+          are. Connected publications remain managed by their home app; Skyreader discovery works
+          best with the Skyreader linkblog.
+        </p>
+      {/if}
       <div class="linkblog-field">
         <label for="linkblog-name">Name</label>
         <input
           id="linkblog-name"
           type="text"
           bind:value={linkblogName}
+          disabled={linkblogPub?.external}
           maxlength="120"
           placeholder="My links"
         />
@@ -558,12 +617,17 @@
         <textarea
           id="linkblog-description"
           bind:value={linkblogDescription}
+          disabled={linkblogPub?.external}
           rows="2"
           maxlength="500"
           placeholder="Optional"
         ></textarea>
       </div>
-      <button class="btn btn-secondary" onclick={handleSaveLinkblog} disabled={isSavingLinkblog}>
+      <button
+        class="btn btn-secondary"
+        onclick={handleSaveLinkblog}
+        disabled={isSavingLinkblog || linkblogPub?.external}
+      >
         {#if isSavingLinkblog}Saving…{:else}Save{/if}
       </button>
       {#if linkblogError}

--- a/linkblog-site/src/lib/server/proxy.ts
+++ b/linkblog-site/src/lib/server/proxy.ts
@@ -10,6 +10,21 @@ export interface ProxyConfig {
   feedProxySecret?: string;
 }
 
+export async function resolveLinkblogTarget(
+  apiBase: string,
+  did: string
+): Promise<{ siteUri: string; defaultSiteUri: string }> {
+  const fallback = publicationUri(did);
+  if (!apiBase) return { siteUri: fallback, defaultSiteUri: fallback };
+  try {
+    const res = await fetch(`${apiBase}/api/linkblog/resolve/${encodeURIComponent(did)}`);
+    if (!res.ok) throw new Error();
+    return (await res.json()) as { siteUri: string; defaultSiteUri: string };
+  } catch {
+    return { siteUri: fallback, defaultSiteUri: fallback };
+  }
+}
+
 function proxyHeaders(cfg: ProxyConfig): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (cfg.feedProxySecret) headers['X-Proxy-Secret'] = cfg.feedProxySecret;
@@ -20,14 +35,15 @@ function proxyHeaders(cfg: ProxyConfig): Record<string, string> {
 // dedicated skyreader-links publication. Returns newest-shared-first.
 export async function fetchLinkblogDocuments(
   cfg: ProxyConfig,
-  did: string
+  did: string,
+  siteUris: string[] = [publicationUri(did)]
 ): Promise<ProxyDocument[]> {
   try {
     const res = await fetch(`${cfg.feedProxyUrl}/documents`, {
       method: 'POST',
       headers: proxyHeaders(cfg),
       body: JSON.stringify({
-        authors: [{ did, siteUri: publicationUri(did) }],
+        authors: [...new Set(siteUris)].map((siteUri) => ({ did, siteUri })),
       }),
     });
     if (!res.ok) return [];
@@ -35,7 +51,11 @@ export async function fetchLinkblogDocuments(
     const data = (await res.json()) as {
       authors?: Array<{ documents?: ProxyDocument[]; status?: string }>;
     };
-    const docs = data.authors?.[0]?.documents ?? [];
+    const docs = [
+      ...new Map(
+        (data.authors ?? []).flatMap((a) => a.documents ?? []).map((d) => [d.recordUri, d])
+      ).values(),
+    ];
     // A linkblog reads newest-shared-first. Order by when each link was shared
     // (the record's `createdAt`), not by the article's own publish date — the
     // proxy sorts its generic document feed by `publishedAt`, which would float

--- a/linkblog-site/src/routes/[id]/+page.server.ts
+++ b/linkblog-site/src/routes/[id]/+page.server.ts
@@ -7,7 +7,12 @@ import { error, redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { apiBaseFor, appUrlFor, blogUrlFor, isDid } from '$lib/fields';
 import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/server/identity';
-import { fetchLinkblogDocuments, fetchSocialContext, type ProxyConfig } from '$lib/server/proxy';
+import {
+  fetchLinkblogDocuments,
+  fetchSocialContext,
+  resolveLinkblogTarget,
+  type ProxyConfig,
+} from '$lib/server/proxy';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, url }) => {
@@ -27,10 +32,12 @@ export const load: PageServerLoad = async ({ params, url }) => {
     feedProxySecret: env.FEED_PROXY_SECRET,
   };
 
+  const apiBase = apiBaseFor(origin, env.API_URL);
+  const target = await resolveLinkblogTarget(apiBase, did);
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did),
-    fetchLinkblogDocuments(cfg, did),
+    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
   ]);
 
   // Counts-only social context for the most recent entries (one proxy batch, no
@@ -47,7 +54,8 @@ export const load: PageServerLoad = async ({ params, url }) => {
     pub,
     docs,
     social,
-    apiBase: apiBaseFor(origin, env.API_URL),
+    apiBase,
+    publication: target.siteUri,
     appUrl: appUrlFor(origin, env.APP_URL),
   };
 };

--- a/linkblog-site/src/routes/[id]/+page.svelte
+++ b/linkblog-site/src/routes/[id]/+page.svelte
@@ -15,7 +15,7 @@
   const countLabel = $derived(count > 0 ? `${count} ${count === 1 ? 'link' : 'links'}` : '');
 
   const feedUrl = $derived(feedUrlFor(data.origin, data.did));
-  const publication = $derived(publicationUri(data.did));
+  const publication = $derived(data.publication || publicationUri(data.did));
   const pageUrl = $derived(`${data.origin}/${encodeURIComponent(data.did)}`);
   const ogDescription = $derived(
     data.pub?.description || `Links shared by ${data.profile?.displayName || data.did}.`

--- a/linkblog-site/src/routes/[id]/[rkey]/+page.server.ts
+++ b/linkblog-site/src/routes/[id]/[rkey]/+page.server.ts
@@ -13,7 +13,12 @@ import {
   rkeyFromUri,
 } from '$lib/fields';
 import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/server/identity';
-import { fetchLinkblogDocuments, fetchSocialContext, type ProxyConfig } from '$lib/server/proxy';
+import {
+  fetchLinkblogDocuments,
+  fetchSocialContext,
+  resolveLinkblogTarget,
+  type ProxyConfig,
+} from '$lib/server/proxy';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, url }) => {
@@ -34,10 +39,12 @@ export const load: PageServerLoad = async ({ params, url }) => {
     feedProxySecret: env.FEED_PROXY_SECRET,
   };
 
+  const apiBase = apiBaseFor(origin, env.API_URL);
+  const target = await resolveLinkblogTarget(apiBase, did);
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did),
-    fetchLinkblogDocuments(cfg, did),
+    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
   ]);
 
   const doc = docs.find((d) => rkeyFromUri(d.recordUri) === rkey);
@@ -61,7 +68,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
     pub,
     doc,
     ctx: social.get(doc.recordUri),
-    apiBase: apiBaseFor(origin, env.API_URL),
+    apiBase,
     appUrl: appUrlFor(origin, env.APP_URL),
   };
 };

--- a/linkblog-site/src/routes/[id]/feed.xml/+server.ts
+++ b/linkblog-site/src/routes/[id]/feed.xml/+server.ts
@@ -6,9 +6,9 @@
 
 import { redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { feedUrlFor, isDid } from '$lib/fields';
+import { apiBaseFor, feedUrlFor, isDid } from '$lib/fields';
 import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/server/identity';
-import { fetchLinkblogDocuments, type ProxyConfig } from '$lib/server/proxy';
+import { fetchLinkblogDocuments, resolveLinkblogTarget, type ProxyConfig } from '$lib/server/proxy';
 import { emptyFeed, renderFeed } from '$lib/server/rss';
 import type { RequestHandler } from './$types';
 
@@ -40,10 +40,11 @@ export const GET: RequestHandler = async ({ params, url }) => {
     feedProxySecret: env.FEED_PROXY_SECRET,
   };
 
+  const target = await resolveLinkblogTarget(apiBaseFor(origin, env.API_URL), did);
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did),
-    fetchLinkblogDocuments(cfg, did),
+    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
   ]);
 
   // Cap the feed length — readers only need the recent window.


### PR DESCRIPTION
## Summary

- connect Skyreader linkblogs to existing owned standard.site publications with format-aware documents
- migrate follower scopes from the actual previous publication on connect, switch, and disconnect
- reconcile portable Atmospheric graph edges by deleting the superseded edge before writing the replacement
- cover default/external transitions and existing-destination deduplication

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-oeuxrsixbzejdhzj3lesbyi6)

## Checks

- `cd backend && npm run check`
- `cd backend && npm exec vitest -- run test/linkblog-follower-migration.spec.ts test/linkblog-sync.spec.ts` (20 passed)
- complete backend Vitest suite attempted; runner was killed at its memory limit
