### PR TITLE
Fix uncached article progress reset

### DIFF
--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
@@ -14,6 +14,43 @@ vi.mock('svelte', () => ({ onDestroy: vi.fn() }));
 
 import { useParagraphTracking } from './useParagraphTracking.svelte';
 
+/**
+ * Build an article body whose paragraphs all report a top edge above the viewport,
+ * so a single scroll event walks the tracker to the last detected paragraph.
+ */
+function renderBody(paragraphCount: number): HTMLElement {
+  const content = document.createElement('article');
+  content.innerHTML = Array.from(
+    { length: paragraphCount },
+    (_, i) => `<p>Paragraph ${i} is comfortably longer than the tracking threshold.</p>`
+  ).join('');
+  for (const para of Array.from(content.querySelectorAll('p'))) {
+    vi.spyOn(para, 'getBoundingClientRect').mockReturnValue({
+      top: -1,
+      bottom: 10,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: 11,
+      x: 0,
+      y: -1,
+      toJSON: () => ({}),
+    });
+  }
+  document.body.append(content);
+  return content;
+}
+
+function track(content: HTMLElement) {
+  return useParagraphTracking({
+    contentEl: () => content,
+    scrollRoot: () => null,
+    itemKey: () => 'article-key',
+    itemType: () => 'article',
+    enabled: () => true,
+  });
+}
+
 describe('useParagraphTracking', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -25,11 +62,15 @@ describe('useParagraphTracking', () => {
       callback(0);
       return 1;
     });
+    // jsdom implements no layout, so it leaves scrollIntoView undefined; the tests
+    // below drive the resulting scroll events by hand instead.
+    Element.prototype.scrollIntoView = vi.fn();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    delete (Element.prototype as Partial<Element>).scrollIntoView;
     document.body.replaceChildren();
   });
 
@@ -64,6 +105,77 @@ describe('useParagraphTracking', () => {
     vi.advanceTimersByTime(1_000);
 
     expect(setReadProgress).not.toHaveBeenCalled();
+
+    tracking.cleanup();
+  });
+
+  it('does not persist the clamped index when a partial restore scrolls', () => {
+    getReadProgress.mockReturnValue({ paragraphIndex: 12, totalParagraphs: 40 });
+    // Only the short description fallback has rendered so far.
+    const content = renderBody(3);
+    const tracking = track(content);
+
+    tracking.setupObserver();
+    expect(tracking.restorePosition()).toBe('partial');
+
+    // The smooth scroll the restore kicked off keeps firing scroll events.
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(200);
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(2_000);
+
+    expect(setReadProgress).not.toHaveBeenCalled();
+
+    tracking.cleanup();
+  });
+
+  it('does not persist a genuine scroll while the body is still partial', () => {
+    getReadProgress.mockReturnValue({ paragraphIndex: 12, totalParagraphs: 40 });
+    const content = renderBody(3);
+    const tracking = track(content);
+
+    tracking.setupObserver();
+    // No restore in flight — the reader themself nudges the fallback body.
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(2_000);
+
+    expect(setReadProgress).not.toHaveBeenCalled();
+
+    tracking.cleanup();
+  });
+
+  it('persists scroll progress once the full body has loaded', () => {
+    getReadProgress.mockReturnValue({ paragraphIndex: 12, totalParagraphs: 40 });
+    const content = renderBody(40);
+    const tracking = track(content);
+
+    tracking.setupObserver();
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(600);
+
+    expect(setReadProgress).toHaveBeenCalledWith('article-key', 'article', 39, 40);
+
+    tracking.cleanup();
+  });
+
+  it('restores into a loaded body without writing, but still saves paragraph steps', () => {
+    getReadProgress.mockReturnValue({ paragraphIndex: 12, totalParagraphs: 40 });
+    const content = renderBody(40);
+    const tracking = track(content);
+
+    tracking.setupObserver();
+    expect(tracking.restorePosition()).toBe('exact');
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(600);
+
+    // The restore's own movement is not progress.
+    expect(setReadProgress).not.toHaveBeenCalled();
+    expect(tracking.currentParagraphIndex).toBe(12);
+
+    // Stepping forward by keyboard still records where the reader got to.
+    tracking.nextParagraph();
+    vi.advanceTimersByTime(600);
+    expect(setReadProgress).toHaveBeenCalledWith('article-key', 'article', 13, 40);
 
     tracking.cleanup();
   });

