### PR TITLE
Unify feed error details in Manage Sources

### DIFF
--- a/frontend/src/lib/components/sources/SourceRow.component.test.ts
+++ b/frontend/src/lib/components/sources/SourceRow.component.test.ts
@@ -1,0 +1,95 @@
+// Mounted component test (jsdom) — see the "component" project in vitest.config.ts.
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import SourceRow from './SourceRow.svelte';
+
+const mounted: Record<string, any>[] = [];
+
+const errorDetails = {
+  title: 'Service Unavailable',
+  description: 'temporarily unavailable',
+  isPermanent: false,
+  errorCount: 3,
+  errorCode: 'HTTP 503',
+  rawError: 'Feed fetch failed (HTTP 503)',
+};
+
+function render() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(SourceRow, {
+    target,
+    props: {
+      iconUrl: null,
+      title: 'Flaky Feed',
+      subtitle: 'flaky.example.com',
+      hasError: true,
+      errorDetails,
+      onRefresh: () => {},
+      onRemove: () => {},
+    },
+  });
+  flushSync();
+  mounted.push(component);
+  return { target };
+}
+
+describe('SourceRow error popover focus region', () => {
+  afterEach(() => {
+    for (const component of mounted.splice(0)) unmount(component);
+    document.body.innerHTML = '';
+  });
+
+  it('keeps the popover open while focus moves from badge into it', () => {
+    const { target } = render();
+    const badge = target.querySelector<HTMLButtonElement>('.error-badge')!;
+    badge.focus();
+    flushSync();
+
+    const popover = target.querySelector('.error-popover-container');
+    expect(popover).not.toBeNull();
+
+    // The popover is a DOM sibling right after the badge, so Tab lands on it.
+    const summary = popover!.querySelector<HTMLElement>('summary')!;
+    expect(badge.compareDocumentPosition(popover!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    summary.focus();
+    flushSync();
+    expect(target.querySelector('.error-popover-container')).not.toBeNull();
+    expect(document.activeElement).toBe(summary);
+
+    // Expanding the details still keeps the popover mounted.
+    summary.click();
+    flushSync();
+    expect(target.querySelector('.error-popover-container')).not.toBeNull();
+    expect(target.querySelector('.error-popover-container')!.textContent).toContain('HTTP 503');
+  });
+
+  it('closes when focus leaves the region', () => {
+    const { target } = render();
+    const badge = target.querySelector<HTMLButtonElement>('.error-badge')!;
+    badge.focus();
+    flushSync();
+    expect(target.querySelector('.error-popover-container')).not.toBeNull();
+
+    const outside = target.querySelector<HTMLButtonElement>('.action-btn')!;
+    outside.focus();
+    flushSync();
+    expect(target.querySelector('.error-popover-container')).toBeNull();
+  });
+
+  it('closes on Escape and returns focus to the badge', () => {
+    const { target } = render();
+    const badge = target.querySelector<HTMLButtonElement>('.error-badge')!;
+    badge.focus();
+    flushSync();
+    const summary = target.querySelector<HTMLElement>('.error-popover-container summary')!;
+    summary.focus();
+    flushSync();
+
+    summary.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    flushSync();
+    expect(target.querySelector('.error-popover-container')).toBeNull();
+    expect(document.activeElement).toBe(badge);
+  });
+});

--- a/frontend/src/lib/components/sources/SourceRow.svelte
+++ b/frontend/src/lib/components/sources/SourceRow.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
+  import FeedErrorPopover from '$lib/components/sidebar/FeedErrorPopover.svelte';
+  import type { ErrorDetails } from '$lib/stores/feedStatus.svelte';
 
   interface Props {
     iconUrl: string | null;
@@ -7,6 +9,7 @@
     title: string;
     subtitle: string;
     hasError?: boolean;
+    errorDetails?: ErrorDetails | null;
     subscribed?: boolean;
     selected?: boolean;
     fallbackIcon?: string;
@@ -25,6 +28,7 @@
     title,
     subtitle,
     hasError = false,
+    errorDetails = null,
     subscribed = true,
     selected = false,
     fallbackIcon = 'rss',
@@ -36,6 +40,33 @@
     onPark = null,
     onReactivate = null,
   }: Props = $props();
+
+  let showErrorPopover = $state(false);
+  let errorBadge: HTMLButtonElement | null = $state(null);
+  let popoverPosition = $state({ top: 0, left: 0 });
+  let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function showErrorDetails() {
+    if (!errorDetails) return;
+    if (hideTimeout) {
+      clearTimeout(hideTimeout);
+      hideTimeout = null;
+    }
+    if (errorBadge) {
+      const rect = errorBadge.getBoundingClientRect();
+      popoverPosition = {
+        top: rect.bottom + 4,
+        left: Math.min(rect.left, window.innerWidth - 292),
+      };
+    }
+    showErrorPopover = true;
+  }
+
+  function hideErrorDetails() {
+    hideTimeout = setTimeout(() => {
+      showErrorPopover = false;
+    }, 150);
+  }
 
   let actions = $derived.by(() => {
     const items: {
@@ -80,10 +111,22 @@
     <span class="source-meta">{subtitle}</span>
   </div>
 
-  {#if subscribed && hasError}
-    <span class="error-badge" title="Feed error">
+  {#if subscribed && (hasError || errorDetails)}
+    <button
+      bind:this={errorBadge}
+      type="button"
+      class="error-badge"
+      class:permanent={errorDetails?.isPermanent}
+      title={errorDetails?.title ?? 'Feed error'}
+      aria-label={errorDetails ? `Feed error: ${errorDetails.title}` : 'Feed error'}
+      onmouseenter={showErrorDetails}
+      onmouseleave={hideErrorDetails}
+      onfocus={showErrorDetails}
+      onblur={hideErrorDetails}
+      onclick={showErrorDetails}
+    >
       <Icon name="alert-triangle" size={14} />
-    </span>
+    </button>
   {/if}
 
   {#if actions.length > 0}
@@ -102,6 +145,18 @@
     </div>
   {/if}
 </div>
+
+{#if showErrorPopover && errorDetails}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="error-popover-container"
+    style="top: {popoverPosition.top}px; left: {popoverPosition.left}px;"
+    onmouseenter={showErrorDetails}
+    onmouseleave={hideErrorDetails}
+  >
+    <FeedErrorPopover {errorDetails} />
+  </div>
+{/if}
 
 <style>
   .source-row {
@@ -185,6 +240,26 @@
     color: var(--color-error, #dc2626);
     display: flex;
     align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border: 0;
+    background: transparent;
+    border-radius: 4px;
+    cursor: help;
+  }
+
+  .error-badge:not(.permanent) {
+    color: var(--color-warning, #ff9800);
+  }
+
+  .error-badge:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+  }
+
+  .error-popover-container {
+    position: fixed;
+    z-index: 1000;
   }
 
   .source-actions {

--- a/frontend/src/lib/components/sources/SourceRow.svelte
+++ b/frontend/src/lib/components/sources/SourceRow.svelte
@@ -41,17 +41,24 @@
     onReactivate = null,
   }: Props = $props();
 
+  const errorPopoverId = $props.id();
+
   let showErrorPopover = $state(false);
   let errorBadge: HTMLButtonElement | null = $state(null);
+  let errorRegion: HTMLDivElement | null = $state(null);
   let popoverPosition = $state({ top: 0, left: 0 });
   let hideTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  function showErrorDetails() {
-    if (!errorDetails) return;
+  function cancelHide() {
     if (hideTimeout) {
       clearTimeout(hideTimeout);
       hideTimeout = null;
     }
+  }
+
+  function showErrorDetails() {
+    if (!errorDetails) return;
+    cancelHide();
     if (errorBadge) {
       const rect = errorBadge.getBoundingClientRect();
       popoverPosition = {
@@ -63,9 +70,51 @@
   }
 
   function hideErrorDetails() {
+    cancelHide();
     hideTimeout = setTimeout(() => {
+      hideTimeout = null;
       showErrorPopover = false;
     }, 150);
+  }
+
+  function hideErrorDetailsNow() {
+    cancelHide();
+    showErrorPopover = false;
+  }
+
+  $effect(() => cancelHide);
+
+  // The badge and the popover are one focus region: keep the popover open while
+  // focus moves between them so keyboard users can reach the technical details.
+  let suppressFocusOpen = false;
+
+  function handleRegionFocusIn() {
+    if (suppressFocusOpen) return;
+    showErrorDetails();
+  }
+
+  function handleRegionFocusOut(event: FocusEvent) {
+    const next = event.relatedTarget;
+    if (next instanceof Node) {
+      if (errorRegion?.contains(next)) return;
+      hideErrorDetailsNow();
+      return;
+    }
+    // Some browsers omit relatedTarget; fall back to the delayed hide so a
+    // focusin landing inside the region can still cancel it.
+    hideErrorDetails();
+  }
+
+  function handleRegionKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape' || !showErrorPopover) return;
+    event.stopPropagation();
+    hideErrorDetailsNow();
+    if (errorBadge && document.activeElement !== errorBadge) {
+      // Returning focus to the badge must not immediately reopen the popover.
+      suppressFocusOpen = true;
+      errorBadge.focus();
+      suppressFocusOpen = false;
+    }
   }
 
   let actions = $derived.by(() => {
@@ -112,21 +161,40 @@
   </div>
 
   {#if subscribed && (hasError || errorDetails)}
-    <button
-      bind:this={errorBadge}
-      type="button"
-      class="error-badge"
-      class:permanent={errorDetails?.isPermanent}
-      title={errorDetails?.title ?? 'Feed error'}
-      aria-label={errorDetails ? `Feed error: ${errorDetails.title}` : 'Feed error'}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      bind:this={errorRegion}
+      class="error-region"
       onmouseenter={showErrorDetails}
       onmouseleave={hideErrorDetails}
-      onfocus={showErrorDetails}
-      onblur={hideErrorDetails}
-      onclick={showErrorDetails}
+      onfocusin={handleRegionFocusIn}
+      onfocusout={handleRegionFocusOut}
+      onkeydown={handleRegionKeydown}
     >
-      <Icon name="alert-triangle" size={14} />
-    </button>
+      <button
+        bind:this={errorBadge}
+        type="button"
+        class="error-badge"
+        class:permanent={errorDetails?.isPermanent}
+        title={errorDetails?.title ?? 'Feed error'}
+        aria-label={errorDetails ? `Feed error: ${errorDetails.title}` : 'Feed error'}
+        aria-expanded={errorDetails ? showErrorPopover : undefined}
+        aria-controls={errorDetails && showErrorPopover ? errorPopoverId : undefined}
+        onclick={showErrorDetails}
+      >
+        <Icon name="alert-triangle" size={14} />
+      </button>
+
+      {#if showErrorPopover && errorDetails}
+        <div
+          id={errorPopoverId}
+          class="error-popover-container"
+          style="top: {popoverPosition.top}px; left: {popoverPosition.left}px;"
+        >
+          <FeedErrorPopover {errorDetails} />
+        </div>
+      {/if}
+    </div>
   {/if}
 
   {#if actions.length > 0}
@@ -145,18 +213,6 @@
     </div>
   {/if}
 </div>
-
-{#if showErrorPopover && errorDetails}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div
-    class="error-popover-container"
-    style="top: {popoverPosition.top}px; left: {popoverPosition.left}px;"
-    onmouseenter={showErrorDetails}
-    onmouseleave={hideErrorDetails}
-  >
-    <FeedErrorPopover {errorDetails} />
-  </div>
-{/if}
 
 <style>
   .source-row {
@@ -233,6 +289,12 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .error-region {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
   }
 
   .error-badge {

--- a/frontend/src/routes/dev/sources/+page.svelte
+++ b/frontend/src/routes/dev/sources/+page.svelte
@@ -67,12 +67,20 @@
     />
   </Case>
 
-  <Case name="SourceRow · error" note="hasError badge on a subscribed feed." frame>
+  <Case name="SourceRow · error" note="Hover or focus the badge for full error details." frame>
     <SourceRow
       iconUrl={FAVICON}
       title="Flaky Feed"
       subtitle="flaky.example.com · last fetch failed"
       hasError
+      errorDetails={{
+        title: 'Service Unavailable',
+        description: "The feed's server is temporarily unavailable for maintenance.",
+        isPermanent: false,
+        errorCount: 3,
+        errorCode: 'HTTP 503',
+        rawError: 'Feed fetch failed (HTTP 503)',
+      }}
       onToggleSelect={() => {}}
       onRefresh={() => {}}
       onRemove={() => {}}

--- a/frontend/src/routes/dev/sources/+page.svelte
+++ b/frontend/src/routes/dev/sources/+page.svelte
@@ -67,7 +67,11 @@
     />
   </Case>
 
-  <Case name="SourceRow · error" note="Hover or focus the badge for full error details." frame>
+  <Case
+    name="SourceRow · error"
+    note="Hover or focus the badge for full error details; Tab reaches Technical details, Escape closes."
+    frame
+  >
     <SourceRow
       iconUrl={FAVICON}
       title="Flaky Feed"

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -734,6 +734,7 @@
                     title={sub.customTitle || sub.title}
                     subtitle={getSubtitle(sub)}
                     hasError={status?.status === 'error' || status?.status === 'circuit-open'}
+                    errorDetails={sub.feedUrl ? feedStatusStore.getErrorDetails(sub.feedUrl) : null}
                     subscribed={true}
                     selected={sub.id != null && selectedIds.has(sub.id)}
                     fallbackIcon="rss"
@@ -762,6 +763,7 @@
                   title={sub.customTitle || sub.title}
                   subtitle={getSubtitle(sub)}
                   hasError={status?.status === 'error' || status?.status === 'circuit-open'}
+                  errorDetails={sub.feedUrl ? feedStatusStore.getErrorDetails(sub.feedUrl) : null}
                   subscribed={true}
                   selected={sub.id != null && selectedIds.has(sub.id)}
                   fallbackIcon="rss"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,13 +1,31 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
+
+const alias = { $lib: path.resolve(__dirname, 'src/lib') };
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
-  },
-  resolve: {
-    alias: {
-      $lib: path.resolve(__dirname, 'src/lib'),
-    },
+    projects: [
+      {
+        // Plain unit tests (node environment).
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.ts'],
+          exclude: ['src/**/*.component.test.ts'],
+        },
+        resolve: { alias },
+      },
+      {
+        // Component tests: compile .svelte files and mount them in jsdom.
+        plugins: [svelte({ hot: false })],
+        test: {
+          name: 'component',
+          include: ['src/**/*.component.test.ts'],
+          environment: 'jsdom',
+        },
+        resolve: { alias, conditions: ['browser'] },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- show the same structured feed error popover in Manage Sources as in the sidebar
- support hover, focus, and click access to error details
- make the keyboard path actually work: the badge and popover are one focus region, so the popover survives tabbing into it, is the next tab stop after the badge, and closes on Escape (returning focus to the badge)
- add a representative error state to the sources development harness
- add a jsdom component-test project to the vitest config plus a SourceRow test covering the focus-region behavior

## Checks
- npm run check (0 errors; 25 pre-existing warnings)
- npm test (265 tests)
- npm run build

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-sxqkuchrfxcjx6gtp6mx6ypq)