### PR TITLE
Fix feed card scroll jumps on expand

### DIFF
--- a/e2e/expand-scroll.spec.ts
+++ b/e2e/expand-scroll.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from './fixtures';
+import { seedSubscription } from './seed';
+import type { Locator, Page } from '@playwright/test';
+
+const FEED_URL = 'https://example.com/expand-scroll.xml';
+
+test.use({ viewport: { width: 393, height: 727 }, hasTouch: true });
+
+function longBody(label: string) {
+  return Array.from(
+    { length: 55 },
+    (_, index) => `<p>${label} paragraph ${index + 1}: ${'reading context '.repeat(12)}</p>`
+  ).join('');
+}
+
+async function seedLongFeed(page: Page, user: Parameters<typeof seedSubscription>[0]) {
+  await seedSubscription(user, { feedUrl: FEED_URL, title: 'Long articles' });
+  await page.route('**/api/v2/feeds/batch', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        feeds: {
+          [FEED_URL]: {
+            title: 'Long articles',
+            status: 'ready',
+            hasMore: false,
+            items: [
+              {
+                guid: 'long-article-a',
+                url: 'https://example.com/a',
+                title: 'Long article A',
+                summary: 'A summary '.repeat(80),
+                content: longBody('A'),
+                publishedAt: '2026-08-12T12:00:00.000Z',
+              },
+              {
+                guid: 'long-article-b',
+                url: 'https://example.com/b',
+                title: 'Long article B',
+                summary: 'B summary '.repeat(80),
+                content: longBody('B'),
+                publishedAt: '2026-08-12T11:00:00.000Z',
+              },
+            ],
+          },
+        },
+        readCursor: Math.floor(Date.now() / 1000),
+      }),
+    });
+  });
+  await page.reload();
+  await expect(page.getByText('Long article B', { exact: true })).toBeVisible({ timeout: 15_000 });
+
+  // Make the regression deterministic instead of depending on Chromium's
+  // heuristic choice of a native scroll anchor.
+  await page.addStyleTag({ content: 'html, body, * { overflow-anchor: none !important; }' });
+}
+
+function card(page: Page, title: string): Locator {
+  return page.locator('.article-item-anchor', {
+    has: page.getByText(title, { exact: true }),
+  });
+}
+
+async function moveCardTo(page: Page, target: Locator, top: number) {
+  await target.evaluate((element, targetTop) => {
+    window.scrollTo({
+      top: window.scrollY + element.getBoundingClientRect().top - targetTop,
+      behavior: 'instant',
+    });
+  }, top);
+  await expect
+    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
+    .toBeCloseTo(top, 0);
+}
+
+async function expectTopNear(target: Locator, expected: number, tolerance = 2) {
+  await expect
+    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
+    .toBeGreaterThanOrEqual(expected - tolerance);
+  await expect
+    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
+    .toBeLessThanOrEqual(expected + tolerance);
+}
+
+test.describe('expand scroll anchoring', () => {
+  test('keeps a tapped card fixed when selecting it collapses a long card above', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedLongFeed(authedPage, testUser);
+    const first = card(authedPage, 'Long article A');
+    const second = card(authedPage, 'Long article B');
+
+    await first.locator('button.article-header').click();
+    await first.locator('button.show-more-btn').click();
+    await expect(first.locator('article.article-item')).toHaveClass(/expanded/);
+
+    await moveCardTo(authedPage, second, 280);
+    const beforeSelect = await second.evaluate((element) => element.getBoundingClientRect().top);
+    await second.locator('button.article-header').click();
+    await expectTopNear(second, beforeSelect);
+
+    const beforeExpand = await second.evaluate((element) => element.getBoundingClientRect().top);
+    await second.locator('button.show-more-btn').click();
+    await expect(second.locator('article.article-item')).toHaveClass(/expanded/);
+    await expect(second.getByText('B paragraph 55:', { exact: false })).toBeVisible();
+    await expectTopNear(second, beforeExpand);
+  });
+
+  test('re-anchors an offscreen card when Less collapses it', async ({ authedPage, testUser }) => {
+    await seedLongFeed(authedPage, testUser);
+    const second = card(authedPage, 'Long article B');
+
+    await second.locator('button.article-header').click();
+    await second.locator('button.show-more-btn').click();
+    await moveCardTo(authedPage, second, -300);
+    await second.locator('button.show-less-btn').click();
+
+    await expectTopNear(second, 8);
+  });
+
+  test('re-anchors an offscreen expanded card when its header deselects it', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedLongFeed(authedPage, testUser);
+    const second = card(authedPage, 'Long article B');
+
+    await second.locator('button.article-header').click();
+    await second.locator('button.show-more-btn').click();
+    await moveCardTo(authedPage, second, -300);
+    await second.locator('button.article-header').click();
+
+    await expect(second.locator('article.article-item')).not.toHaveClass(/expanded/);
+    await expectTopNear(second, 8);
+  });
+});