--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { setReadProgress, getReadProgress } = vi.hoisted(() => ({
+  setReadProgress: vi.fn(),
+  getReadProgress: vi.fn(),
+}));
+
+vi.mock('$lib/stores/itemLabels.svelte', () => ({
+  itemLabelsStore: { setReadProgress, getReadProgress },
+}));
+
+vi.mock('svelte', () => ({ onDestroy: vi.fn() }));
+
+import { useParagraphTracking } from './useParagraphTracking.svelte';
+
+describe('useParagraphTracking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setReadProgress.mockReset();
+    getReadProgress.mockReset();
+    getReadProgress.mockReturnValue({ paragraphIndex: 8, totalParagraphs: 20 });
+    vi.stubGlobal('$state', <T>(value: T) => value);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.replaceChildren();
+  });
+
+  it('does not overwrite hydrated progress during the initial body measurement', () => {
+    const content = document.createElement('article');
+    content.innerHTML =
+      '<p>This fallback paragraph is long enough to be tracked while loading.</p>' +
+      '<p>A second fallback paragraph makes a genuine scroll position observable.</p>';
+    const firstParagraph = content.querySelector('p')!;
+    vi.spyOn(firstParagraph, 'getBoundingClientRect').mockReturnValue({
+      top: -1,
+      bottom: 10,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: 11,
+      x: 0,
+      y: -1,
+      toJSON: () => ({}),
+    });
+    document.body.append(content);
+
+    const tracking = useParagraphTracking({
+      contentEl: () => content,
+      scrollRoot: () => null,
+      itemKey: () => 'article-key',
+      itemType: () => 'article',
+      enabled: () => true,
+    });
+
+    tracking.setupObserver();
+    vi.advanceTimersByTime(1_000);
+
+    expect(setReadProgress).not.toHaveBeenCalled();
+
+    tracking.cleanup();
+  });
+});

--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
@@ -5,6 +5,10 @@ import type { ItemLabelType } from '$lib/types';
 const BLOCK_SELECTORS = 'p, h1, h2, h3, h4, h5, h6, blockquote, pre, figure, li';
 const MIN_TEXT_LENGTH = 20;
 const SAVE_DEBOUNCE_MS = 500;
