### PR TITLE
Keep parked subscriptions sticky across sync

### DIFF
--- a/backend/migrations/0060_subscription_user_parked.sql
+++ b/backend/migrations/0060_subscription_user_parked.sql
@@ -1,0 +1,8 @@
+-- Distinguish subscriptions explicitly parked by the user from subscriptions
+-- automatically parked because the plan's active capacity was full.
+-- Like `active`, this is local servicing state and is never written to the PDS.
+ALTER TABLE subscriptions_cache ADD COLUMN user_parked INTEGER NOT NULL DEFAULT 0;
+
+-- Preserve every existing user's current choices. Older auto-parked rows become
+-- sticky too, which is safer than unexpectedly reactivating them after deploy.
+UPDATE subscriptions_cache SET user_parked = 1 WHERE active = 0;

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../types';
 import { resolveCanonicalUrl } from '../utils/canonical-url';
+import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
 
 // Jetstream event types
 interface JetstreamEvent {
@@ -295,36 +296,8 @@ export class JetstreamPoller implements DurableObject {
     const recordUri = `at://${did}/app.skyreader.feed.subscription/${rkey}`;
 
     if ((operation === 'create' || operation === 'update') && record) {
-      // Extract fields from the record (cast to access AT Proto fields)
-      const recAny = record as Record<string, unknown>;
-      const sourceType = (recAny.sourceType as string) || null;
-      const subjectDid = (recAny.subjectDid as string) || null;
-      const customTitle = (recAny.customTitle as string) || null;
-      const customIconUrl = (recAny.customIconUrl as string) || null;
-      const category = (recAny.category as string) || null;
-
       try {
-        await this.env.DB.prepare(
-          `
-					INSERT OR REPLACE INTO subscriptions_cache (user_did, record_uri, feed_url, title, created_at, source_type, subject_did, custom_title, custom_icon_url, category)
-					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-				`
-        )
-          .bind(
-            did,
-            recordUri,
-            record.feedUrl || '',
-            record.title || null,
-            record.createdAt
-              ? Math.floor(new Date(record.createdAt).getTime() / 1000)
-              : Math.floor(Date.now() / 1000),
-            sourceType,
-            subjectDid,
-            customTitle,
-            customIconUrl,
-            category
-          )
-          .run();
+        await upsertSubscriptionFromFirehose(this.env.DB, did, rkey, record);
       } catch (dbError) {
         console.error(
           `[JetstreamPoller] D1 WRITE ERROR upserting subscription for ${did}:`,
@@ -334,7 +307,7 @@ export class JetstreamPoller implements DurableObject {
       }
 
       console.log(
-        `[JetstreamPoller] ${did} ${operation}d subscription: ${record.feedUrl || sourceType + ':' + subjectDid}`
+        `[JetstreamPoller] ${did} ${operation}d subscription: ${record.feedUrl || recordUri}`
       );
     } else if (operation === 'delete') {
       try {

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -1610,8 +1610,16 @@ export async function handleSetSubscriptionActive(
       });
     }
 
-    // Already in the desired state — nothing to do.
+    // Already in the desired state — parking still records explicit user intent
+    // for rows that were previously parked automatically due to capacity.
     if (!!existing.active === active) {
+      if (!active) {
+        await env.DB.prepare(
+          'UPDATE subscriptions_cache SET user_parked = 1 WHERE user_did = ? AND record_uri LIKE ?'
+        )
+          .bind(session.did, `%/${rkey}`)
+          .run();
+      }
       return new Response(JSON.stringify({ success: true, active }), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -1638,9 +1646,9 @@ export async function handleSetSubscriptionActive(
     }
 
     await env.DB.prepare(
-      'UPDATE subscriptions_cache SET active = ? WHERE user_did = ? AND record_uri LIKE ?'
+      'UPDATE subscriptions_cache SET active = ?, user_parked = ? WHERE user_did = ? AND record_uri LIKE ?'
     )
-      .bind(active ? 1 : 0, session.did, `%/${rkey}`)
+      .bind(active ? 1 : 0, active ? 0 : 1, session.did, `%/${rkey}`)
       .run();
 
     return new Response(JSON.stringify({ success: true, active }), {

--- a/backend/src/services/firehose-subscription.ts
+++ b/backend/src/services/firehose-subscription.ts
@@ -1,0 +1,59 @@
+export interface FirehoseSubscriptionRecord {
+  feedUrl?: string;
+  title?: string;
+  createdAt?: string;
+  sourceType?: string;
+  subjectDid?: string;
+  customTitle?: string;
+  customIconUrl?: string;
+  category?: string;
+}
+
+/**
+ * Mirror PDS-owned subscription fields without replacing Skyreader's local state.
+ * A genuinely new record is active by default; a duplicate feed under another
+ * rkey is ignored by the cache's (user_did, source_type, feed_url) unique index.
+ */
+export async function upsertSubscriptionFromFirehose(
+  db: D1Database,
+  did: string,
+  rkey: string,
+  record: FirehoseSubscriptionRecord
+): Promise<void> {
+  const recordUri = `at://${did}/app.skyreader.feed.subscription/${rkey}`;
+  const createdAt = record.createdAt
+    ? Math.floor(new Date(record.createdAt).getTime() / 1000)
+    : Math.floor(Date.now() / 1000);
+  const values = [
+    record.feedUrl || '',
+    record.title || null,
+    createdAt,
+    record.sourceType || null,
+    record.subjectDid || null,
+    record.customTitle || null,
+    record.customIconUrl || null,
+    record.category || null,
+  ] as const;
+
+  const updated = await db
+    .prepare(
+      `UPDATE subscriptions_cache
+       SET feed_url = ?, title = ?, created_at = ?, source_type = ?, subject_did = ?,
+           custom_title = ?, custom_icon_url = ?, category = ?
+       WHERE record_uri = ?`
+    )
+    .bind(...values, recordUri)
+    .run();
+
+  if (updated.meta.changes === 0) {
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO subscriptions_cache
+         (user_did, record_uri, feed_url, title, created_at, source_type, subject_did,
+          custom_title, custom_icon_url, category)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(did, recordUri, ...values)
+      .run();
+  }
+}

--- a/backend/src/services/subscription-sync.ts
+++ b/backend/src/services/subscription-sync.ts
@@ -319,12 +319,9 @@ export async function syncSubscriptions(
       console.log(`[SubscriptionSync] Successfully inserted ${toAddLocally.length} subscriptions`);
     }
 
-    // Step 3b: Auto-fill freed active slots. Parking is sticky, but capacity does
-    // change — a tier upgrade raises maxSubscriptions, and removing/parking active
-    // feeds frees slots. Rather than leaving those slots empty until the user
-    // manually reactivates, promote the oldest parked rows (createdAt order, the
-    // same order parking fills) back to active to fill the headroom. Re-query the
-    // live active count so concurrent syncs / ignored inserts can't drift it.
+    // Step 3b: Auto-fill freed active slots from capacity-parked rows. Rows the
+    // user explicitly parked are sticky and must never be promoted by sync.
+    // Re-query the live active count so concurrent syncs / ignored inserts can't drift it.
     const activeRow = await env.DB.prepare(
       'SELECT COUNT(*) as count FROM subscriptions_cache WHERE user_did = ? AND active = 1'
     )
@@ -335,7 +332,7 @@ export async function syncSubscriptions(
       const slack = maxSubscriptions - liveActive;
       const parkedRows = await env.DB.prepare(
         `SELECT record_uri FROM subscriptions_cache
-         WHERE user_did = ? AND active = 0
+         WHERE user_did = ? AND active = 0 AND user_parked = 0
          ORDER BY created_at ASC, record_uri ASC
          LIMIT ?`
       )

--- a/backend/test/subscription-parking.spec.ts
+++ b/backend/test/subscription-parking.spec.ts
@@ -1,6 +1,7 @@
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { syncSubscriptions } from '../src/services/subscription-sync';
+import { upsertSubscriptionFromFirehose } from '../src/services/firehose-subscription';
 import type { Session } from '../src/types';
 import worker from '../src/index';
 
@@ -109,6 +110,19 @@ async function getActive(rkey: string): Promise<number | undefined> {
   return row?.active;
 }
 
+async function getParkingState(rkey: string) {
+  return env.DB.prepare(
+    'SELECT active, user_parked, atmosphere_synced, title FROM subscriptions_cache WHERE user_did = ? AND record_uri LIKE ?'
+  )
+    .bind(TEST_DID, `%/${rkey}`)
+    .first<{
+      active: number;
+      user_parked: number;
+      atmosphere_synced: number | null;
+      title: string;
+    }>();
+}
+
 function makeAuthRequest(path: string, opts?: { method?: string; body?: unknown }) {
   return new IncomingRequest(`http://localhost${path}`, {
     method: opts?.method ?? 'GET',
@@ -161,7 +175,7 @@ describe('Subscription parking', () => {
       await waitOnExecutionContext(ctx);
 
       expect(res.status).toBe(200);
-      expect(await getActive(RKEY_A)).toBe(0);
+      expect(await getParkingState(RKEY_A)).toMatchObject({ active: 0, user_parked: 1 });
     });
 
     it('excludes a parked sub from /api/records/list but lists it under /parked', async () => {
@@ -238,7 +252,7 @@ describe('Subscription parking', () => {
       await waitOnExecutionContext(ctx);
 
       expect(res.status).toBe(200);
-      expect(await getActive(RKEY_A)).toBe(1);
+      expect(await getParkingState(RKEY_A)).toMatchObject({ active: 1, user_parked: 0 });
     });
 
     it('is blocked with 403 when already at the active limit', async () => {
@@ -362,15 +376,15 @@ describe('Subscription parking', () => {
   });
 
   describe('syncSubscriptions auto-fill', () => {
-    it('promotes the oldest parked rows into freed active slots', async () => {
+    it('promotes only capacity-parked rows and keeps user-parked rows sticky', async () => {
       await setupTestUser(); // free → 100 active limit
 
       // 99 active + 2 parked: one active slot is free. The parked rows are older
       // (created_at 1) than the seeded active rows (created_at = now).
       await seedActiveRows(99);
       await env.DB.prepare(
-        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, title, created_at, active)
-         VALUES (?, ?, ?, 'Old parked A', 1, 0), (?, ?, ?, 'Old parked B', 2, 0)`
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, title, created_at, active, user_parked)
+         VALUES (?, ?, ?, 'User parked', 1, 0, 1), (?, ?, ?, 'Capacity parked', 2, 0, 0)`
       )
         .bind(
           TEST_DID,
@@ -397,11 +411,61 @@ describe('Subscription parking', () => {
       const result = await syncSubscriptions(createTestSession(), env);
 
       expect(result.success).toBe(true);
-      // Exactly one slot was free, so only the oldest parked row (A) is promoted.
+      // Exactly one slot was free. The newer capacity-parked row is eligible;
+      // the older user-parked row is deliberately skipped.
       expect(result.reactivated).toBe(1);
       expect(await countWhere('active = 1')).toBe(100);
-      expect(await getActive('oldparkedaaaa1')).toBe(1);
-      expect(await getActive('oldparkedbbbb2')).toBe(0);
+      expect(await getActive('oldparkedaaaa1')).toBe(0);
+      expect(await getActive('oldparkedbbbb2')).toBe(1);
+
+      const second = await syncSubscriptions(createTestSession(), env);
+      expect(second.reactivated).toBe(0);
+      expect(await getActive('oldparkedaaaa1')).toBe(0);
+    });
+  });
+
+  describe('firehose subscription upsert', () => {
+    it('refreshes PDS fields while preserving local parked and sync state', async () => {
+      await setupTestUser();
+      await insertSub(RKEY_A, 0);
+      await env.DB.prepare(
+        'UPDATE subscriptions_cache SET user_parked = 1, atmosphere_synced = 12345 WHERE record_uri LIKE ?'
+      )
+        .bind(`%/${RKEY_A}`)
+        .run();
+
+      await upsertSubscriptionFromFirehose(env.DB, TEST_DID, RKEY_A, {
+        feedUrl: `https://example.com/${RKEY_A}.xml`,
+        title: 'Updated on PDS',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      });
+
+      expect(await getParkingState(RKEY_A)).toMatchObject({
+        active: 0,
+        user_parked: 1,
+        atmosphere_synced: 12345,
+        title: 'Updated on PDS',
+      });
+    });
+
+    it('ignores a new rkey that duplicates an existing feed', async () => {
+      await setupTestUser();
+      await insertSub(RKEY_A, 0, 'https://example.com/duplicate.xml');
+      await env.DB.prepare('UPDATE subscriptions_cache SET source_type = ? WHERE record_uri LIKE ?')
+        .bind('atproto.documents', `%/${RKEY_A}`)
+        .run();
+
+      await expect(
+        upsertSubscriptionFromFirehose(env.DB, TEST_DID, RKEY_B, {
+          feedUrl: 'https://example.com/duplicate.xml',
+          title: 'Duplicate echo',
+          sourceType: 'atproto.documents',
+        })
+      ).resolves.toBeUndefined();
+
+      expect(await countWhere('')).toBe(1);
+      expect(await getActive(RKEY_A)).toBe(0);
+      expect(await getActive(RKEY_B)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

- preserve explicit user parking across repeated Atmospheric syncs
- auto-promote only subscriptions parked because of plan capacity
- preserve local cache state when Jetstream echoes PDS subscription updates

## Checks

- `cd backend && npm run check`
- `cd backend && npm run test -- subscription-parking.spec.ts` (12 passed)
- `cd backend && npm run test` (339 passed)

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-qndxd2uxlljaiq54mim4q4ph)