--- a/e2e/expand-scroll.spec.ts
+++ b/e2e/expand-scroll.spec.ts
@@ -48,7 +48,7 @@ async function seedLongFeed(page: Page, user: Parameters<typeof seedSubscription
       }),
     });
   });
-  await page.reload();
+  await page.goto('/feeds');
   await expect(page.getByText('Long article B', { exact: true })).toBeVisible({ timeout: 15_000 });
 
   // Make the regression deterministic instead of depending on Chromium's

--- a/e2e/expand-scroll.spec.ts
+++ b/e2e/expand-scroll.spec.ts
@@ -13,6 +13,24 @@ function longBody(label: string) {
   ).join('');
 }
 
+// Collapsing a long card removes thousands of pixels of height. For the
+// re-anchor (`scrollIntoView({ block: 'start' })`) to actually be able to put
+// the card at the top of the viewport there has to be at least a viewport's
+// worth of content left below it — otherwise the browser clamps at max scroll
+// and the card lands wherever the shortened document allows.
+const FILLER_COUNT = 10;
+
+function fillerItems() {
+  return Array.from({ length: FILLER_COUNT }, (_, index) => ({
+    guid: `filler-${index}`,
+    url: `https://example.com/filler-${index}`,
+    title: `Filler article ${index + 1}`,
+    summary: `Filler ${index + 1} summary `.repeat(20),
+    content: `<p>Filler ${index + 1} body</p>`,
+    publishedAt: new Date(Date.UTC(2026, 7, 12, 10, 0, 0) - index * 60_000).toISOString(),
+  }));
+}
+
 async function seedLongFeed(page: Page, user: Parameters<typeof seedSubscription>[0]) {
   await seedSubscription(user, { feedUrl: FEED_URL, title: 'Long articles' });
   await page.route('**/api/v2/feeds/batch', async (route) => {
@@ -41,6 +59,7 @@ async function seedLongFeed(page: Page, user: Parameters<typeof seedSubscription
                 content: longBody('B'),
                 publishedAt: '2026-08-12T11:00:00.000Z',
               },
+              ...fillerItems(),
             ],
           },
         },
@@ -49,7 +68,9 @@ async function seedLongFeed(page: Page, user: Parameters<typeof seedSubscription
     });
   });
   await page.goto('/feeds');
-  await expect(page.getByText('Long article B', { exact: true })).toBeVisible({ timeout: 15_000 });
+  // Wait on the card wrapper the assertions measure, not on the title text.
+  await expect(card(page, 'Long article B')).toBeVisible({ timeout: 15_000 });
+  await expect(card(page, `Filler article ${FILLER_COUNT}`)).toBeAttached();
 
   // Make the regression deterministic instead of depending on Chromium's
   // heuristic choice of a native scroll anchor.
@@ -62,25 +83,65 @@ function card(page: Page, title: string): Locator {
   });
 }
 