+// `scrollIntoView({ behavior: 'smooth' })` keeps emitting scroll events for a few
+// hundred ms after it starts. Ignore them for a little longer than that so a jump
+// we initiated is never mistaken for the reader moving.
+const PROGRAMMATIC_SCROLL_SETTLE_MS = 1000;
 
 interface ParagraphTrackingParams {
   contentEl: () => HTMLElement | undefined;
@@ -25,6 +29,8 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
   let scrollTarget: EventTarget | null = null;
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let lastScrollTop = 0;
+  let programmaticScroll = false;
+  let programmaticScrollTimer: ReturnType<typeof setTimeout> | null = null;
 
   function detectParagraphs() {
     const el = params.contentEl();
@@ -146,9 +152,45 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     highlightEl.style.opacity = '1';
   }
 
+  /**
+   * True while the detected body is too short to contain the saved position — the
+   * lazily-loaded article hasn't landed yet and we're still looking at the short
+   * description fallback (the same condition `restorePosition` reports as
+   * `'partial'`). Every index measurable against that stub is an artifact of the
+   * partial DOM, so persisting one would replace progress synced from another
+   * device with a near-zero value.
+   */
+  function bodyIsPartial(): boolean {
+    const saved = itemLabelsStore.getReadProgress(params.itemKey());
+    if (!saved || saved.paragraphIndex <= 0) return false;
+    return saved.paragraphIndex > paragraphs.length - 1;
+  }
+
+  /**
+   * Mute the scroll handler while a `scrollIntoView` we triggered plays out.
+   * Restoring a position (or stepping to the next paragraph) is not reading, and
+   * the intermediate positions the animation sweeps through are always behind the
+   * destination we already recorded.
+   */
+  function beginProgrammaticScroll() {
+    programmaticScroll = true;
+    if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
+    programmaticScrollTimer = setTimeout(() => {
+      programmaticScrollTimer = null;
+      programmaticScroll = false;
+      // Re-baseline the direction heuristic against where the jump landed, so the
+      // next real scroll isn't compared with a pre-jump offset.
+      lastScrollTop = params.scrollRoot()?.scrollTop ?? window.scrollY;
+    }, PROGRAMMATIC_SCROLL_SETTLE_MS);
+  }
+
   function debouncedSave() {
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
+      saveTimer = null;
+      // Re-checked at flush time rather than when the save was queued: the full
+      // body may have arrived in the meantime, which makes the position real.
+      if (bodyIsPartial()) return;
       itemLabelsStore.setReadProgress(
         params.itemKey(),
         params.itemType(),
@@ -181,7 +223,11 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     scrollTarget = root ?? window;
 
     scrollHandler = () => {
-      requestAnimationFrame(() => updateCurrentParagraph());
+      if (programmaticScroll) return;
+      requestAnimationFrame(() => {
+        if (programmaticScroll) return;
+        updateCurrentParagraph();
+      });
     };
 
     scrollTarget.addEventListener('scroll', scrollHandler, { passive: true });
@@ -190,13 +236,34 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     updateCurrentParagraph(false);
   }
 
-  function scrollToParagraph(index: number) {
+  /**
+   * Jump to a paragraph. The scroll handler is muted for the duration of the
+   * animation, so the destination set here — not whatever the animation happens to
+   * sweep past — is what gets recorded. `persist: false` additionally keeps the
+   * jump out of the saved position; restores use it, since replaying where the
+   * reader already was is not progress.
+   */
+  function scrollToParagraph(index: number, { persist = true }: { persist?: boolean } = {}) {
     if (index < 0 || index >= paragraphs.length) return;
     const el = paragraphs[index];
     if (!el) return;
+    beginProgrammaticScroll();
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     currentParagraphIndex = index;
+    if (currentParagraphIndex > furthestParagraphIndex) {
+      furthestParagraphIndex = currentParagraphIndex;
+    }
     updateHighlight();
+    if (persist) {
+      // The muted scroll handler no longer persists this move for us.
+      debouncedSave();
+    } else if (saveTimer) {
+      // Drop anything queued before this jump. A restore that re-runs after the
+      // body settles can otherwise let a measurement taken mid-animation — while
+      // the fallback body was still on screen — flush behind it.
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
   }
 
   function nextParagraph() {
@@ -228,7 +295,10 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     if (!saved || saved.paragraphIndex <= 0 || paragraphs.length === 0) return 'none';
     const exact = saved.paragraphIndex <= paragraphs.length - 1;
     const targetIdx = Math.min(saved.paragraphIndex, paragraphs.length - 1);
-    scrollToParagraph(targetIdx);
+    // Never persist a restore: on the `'partial'` path `targetIdx` is clamped to the
+    // end of the fallback body, and writing that back would be the reset this hook
+    // exists to prevent.
+    scrollToParagraph(targetIdx, { persist: false });
     return exact ? 'exact' : 'partial';
   }
 
@@ -263,6 +333,11 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
       clearTimeout(saveTimer);
       saveTimer = null;
     }
+    if (programmaticScrollTimer) {
+      clearTimeout(programmaticScrollTimer);
+      programmaticScrollTimer = null;
+    }
+    programmaticScroll = false;
     if (highlightEl) {
       highlightEl.remove();
       highlightEl = null;

--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
@@ -52,7 +52,7 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
    * - Scrolling up: go back when the current paragraph's bottom goes past
    *   the viewport bottom (it's fully off-screen below)
    */
-  function updateCurrentParagraph() {
+  function updateCurrentParagraph(save = true) {
     if (paragraphs.length === 0) return;
 
     const scrollTop = params.scrollRoot()?.scrollTop ?? window.scrollY;
@@ -92,8 +92,10 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
       furthestParagraphIndex = currentParagraphIndex;
     }
 
-    // Save on every position change (up or down)
-    debouncedSave();
+    // Persist only in response to an actual scroll. setupObserver also measures
+    // the initial position, but doing so must not overwrite progress hydrated
+    // from the server while an uncached article body is still loading.
+    if (save) debouncedSave();
   }
 
   function getOffsetRelativeTo(el: HTMLElement, ancestor: HTMLElement): number {
@@ -179,13 +181,13 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
     scrollTarget = root ?? window;
 
     scrollHandler = () => {
-      requestAnimationFrame(updateCurrentParagraph);
+      requestAnimationFrame(() => updateCurrentParagraph());
     };
 
     scrollTarget.addEventListener('scroll', scrollHandler, { passive: true });
 
     // Initial position check
-    updateCurrentParagraph();
+    updateCurrentParagraph(false);
   }
 
   function scrollToParagraph(index: number) {


### PR DESCRIPTION
Fixes reading progress being reset when opening an article whose body has not been cached locally yet (e.g. progress synced from another device).

Two paths could overwrite the hydrated position while the lazily-loaded body was still the short description fallback:

- The initial observer measurement — fixed previously; it is now read-only.
- The restore itself. `restorePosition()` clamps an out-of-range saved index to the end of the fallback body and smooth-scrolls to it; that programmatic movement dispatches `scroll`, so the tracker debounced a save of the clamped index and replaced the real progress whenever the body took longer than the 500 ms debounce to arrive.

Changes:

- Mute the scroll handler while a `scrollIntoView` the hook initiated plays out, so a jump is never mistaken for reading. The destination recorded by `scrollToParagraph` wins over whatever the animation sweeps past.
- Restores scroll with `persist: false` — replaying where the reader already was is not progress — and drop any save queued before the jump.
- Paragraph steps (next/prev) now persist explicitly, since the muted handler no longer does it for them.
- Backstop: never flush a save while the detected body is too short to contain the saved position. This also covers a genuine reader scroll during the loading window.
- Regression tests over the real partial-restore lifecycle: partial restore + scroll events, a genuine scroll while partial, persistence once the full body loads, and that restore-then-step still records the step. All three new tests fail against the pre-fix hook.

Checks: `npm test` (262 passed), `npm run check` (0 errors).

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-anyqxfbwwzeagynrezek3eu6)