-async function moveCardTo(page: Page, target: Locator, top: number) {
-  await target.evaluate((element, targetTop) => {
-    window.scrollTo({
-      top: window.scrollY + element.getBoundingClientRect().top - targetTop,
-      behavior: 'instant',
-    });
-  }, top);
+// Scroll until the card sits at `top` and stays there. Each attempt scrolls, then
+// re-measures after a beat: scrolling into a fresh part of a long expanded article
+// can shift the layout slightly (read-marking, the sticky action bar), and the
+// retry absorbs that so a test never takes its baseline from a position the layout
+// is about to invalidate.
+async function moveCardTo(target: Locator, top: number) {
   await expect
-    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
+    .poll(
+      () =>
+        target.evaluate(
+          (element, targetTop) =>
+            new Promise<number>((resolve) => {
+              window.scrollTo({
+                top: window.scrollY + element.getBoundingClientRect().top - targetTop,
+                behavior: 'instant',
+              });
+              setTimeout(() => resolve(element.getBoundingClientRect().top), 250);
+            }),
+          top
+        ),
+      { timeout: 10_000 }
+    )
     .toBeCloseTo(top, 0);
 }
 
-async function expectTopNear(target: Locator, expected: number, tolerance = 2) {
-  await expect
-    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
-    .toBeGreaterThanOrEqual(expected - tolerance);
-  await expect
-    .poll(() => target.evaluate((element) => element.getBoundingClientRect().top))
-    .toBeLessThanOrEqual(expected + tolerance);
+function cardTop(target: Locator): Promise<number> {
+  return target.evaluate((element) => element.getBoundingClientRect().top);
+}
+
+// The component's compensation runs across a `tick()` and a `requestAnimationFrame`,
+// so read the position only once it has stopped moving. Waiting for a stable value
+// (instead of retrying the assertion) means a transiently-correct frame can't make a
+// broken fix look green.
+async function settledTop(target: Locator): Promise<number> {
+  return target.evaluate(
+    (element) =>
+      new Promise<number>((resolve) => {
+        const deadline = performance.now() + 4000;
+        let previous = element.getBoundingClientRect().top;
+        let stableFrames = 0;
+        const step = () => {
+          const top = element.getBoundingClientRect().top;
+          stableFrames = Math.abs(top - previous) < 0.5 ? stableFrames + 1 : 0;
+          previous = top;
+          // Report the last position rather than hanging until the test timeout if
+          // it never settles — a failure that names the real number is more useful.
+          if (stableFrames >= 4 || performance.now() > deadline) resolve(top);
+          else requestAnimationFrame(step);
+        };
+        requestAnimationFrame(step);
+      })
+  );
+}
+
+async function expectSettledTopNear(target: Locator, expected: number, tolerance = 2) {
+  const top = await settledTop(target);
+  const message = `card top settled at ${top}, expected within ${tolerance}px of ${expected}`;
+  expect(top, message).toBeGreaterThanOrEqual(expected - tolerance);
+  expect(top, message).toBeLessThanOrEqual(expected + tolerance);
 }
 
 test.describe('expand scroll anchoring', () => {
@@ -93,19 +154,24 @@ test.describe('expand scroll anchoring', () => {
     const second = card(authedPage, 'Long article B');
 
     await first.locator('button.article-header').click();
-    await first.locator('button.show-more-btn').click();
+    await first.locator('button.show-more-btn:not(.disabled)').click();
     await expect(first.locator('article.article-item')).toHaveClass(/expanded/);
+    // Let A's full body finish hydrating before measuring anything below it.
+    await expect(first.getByText('A paragraph 55:', { exact: false })).toBeVisible();
 
-    await moveCardTo(authedPage, second, 280);
-    const beforeSelect = await second.evaluate((element) => element.getBoundingClientRect().top);
+    await moveCardTo(second, 280);
+    const beforeSelect = await cardTop(second);
     await second.locator('button.article-header').click();
-    await expectTopNear(second, beforeSelect);
+    await expect(second.locator('article.article-item')).toHaveClass(/selected/);
+    await expectSettledTopNear(second, beforeSelect);
 
-    const beforeExpand = await second.evaluate((element) => element.getBoundingClientRect().top);
-    await second.locator('button.show-more-btn').click();
+    const beforeExpand = await cardTop(second);
+    await second.locator('button.show-more-btn:not(.disabled)').click();
     await expect(second.locator('article.article-item')).toHaveClass(/expanded/);
+    // The summary → full body swap happens after expand; the card top must
+    // survive it too.
     await expect(second.getByText('B paragraph 55:', { exact: false })).toBeVisible();
-    await expectTopNear(second, beforeExpand);
+    await expectSettledTopNear(second, beforeExpand);
   });
 
   test('re-anchors an offscreen card when Less collapses it', async ({ authedPage, testUser }) => {
@@ -113,26 +179,37 @@ test.describe('expand scroll anchoring', () => {
     const second = card(authedPage, 'Long article B');
 
     await second.locator('button.article-header').click();
-    await second.locator('button.show-more-btn').click();
-    await moveCardTo(authedPage, second, -300);
-    await second.locator('button.show-less-btn').click();
+    await second.locator('button.show-more-btn:not(.disabled)').click();
+    await expect(second.locator('article.article-item')).toHaveClass(/expanded/);
 
-    await expectTopNear(second, 8);
+    // Reading down a long post puts its top well above the viewport; the Less
+    // button stays reachable because the action bar is sticky.
+    await moveCardTo(second, -300);
+    await second.locator('button.show-less-btn').click();
+    await expect(second.locator('article.article-item')).not.toHaveClass(/expanded/);
+
+    // `.article-item-anchor` has scroll-margin-top: 0.5rem at this width.
+    await expectSettledTopNear(second, 8);
   });
 
-  test('re-anchors an offscreen expanded card when its header deselects it', async ({
-    authedPage,
-    testUser,
-  }) => {
+  test('keeps a card in place when its header deselects it', async ({ authedPage, testUser }) => {
     await seedLongFeed(authedPage, testUser);
     const second = card(authedPage, 'Long article B');
 
     await second.locator('button.article-header').click();
-    await second.locator('button.show-more-btn').click();
-    await moveCardTo(authedPage, second, -300);
-    await second.locator('button.article-header').click();
+    await second.locator('button.show-more-btn:not(.disabled)').click();
+    await expect(second.locator('article.article-item')).toHaveClass(/expanded/);
 
+    // The header is only tappable while it is on screen, so this is the
+    // reachable deselect: collapsing the card must not move it under the finger,
+    // even though the page shrinks by the whole article body.
+    await moveCardTo(second, 120);
+    await second.locator('button.article-header').click();
     await expect(second.locator('article.article-item')).not.toHaveClass(/expanded/);
-    await expectTopNear(second, 8);
+    // `selected` stays on every card in the default expand-all view; `highlighted`
+    // is the class that actually tracks the selected key.
+    await expect(second.locator('article.article-item')).not.toHaveClass(/highlighted/);
+
+    await expectSettledTopNear(second, 120);
   });
 });

--- a/frontend/src/lib/components/feed/FeedListView.svelte
+++ b/frontend/src/lib/components/feed/FeedListView.svelte
@@ -63,6 +63,53 @@
 
   // Element refs for scroll observation
   let articleElements = $state<HTMLElement[]>([]);
+  let anchorSuppressed = $state(false);
+  let anchorTransitionCount = 0;
+
+  async function beginAnchorTransition() {
+    anchorTransitionCount += 1;
+    anchorSuppressed = true;
+    // Apply overflow-anchor before changing the list's layout so native scroll
+    // anchoring cannot race or double-correct our explicit compensation.
+    await tick();
+  }
+
+  async function endAnchorTransition() {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    anchorTransitionCount -= 1;
+    if (anchorTransitionCount === 0) anchorSuppressed = false;
+  }
+
+  async function preservingCardTop(index: number, mutate: () => void) {
+    const el = articleElements[index];
+    const before = el?.getBoundingClientRect().top;
+    await beginAnchorTransition();
+    try {
+      mutate();
+      await tick();
+      const after = el?.getBoundingClientRect().top;
+      if (before !== undefined && after !== undefined && Math.abs(after - before) > 1) {
+        // An absolute post-layout scroll avoids racing Chrome mobile's URL-bar resize.
+        window.scrollTo({ top: window.scrollY + (after - before), behavior: 'instant' });
+      }
+    } finally {
+      await endAnchorTransition();
+    }
+  }
+
+  async function collapseAndReanchor(index: number, collapse: () => void) {
+    const wasAboveViewport = (articleElements[index]?.getBoundingClientRect().top ?? 0) < 0;
+    await beginAnchorTransition();
+    try {
+      collapse();
+      await tick();
+      if (wasAboveViewport) {
+        articleElements[index]?.scrollIntoView({ block: 'start' });
+      }
+    } finally {
+      await endAnchorTransition();
+    }
+  }
 
   function scrollToCenter(index?: number) {
     const targetIndex = index ?? feedViewStore.selectedIndex;
@@ -90,26 +137,23 @@
       // mobile a relative scroll races the body shrink and the URL-bar resize
       // and can overshoot all the way to the page top. scroll-margin-top on the
       // wrapper keeps it clear of the (desktop) fixed header.
-      const wasAboveViewport = (articleElements[index]?.getBoundingClientRect().top ?? 0) < 0;
-      feedViewStore.collapse();
-      await tick();
-      if (wasAboveViewport) {
-        articleElements[index]?.scrollIntoView({ block: 'start' });
-      }
+      await collapseAndReanchor(index, () => feedViewStore.collapse());
     } else {
-      feedViewStore.select(index);
-      feedViewStore.expand(index);
-      // No scroll on expand: the body grows downward, so the card's top stays put.
-      // (Keyboard nav still calls the exported scrollToCenter explicitly.)
+      // Selecting this card can collapse a taller card above it. Preserve the
+      // tapped card's viewport position across both state changes.
+      await preservingCardTop(index, () => {
+        feedViewStore.select(index);
+        feedViewStore.expand(index);
+      });
     }
   }
 
-  function handleSelect(index: number) {
+  async function handleSelect(index: number) {
     const key = feedViewStore.currentItems[index]?.key ?? null;
     if (key !== null && feedViewStore.selectedKey === key) {
-      feedViewStore.deselect();
+      await collapseAndReanchor(index, () => feedViewStore.deselect());
     } else {
-      feedViewStore.select(index);
+      await preservingCardTop(index, () => feedViewStore.select(index));
     }
   }
 
@@ -198,7 +242,11 @@
   />
 {/if}
 
-<div class="article-list" class:hidden-behind-reader={readerItem !== null}>
+<div
+  class="article-list"
+  class:anchor-suppressed={anchorSuppressed}
+  class:hidden-behind-reader={readerItem !== null}
+>
   {#each feedViewStore.currentItems as displayItem, index (displayItem.key)}
     <div class="article-item-anchor" bind:this={articleElements[index]}>
       {#if displayItem.type === 'article'}
@@ -283,6 +331,10 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  .article-list.anchor-suppressed {
+    overflow-anchor: none;
   }
 
   /* When a collapse re-anchors a card to the top (see handleExpand), land it


### PR DESCRIPTION
## Summary

- preserve the tapped feed card position when selecting or expanding collapses a taller card above it
- suppress native scroll anchoring during explicit compensation and share collapse re-anchoring across Less/header toggles
- run the mobile scroll regression suite on `/feeds`, where seeded articles are rendered
- make that regression suite actually pass: seed filler items so the Less-collapse re-anchor target is reachable, replace the unreachable off-screen header deselect with the reachable one, and take every measurement only once the layout has settled

## Checks

- `npx playwright test` — **33/33 pass** (full suite, chromium), including all three `e2e/expand-scroll.spec.ts` tests and `Channels › rename a channel via context menu`
- `cd frontend && npm run check` (passes: 0 errors, 25 existing warnings; Prettier clean)

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-wa4x3pela2dmf62ofvrpidms)
