### PR TITLE
Add linkblog deletion and restore

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,256 +1,340 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-05-31T00:00:00Z",
+  "generatedAt": "2026-08-13T00:00:00Z",
   "title": "Design System: Skyreader",
   "extensions": {
     "colorMeta": {
       "primary": {
         "role": "primary",
         "displayName": "Skyreader Blue",
-        "canonical": "#0066cc",
+        "canonical": "oklch(52.2% 0.177 255.8)",
         "tonalRamp": [
-          "#001b33",
-          "#002b52",
-          "#003e75",
-          "#005299",
-          "#0066cc",
-          "#3389d6",
-          "#74b1e3",
-          "#cce3f5"
+          "oklch(15% 0.141 255.8)",
+          "oklch(26% 0.152 255.8)",
+          "oklch(38% 0.163 255.8)",
+          "oklch(50% 0.175 255.8)",
+          "oklch(62% 0.168 255.8)",
+          "oklch(73% 0.157 255.8)",
+          "oklch(84% 0.146 255.8)",
+          "oklch(95% 0.135 255.8)"
         ]
       },
       "primary-dark": {
         "role": "primary",
         "displayName": "Pressed Blue",
-        "canonical": "#0052a3",
+        "canonical": "oklch(44.4% 0.155 256.4)",
         "tonalRamp": [
-          "#001426",
-          "#002247",
-          "#003366",
-          "#00427f",
-          "#0052a3",
-          "#2e7bc4",
-          "#6fa9dd",
-          "#c7e0f3"
+          "oklch(15% 0.131 256.4)",
+          "oklch(26% 0.140 256.4)",
+          "oklch(38% 0.150 256.4)",
+          "oklch(50% 0.150 256.4)",
+          "oklch(62% 0.140 256.4)",
+          "oklch(73% 0.131 256.4)",
+          "oklch(84% 0.121 256.4)",
+          "oklch(95% 0.112 256.4)"
+        ]
+      },
+      "primary-wash": {
+        "role": "primary",
+        "displayName": "Wash Blue",
+        "canonical": "rgba(0, 102, 204, 0.1)",
+        "tonalRamp": [
+          "rgba(0, 102, 204, 0.04)",
+          "rgba(0, 102, 204, 0.08)",
+          "rgba(0, 102, 204, 0.10)",
+          "rgba(0, 102, 204, 0.15)",
+          "rgba(0, 102, 204, 0.25)",
+          "rgba(0, 102, 204, 0.40)",
+          "rgba(0, 102, 204, 0.65)",
+          "rgba(0, 102, 204, 1.00)"
+        ]
+      },
+      "night-primary": {
+        "role": "primary",
+        "displayName": "Lifted Blue",
+        "canonical": "oklch(71.1% 0.156 251.0)",
+        "tonalRamp": [
+          "oklch(15% 0.108 251.0)",
+          "oklch(26% 0.117 251.0)",
+          "oklch(38% 0.127 251.0)",
+          "oklch(50% 0.138 251.0)",
+          "oklch(62% 0.148 251.0)",
+          "oklch(73% 0.154 251.0)",
+          "oklch(84% 0.145 251.0)",
+          "oklch(95% 0.135 251.0)"
         ]
       },
       "sky": {
         "role": "secondary",
         "displayName": "Sky Identity",
-        "canonical": "#4a9fd4",
+        "canonical": "oklch(67.2% 0.113 239.0)",
         "tonalRamp": [
-          "#0f2e44",
-          "#16475f",
-          "#1f6388",
-          "#2f82ac",
-          "#4a9fd4",
-          "#74b6df",
-          "#a6d2ec",
-          "#dceef8"
+          "oklch(15% 0.081 239.0)",
+          "oklch(26% 0.088 239.0)",
+          "oklch(38% 0.095 239.0)",
+          "oklch(50% 0.103 239.0)",
+          "oklch(62% 0.110 239.0)",
+          "oklch(73% 0.110 239.0)",
+          "oklch(84% 0.103 239.0)",
+          "oklch(95% 0.096 239.0)"
         ]
       },
       "highlight": {
         "role": "tertiary",
         "displayName": "Highlight Gold",
-        "canonical": "#f5c518",
+        "canonical": "oklch(84.2% 0.168 90.4)",
         "tonalRamp": [
-          "#3d3104",
-          "#5c4a06",
-          "#7a630a",
-          "#a8850d",
-          "#d6a912",
-          "#f5c518",
-          "#f8d556",
-          "#fdeeb0"
+          "oklch(15% 0.104 90.4)",
+          "oklch(26% 0.114 90.4)",
+          "oklch(38% 0.126 90.4)",
+          "oklch(50% 0.137 90.4)",
+          "oklch(62% 0.148 90.4)",
+          "oklch(73% 0.158 90.4)",
+          "oklch(84% 0.168 90.4)",
+          "oklch(95% 0.158 90.4)"
         ]
       },
       "bg": {
         "role": "neutral",
         "displayName": "Surface",
-        "canonical": "#ffffff",
+        "canonical": "oklch(100.0% 0.000 89.9)",
         "tonalRamp": [
-          "#1a1a1a",
-          "#333333",
-          "#4d4d4d",
-          "#737373",
-          "#999999",
-          "#bfbfbf",
-          "#e0e0e0",
-          "#ffffff"
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
         ]
       },
       "bg-secondary": {
         "role": "neutral",
         "displayName": "Sunken",
-        "canonical": "#f5f5f5",
+        "canonical": "oklch(97.0% 0.000 89.9)",
         "tonalRamp": [
-          "#2a2a2a",
-          "#404040",
-          "#595959",
-          "#808080",
-          "#a6a6a6",
-          "#cccccc",
-          "#e8e8e8",
-          "#f5f5f5"
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
         ]
       },
       "text": {
         "role": "neutral",
         "displayName": "Ink",
-        "canonical": "#333333",
+        "canonical": "oklch(32.1% 0.000 89.9)",
         "tonalRamp": [
-          "#0d0d0d",
-          "#1a1a1a",
-          "#262626",
-          "#333333",
-          "#4d4d4d",
-          "#737373",
-          "#999999",
-          "#cccccc"
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
         ]
       },
       "text-secondary": {
         "role": "neutral",
         "displayName": "Muted Ink",
-        "canonical": "#666666",
+        "canonical": "oklch(51.0% 0.000 89.9)",
         "tonalRamp": [
-          "#1a1a1a",
-          "#333333",
-          "#4d4d4d",
-          "#666666",
-          "#808080",
-          "#999999",
-          "#b3b3b3",
-          "#d9d9d9"
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
         ]
       },
       "border": {
         "role": "neutral",
         "displayName": "Divider",
-        "canonical": "#e0e0e0",
+        "canonical": "oklch(90.7% 0.000 89.9)",
         "tonalRamp": [
-          "#404040",
-          "#595959",
-          "#737373",
-          "#8c8c8c",
-          "#a6a6a6",
-          "#c0c0c0",
-          "#e0e0e0",
-          "#f2f2f2"
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
+        ]
+      },
+      "night-bg": {
+        "role": "neutral",
+        "displayName": "Night Surface",
+        "canonical": "oklch(21.8% 0.000 89.9)",
+        "tonalRamp": [
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(38% 0 0)",
+          "oklch(50% 0 0)",
+          "oklch(62% 0 0)",
+          "oklch(73% 0 0)",
+          "oklch(84% 0 0)",
+          "oklch(95% 0 0)"
         ]
       },
       "success": {
         "role": "semantic",
         "displayName": "Success Green",
-        "canonical": "#4caf50",
+        "canonical": "oklch(67.3% 0.162 144.2)",
         "tonalRamp": [
-          "#10300f",
-          "#1a4a18",
-          "#266b23",
-          "#327f2f",
-          "#4caf50",
-          "#74c476",
-          "#a4d9a6",
-          "#d8efd9"
+          "oklch(15% 0.116 144.2)",
+          "oklch(26% 0.126 144.2)",
+          "oklch(38% 0.136 144.2)",
+          "oklch(50% 0.147 144.2)",
+          "oklch(62% 0.158 144.2)",
+          "oklch(73% 0.157 144.2)",
+          "oklch(84% 0.148 144.2)",
+          "oklch(95% 0.138 144.2)"
         ]
       },
       "warning": {
         "role": "semantic",
         "displayName": "Warning Amber",
-        "canonical": "#ff9800",
+        "canonical": "oklch(77.0% 0.174 64.1)",
         "tonalRamp": [
-          "#3d2500",
-          "#5c3800",
-          "#7a4b00",
-          "#a86600",
-          "#d68000",
-          "#ff9800",
-          "#ffb74d",
-          "#ffe0b2"
+          "oklch(15% 0.115 64.1)",
+          "oklch(26% 0.125 64.1)",
+          "oklch(38% 0.137 64.1)",
+          "oklch(50% 0.148 64.1)",
+          "oklch(62% 0.160 64.1)",
+          "oklch(73% 0.170 64.1)",
+          "oklch(84% 0.167 64.1)",
+          "oklch(95% 0.157 64.1)"
         ]
       },
       "error": {
         "role": "semantic",
         "displayName": "Error Red",
-        "canonical": "#f44336",
+        "canonical": "oklch(64.3% 0.215 28.8)",
         "tonalRamp": [
-          "#3d0f0b",
-          "#5c1712",
-          "#7a1f18",
-          "#a82a20",
-          "#d6362a",
-          "#f44336",
-          "#f88078",
-          "#fcc7c2"
+          "oklch(15% 0.157 28.8)",
+          "oklch(26% 0.170 28.8)",
+          "oklch(38% 0.184 28.8)",
+          "oklch(50% 0.198 28.8)",
+          "oklch(62% 0.213 28.8)",
+          "oklch(73% 0.205 28.8)",
+          "oklch(84% 0.192 28.8)",
+          "oklch(95% 0.179 28.8)"
         ]
       }
     },
     "typographyMeta": {
       "headline": {
         "displayName": "Headline",
-        "purpose": "Page and major section titles. The largest type in the chrome (1.25rem ceiling)."
+        "purpose": "Page titles, modal headers, major section titles. The largest type the chrome is allowed (--text-2xl)."
       },
       "title": {
         "displayName": "Title",
-        "purpose": "Article titles in list/card rows and modal headers."
+        "purpose": "List titles, source names, emphasized UI text (--text-lg)."
       },
       "body": {
         "displayName": "Body",
-        "purpose": "Default UI text and controls."
+        "purpose": "Default UI text, controls, and feed-row article titles at weight 400 (--text-base)."
       },
-      "article": {
-        "displayName": "Article",
-        "purpose": "The reading surface. Reader-controlled font family and size; measure capped 65-75ch."
+      "meta": {
+        "displayName": "Meta",
+        "purpose": "The workhorse secondary line: timestamps, feed names, counts, usually in Muted Ink (--text-sm)."
       },
       "label": {
         "displayName": "Label",
-        "purpose": "Metadata, timestamps, feed names. Muted Ink, never below 4.5:1."
+        "purpose": "Buttons, form labels, menu items, secondary actions (--text-md)."
+      },
+      "micro": {
+        "displayName": "Micro",
+        "purpose": "Eyebrow labels, badge counts, chip text. The one place tracking opens up (--text-2xs)."
+      },
+      "article": {
+        "displayName": "Article",
+        "purpose": "The reading surface. Reader-selected family (serif default, plus sans, mono, Literata) and size, at 1.8 line-height in an 800px band."
+      },
+      "article-title": {
+        "displayName": "Article Title",
+        "purpose": "The reader's own headline and the single largest type in the product (--text-4xl)."
       }
     },
     "shadows": [
       {
         "name": "raised",
         "value": "0 2px 8px rgba(0,0,0,0.1)",
-        "purpose": "Small floating elements: popover menus, tooltips, context menus. Dark mode bumps to 0.3."
+        "purpose": "Small floating elements: context menus, compact popovers. Night value 0.4 alpha."
       },
       {
         "name": "floating",
-        "value": "0 4px 16px rgba(0,0,0,0.15)",
-        "purpose": "Mid-level overlays: dropdowns, toasts. Dark mode bumps to 0.4."
+        "value": "0 4px 12px rgba(0,0,0,0.15)",
+        "purpose": "Tooltips (.app-tooltip) and popover menus. Night value 0.4 alpha."
       },
       {
-        "name": "overlay",
-        "value": "0 8px 32px rgba(0,0,0,0.25)",
-        "purpose": "Modals and dialogs above a backdrop. Dark mode bumps to 0.5."
+        "name": "lifted",
+        "value": "0 4px 16px rgba(0,0,0,0.15)",
+        "purpose": "The workhorse overlay shadow: dropdowns, floating toolbars, action bars. Night value 0.4 alpha."
+      },
+      {
+        "name": "dialog",
+        "value": "0 4px 20px rgba(0,0,0,0.15)",
+        "purpose": "The shared Modal, above a rgba(0,0,0,0.5) backdrop. Night value 0.4 alpha."
+      },
+      {
+        "name": "sheet",
+        "value": "0 -4px 24px rgba(0,0,0,0.15)",
+        "purpose": "The mobile BottomSheet, cast upward, above a rgba(0,0,0,0.4) backdrop. Night value 0.4 alpha."
       },
       {
         "name": "focus-ring",
         "value": "0 0 0 2px rgba(0,102,204,0.1)",
-        "purpose": "Primary-tinted focus indicator on interactive elements."
+        "purpose": "The primary-tinted focus indicator. A glow rather than a shadow, but part of the same vocabulary."
       }
     ],
     "motion": [
       {
-        "name": "ease-standard",
-        "value": "ease",
-        "purpose": "Default easing for state transitions."
-      },
-      {
-        "name": "duration-fast",
+        "name": "duration-hover",
         "value": "0.15s",
-        "purpose": "Color, opacity, and background state changes (hover, active)."
+        "purpose": "Default for hover and background-color changes. The most common duration in the app."
       },
       {
-        "name": "duration-base",
+        "name": "duration-control",
         "value": "0.2s",
-        "purpose": "Button background shifts and larger state transitions."
+        "purpose": "Buttons and sidebar width changes."
+      },
+      {
+        "name": "duration-reveal",
+        "value": "0.25s",
+        "purpose": "Larger reveals: sheets, drawers, expanding cards."
+      },
+      {
+        "name": "duration-press",
+        "value": "0.1s",
+        "purpose": "Press feedback (transform: scale(0.9) on the note marker)."
+      },
+      {
+        "name": "ease-settle",
+        "value": "cubic-bezier(0.22, 1, 0.36, 1)",
+        "purpose": "Entrances that should settle rather than bounce."
       }
     ],
     "breakpoints": [
       {
-        "name": "mobile",
-        "value": "768px",
-        "purpose": "Below this the sidebar collapses to an overlay drawer and the bottom bar appears."
+        "name": "phone",
+        "value": "640px"
+      },
+      {
+        "name": "shell",
+        "value": "1000px"
+      },
+      {
+        "name": "reader-wide",
+        "value": "1100px"
       }
     ]
   },
@@ -259,107 +343,172 @@
       "name": "Primary Button",
       "kind": "button",
       "refersTo": "button-primary",
-      "description": "The single high-emphasis action per view. Quiet hover, no transform.",
-      "html": "<button class=\"ds-btn-primary\">Add feed</button>",
-      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: var(--color-primary, #0066cc); color: #fff; border: none; border-radius: 6px; padding: 8px 16px; font-weight: 500; font-size: 1rem; cursor: pointer; transition: background-color 0.2s; } .ds-btn-primary:hover { background: var(--color-primary-dark, #0052a3); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(0,102,204,0.3); }"
+      "description": "The single high-emphasis action per view. Background-only transition; no transform, no bounce.",
+      "html": "<button class=\"ds-btn ds-btn-primary\">Save article</button>",
+      "css": ".ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 8px 16px; border-radius: 6px; border: none; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1.4; cursor: pointer; transition: background-color 0.2s; } .ds-btn-primary { background: var(--color-primary, #0066cc); color: #fff; } .ds-btn-primary:hover { background: var(--color-primary-dark, #0052a3); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(0,102,204,0.1); }"
     },
     {
       "name": "Secondary Button",
       "kind": "button",
       "refersTo": "button-secondary",
-      "description": "Lower-emphasis action. Sunken fill with a Divider border.",
-      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
-      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: var(--color-bg-secondary, #f5f5f5); color: var(--color-text, #333); border: 1px solid var(--color-border, #e0e0e0); border-radius: 6px; padding: 8px 16px; font-weight: 500; font-size: 1rem; cursor: pointer; transition: background-color 0.15s; } .ds-btn-secondary:hover { background: var(--color-border, #e0e0e0); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(0,102,204,0.3); }"
+      "description": "Lower-emphasis action. The only button variant that carries a border.",
+      "html": "<button class=\"ds-btn ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 8px 16px; border-radius: 6px; border: 1px solid var(--color-border, #e0e0e0); background: var(--color-bg-secondary, #f5f5f5); color: var(--color-text, #333); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: background-color 0.2s; } .ds-btn-secondary:hover { background: var(--color-border, #e0e0e0); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(0,102,204,0.1); }"
+    },
+    {
+      "name": "Danger Button",
+      "kind": "button",
+      "refersTo": "button-danger",
+      "description": "Destructive actions only: unsubscribe, delete a linkblog post, clear cache.",
+      "html": "<button class=\"ds-btn ds-btn-danger\">Unsubscribe</button>",
+      "css": ".ds-btn-danger { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 8px 16px; border-radius: 6px; border: none; background: var(--color-error, #f44336); color: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: background-color 0.2s; } .ds-btn-danger:hover { background: #d32f2f; } .ds-btn-danger:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(244,67,54,0.25); }"
     },
     {
       "name": "Text Input",
       "kind": "input",
       "refersTo": "input",
-      "description": "Full-width field. Focus shifts the border to primary; outline is replaced, never removed.",
-      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search feeds\" />",
-      "css": ".ds-input { width: 100%; box-sizing: border-box; padding: 8px 12px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 6px; background: var(--color-bg, #fff); color: var(--color-text, #333); font-size: 1rem; transition: border-color 0.15s; } .ds-input::placeholder { color: var(--color-text-secondary, #666); } .ds-input:focus { outline: none; border-color: var(--color-primary, #0066cc); }"
+      "description": "Full-width field. Focus replaces the default outline with a border shift to the primary.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Feed URL or site address\" />",
+      "css": ".ds-input { width: 100%; padding: 8px 12px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 6px; background: var(--color-bg, #fff); color: var(--color-text, #333); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 1rem; line-height: 1.5; } .ds-input::placeholder { color: var(--color-text-secondary, #666); } .ds-input:focus { outline: none; border-color: var(--color-primary, #0066cc); }"
+    },
+    {
+      "name": "Chip",
+      "kind": "chip",
+      "refersTo": "chip",
+      "description": "Pill-shaped source label, tag, or filter. Active state takes the Wash Blue tint rather than a solid fill.",
+      "html": "<span class=\"ds-chip\">RSS</span> <span class=\"ds-chip ds-chip-active\">Longform</span>",
+      "css": ".ds-chip { display: inline-flex; align-items: center; padding: 2px 7px; border-radius: 999px; background: var(--color-bg-secondary, #f5f5f5); color: var(--color-text-secondary, #666); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.6875rem; font-weight: 500; letter-spacing: 0.05em; line-height: 1.4; transition: background-color 0.15s; } .ds-chip-active { background: var(--color-sidebar-active, rgba(0,102,204,0.1)); color: var(--color-primary, #0066cc); }"
+    },
+    {
+      "name": "Unread Badge",
+      "kind": "chip",
+      "refersTo": "unread-badge",
+      "description": "The one chip that takes a solid primary fill, so a count reads as a signal rather than a label.",
+      "html": "<span class=\"ds-badge\">12</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; padding: 2px 6px; border-radius: 4px; background: var(--color-primary, #0066cc); color: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.625rem; font-weight: 500; line-height: 1.4; font-variant-numeric: tabular-nums; }"
+    },
+    {
+      "name": "Sidebar Nav Item",
+      "kind": "nav",
+      "refersTo": "nav-item",
+      "description": "A source or channel row in the 320px rail. Radius 12px is deliberately larger than a card so selection reads as a resting pill, not a box drawn around a link.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav-item\" href=\"#\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 11a9 9 0 0 1 9 9\"/><path d=\"M4 4a16 16 0 0 1 16 16\"/><circle cx=\"5\" cy=\"19\" r=\"1\"/></svg><span>All sources</span></a><a class=\"ds-nav-item ds-nav-item-active\" href=\"#\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z\"/></svg><span>Saved</span><span class=\"ds-badge\">12</span></a></nav>",
+      "css": ".ds-nav { display: flex; flex-direction: column; gap: 2px; width: 260px; padding: 8px; background: var(--color-bg-secondary, #f5f5f5); border-radius: 8px; } .ds-nav-item { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 12px; color: var(--color-text, #333); text-decoration: none; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1.4; transition: background-color 0.15s; } .ds-nav-item span:first-of-type { flex: 1; } .ds-nav-item:hover { background-color: rgba(0,0,0,0.05); } .ds-nav-item-active, .ds-nav-item-active:hover { background-color: var(--color-sidebar-active, rgba(0,102,204,0.1)); color: var(--color-primary, #0066cc); } .ds-nav .ds-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; padding: 2px 6px; border-radius: 4px; background: var(--color-primary, #0066cc); color: #fff; font-size: 0.625rem; font-weight: 500; }"
     },
     {
       "name": "Card",
       "kind": "card",
       "refersTo": "card",
-      "description": "Sparingly-used container for genuinely grouped content. Flat at rest; defined by a 1px border. No nesting.",
-      "html": "<div class=\"ds-card\"><h3 class=\"ds-card-title\">The Verge</h3><p class=\"ds-card-meta\">12 unread &middot; updated 4m ago</p></div>",
-      "css": ".ds-card { background: var(--color-bg, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; padding: 16px; color: var(--color-text, #333); } .ds-card-title { margin: 0 0 4px; font-size: 1rem; font-weight: 600; } .ds-card-meta { margin: 0; font-size: 0.875rem; color: var(--color-text-secondary, #666); }"
+      "description": "Used sparingly, for genuinely grouped content. No resting shadow; definition comes from a 1px Divider border. Nested cards are forbidden.",
+      "html": "<div class=\"ds-card\"><h3>Atmospheric sync</h3><p>Your subscriptions are stored privately on Skyreader. Turning this on also stores them on your PDS.</p></div>",
+      "css": ".ds-card { max-width: 380px; padding: 16px; background: var(--color-bg, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; } .ds-card h3 { margin: 0 0 8px; font-size: 0.9375rem; font-weight: 600; line-height: 1.4; color: var(--color-text, #333); } .ds-card p { margin: 0; font-size: 0.8125rem; line-height: 1.5; color: var(--color-text-secondary, #666); }"
     },
     {
-      "name": "Sidebar Nav Item (active)",
-      "kind": "nav",
-      "refersTo": "nav",
-      "description": "Feed/channel row. Selection is a Wash Blue tint, never a colored side-stripe or heavy fill.",
-      "html": "<div class=\"ds-nav-item active\"><svg class=\"ds-nav-icon\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 11a9 9 0 0 1 9 9\"/><path d=\"M4 4a16 16 0 0 1 16 16\"/><circle cx=\"5\" cy=\"19\" r=\"1\"/></svg><span>Top Stories</span></div>",
-      "css": ".ds-nav-item { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 6px; color: var(--color-text, #333); font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: background-color 0.15s; } .ds-nav-item:hover { background: var(--color-bg-secondary, #f5f5f5); } .ds-nav-item.active { background: var(--color-sidebar-active, rgba(0,102,204,0.1)); color: var(--color-primary, #0066cc); } .ds-nav-icon { flex: none; }"
-    },
-    {
-      "name": "Success Toast",
+      "name": "Feed Row",
       "kind": "custom",
-      "refersTo": "toast",
-      "description": "Floating confirmation. Uses the Floating shadow; color pairs with a checkmark icon, never color alone.",
-      "html": "<div class=\"ds-toast\"><svg class=\"ds-toast-icon\" width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M20 6 9 17l-5-5\"/></svg><span>Synced to your PDS</span></div>",
-      "css": ".ds-toast { display: inline-flex; align-items: center; gap: 8px; background: var(--color-bg, #fff); border: 1px solid var(--color-success, #4caf50); border-radius: 8px; padding: 12px 16px; font-size: 0.9375rem; color: var(--color-text, #333); box-shadow: 0 4px 16px rgba(0,0,0,0.15); } .ds-toast-icon { flex: none; color: var(--color-success, #4caf50); }"
+      "refersTo": "article-row",
+      "description": "Signature surface. Borderless, transparent, separated only by rhythm. Read state is carried three ways at once (opacity, title color, and the filled toggle ring), never by color alone. The title is weight 400: in a list of forty rows, bolding is noise rather than hierarchy.",
+      "html": "<div class=\"ds-rows\"><div class=\"ds-row\"><span class=\"ds-row-dot\"></span><span class=\"ds-row-title\">The quiet case for reading less, but better</span><span class=\"ds-row-meta\">Craft &middot; 4h</span></div><div class=\"ds-row ds-row-read\"><span class=\"ds-row-dot ds-row-dot-read\"></span><span class=\"ds-row-title\">What the Atmosphere gets right about portability</span><span class=\"ds-row-meta\">Protocol &middot; 1d</span></div></div>",
+      "css": ".ds-rows { width: 100%; max-width: 560px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; } .ds-row { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-radius: 8px; transition: background-color 0.15s, opacity 0.15s; } .ds-row:hover { background-color: rgba(128,128,128,0.05); } .ds-row-read { opacity: 0.6; } .ds-row-read:hover { opacity: 0.8; } .ds-row-dot { flex: none; width: 14px; height: 14px; border-radius: 50%; border: 1.5px solid var(--color-text-secondary, #666); background: transparent; } .ds-row-dot-read { background: var(--color-text-secondary, #666); } .ds-row-title { flex: 1; min-width: 0; font-size: 1rem; font-weight: 400; line-height: 1.5; color: var(--color-text, #333); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; } .ds-row-read .ds-row-title { color: var(--color-text-secondary, #666); } .ds-row-meta { flex: none; font-size: 0.8125rem; line-height: 1.4; color: var(--color-text-secondary, #666); }"
+    },
+    {
+      "name": "Popover Menu",
+      "kind": "custom",
+      "refersTo": "popover-menu",
+      "description": "The shared context menu. Floating shadow, 140px minimum width, destructive items hovering to a 10% Error tint.",
+      "html": "<div class=\"ds-menu\"><button class=\"ds-menu-item\">Mark read</button><button class=\"ds-menu-item\">Save for later</button><button class=\"ds-menu-item ds-menu-item-danger\">Unsubscribe</button></div>",
+      "css": ".ds-menu { display: flex; flex-direction: column; min-width: 140px; padding: 4px 0; background: var(--color-bg, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); overflow: hidden; } .ds-menu-item { display: block; width: 100%; padding: 10px 14px; border: none; background: transparent; color: var(--color-text, #333); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 0.875rem; text-align: left; cursor: pointer; transition: background-color 0.15s; } .ds-menu-item:hover { background: var(--color-bg-secondary, #f5f5f5); } .ds-menu-item-danger { color: var(--color-error, #f44336); } .ds-menu-item-danger:hover { background: rgba(244,67,54,0.1); }"
     }
   ],
   "narrative": {
     "northStar": "The Reading Room",
-    "overview": "Skyreader is a quiet place to read deeply and think clearly - open to the people you trust, closed to the algorithm. Everything you follow comes into one calm room; the design exists to make reading it, and making sense of it, feel unhurried and ordered. The room is also yours - it lives on infrastructure you own - but that's the foundation under the calm, not something the design needs to shout. Chrome is quiet and recedes; the text you came to read is the one element allowed to raise its voice. Every surface decision is measured against a single question: does this help or distract from reading? When in doubt, it goes. The system is flat, restrained, and content-forward. Depth is conveyed through 1px borders and tonal background layering, not decoration - shadows appear only when something genuinely floats above the page. Color is held in reserve: a single confident blue carries interaction, and the rest of the interface is a disciplined neutral ramp so that an article, a highlight, or an unread marker reads instantly. It works in both light and dark, both must independently pass contrast, and it respects prefers-reduced-motion on every transition.",
+    "overview": "Skyreader is a quiet place to read deeply and think clearly, open to the people you trust and closed to the algorithm. Everything you follow comes into one calm room; the design exists to make reading it, and making sense of it, feel unhurried and ordered. Chrome is quiet and recedes; the text you came to read is the one element allowed to raise its voice. Every surface decision is measured against a single question from PRODUCT.md: does this help or distract from reading? When in doubt, it goes. (The room is also yours, running on infrastructure you own, but that is the foundation under the calm rather than something the design needs to shout.)\n\nThe system is flat, restrained, and content-forward. Depth comes from 1px borders and tonal background layering, not decoration; shadows appear only when something genuinely floats above the page. Color is held in reserve: a single confident blue carries interaction and the rest of the interface is a disciplined neutral ramp, so an article, a highlight, or an unread marker reads instantly. Density is deliberately tight in the chrome (an 11px to 15px band does most of the work in lists and toolbars) and deliberately generous in the reading surface, where an 18px serif at 1.8 line-height sits in an 800px band. That contrast between compact chrome and open prose is the system's signature: the app is efficient everywhere except where you are actually reading.\n\nIt works in light and dark, both passing contrast independently, and it honors prefers-reduced-motion on every transition. This system explicitly rejects four things, carried from PRODUCT.md's anti-references: the cards-everywhere, gradient-accent generic SaaS dashboard; the dense-toolbar cluttered legacy reader; the warm-paper, serif-everything cream/beige editorial cliche; and the engagement-bait algorithmic social feed.",
     "keyCharacteristics": [
       "Flat by default; depth only where things overlap.",
       "One blue. Color is rare and therefore meaningful.",
       "Neutral, near-monochrome chrome so content is the only color event.",
-      "Reader-controlled article typography (family + size) is a first-class feature.",
-      "Calm density: efficient for many feeds, never cramped."
+      "Compact chrome, open prose: a tight 11px to 15px UI band around an 18px, 1.8-leading reading column.",
+      "Reader-controlled article typography (four families, eleven sizes) is a first-class feature.",
+      "Everything is theme-paired: every neutral and the primary itself have a night value."
     ],
     "rules": [
       {
         "name": "The One Blue Rule",
-        "body": "There is exactly one interaction blue: #0066cc (--color-primary). The values #2563eb, #3b82f6, and #0085ff in the current code are drift, not palette, and are scheduled for consolidation. Never introduce a new blue.",
+        "body": "There is exactly one interaction blue: #0066cc (--color-primary). The values #2563eb (21 uses), #0085ff (19 uses), and #3b82f6 (4 uses) currently present across twelve components are drift, not palette, and are scheduled for consolidation into --color-primary. The #0085ff cluster is concentrated in AddHandleModal, AddFeedModal, and SidebarAddFeed; #3b82f6 survives as a stale fallback in Sidebar.svelte. Never introduce a new blue. If a surface needs a blue, it is this blue or a documented tint of it.",
+        "section": "colors"
+      },
+      {
+        "name": "The Lifted-Primary Rule",
+        "body": "The primary is the one non-neutral token that changes value by theme. #0066cc on the night surface #1a1a1a measures roughly 3.1:1, below the AA body-text bar, so dark mode lifts it to #4da6ff (roughly 6.8:1) and its pressed state to #3399ff, with the selection wash correspondingly raised to 15% alpha. Any new primary-derived value must ship a night pair; never hard-code #0066cc where the token would have been theme-swapped.",
         "section": "colors"
       },
       {
         "name": "The Reserved Color Rule",
-        "body": "Outside of the one blue and the semantic trio, the interface is neutral. Color is an event: an unread dot, a highlight, a sync state. No screen has more than one non-neutral hue competing for attention (excluding semantic state).",
+        "body": "Outside of the one blue and the semantic trio, the interface is neutral. Color is an event: an unread dot, a highlight, a sync state. If a screen has more than one non-neutral hue competing for attention (excluding semantic state), something is wrong.",
+        "section": "colors"
+      },
+      {
+        "name": "The Phantom Token Rule",
+        "body": "Every color must be defined in :root before it is referenced. --color-bg-hover (51 uses), --color-accent (21), --color-surface-2, --color-text-tertiary, --color-danger, --color-warning-bg/-text/-border, --color-error-bg, --color-shadow, and --radius-md are referenced but never declared anywhere, so every use silently resolves to its inline fallback. That is worse than a hard-coded value, because the fallbacks are light-theme constants: var(--color-bg-hover, rgba(0, 0, 0, 0.05)) renders an invisible hover on a #1a1a1a night surface. Either declare the token in both themes or inline the literal. Never add a new var(--color-X, fallback) for an undeclared X.",
         "section": "colors"
       },
       {
         "name": "The One Voice Rule",
-        "body": "The chrome uses a single typeface family. Hierarchy comes from weight (400 vs 600) and size, never from a second UI font. The only typographic variety the user sees is the one they chose for the article body.",
+        "body": "The chrome uses a single typeface family. Hierarchy comes from size, weight (400 / 500 / 600), and color, never from introducing a second UI font. The only typographic variety the user should see is the one they chose for the article body.",
         "section": "typography"
       },
       {
         "name": "The No-Shout Rule",
-        "body": "UI headings top out around 1.25rem. There is no hero display type; oversized headings would be chrome competing with content.",
+        "body": "Chrome headings top out at --text-2xl (1.25rem). There is no hero display type in the app shell. --text-3xl (24px) and --text-4xl (28px) exist and are legitimate, but only on three surfaces: the reader's article title, empty-state and welcome heroes, and roomy public pages. If a step above 20px appears in a sidebar, toolbar, list row, or modal, it is a mistake.",
+        "section": "typography"
+      },
+      {
+        "name": "The Reader-Owns-The-Article Rule",
+        "body": "Never hard-code a family or size on article body text. Read var(--article-font) and var(--article-font-size), and size anything that sits inside the prose (footnote markers, note glyphs, pull quotes) in em so it tracks the reader's choice rather than the app's scale.",
         "section": "typography"
       },
       {
         "name": "The Flat-By-Default Rule",
-        "body": "A surface at rest casts no shadow. If you are adding a box-shadow to a card, list row, or panel in the page flow, stop - use a border or a tonal background instead. Shadow signals that an element has left the page plane.",
+        "body": "A surface at rest casts no shadow. If you are adding a box-shadow to a card, list row, panel, or sticky header that is part of the page flow, stop and use a border or a tonal background instead. Shadow signals that an element has left the page plane.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Night-Alpha Rule",
+        "body": "Diffuse shadow reads weakly on dark surfaces, so every shadow ships a night value at roughly triple the alpha: 0.1 becomes 0.3, 0.15 becomes 0.4, 0.25 becomes 0.5. A shadow declared without a prefers-color-scheme: dark counterpart is incomplete.",
+        "section": "elevation"
+      },
+      {
+        "name": "The One Ring Rule",
+        "body": "Focus indication currently ships in five shapes (2px at 0.1, 0.15, and 0.18 alpha; 3px at 0.35 and against --color-sidebar-active; and a solid 2px var(--color-primary)). That inconsistency is drift. Standardize on the primary-tinted 2px ring, and never remove a focus affordance without replacing it.",
         "section": "elevation"
       }
     ],
     "dos": [
-      "Do use exactly one interaction blue, #0066cc (--color-primary). Consolidate any #2563eb / #3b82f6 / #0085ff you encounter into the token.",
-      "Do keep content surfaces flat and separate them with 1px Divider borders and Surface-vs-Sunken tonal layering.",
-      "Do reserve shadows (Raised / Floating / Overlay) for elements that float above the page - modals, dropdowns, toasts, popovers - and bump shadow opacity in dark mode.",
-      "Do hold muted text (#666666 / dark #999999) and placeholders to at least 4.5:1; bump toward Ink before reaching for a lighter gray.",
-      "Do keep article measure at 65-75ch and preserve reader control over article font family and size.",
-      "Do pair every color signal (unread, sync state, social cue) with shape, weight, or text - color is never the sole carrier of meaning.",
-      "Do provide a prefers-reduced-motion fallback (crossfade or instant) for every transition."
+      "Do use exactly one interaction blue, #0066cc (--color-primary). Consolidate any #2563eb, #3b82f6, or #0085ff you encounter into the token.",
+      "Do ship a night value for every primary-derived color and every shadow. The primary itself lifts to #4da6ff in dark mode; shadows roughly triple their alpha.",
+      "Do declare a CSS custom property in :root before referencing it. A var(--x, fallback) for an undeclared --x is a light-theme constant wearing a token's clothes.",
+      "Do keep content surfaces flat and separate them with 1px Divider borders and Surface-against-Sunken tonal layering.",
+      "Do reserve shadows for elements that float above the page: modals, sheets, dropdowns, popovers, tooltips.",
+      "Do hold muted text (#666666, night #999999) and placeholders to 4.5:1; move toward Ink before reaching for a lighter gray.",
+      "Do read var(--article-font) and var(--article-font-size) on every reading surface, and size anything inside the prose in em.",
+      "Do keep the 800px reading band shared between the feed body and the reader, so expanding an article does not shift the page.",
+      "Do reach for a container query when a component appears at more than one width, and add it to the /dev harness registry.",
+      "Do pair every color signal (unread, sync state, social cue) with opacity, shape, weight, or text. Color is never the sole carrier of meaning.",
+      "Do provide a prefers-reduced-motion fallback for every transition."
     ],
     "donts": [
-      "Don't build a generic SaaS dashboard: no cards-everywhere grids, gradient accents, or hero-metric templates.",
+      "Don't build a generic SaaS dashboard: no cards-everywhere grids, gradient accents, or hero-metric templates. This is a reading app.",
       "Don't recreate a cluttered legacy reader: no dense toolbar walls or every-feature-visible chrome crowding the content.",
-      "Don't drift toward the cream/beige editorial cliche: the body background is true white (#ffffff) / dark (#1a1a1a), never warm paper.",
+      "Don't drift toward the cream/beige editorial cliche: the body background is true white (#ffffff) or #1a1a1a, never warm paper. Warmth comes only from Highlight Gold inside the article.",
       "Don't let the social layer look like an algorithmic feed: shares and notes stay quiet, chronological, and human-scaled.",
-      "Don't add resting box-shadow to in-flow cards, rows, or panels (The Flat-By-Default Rule).",
-      "Don't introduce a second UI typeface; hierarchy is weight and size in the system sans.",
-      "Don't use a colored border-left / border-right stripe as an accent on rows, cards, or alerts.",
-      "Don't exceed 1.25rem for UI headings; there is no hero display type in this app.",
-      "Don't use background-clip: text gradient text anywhere."
+      "Don't add a resting box-shadow, backdrop blur, or border to an in-flow card, row, or sticky header (The Flat-By-Default Rule).",
+      "Don't introduce a second UI typeface. Hierarchy is size, weight, and color in the system sans.",
+      "Don't use a type step above --text-2xl (1.25rem) anywhere in the app shell. 24px and 28px belong to the reader's article title, empty-state heroes, and public pages only.",
+      "Don't bold feed-row titles. Weight in a long list is noise, not hierarchy.",
+      "Don't use a colored border-left or border-right stripe as an accent on rows, cards, or alerts. The 3px gold rule on a quoted highlight is the one exception, and it is a quotation mark, not a status.",
+      "Don't add a fourth structural breakpoint. 1000px is the shell line, 640px the density step.",
+      "Don't animate all, and don't add transform, scale, or bounce to a button's hover.",
+      "Don't use background-clip: text gradient text anywhere. Emphasis is weight and size."
     ]
   }
 }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,84 +1,127 @@
 ---
 name: Skyreader
-description: A calm reading app that helps you make sense of everything you read — reading-first, social without the timeline, portable by foundation.
+description: A calm reading app for making sense of everything you read. Reading-first, social without the timeline, portable by foundation.
 colors:
   primary: '#0066cc'
   primary-dark: '#0052a3'
-  primary-tint: '#e8f4fc'
-  sky: '#4a9fd4'
-  highlight: '#f5c518'
+  primary-wash: 'rgba(0, 102, 204, 0.1)'
+  night-primary: '#4da6ff'
+  night-primary-dark: '#3399ff'
+  night-wash: 'rgba(77, 166, 255, 0.15)'
   bg: '#ffffff'
   bg-secondary: '#f5f5f5'
   text: '#333333'
   text-secondary: '#666666'
   border: '#e0e0e0'
+  night-bg: '#1a1a1a'
+  night-bg-secondary: '#2a2a2a'
+  night-text: '#e0e0e0'
+  night-text-secondary: '#999999'
+  night-border: '#404040'
   success: '#4caf50'
   warning: '#ff9800'
   error: '#f44336'
+  error-dark: '#d32f2f'
+  highlight: '#f5c518'
+  highlight-ink: '#9a7700'
+  night-highlight-ink: '#e3b94a'
+  sky: '#4a9fd4'
+  sky-deep: '#1e6fa8'
+  sky-light: '#87ceeb'
+  sky-wash: '#e8f4fc'
 typography:
   headline:
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
     fontSize: '1.25rem'
     fontWeight: 600
     lineHeight: 1.3
     letterSpacing: '-0.01em'
   title:
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
-    fontSize: '1rem'
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
+    fontSize: '0.9375rem'
     fontWeight: 600
     lineHeight: 1.4
     letterSpacing: 'normal'
   body:
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
     fontSize: '1rem'
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: 'normal'
-  article:
-    fontFamily: "var(--article-font, Georgia, Cambria, 'Times New Roman', serif)"
-    fontSize: '1rem'
-    fontWeight: 400
-    lineHeight: 1.6
-    letterSpacing: 'normal'
   label:
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
     fontSize: '0.875rem'
     fontWeight: 500
     lineHeight: 1.4
     letterSpacing: 'normal'
+  meta:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
+    fontSize: '0.8125rem'
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: 'normal'
+  micro:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
+    fontSize: '0.6875rem'
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: '0.05em'
+  article:
+    fontFamily: "var(--article-font, Charter, 'Bitstream Charter', 'Iowan Old Style', Georgia, Cambria, serif)"
+    fontSize: '1.125rem'
+    fontWeight: 400
+    lineHeight: 1.8
+    letterSpacing: 'normal'
+  article-title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif"
+    fontSize: '1.75rem'
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: '-0.01em'
 rounded:
+  xs: '2px'
   sm: '4px'
   md: '6px'
   lg: '8px'
   xl: '12px'
+  sheet: '16px'
   pill: '999px'
 spacing:
-  xs: '4px'
+  2xs: '4px'
+  xs: '6px'
   sm: '8px'
-  md: '16px'
-  lg: '24px'
-  xl: '48px'
+  md: '12px'
+  lg: '16px'
+  xl: '24px'
+  2xl: '32px'
 components:
   button-primary:
     backgroundColor: '{colors.primary}'
     textColor: '#ffffff'
+    typography: '{typography.label}'
     rounded: '{rounded.md}'
     padding: '8px 16px'
   button-primary-hover:
     backgroundColor: '{colors.primary-dark}'
     textColor: '#ffffff'
-    rounded: '{rounded.md}'
-    padding: '8px 16px'
   button-secondary:
     backgroundColor: '{colors.bg-secondary}'
     textColor: '{colors.text}'
+    typography: '{typography.label}'
     rounded: '{rounded.md}'
     padding: '8px 16px'
+  button-secondary-hover:
+    backgroundColor: '{colors.border}'
+    textColor: '{colors.text}'
   button-danger:
     backgroundColor: '{colors.error}'
     textColor: '#ffffff'
+    typography: '{typography.label}'
     rounded: '{rounded.md}'
     padding: '8px 16px'
+  button-danger-hover:
+    backgroundColor: '{colors.error-dark}'
+    textColor: '#ffffff'
   card:
     backgroundColor: '{colors.bg}'
     textColor: '{colors.text}'
@@ -87,46 +130,109 @@ components:
   input:
     backgroundColor: '{colors.bg}'
     textColor: '{colors.text}'
+    typography: '{typography.body}'
     rounded: '{rounded.md}'
     padding: '8px 12px'
+    width: '100%'
+  nav-item:
+    backgroundColor: 'transparent'
+    textColor: '{colors.text}'
+    typography: '{typography.label}'
+    rounded: '{rounded.xl}'
+    padding: '8px 12px'
+  nav-item-active:
+    backgroundColor: '{colors.primary-wash}'
+    textColor: '{colors.primary}'
+    rounded: '{rounded.xl}'
+    padding: '8px 12px'
+  chip:
+    backgroundColor: '{colors.bg-secondary}'
+    textColor: '{colors.text-secondary}'
+    typography: '{typography.micro}'
+    rounded: '{rounded.pill}'
+    padding: '2px 7px'
+  chip-active:
+    backgroundColor: '{colors.primary-wash}'
+    textColor: '{colors.primary}'
+  unread-badge:
+    backgroundColor: '{colors.primary}'
+    textColor: '#ffffff'
+    typography: '{typography.micro}'
+    rounded: '{rounded.sm}'
+    padding: '2px 6px'
+  article-row:
+    backgroundColor: 'transparent'
+    textColor: '{colors.text}'
+    typography: '{typography.body}'
+    rounded: '{rounded.lg}'
+    padding: '0 16px'
+  modal:
+    backgroundColor: '{colors.bg}'
+    textColor: '{colors.text}'
+    rounded: '{rounded.lg}'
+    padding: '24px'
+    width: '100%'
+    size: '480px'
+  bottom-sheet:
+    backgroundColor: '{colors.bg}'
+    textColor: '{colors.text}'
+    rounded: '{rounded.sheet}'
+    padding: '12px 16px 8px'
+    width: '100%'
+  popover-menu:
+    backgroundColor: '{colors.bg}'
+    textColor: '{colors.text}'
+    typography: '{typography.label}'
+    rounded: '{rounded.lg}'
+    padding: '10px 14px'
+    size: '140px'
+  tooltip:
+    backgroundColor: '{colors.bg}'
+    textColor: '{colors.text-secondary}'
+    typography: '{typography.micro}'
+    rounded: '{rounded.md}'
+    padding: '4px 8px'
 ---
 
 # Design System: Skyreader
 
-## 1. Overview
+## Overview
 
 **Creative North Star: "The Reading Room"**
 
-Skyreader is a quiet place to read deeply and think clearly — open to the people you trust, closed
+Skyreader is a quiet place to read deeply and think clearly, open to the people you trust and closed
 to the algorithm. Everything you follow comes into one calm room; the design exists to make reading
 it, and making sense of it, feel unhurried and ordered. Chrome is quiet and recedes; the text you
 came to read is the one element allowed to raise its voice. Every surface decision is measured
-against a single question from PRODUCT.md: _does this help or distract from reading?_ When in doubt,
-it goes. (The room is also _yours_ — it lives on infrastructure you own — but that's the foundation
-under the calm, not something the design needs to shout.)
+against a single question from PRODUCT.md: does this help or distract from reading? When in doubt,
+it goes. (The room is also yours, running on infrastructure you own, but that is the foundation
+under the calm rather than something the design needs to shout.)
 
-The system is **flat, restrained, and content-forward**. Depth is conveyed through 1px borders and
-tonal background layering, not decoration — shadows appear only when something genuinely floats
-above the page. Color is held in reserve: a single confident blue carries interaction, and the rest
-of the interface is a disciplined neutral ramp so that an article, a highlight, or an unread marker
-reads instantly. It works in both light and dark, both must independently pass contrast, and it
-respects `prefers-reduced-motion` on every transition.
+The system is **flat, restrained, and content-forward**. Depth comes from 1px borders and tonal
+background layering, not decoration; shadows appear only when something genuinely floats above the
+page. Color is held in reserve: a single confident blue carries interaction and the rest of the
+interface is a disciplined neutral ramp, so an article, a highlight, or an unread marker reads
+instantly. Density is deliberately tight in the chrome (an 11px to 15px band does most of the work
+in lists and toolbars) and deliberately generous in the reading surface, where an 18px serif at
+1.8 line-height sits in an 800px band. That contrast between compact chrome and open prose is the
+system's signature: the app is efficient everywhere except where you are actually reading.
 
-This system explicitly **rejects** four things, carried verbatim from PRODUCT.md's anti-references:
-the cards-everywhere, gradient-accent **generic SaaS dashboard**; the dense-toolbar **cluttered
-legacy reader**; the warm-paper, serif-everything **cream/beige editorial cliché**; and the
-engagement-bait **algorithmic social feed**. Skyreader is a place to read and think, built to
-outlast any one app.
+It works in light and dark, both passing contrast independently, and it honors
+`prefers-reduced-motion` on every transition. This system explicitly **rejects** four things,
+carried from PRODUCT.md's anti-references: the cards-everywhere, gradient-accent **generic SaaS
+dashboard**; the dense-toolbar **cluttered legacy reader**; the warm-paper, serif-everything
+**cream/beige editorial cliché**; and the engagement-bait **algorithmic social feed**.
 
 **Key Characteristics:**
 
 - Flat by default; depth only where things overlap.
 - One blue. Color is rare and therefore meaningful.
 - Neutral, near-monochrome chrome so content is the only color event.
-- Reader-controlled article typography (family + size) is a first-class feature.
-- Calm density: efficient for many feeds, never cramped.
+- Compact chrome, open prose: a tight 11px to 15px UI band around an 18px, 1.8-leading reading column.
+- Reader-controlled article typography (four families, eleven sizes) is a first-class feature.
+- Everything is theme-paired: every neutral and the primary itself have a night value.
 
-## 2. Colors
+## Colors
 
 A near-monochrome neutral system with one disciplined blue for interaction and a small set of
 semantic signals. The point of the restraint is that when color appears, it means something.
@@ -134,190 +240,380 @@ semantic signals. The point of the restraint is that when color appears, it mean
 ### Primary
 
 - **Skyreader Blue** (`#0066cc`): The single interaction color. Primary buttons, links, active
-  navigation, focus rings, and the sidebar's selected state. This is the **only** blue in the
-  interface — see The One Blue Rule.
-- **Pressed Blue** (`#0052a3`): The darker hover/active state for primary buttons and pressed
-  controls. Used only as a state shift of the primary, never as a standalone fill.
-- **Wash Blue** (`#e8f4fc`): A faint blue tint for selected rows and subtle active backgrounds
-  (also expressed as `rgba(0, 102, 204, 0.1)` via `--color-sidebar-active`). Carries the primary's
-  hue at low intensity so selection reads without a heavy fill.
+  navigation, focus rings, unread badges, and the sidebar's selected state. This is the **only**
+  blue in the interface. See The One Blue Rule.
+- **Pressed Blue** (`#0052a3`): The hover and active state for primary buttons and pressed controls.
+  Only ever a state shift of the primary, never a standalone fill.
+- **Wash Blue** (`rgba(0, 102, 204, 0.1)`, shipped as `--color-sidebar-active`): The primary at low
+  intensity, for selected sidebar rows, active chips, and highlighted feed rows. Selection reads as
+  a tint, not a heavy fill.
+- **Lifted Blue** (`#4da6ff`) and **Lifted Pressed** (`#3399ff`): The dark-theme substitutions for
+  the primary pair, with **Night Wash** (`rgba(77, 166, 255, 0.15)`) as the matching tint. See The
+  Lifted-Primary Rule.
 
 ### Secondary
 
-- **Sky Identity** (`#4a9fd4`): The "Sky" in Skyreader. Reserved for **brand identity marks only** —
-  the app icon, the logo gradient, the PWA mask-icon, the OG image. It sets the lighter, airier brand
-  note the OS shows around the installed app's icon. It is **not** an in-app UI color; inside the
-  app, the primary is `#0066cc`.
+- **Sky Identity** (`#4a9fd4`), with **Sky Deep** (`#1e6fa8`), **Sky Light** (`#87ceeb`), and
+  **Sky Wash** (`#e8f4fc`): The "Sky" in Skyreader. Reserved for **brand identity marks only**, as
+  the gradient in the app icon (`static/icons/icon-512.svg`) and the OG image. It sets the lighter,
+  airier brand note the OS shows around the installed app's icon. It is **not** an in-app UI color;
+  inside the app, the primary is Skyreader Blue.
 
-  **Not `theme-color`.** Browser and OS chrome takes the reading surface instead (`#ffffff` light /
-  `#1a1a1a` dark, declared per `prefers-color-scheme` in `app.html`). Mobile Safari paints its own
-  bottom toolbar with `theme-color`, and that toolbar sits directly beneath the app's mobile bottom
-  bar — a brand-blue band under a white bar reads as two mismatched surfaces. Matching them makes the
-  pair read as one, and the installed app opens into the same quiet surface it reads on. Declare
-  `theme-color` only in `app.html`: a copy in a `<svelte:head>` renders later and would override both
-  scheme variants with a single value.
+  **Not `theme-color`.** Browser and OS chrome takes the reading surface instead (`#ffffff` light,
+  `#1a1a1a` dark, declared per `prefers-color-scheme` in `app.html`; the web manifest carries
+  `#ffffff`). Mobile Safari paints its own bottom toolbar with `theme-color`, and that toolbar sits
+  directly beneath the app's mobile bottom bar. A brand-blue band under a white bar reads as two
+  mismatched surfaces; matching them makes the pair read as one, and the installed app opens into
+  the same quiet surface it reads on. Declare `theme-color` only in `app.html`: a copy in a
+  `<svelte:head>` renders later and would override both scheme variants with a single value.
 
 ### Tertiary
 
-- **Highlight Gold** (`#f5c518`): The reader's text-highlight color, applied as a translucent
-  `mark` background (25% at rest, 40% on hover) over article body text. The one warm accent in the
-  system, and only ever in the reading surface.
+- **Highlight Gold** (`#f5c518`): The reader's text-highlight color, applied as a translucent `mark`
+  background via `color-mix` (25% at rest, 40% on hover, 32% behind a note marker, 70% as the rule
+  on a quoted highlight). The one warm accent in the system, and only ever in reading surfaces.
+- **Highlight Ink** (`#9a7700`, night `#e3b94a`): The darker and lighter shades of the same hue used
+  for the inline note-marker glyph, so a note reads as part of its highlight rather than as new
+  chrome.
 
 ### Neutral
 
-- **Surface** (`#ffffff` light / `#1a1a1a` dark): The base reading background. The article sits here.
-- **Sunken** (`#f5f5f5` light / `#2a2a2a` dark): Secondary surface for sidebars, secondary buttons,
-  and recessed panels. Tonal layering, not shadow, separates it from Surface.
-- **Ink** (`#333333` light / `#e0e0e0` dark): Primary body and heading text. Meets ≥4.5:1 on Surface.
-- **Muted Ink** (`#666666` light / `#999999` dark): Metadata, timestamps, secondary labels. Held to
-  the 4.5:1 bar for body-sized text — never drifts into decorative light gray.
-- **Divider** (`#e0e0e0` light / `#404040` dark): 1px borders, dividers, input strokes, card edges.
-  The primary depth mechanism in a flat system.
+- **Surface** (`#ffffff` light, `#1a1a1a` night): The base reading background. The article sits here.
+- **Sunken** (`#f5f5f5` light, `#2a2a2a` night): Secondary surface for sidebars, secondary buttons,
+  inline code, and recessed panels. Tonal layering, not shadow, separates it from Surface.
+- **Ink** (`#333333` light, `#e0e0e0` night): Primary body and heading text.
+- **Muted Ink** (`#666666` light, `#999999` night): Metadata, timestamps, secondary labels, read
+  article titles. Held to the 4.5:1 bar for body-sized text, never drifting into decorative gray.
+- **Divider** (`#e0e0e0` light, `#404040` night): 1px borders, dividers, input strokes, card edges,
+  the bottom-sheet grab handle. The primary depth mechanism in a flat system.
 
 ### Semantic
 
 - **Success** (`#4caf50`): Sync-complete, confirmation toasts, online status.
 - **Warning** (`#ff9800`): Stale-feed and degraded-state signals.
-- **Error** (`#f44336`): Failed sync, destructive actions, validation errors.
+- **Error** (`#f44336`) and **Error Pressed** (`#d32f2f`): Failed sync, destructive actions,
+  validation errors, and the danger button's hover.
 
 ### Named Rules
 
 **The One Blue Rule.** There is exactly one interaction blue: `#0066cc` (`--color-primary`). The
-values `#2563eb`, `#3b82f6`, `#0085ff`, and `#0085ff`-as-`--color-accent` that exist in the current
-code are **drift, not palette** — they are scheduled for consolidation into `--color-primary`. Never
-introduce a new blue. If a surface needs a blue, it is this blue or a documented tint of it.
+values `#2563eb` (21 uses), `#0085ff` (19 uses), and `#3b82f6` (4 uses) currently present across
+twelve components are **drift, not palette**, and are scheduled for consolidation into
+`--color-primary`. The `#0085ff` cluster is concentrated in `AddHandleModal`, `AddFeedModal`, and
+`SidebarAddFeed`; `#3b82f6` survives as a stale fallback in `Sidebar.svelte`. Never introduce a new
+blue. If a surface needs a blue, it is this blue or a documented tint of it.
+
+**The Lifted-Primary Rule.** The primary is the one non-neutral token that changes value by theme.
+`#0066cc` on the night surface `#1a1a1a` measures roughly 3.1:1, below the AA body-text bar, so dark
+mode lifts it to `#4da6ff` (roughly 6.8:1) and its pressed state to `#3399ff`, with the selection
+wash correspondingly raised to 15% alpha. Any new primary-derived value must ship a night pair;
+never hard-code `#0066cc` where the token would have been theme-swapped.
 
 **The Reserved Color Rule.** Outside of the one blue and the semantic trio, the interface is
 neutral. Color is an event: an unread dot, a highlight, a sync state. If a screen has more than one
 non-neutral hue competing for attention (excluding semantic state), something is wrong.
 
-## 3. Typography
+**The Phantom Token Rule.** Every color must be defined in `:root` before it is referenced.
+`--color-bg-hover` (51 uses), `--color-accent` (21), `--color-surface-2`, `--color-text-tertiary`,
+`--color-danger`, `--color-warning-bg`/`-text`/`-border`, `--color-error-bg`, `--color-shadow`, and
+`--radius-md` are referenced but **never declared anywhere**, so every use silently resolves to its
+inline fallback. That is worse than a hard-coded value, because the fallbacks are light-theme
+constants: `var(--color-bg-hover, rgba(0, 0, 0, 0.05))` renders an invisible hover on a `#1a1a1a`
+night surface. Either declare the token in both themes or inline the literal. Never add a new
+`var(--color-X, fallback)` for an undeclared `X`.
 
-**Display / Body Font:** The native system sans stack — `-apple-system, BlinkMacSystemFont,
-'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif`. Skyreader uses **one UI typeface**, expressed
-through weight and size rather than multiple families. It loads instantly, matches each OS, and
-disappears — exactly what reader-first chrome wants.
+## Typography
 
-**Article Font:** Reader-selectable via `--article-font` and the `data-article-font` attribute:
-**sans** (system stack), **serif** (`Georgia, Cambria, 'Times New Roman', serif`), or **mono**
-(`ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace`). Size is reader-selectable across
-five steps (xs `0.75rem` → xl `1.25rem`) via `data-article-font-size`.
+**UI Font:** The native system sans stack (`--font-sans-serif`): `-apple-system,
+BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif`. Skyreader uses **one UI
+typeface**, expressed through weight and size rather than multiple families. It loads instantly,
+matches each OS, and disappears, which is exactly what reader-first chrome wants.
+
+**Article Font:** Reader-selectable via `--article-font` and the `data-article-font` attribute
+across four choices: **serif** (the default: `Charter, 'Bitstream Charter', 'Iowan Old Style',
+Georgia, Cambria, serif`, preferring the screen-grade serifs that ship on Apple platforms before
+falling back to Georgia), **sans** (the system stack), **mono** (`ui-monospace, SFMono-Regular,
+'SF Mono', Menlo, Consolas, monospace`), and **Literata** (`--font-literata`), the one opt-in web
+font: self-hosted variable weight 200 to 900 with an optical-size axis, `font-display: swap`, and
+split latin / latin-ext unicode ranges so it only downloads when a reader actually selects it. Size
+is reader-selectable and applied as an inline px value on the document root by AppShell; the CSS
+default (`1.125rem`, 18px) exists only to keep the pre-hydration paint from flashing.
 
 **Character:** Quiet and native in the chrome; reader-owned in the article. The UI never imposes a
-typographic personality that competes with the text the reader chose to format.
+typographic personality that competes with the text the reader chose to format. `font-optical-sizing:
+auto` is set on the root so a variable article face picks its own optical master by size.
+
+### Scale
+
+A fixed-rem ladder of eleven steps, deliberately dense in the middle. The 11px to 15px band is
+tightly stepped (11, 12, 13, 14, 15) because the app serves readers tracking many feeds and needs
+several distinguishable weights of secondary information in one row. The steps above 20px exist for
+exactly three places: the reader's article title, the empty-state hero, and roomy public pages.
+
+`--text-3xs` 10px · `--text-2xs` 11px · `--text-xs` 12px · `--text-sm` 13px · `--text-md` 14px ·
+`--text-lg` 15px · `--text-base` 16px · `--text-xl` 18px · `--text-2xl` 20px · `--text-3xl` 24px ·
+`--text-4xl` 28px.
+
+Weights are `--weight-regular` 400, `--weight-medium` 500, `--weight-semibold` 600, `--weight-bold` 700. Line heights are `--leading-none` 1, `--leading-tight` 1.3, `--leading-snug` 1.4,
+`--leading-normal` 1.5, `--leading-relaxed` 1.6. Tracking is `--tracking-tight` -0.01em,
+`--tracking-wide` 0.03em, `--tracking-wider` 0.05em.
 
 ### Hierarchy
 
-- **Headline** (600, `1.25rem`, line-height 1.3, letter-spacing -0.01em): Page and major section
-  titles. The largest type in the chrome — Skyreader does not shout with oversized display type.
-- **Title** (600, `1rem`, line-height 1.4): Article titles in list/card rows, modal headers.
-- **Body** (400, `1rem`, line-height 1.5): Default UI text and controls.
-- **Article** (400, `1rem` default, line-height ≈1.6): The reading surface. Reader-controlled
-  family and size. Cap measure at **65–75ch** for comfortable long-form reading.
-- **Label** (500, `0.875rem`): Metadata, timestamps, feed names, secondary actions. Usually in
-  Muted Ink, never below 4.5:1.
+- **Headline** (600, `1.25rem`, line-height 1.3, tracking -0.01em): Page titles, modal headers, and
+  major section titles. The largest type the chrome is allowed.
+- **Title** (600, `0.9375rem`, line-height 1.4): List titles, source names, emphasized UI text.
+- **Body** (400, `1rem`, line-height 1.5): Default UI text, controls, and feed-row article titles.
+  Note the feed title is `regular`, not semibold: in a list of forty rows, weight is scanning noise,
+  so hierarchy there comes from color and position instead.
+- **Meta** (400, `0.8125rem`, line-height 1.4): The workhorse secondary line. Timestamps, feed
+  names, counts. Usually in Muted Ink.
+- **Label** (500, `0.875rem`, line-height 1.4): Buttons, form labels, menu items, secondary actions.
+- **Micro** (500, `0.6875rem`, tracking 0.05em): Eyebrow labels, badge counts, chip text. The one
+  place letter-spacing is opened up.
+- **Article** (400, reader-set size defaulting to `1.125rem`, line-height 1.8): The reading surface.
+  Reader-controlled family and size, in an 800px column.
+- **Article Title** (600, `1.75rem`, line-height 1.3, tracking -0.01em): The reader's own headline,
+  and the single largest type in the product.
 
 ### Named Rules
 
-**The One Voice Rule.** The chrome uses a single typeface family. Hierarchy comes from weight (400
-vs 600) and size, never from introducing a second UI font. The only typographic variety the user
-should see is the one _they_ chose for the article body.
+**The One Voice Rule.** The chrome uses a single typeface family. Hierarchy comes from size, weight
+(400 / 500 / 600), and color, never from introducing a second UI font. The only typographic variety
+the user should see is the one _they_ chose for the article body.
 
-**The No-Shout Rule.** UI headings top out around `1.25rem`. There is no hero display type; this is
-a reading app, and oversized headings would be chrome competing with content.
+**The No-Shout Rule.** Chrome headings top out at `--text-2xl` (1.25rem). There is no hero display
+type in the app shell. `--text-3xl` (24px) and `--text-4xl` (28px) exist and are legitimate, but
+only on three surfaces: the reader's article title, empty-state and welcome heroes, and roomy public
+pages. If a step above 20px appears in a sidebar, toolbar, list row, or modal, it is a mistake.
 
-## 4. Elevation
+**The Reader-Owns-The-Article Rule.** Never hard-code a family or size on article body text. Read
+`var(--article-font)` and `var(--article-font-size)`, and size anything that sits inside the prose
+(footnote markers, note glyphs, pull quotes) in `em` so it tracks the reader's choice rather than
+the app's scale.
 
-**Flat by default; shadow only on overlap.** Content surfaces — the feed, the article, the sidebar,
-cards, rows — are flat. They separate from each other through 1px borders (Divider) and tonal
-layering (Surface vs Sunken), never through resting shadows. Shadow is reserved exclusively for
-elements that genuinely float above the page: modals, dropdowns, popovers, toasts, and the
-pull-to-refresh affordance. In dark mode the same shadows use higher opacity (0.3–0.5 vs 0.1–0.15)
-because diffuse shadow reads weakly on dark surfaces.
+## Layout
+
+**The shell.** A 320px sidebar (`--sidebar-width`, drag-resizable, with `body.sidebar-resizing`
+suppressing transitions during the drag) holds sources and channels; the content column fills the
+rest. Reading surfaces open as opaque full-screen overlays _above_ the sidebar rather than beside
+it, which is why the reader's chrome frames the viewport instead of tracking the column.
+
+**One structural breakpoint.** `1000px` is the line that matters: above it the sidebar is
+persistent, below it becomes an overlay drawer with `body.sidebar-open-mobile` locking page scroll,
+and a `--bottom-bar-height` (3.5rem) bottom bar appears. Safe-area insets (`--safe-area-bottom`,
+`--safe-area-top`) are respected on both. `640px` is the secondary phone-density step for tightening
+padding and dropping optional furniture; `1100px` and `900px` trim wide reader chrome. Do not add a
+new structural breakpoint without a reason the existing three cannot carry.
+
+**The 800px band.** The feed body (`.feed-page-body`) and the reader (`.reader-container`) share the
+same `max-width: 800px; margin: 0 auto; padding: 0 1rem` column, so an article occupies the exact
+horizontal space its list row did and expanding one does not shift the page. Paged reading mode is
+the one exception: it widens to a 1200px two-column spread.
+
+**Measure for chrome prose.** Explanatory copy caps between 42ch and 62ch (empty states 42ch, intro
+and comment copy 60ch, the welcome page 62ch). Article prose uses the 800px band rather than a `ch`
+cap, since the reader's chosen size determines the effective measure.
+
+**Spacing rhythm.** 8px is the workhorse (roughly twice as common as any other step), with 12px and
+4px next, and 6px for tight icon gaps. 16px is the standard card and section inset; 24px and 32px
+handle page-level separation. Modals use a 24px header and body inset with a 16px/24px footer.
+
+**Container queries over viewport queries for components.** The article card declares
+`container: card / inline-size` and responds to the column width it is handed, not the viewport, so
+it renders correctly in the feed, in a narrow lane, and in the `/dev/cards` width-slider harness
+alike. Prefer this for any component that appears at more than one width.
+
+**The component harness.** `/dev/*` is a dev-only tree (404s in production) of isolated component
+canvases, cataloged in `src/routes/dev/_harness/registry.ts`. Add an entry when adding a component
+worth seeing in every state.
+
+## Elevation & Depth
+
+**Flat by default; shadow only on overlap.** Content surfaces (the feed, the article, the sidebar,
+cards, rows, the sticky reader header) are flat. They separate through 1px Divider borders and tonal
+layering (Surface against Sunken), never through resting shadows or blur. Shadow is reserved for
+elements that genuinely float above the page: modals, sheets, dropdowns, popovers, tooltips, and the
+pull-to-refresh affordance.
 
 ### Shadow Vocabulary
 
-- **Raised** (`box-shadow: 0 2px 8px rgba(0,0,0,0.1)` light / `0.3` dark): Small floating elements —
-  popover menus, tooltips, context menus.
-- **Floating** (`box-shadow: 0 4px 16px rgba(0,0,0,0.15)` light / `0.4` dark): Dropdowns, toasts,
-  the primary mid-level overlay.
-- **Overlay** (`box-shadow: 0 8px 32px rgba(0,0,0,0.25)` light / `0.5` dark): Modals and full
-  dialogs that sit above a backdrop.
-- **Focus Ring** (`box-shadow: 0 0 0 2px rgba(0,102,204,0.1)`): The primary-tinted focus indicator
-  on interactive elements. A glow, not a shadow, but lives in the same vocabulary.
+- **Raised** (`0 2px 8px rgba(0,0,0,0.1)`, night `0.4`): Small floating elements. Context menus,
+  compact popovers.
+- **Floating** (`0 4px 12px rgba(0,0,0,0.15)`, night `0.4`): Tooltips (`.app-tooltip`) and popover
+  menus.
+- **Lifted** (`0 4px 16px rgba(0,0,0,0.15)`, night `0.4`): The workhorse overlay shadow. Dropdowns,
+  floating toolbars, action bars.
+- **Dialog** (`0 4px 20px rgba(0,0,0,0.15)`, night `0.4`): The shared `Modal` above a
+  `rgba(0,0,0,0.5)` backdrop.
+- **Sheet** (`0 -4px 24px rgba(0,0,0,0.15)`, night `0.4`): The mobile `BottomSheet`, cast upward,
+  above a `rgba(0,0,0,0.4)` backdrop (night `0.6`).
+- **Focus Ring** (`0 0 0 2px rgba(0,102,204,0.1)`): The primary-tinted focus indicator. A glow
+  rather than a shadow, but it lives in the same vocabulary.
 
 ### Named Rules
 
 **The Flat-By-Default Rule.** A surface at rest casts no shadow. If you are adding a `box-shadow` to
-a card, list row, or panel that is part of the page flow, stop — use a border or a tonal background
-instead. Shadow is a signal that an element has left the page plane.
+a card, list row, panel, or sticky header that is part of the page flow, stop and use a border or a
+tonal background instead. Shadow signals that an element has left the page plane.
 
-## 5. Components
+**The Night-Alpha Rule.** Diffuse shadow reads weakly on dark surfaces, so every shadow ships a
+night value at roughly triple the alpha: 0.1 becomes 0.3, 0.15 becomes 0.4, 0.25 becomes 0.5. A
+shadow declared without a `prefers-color-scheme: dark` counterpart is incomplete.
+
+**The One Ring Rule.** Focus indication currently ships in five shapes (`2px` at 0.1, 0.15, and 0.18
+alpha; `3px` at 0.35 and against `--color-sidebar-active`; and a solid `2px var(--color-primary)`).
+That inconsistency is drift. Standardize on the primary-tinted 2px ring, and never remove a focus
+affordance without replacing it.
+
+## Shapes
+
+**A four-step radius ladder, assigned by role rather than by size.**
+
+- **2px** (`xs`): The bottom-sheet grab handle and other hairline affordances.
+- **4px** (`sm`): Micro surfaces. Unread count badges, inline code spans, small tags.
+- **6px** (`md`): Controls. Buttons, inputs, tooltips, icon-button hit targets.
+- **8px** (`lg`): Containers. Cards, modals, popover menus, and the feed row's hover tint.
+- **12px** (`xl`): Sidebar navigation rows. Deliberately _larger_ than a card, which is the one
+  intentional inversion in the ladder: a softer pill makes selection read as a resting state inside
+  the rail rather than as a box drawn around a link.
+- **16px** (`sheet`): The bottom sheet's top corners only, where the radius reads as the sheet
+  lifting off the screen edge.
+- **999px** (`pill`): Chips, tags, source labels, counts, segmented controls.
+- **50%**: Avatars, the read/unread dot, circular icon toggles.
+
+**Borders.** A 1px solid Divider is the universal separator and the primary depth mechanism. The one
+thicker stroke is the 1.5px ring on the read/unread toggle, which needs to read as a target at 14px.
+
+**Stripes.** Colored side-borders are not an accent device: use the Wash Blue tint or a full border
+instead. The single sanctioned exception is the 3px gold rule on a quoted highlight in the highlights
+page, where the stripe is a quotation convention rather than a status accent.
+
+**Motion.** Transitions are short and property-scoped. `0.15s` is the default for hover and
+background changes, `0.2s` for buttons and width changes, `0.25s` for larger reveals, `0.1s` for
+press feedback. Easing is `ease` by default, with `cubic-bezier(0.22, 1, 0.36, 1)` for entrances
+that should settle rather than bounce. Never animate `all`. Every animated rule needs a
+`@media (prefers-reduced-motion: reduce)` counterpart that drops to a crossfade or nothing; 24 files
+already carry one.
+
+## Components
 
 Components are **refined and restrained**: modest radii, quiet state changes, no heavy fills or
-bouncy motion. They are reliable and unobtrusive — the UI never competes with content.
+bouncy motion. They are reliable and unobtrusive, and the UI never competes with content.
 
 ### Buttons
 
-- **Shape:** Gently rounded, 6px radius (`{rounded.md}`). Padding `8px 16px`, weight 500, with an
-  inline-flex layout and an 8px gap for optional icons.
-- **Primary:** Skyreader Blue (`#0066cc`) fill, white text. The single high-emphasis action per view.
-- **Hover / Focus:** Background shifts to Pressed Blue (`#0052a3`) over a 0.2s `background-color`
-  transition. Focus shows the primary-tinted Focus Ring. No transform, no scale, no bounce.
-- **Secondary:** Sunken (`#f5f5f5`) fill, Ink text, 1px Divider border — for lower-emphasis actions.
-- **Danger:** Error (`#f44336`) fill, white text — destructive actions only.
+- **Shape:** 6px radius, `8px 16px` padding, weight 500, inline-flex with an 8px gap for optional
+  icons. No borders on primary or danger.
+- **Primary:** Skyreader Blue fill, white text. One high-emphasis action per view.
+- **Secondary:** Sunken fill, Ink text, 1px Divider border. Hover deepens to the Divider color.
+- **Danger:** Error fill, white text, hovering to Error Pressed. Destructive actions only.
+- **Hover / Focus:** A 0.2s `background-color` transition only. No transform, no scale, no bounce.
+  Focus shows the primary-tinted ring.
+
+### Chips
+
+- **Style:** Pill (999px), Sunken background, Muted Ink text, Micro type at `2px 7px`. No border.
+- **State:** Active chips take the Wash Blue background and primary text. Counts and source labels
+  use the same shape at Micro size.
+- **Unread badge:** The one chip that takes a solid primary fill with white text, at 4px radius and
+  `--text-3xs`, so a count reads as a signal rather than a label.
 
 ### Cards / Containers
 
-- **Corner Style:** 8px radius (`{rounded.lg}`).
-- **Background:** Surface (`#ffffff` / dark `#1a1a1a`).
-- **Shadow Strategy:** None at rest (see Elevation). Definition comes from a 1px Divider border.
-- **Border:** 1px solid Divider (`#e0e0e0` / dark `#404040`).
-- **Internal Padding:** 16px (`{spacing.md}`).
-- **Note:** Cards are used sparingly, for genuinely grouped content. Nested cards are forbidden;
-  the feed is a list of rows, not a grid of boxes.
+- **Corner Style:** 8px radius. **Background:** Surface. **Border:** 1px solid Divider.
+  **Internal Padding:** 16px. **Shadow:** none at rest.
+- Cards are used sparingly, for genuinely grouped content. Nested cards are forbidden. The feed is a
+  list of rows, not a grid of boxes.
 
 ### Inputs / Fields
 
-- **Style:** Full-width, 1px Divider stroke, Surface background, 6px radius, `8px 12px` padding.
-- **Focus:** Border shifts to Skyreader Blue (`#0066cc`); the default outline is removed in favor
-  of the border shift (and, where present, the primary-tinted Focus Ring). Never remove focus
-  affordance without replacing it.
-- **Error:** Error-colored helper text at `0.875rem` below the field.
+- **Style:** Full-width, 1px Divider stroke, Surface background, 6px radius, `8px 12px` padding,
+  inheriting the UI font and size.
+- **Focus:** The default outline is removed in favor of a border shift to the primary. Where a ring
+  is also shown, it is the primary-tinted 2px ring.
+- **Error:** Error-colored helper text at `--text-md` with a 4px top margin.
 
 ### Navigation (Sidebar)
 
-- **Style:** A 320px (resizable) Sunken-background sidebar of feed sources and channels, organized
-  into expandable sections.
-- **States:** Default rows in Ink/Muted Ink; hover gets a subtle Sunken shift; the **active** row
-  uses the Wash Blue background (`--color-sidebar-active`) — selection by tint, not by a heavy fill
-  or a colored side-stripe.
-- **Mobile:** The sidebar becomes an overlay drawer; `body.sidebar-open-mobile` locks page scroll
-  behind it. A bottom bar (`--bottom-bar-height: 3.5rem`) respects iOS safe-area insets.
+- **Style:** A 320px resizable Sunken rail of sources and channels in expandable sections. Rows are
+  `8px 12px` at 12px radius, Label type.
+- **States:** Default rows in Ink; hover takes a faint neutral tint; the **active** row uses Wash
+  Blue with primary text. Selection by tint, never by a heavy fill or a colored side stripe.
+- **Mobile:** Below 1000px the rail becomes an overlay drawer over a `rgba(0,0,0,0.5)` scrim, with
+  `body.sidebar-open-mobile` locking scroll behind it and a 3.5rem bottom bar respecting safe-area
+  insets.
+
+### Overlays
+
+- **Modal** (`common/Modal.svelte`): Portaled to `<body>` so it escapes ancestor stacking contexts.
+  Surface background, 8px radius, 480px default max-width, `80vh` max-height, Dialog shadow, over a
+  `rgba(0,0,0,0.5)` backdrop. Header and body inset 24px, footer `16px 24px` with a 12px gap, both
+  divided by 1px Divider rules. Header title is Headline; the close control is a bare glyph in Muted
+  Ink.
+- **BottomSheet** (`common/BottomSheet.svelte`): The mobile counterpart. Bottom-anchored, 16px top
+  corners, Sheet shadow, a 36x4px Divider grab handle, `env(safe-area-inset-bottom)` padding, and a
+  `translateY(100%)` to `0` entrance.
+- **PopoverMenu**: Surface background, 1px Divider border, 8px radius, Floating shadow, 140px
+  minimum width. Items are `10px 14px` at Label size, hovering to Sunken; destructive items hover to
+  a 10% Error tint.
+- **Tooltip** (`.app-tooltip`, body-portaled): Surface background, 1px Divider border, 6px radius,
+  Floating shadow, `4px 8px` padding, Micro size in Muted Ink, fading in over 0.12s.
+
+### Feed Row (Signature Surface)
+
+The densest and most-repeated element in the product, and the reason the chrome scale is tight.
+
+- **No border, no card.** Rows are borderless, transparent, and separated only by rhythm. Padding is
+  `0 16px`; the row is its own inline-size container.
+- **Hover** paints a faint neutral tint at 8px radius. Nothing else moves.
+- **Read state** is carried three ways at once, never by color alone: the whole row drops to 0.6
+  opacity (0.8 on hover), the title shifts from Ink to Muted Ink, and the read toggle's ring fills.
+- **Title** is Body weight 400, not semibold, truncated to one line. In a list of forty rows, bolding
+  every title is noise rather than hierarchy.
+- **Highlighted** (keyboard-selected) rows take a faint blue tint at 8px radius.
 
 ### Reading View (Signature Surface)
 
-- The most precious surface in the app. Article body renders with reader-chosen `--article-font`
-  and `--article-font-size`, measure capped at 65–75ch, line-height ≈1.6.
-- Text highlights use translucent Highlight Gold (`#f5c518`) `mark` backgrounds. This is the only
-  place warm color appears, and the only color besides links inside the prose.
+The most precious surface in the app.
 
-## 6. Do's and Don'ts
+- Opens as an opaque full-screen overlay above the sidebar, centering an 800px column in the whole
+  viewport. The sticky header is a flat, full-bleed bar with no blur and no shadow; the rule at its
+  bottom is the only edge it needs.
+- Body renders with `--article-font` and `--article-font-size` at 1.8 line-height. Paged mode
+  switches to a 1200px two-column spread.
+- Text highlights use translucent Highlight Gold `mark` backgrounds (25% at rest, 40% on hover),
+  with an inline note glyph in Highlight Ink sized in `em`. This is the only place warm color
+  appears, and the only color besides links inside the prose.
+- Footnotes render text-first: a superscript reference and a hairline-ruled list at the end, muted
+  off `currentColor` with `color-mix` rather than off app tokens, so they stay legible on a curated
+  edition's own themed background. No boxes, no backgrounds.
+
+## Do's and Don'ts
 
 ### Do:
 
-- **Do** use exactly one interaction blue, `#0066cc` (`--color-primary`). Consolidate any
-  `#2563eb` / `#3b82f6` / `#0085ff` you encounter into the token.
-- **Do** keep content surfaces flat and separate them with 1px Divider borders and Surface-vs-Sunken
+- **Do** use exactly one interaction blue, `#0066cc` (`--color-primary`). Consolidate any `#2563eb`,
+  `#3b82f6`, or `#0085ff` you encounter into the token.
+- **Do** ship a night value for every primary-derived color and every shadow. The primary itself
+  lifts to `#4da6ff` in dark mode; shadows roughly triple their alpha.
+- **Do** declare a CSS custom property in `:root` before referencing it. A `var(--x, fallback)` for
+  an undeclared `--x` is a light-theme constant wearing a token's clothes.
+- **Do** keep content surfaces flat and separate them with 1px Divider borders and Surface-against-Sunken
   tonal layering.
-- **Do** reserve shadows (`Raised` / `Floating` / `Overlay`) for elements that float above the page —
-  modals, dropdowns, toasts, popovers — and bump shadow opacity in dark mode.
-- **Do** hold muted text (`#666666` / dark `#999999`) and placeholders to ≥4.5:1; bump toward Ink
+- **Do** reserve shadows for elements that float above the page: modals, sheets, dropdowns, popovers,
+  tooltips.
+- **Do** hold muted text (`#666666`, night `#999999`) and placeholders to 4.5:1; move toward Ink
   before reaching for a lighter gray.
-- **Do** keep article measure at 65–75ch and preserve reader control over article font family and size.
-- **Do** pair every color signal (unread, sync state, social cue) with shape, weight, or text — color
-  is never the sole carrier of meaning.
-- **Do** provide a `prefers-reduced-motion` fallback (crossfade or instant) for every transition.
+- **Do** read `var(--article-font)` and `var(--article-font-size)` on every reading surface, and size
+  anything inside the prose in `em`.
+- **Do** keep the 800px reading band shared between the feed body and the reader, so expanding an
+  article does not shift the page.
+- **Do** reach for a container query when a component appears at more than one width, and add it to
+  the `/dev` harness registry.
+- **Do** pair every color signal (unread, sync state, social cue) with opacity, shape, weight, or
+  text. Color is never the sole carrier of meaning.
+- **Do** provide a `prefers-reduced-motion` fallback for every transition.
 
 ### Don't:
 
@@ -326,13 +622,19 @@ bouncy motion. They are reliable and unobtrusive — the UI never competes with 
 - **Don't** recreate a **cluttered legacy reader**: no dense toolbar walls or every-feature-visible
   chrome crowding the content.
 - **Don't** drift toward the **cream/beige editorial cliché**: the body background is true white
-  (`#ffffff`) / dark (`#1a1a1a`), never warm paper. Warmth, if any, comes only from Highlight Gold
-  inside the article.
+  (`#ffffff`) or `#1a1a1a`, never warm paper. Warmth comes only from Highlight Gold inside the
+  article.
 - **Don't** let the social layer look like an **algorithmic feed**: shares and notes stay quiet,
-  chronological, and human-scaled — no engagement-bait styling.
-- **Don't** add resting `box-shadow` to in-flow cards, rows, or panels (The Flat-By-Default Rule).
-- **Don't** introduce a second UI typeface; hierarchy is weight and size in the system sans.
-- **Don't** use a colored `border-left` / `border-right` stripe as an accent on rows, cards, or
-  alerts — use the Wash Blue tint or a full border.
-- **Don't** exceed `1.25rem` for UI headings; there is no hero display type in this app.
+  chronological, and human-scaled.
+- **Don't** add a resting `box-shadow`, backdrop blur, or border to an in-flow card, row, or sticky
+  header (The Flat-By-Default Rule).
+- **Don't** introduce a second UI typeface. Hierarchy is size, weight, and color in the system sans.
+- **Don't** use a type step above `--text-2xl` (1.25rem) anywhere in the app shell. 24px and 28px
+  belong to the reader's article title, empty-state heroes, and public pages only.
+- **Don't** bold feed-row titles. Weight in a long list is noise, not hierarchy.
+- **Don't** use a colored `border-left` or `border-right` stripe as an accent on rows, cards, or
+  alerts. The 3px gold rule on a quoted highlight is the one exception, and it is a quotation mark,
+  not a status.
+- **Don't** add a fourth structural breakpoint. 1000px is the shell line, 640px the density step.
+- **Don't** animate `all`, and don't add transform, scale, or bounce to a button's hover.
 - **Don't** use `background-clip: text` gradient text anywhere. Emphasis is weight and size.

--- a/backend/migrations/0065_user_settings_linkblog_disabled.sql
+++ b/backend/migrations/0065_user_settings_linkblog_disabled.sql
@@ -1,4 +1,6 @@
+-- No companion index. The only reader is getDisabledLinkblogAuthors, whose
+-- `WHERE linkblog_disabled = 1 AND user_did IN (...)` is served by the user_did
+-- PRIMARY KEY; a partial index keyed on user_did would never be chosen. (Compare
+-- 0064, which leads with linkblog_publication — a non-key column — and does earn
+-- its keep.) Nothing asks for "every disabled user", so there is no scan to fix.
 ALTER TABLE user_settings ADD COLUMN linkblog_disabled INTEGER NOT NULL DEFAULT 0;
-
-CREATE INDEX IF NOT EXISTS idx_user_settings_linkblog_disabled
-  ON user_settings(user_did) WHERE linkblog_disabled = 1;

--- a/backend/migrations/0065_user_settings_linkblog_disabled.sql
+++ b/backend/migrations/0065_user_settings_linkblog_disabled.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_settings ADD COLUMN linkblog_disabled INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_user_settings_linkblog_disabled
+  ON user_settings(user_did) WHERE linkblog_disabled = 1;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,8 @@ import {
   handleListPublications,
   handleConnectPublication,
   handleResolvePublication,
+  handleDeletePublication,
+  handleRestorePublication,
 } from './routes/linkblog';
 import { handleAtmosphereSubscription } from './routes/atmosphere';
 import {
@@ -288,6 +290,10 @@ export default {
           if (!session) return unauthorizedResponse(headers);
           if (request.method === 'GET') {
             response = await handleGetPublication(request, env);
+          } else if (request.method === 'DELETE') {
+            response = await handleDeletePublication(request, env);
+          } else if (request.method === 'POST') {
+            response = await handleRestorePublication(request, env);
           } else {
             response = await handleUpdatePublication(request, env);
           }

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -623,6 +623,16 @@ export async function handleDeletePublication(request: Request, env: Env): Promi
   }
   const result = await deleteLinkblog(session, env);
   if (!result.success) return json({ error: result.error }, result.retryable ? 503 : 502);
+  // Delete moves the target back to the default publication the same way
+  // disconnecting does, so followers of a connected publication have to come
+  // with it — otherwise a restore publishes to `skyreader-links` while every
+  // existing subscriber still points at a feed that will never update again.
+  await migrateLinkblogFollowers(
+    env,
+    session.did,
+    result.data.previousSiteUri,
+    publicationUri(session.did)
+  );
   return json({ success: true, deletedPosts: result.data.deletedPosts });
 }
 

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -639,6 +639,12 @@ export async function handleDeletePublication(request: Request, env: Env): Promi
 export async function handleRestorePublication(request: Request, env: Env): Promise<Response> {
   const session = await getSessionFromRequest(request, env);
   if (!session) return json({ error: 'Unauthorized' }, 401);
+  // Gated like every other linkblog mutation. Restoring only flips a D1 flag, but
+  // a session that can't write is one whose next share fails — better to send it
+  // into the re-auth flow here than to hand back a linkblog it can't publish to.
+  if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
+    return insufficientScopesResponse();
+  }
   await restoreLinkblog(session, env);
   return json(await getPublicationMeta(session, env));
 }

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -15,14 +15,17 @@ import {
 import { isValidRkey, invalidRkeyResponse } from '../utils/validation';
 import {
   deleteLinkblogShare,
+  deleteLinkblog,
   DOCUMENT_COLLECTION,
   FOREIGN_RECORD_ERROR,
   getPublicationMeta,
   getLinkblogTarget,
+  isLinkblogDisabled,
   httpUrlOrUndefined,
   linkblogBaseUrl,
   PUBLICATION_COLLECTION,
   publicationUri,
+  restoreLinkblog,
   updateLinkblogShareNote,
   updatePublication,
   writeLinkblogShare,
@@ -107,6 +110,9 @@ export async function handleCreateLinkblogShare(request: Request, env: Env): Pro
   if (!session) return json({ error: 'Unauthorized' }, 401);
   if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
     return insufficientScopesResponse();
+  }
+  if (await isLinkblogDisabled(env, session.did)) {
+    return json({ error: 'linkblog_deleted' }, 409);
   }
 
   let body: CreateLinkblogShareRequest;
@@ -271,6 +277,9 @@ export async function handleUpdatePublication(request: Request, env: Env): Promi
   if (!session) return json({ error: 'Unauthorized' }, 401);
   if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
     return insufficientScopesResponse();
+  }
+  if (await isLinkblogDisabled(env, session.did)) {
+    return json({ error: 'linkblog_deleted' }, 409);
   }
   if ((await getLinkblogTarget(env, session.did)).external) {
     return json({ error: 'This publication is managed by its home app' }, 409);
@@ -548,6 +557,9 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
     return json(await getPublicationMeta(session, env));
   }
   if (request.method !== 'PUT') return json({ error: 'Method not allowed' }, 405);
+  if (await isLinkblogDisabled(env, session.did)) {
+    return json({ error: 'linkblog_deleted' }, 409);
+  }
   let body: { publicationUri?: string; format?: ContentFormat };
   try {
     body = await request.json();
@@ -600,6 +612,24 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
     .bind(session.did, selectedPublicationUri, format, now, now)
     .run();
   await migrateLinkblogFollowers(env, session.did, previousTarget.siteUri, selectedPublicationUri);
+  return json(await getPublicationMeta(session, env));
+}
+
+export async function handleDeletePublication(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return json({ error: 'Unauthorized' }, 401);
+  if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
+    return insufficientScopesResponse();
+  }
+  const result = await deleteLinkblog(session, env);
+  if (!result.success) return json({ error: result.error }, result.retryable ? 503 : 502);
+  return json({ success: true, deletedPosts: result.data.deletedPosts });
+}
+
+export async function handleRestorePublication(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return json({ error: 'Unauthorized' }, 401);
+  await restoreLinkblog(session, env);
   return json(await getPublicationMeta(session, env));
 }
 

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -47,6 +47,7 @@ export interface UserSettings {
   lastPdsSyncSubscriptions: number | null;
   /** External-backed saves: which engine backs the Saved list (one per account). */
   backing: SaveBacking;
+  linkblogDisabled: boolean;
   createdAt: number;
   updatedAt: number;
 }
@@ -56,6 +57,7 @@ interface UserSettingsRow {
   pds_sync_enabled: number;
   last_pds_sync_subscriptions: number | null;
   backing: string | null;
+  linkblog_disabled: number;
   created_at: number;
   updated_at: number;
 }
@@ -66,6 +68,7 @@ function rowToSettings(row: UserSettingsRow | null): UserSettings {
       pdsSyncEnabled: false,
       lastPdsSyncSubscriptions: null,
       backing: { provider: 'skyreader' },
+      linkblogDisabled: false,
       createdAt: Math.floor(Date.now() / 1000),
       updatedAt: Math.floor(Date.now() / 1000),
     };
@@ -74,6 +77,7 @@ function rowToSettings(row: UserSettingsRow | null): UserSettings {
     pdsSyncEnabled: row.pds_sync_enabled === 1,
     lastPdsSyncSubscriptions: row.last_pds_sync_subscriptions,
     backing: parseBacking(row.backing),
+    linkblogDisabled: row.linkblog_disabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/backend/src/services/linkblog-discovery.ts
+++ b/backend/src/services/linkblog-discovery.ts
@@ -77,11 +77,20 @@ export async function getLinkblogFriends(session: Session, env: Env): Promise<Li
     fetchFollows(session.did),
   ]);
 
-  const candidates = [...new Set([...registry, ...connected])];
-  const disabled = await getDisabledLinkblogAuthors(env, candidates);
-  const disabledSet = new Set(disabled);
-  const registrySet = new Set(candidates.filter((did) => !disabledSet.has(did)));
-  const people = follows.filter((f) => f.did !== session.did && registrySet.has(f.did));
+  const registrySet = new Set([...registry, ...connected]);
+  // Intersect with the follows first. getDisabledLinkblogAuthors costs one
+  // sequential D1 query per 100 DIDs, and the whole registry is orders of
+  // magnitude larger than the handful of it a given user follows — the answer is
+  // the same either way (getLinkblogTargets on the next line already reads this
+  // way round).
+  const followed = follows.filter((f) => f.did !== session.did && registrySet.has(f.did));
+  const disabledSet = new Set(
+    await getDisabledLinkblogAuthors(
+      env,
+      followed.map((f) => f.did)
+    )
+  );
+  const people = followed.filter((f) => !disabledSet.has(f.did));
   // One batched settings lookup resolves everyone's current publication.
   const targets = await getLinkblogTargets(
     env,

--- a/backend/src/services/linkblog-discovery.ts
+++ b/backend/src/services/linkblog-discovery.ts
@@ -17,6 +17,7 @@ import { FeedProxyClient } from './feed-proxy-client';
 import { fetchFollows, fetchProfiles, type BskyProfileLite } from './bsky-appview';
 import {
   getConnectedLinkblogAuthors,
+  getDisabledLinkblogAuthors,
   getLinkblogTargets,
   linkblogBaseUrl,
   publicationUri,
@@ -70,13 +71,15 @@ function toPerson(
  */
 export async function getLinkblogFriends(session: Session, env: Env): Promise<LinkblogPerson[]> {
   const proxy = new FeedProxyClient(env);
-  const [registry, connected, follows] = await Promise.all([
+  const [registry, connected, disabled, follows] = await Promise.all([
     proxy.fetchLinkblogRegistry().catch(() => [] as string[]),
     getConnectedLinkblogAuthors(env),
+    getDisabledLinkblogAuthors(env),
     fetchFollows(session.did),
   ]);
 
-  const registrySet = new Set([...registry, ...connected]);
+  const disabledSet = new Set(disabled);
+  const registrySet = new Set([...registry, ...connected].filter((did) => !disabledSet.has(did)));
   const people = follows.filter((f) => f.did !== session.did && registrySet.has(f.did));
   // One batched settings lookup resolves everyone's current publication.
   const targets = await getLinkblogTargets(
@@ -93,14 +96,18 @@ export async function getLinkblogFriends(session: Session, env: Env): Promise<Li
  */
 export async function getLinkblogDiscover(session: Session, env: Env): Promise<LinkblogPerson[]> {
   const proxy = new FeedProxyClient(env);
-  const [registry, connected, follows] = await Promise.all([
+  const [registry, connected, disabled, follows] = await Promise.all([
     proxy.fetchLinkblogRegistry().catch(() => [] as string[]),
     getConnectedLinkblogAuthors(env),
+    getDisabledLinkblogAuthors(env),
     fetchFollows(session.did).catch(() => [] as BskyProfileLite[]),
   ]);
 
   const followMap = new Map(follows.map((f) => [f.did, f]));
-  const authors = [...new Set([...registry, ...connected])].filter((did) => did !== session.did);
+  const disabledSet = new Set(disabled);
+  const authors = [...new Set([...registry, ...connected])].filter(
+    (did) => did !== session.did && !disabledSet.has(did)
+  );
 
   const friendDids = authors.filter((did) => followMap.has(did));
   const otherDids = authors.filter((did) => !followMap.has(did)).slice(0, MAX_DISCOVER_OTHERS);

--- a/backend/src/services/linkblog-discovery.ts
+++ b/backend/src/services/linkblog-discovery.ts
@@ -112,14 +112,27 @@ export async function getLinkblogDiscover(session: Session, env: Env): Promise<L
     fetchFollows(session.did).catch(() => [] as BskyProfileLite[]),
   ]);
 
-  const candidates = [...new Set([...registry, ...connected])];
-  const disabled = await getDisabledLinkblogAuthors(env, candidates);
+  const candidates = [...new Set([...registry, ...connected])].filter((did) => did !== session.did);
   const followMap = new Map(follows.map((f) => [f.did, f]));
-  const disabledSet = new Set(disabled);
-  const authors = candidates.filter((did) => did !== session.did && !disabledSet.has(did));
 
-  const friendDids = authors.filter((did) => followMap.has(did));
-  const otherDids = authors.filter((did) => !followMap.has(did)).slice(0, MAX_DISCOVER_OTHERS);
+  // Narrow to the DIDs this response can actually contain BEFORE asking which are
+  // disabled: that lookup costs one sequential D1 query per 100 DIDs, and the
+  // registry is orders of magnitude larger than the page we return (friends, plus
+  // a capped slice of everyone else). Same reasoning as getLinkblogFriends above.
+  // The "others" window is oversampled so a few deleted linkblogs in it don't
+  // shorten the list, and it stays bounded either way.
+  const friendCandidates = candidates.filter((did) => followMap.has(did));
+  const otherCandidates = candidates
+    .filter((did) => !followMap.has(did))
+    .slice(0, MAX_DISCOVER_OTHERS * 2);
+  const disabledSet = new Set(
+    await getDisabledLinkblogAuthors(env, [...friendCandidates, ...otherCandidates])
+  );
+
+  const friendDids = friendCandidates.filter((did) => !disabledSet.has(did));
+  const otherDids = otherCandidates
+    .filter((did) => !disabledSet.has(did))
+    .slice(0, MAX_DISCOVER_OTHERS);
 
   // Friends already have profiles from getFollows; resolve only the rest.
   const [otherProfiles, targets] = await Promise.all([

--- a/backend/src/services/linkblog-discovery.ts
+++ b/backend/src/services/linkblog-discovery.ts
@@ -71,15 +71,16 @@ function toPerson(
  */
 export async function getLinkblogFriends(session: Session, env: Env): Promise<LinkblogPerson[]> {
   const proxy = new FeedProxyClient(env);
-  const [registry, connected, disabled, follows] = await Promise.all([
+  const [registry, connected, follows] = await Promise.all([
     proxy.fetchLinkblogRegistry().catch(() => [] as string[]),
     getConnectedLinkblogAuthors(env),
-    getDisabledLinkblogAuthors(env),
     fetchFollows(session.did),
   ]);
 
+  const candidates = [...new Set([...registry, ...connected])];
+  const disabled = await getDisabledLinkblogAuthors(env, candidates);
   const disabledSet = new Set(disabled);
-  const registrySet = new Set([...registry, ...connected].filter((did) => !disabledSet.has(did)));
+  const registrySet = new Set(candidates.filter((did) => !disabledSet.has(did)));
   const people = follows.filter((f) => f.did !== session.did && registrySet.has(f.did));
   // One batched settings lookup resolves everyone's current publication.
   const targets = await getLinkblogTargets(
@@ -96,18 +97,17 @@ export async function getLinkblogFriends(session: Session, env: Env): Promise<Li
  */
 export async function getLinkblogDiscover(session: Session, env: Env): Promise<LinkblogPerson[]> {
   const proxy = new FeedProxyClient(env);
-  const [registry, connected, disabled, follows] = await Promise.all([
+  const [registry, connected, follows] = await Promise.all([
     proxy.fetchLinkblogRegistry().catch(() => [] as string[]),
     getConnectedLinkblogAuthors(env),
-    getDisabledLinkblogAuthors(env),
     fetchFollows(session.did).catch(() => [] as BskyProfileLite[]),
   ]);
 
+  const candidates = [...new Set([...registry, ...connected])];
+  const disabled = await getDisabledLinkblogAuthors(env, candidates);
   const followMap = new Map(follows.map((f) => [f.did, f]));
   const disabledSet = new Set(disabled);
-  const authors = [...new Set([...registry, ...connected])].filter(
-    (did) => did !== session.did && !disabledSet.has(did)
-  );
+  const authors = candidates.filter((did) => did !== session.did && !disabledSet.has(did));
 
   const friendDids = authors.filter((did) => followMap.has(did));
   const otherDids = authors.filter((did) => !followMap.has(did)).slice(0, MAX_DISCOVER_OTHERS);

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -300,6 +300,7 @@ export interface PublicationMeta {
   exists: boolean;
   external: boolean;
   format: ContentFormat;
+  disabled: boolean;
 }
 
 // PDS records are user-controlled, so a `url` can be any string. Only surface it
@@ -322,7 +323,10 @@ function iconUrlFromBlob(did: string, icon: BlobRef | undefined): string | undef
 // Read the current linkblog publication, or synthesize sensible defaults when it
 // doesn't exist yet (so the settings UI can render before the first share).
 export async function getPublicationMeta(session: Session, env: Env): Promise<PublicationMeta> {
-  const target = await getLinkblogTarget(env, session.did);
+  const [target, disabled] = await Promise.all([
+    getLinkblogTarget(env, session.did),
+    isLinkblogDisabled(env, session.did),
+  ]);
   const pdsClient = createPDSClient(session);
   const rkey = target.siteUri.split('/').pop() || LINKBLOG_RKEY;
   const result = await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, rkey);
@@ -336,6 +340,7 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
       exists: false,
       external: target.external,
       format: target.format,
+      disabled,
     };
   }
 
@@ -355,6 +360,7 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
     exists: true,
     external: target.external,
     format: target.format,
+    disabled,
   };
 }
 
@@ -498,11 +504,35 @@ interface DocumentRecord {
 // Whether a `site.standard.document` is one of OUR link posts: it carries the
 // marker, or it lives in the user's own Skyreader publication (where everything
 // is ours, marker or not — pre-marker records still count).
-function isSkyreaderShareRecord(
+export function isSkyreaderShareRecord(
   did: string,
   rec: Pick<DocumentRecord, 'site' | 'skyreaderLinkblog'>
 ): boolean {
   return rec.skyreaderLinkblog === LINKBLOG_MARKER_URL || rec.site === publicationUri(did);
+}
+
+export async function isLinkblogDisabled(env: Env, did: string): Promise<boolean> {
+  try {
+    const row = await env.DB.prepare(
+      'SELECT linkblog_disabled FROM user_settings WHERE user_did = ?'
+    )
+      .bind(did)
+      .first<{ linkblog_disabled: number }>();
+    return row?.linkblog_disabled === 1;
+  } catch {
+    return false;
+  }
+}
+
+export async function getDisabledLinkblogAuthors(env: Env): Promise<string[]> {
+  try {
+    const rows = await env.DB.prepare(
+      'SELECT user_did FROM user_settings WHERE linkblog_disabled = 1 LIMIT 2000'
+    ).all<{ user_did: string }>();
+    return (rows.results ?? []).map((row) => row.user_did);
+  } catch {
+    return [];
+  }
 }
 
 // The article excerpt stored on a record's website link-card block. The card is
@@ -974,6 +1004,77 @@ export async function writeLinkblogShare(
 // A read that came back "no such record" — a normal outcome, not a failure.
 function isNotFoundError(error: string): boolean {
   return /RecordNotFound|could not locate record/i.test(error);
+}
+
+const DELETE_BATCH_SIZE = 200;
+
+async function deleteRecordBatch(
+  client: ReturnType<typeof createPDSClient>,
+  collection: string,
+  rkeys: string[],
+  bestEffort: boolean
+): Promise<PDSResult<void>> {
+  for (let i = 0; i < rkeys.length; i += DELETE_BATCH_SIZE) {
+    const chunk = rkeys.slice(i, i + DELETE_BATCH_SIZE);
+    const batch = await client.applyWrites(
+      chunk.map((rkey) => ({
+        $type: 'com.atproto.repo.applyWrites#delete' as const,
+        collection,
+        rkey,
+      }))
+    );
+    if (batch.success) continue;
+    if (!bestEffort) return batch;
+    for (const rkey of chunk) {
+      const result = await client.deleteRecord(collection, rkey);
+      if (!result.success && !isNotFoundError(result.error)) {
+        console.warn(`[linkblog] ${collection} delete failed for ${rkey}: ${result.error}`);
+      }
+    }
+  }
+  return { success: true, data: undefined };
+}
+
+export async function deleteLinkblog(
+  session: Session,
+  env: Env
+): Promise<PDSResult<{ deletedPosts: number }>> {
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO user_settings (user_did, linkblog_disabled, created_at, updated_at)
+     VALUES (?, 1, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_disabled = 1,
+     linkblog_publication = NULL, linkblog_content_format = NULL, updated_at = excluded.updated_at`
+  )
+    .bind(session.did, now, now)
+    .run();
+
+  const client = createPDSClient(session);
+  const records = await client.listAllRecords<DocumentRecord>(DOCUMENT_COLLECTION);
+  if (!records.success) return records;
+  const rkeys = records.data
+    .filter((record) => isSkyreaderShareRecord(session.did, record.value))
+    .map((record) => record.uri.split('/').pop()!)
+    .filter(Boolean);
+  const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
+  if (!documents.success) return documents;
+
+  for (const collection of new Set(Object.values(COMPANION_COLLECTIONS))) {
+    await deleteRecordBatch(client, collection, rkeys, true);
+  }
+  const publication = await client.deleteRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY);
+  if (!publication.success && !isNotFoundError(publication.error)) return publication;
+  return { success: true, data: { deletedPosts: rkeys.length } };
+}
+
+export async function restoreLinkblog(session: Session, env: Env): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO user_settings (user_did, linkblog_disabled, created_at, updated_at)
+     VALUES (?, 0, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_disabled = 0,
+     updated_at = excluded.updated_at`
+  )
+    .bind(session.did, now, now)
+    .run();
 }
 
 // Returned when a mutation targets a record Skyreader didn't write. The routes

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -1022,11 +1022,28 @@ function isNotFoundError(error: string): boolean {
 
 const DELETE_BATCH_SIZE = 200;
 
+// Total one-at-a-time companion deletes a single purge may spend across the whole
+// walk. The per-record fallback exists so a companion batch that fails for a
+// reason we can't pre-check still gets cleaned up, but it's the one part of the
+// delete whose cost isn't bounded by the repo size: a companion collection whose
+// batch keeps failing (transient 5xx, one rejected write) would spend a
+// subrequest per record for every page, and exhausting the Worker's budget
+// partway leaves the linkblog half-deleted. Orphaned companions are untidy;
+// a stalled delete is worse, so the fallback yields first.
+const MAX_COMPANION_FALLBACK_DELETES = 200;
+
+interface FallbackBudget {
+  remaining: number;
+  exhaustedLogged: boolean;
+}
+
+// `fallback` present = best-effort: a failed batch degrades to per-record deletes
+// against the shared budget. Absent = strict, and the batch error is returned.
 async function deleteRecordBatch(
   client: ReturnType<typeof createPDSClient>,
   collection: string,
   rkeys: string[],
-  bestEffort: boolean
+  fallback?: FallbackBudget
 ): Promise<PDSResult<void>> {
   for (let i = 0; i < rkeys.length; i += DELETE_BATCH_SIZE) {
     const chunk = rkeys.slice(i, i + DELETE_BATCH_SIZE);
@@ -1038,8 +1055,19 @@ async function deleteRecordBatch(
       }))
     );
     if (batch.success) continue;
-    if (!bestEffort) return batch;
+    if (!fallback) return batch;
+    if (fallback.remaining <= 0) {
+      if (!fallback.exhaustedLogged) {
+        fallback.exhaustedLogged = true;
+        console.warn(
+          `[linkblog] companion fallback budget spent; leaving remaining ${collection} companions orphaned`
+        );
+      }
+      continue;
+    }
     for (const rkey of chunk) {
+      if (fallback.remaining <= 0) break;
+      fallback.remaining--;
       const result = await client.deleteRecord(collection, rkey);
       if (!result.success && !isNotFoundError(result.error)) {
         console.warn(`[linkblog] ${collection} delete failed for ${rkey}: ${result.error}`);
@@ -1119,6 +1147,11 @@ async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
   const client = createPDSClient(session);
   let cursor: string | undefined;
   let deletedPosts = 0;
+  // Shared across every page: the cap is on the whole delete, not per page.
+  const companionFallback: FallbackBudget = {
+    remaining: MAX_COMPANION_FALLBACK_DELETES,
+    exhaustedLogged: false,
+  };
 
   for (let page = 0; page < MAX_DELETE_PAGES; page++) {
     const listed = await client.listRecords<DocumentRecord>(DOCUMENT_COLLECTION, cursor);
@@ -1131,7 +1164,7 @@ async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
       .filter((record) => record.rkey);
     if (ours.length > 0) {
       const rkeys = ours.map((record) => record.rkey);
-      const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
+      const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys);
       if (!documents.success) {
         return {
           success: false,
@@ -1141,7 +1174,7 @@ async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
         };
       }
       for (const [collection, companionRkeys] of companionDeletes(session, ours)) {
-        await deleteRecordBatch(client, collection, companionRkeys, true);
+        await deleteRecordBatch(client, collection, companionRkeys, companionFallback);
       }
       deletedPosts += rkeys.length;
     }
@@ -1177,7 +1210,13 @@ export async function deleteLinkblog(
   env: Env
 ): Promise<PDSResult<{ deletedPosts: number; previousSiteUri: string }>> {
   const now = Math.floor(Date.now() / 1000);
-  const previous = await getLinkblogTarget(env, session.did);
+  // Read the flag BEFORE setting it: a delete that starts already-disabled is
+  // resuming an earlier one that got partway, which changes what a failure here
+  // is allowed to undo (see the rollback below).
+  const [previous, alreadyDisabled] = await Promise.all([
+    getLinkblogTarget(env, session.did),
+    isLinkblogDisabled(env, session.did),
+  ]);
 
   // Disable first: every write path checks the flag, so this is what stops a
   // share racing the walk and landing a document behind it. The connected
@@ -1192,13 +1231,31 @@ export async function deleteLinkblog(
     .bind(session.did, now, now)
     .run();
 
-  const purged = await purgeLinkblogRecords(session);
+  let purged: PurgeResult;
+  try {
+    purged = await purgeLinkblogRecords(session);
+  } catch (e) {
+    // purgeLinkblogRecords reports PDS failures as values, but an unexpected
+    // throw (a D1 error, a client it couldn't build) would escape past the
+    // rollback below and leave the flag on with nothing deleted. Fold it into
+    // the same shape so every failure exits through one path.
+    purged = {
+      success: false,
+      error: e instanceof Error ? e.message : 'Could not delete your linkblog',
+      retryable: true,
+      deletedPosts: 0,
+    };
+  }
+
   if (!purged.success) {
     // Nothing went yet, so the linkblog is exactly as the user left it: take the
     // flag back rather than strand them with a live blog that every write path
-    // rejects. A partial purge keeps the flag — that blog is already half gone,
-    // and retrying the delete resumes where this one stopped.
-    if (purged.deletedPosts === 0) await restoreLinkblog(session, env);
+    // rejects. Two cases keep it. A partial purge — that blog is already half
+    // gone. And a delete that was ALREADY disabled when it started: it is
+    // retrying an earlier partial one, so "this call deleted nothing" says
+    // nothing about the posts the first attempt took. Restoring on that would
+    // hand back a linkblog silently missing them.
+    if (purged.deletedPosts === 0 && !alreadyDisabled) await restoreLinkblog(session, env);
     return { success: false, error: purged.error, retryable: purged.retryable };
   }
 

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -524,12 +524,25 @@ export async function isLinkblogDisabled(env: Env, did: string): Promise<boolean
   }
 }
 
-export async function getDisabledLinkblogAuthors(env: Env): Promise<string[]> {
+export async function getDisabledLinkblogAuthors(env: Env, dids: string[]): Promise<string[]> {
+  const candidates = [...new Set(dids)];
+  if (candidates.length === 0) return [];
   try {
-    const rows = await env.DB.prepare(
-      'SELECT user_did FROM user_settings WHERE linkblog_disabled = 1 LIMIT 2000'
-    ).all<{ user_did: string }>();
-    return (rows.results ?? []).map((row) => row.user_did);
+    const disabled: string[] = [];
+    // Stay comfortably below SQLite/D1's bind-parameter ceiling while filtering
+    // exactly the registry candidates; no global row cap can leak disabled blogs.
+    for (let i = 0; i < candidates.length; i += 100) {
+      const chunk = candidates.slice(i, i + 100);
+      const placeholders = chunk.map(() => '?').join(', ');
+      const rows = await env.DB.prepare(
+        `SELECT user_did FROM user_settings
+         WHERE linkblog_disabled = 1 AND user_did IN (${placeholders})`
+      )
+        .bind(...chunk)
+        .all<{ user_did: string }>();
+      disabled.push(...(rows.results ?? []).map((row) => row.user_did));
+    }
+    return disabled;
   } catch {
     return [];
   }
@@ -1049,21 +1062,44 @@ export async function deleteLinkblog(
     .run();
 
   const client = createPDSClient(session);
-  const records = await client.listAllRecords<DocumentRecord>(DOCUMENT_COLLECTION);
-  if (!records.success) return records;
-  const rkeys = records.data
-    .filter((record) => isSkyreaderShareRecord(session.did, record.value))
-    .map((record) => record.uri.split('/').pop()!)
-    .filter(Boolean);
-  const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
-  if (!documents.success) return documents;
-
-  for (const collection of new Set(Object.values(COMPANION_COLLECTIONS))) {
-    await deleteRecordBatch(client, collection, rkeys, true);
+  let cursor: string | undefined;
+  let deletedPosts = 0;
+  const seenCursors = new Set<string>();
+  while (true) {
+    const page = await client.listRecords<DocumentRecord>(DOCUMENT_COLLECTION, cursor);
+    if (!page.success) return page;
+    const rkeys = page.data.records
+      .filter((record) => isSkyreaderShareRecord(session.did, record.value))
+      .map((record) => record.uri.split('/').pop()!)
+      .filter(Boolean);
+    if (rkeys.length > 0) {
+      const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
+      if (!documents.success) return documents;
+      for (const collection of new Set(Object.values(COMPANION_COLLECTIONS))) {
+        await deleteRecordBatch(client, collection, rkeys, true);
+      }
+      deletedPosts += rkeys.length;
+      // Mutating a collection can invalidate its cursor. Restarting guarantees
+      // that records shifted across page boundaries cannot be skipped.
+      cursor = undefined;
+      seenCursors.clear();
+      continue;
+    }
+    const nextCursor = page.data.cursor || undefined;
+    if (!nextCursor) break;
+    if (seenCursors.has(nextCursor)) {
+      return {
+        success: false,
+        error: 'PDS returned a repeated cursor while deleting linkblog',
+        retryable: true,
+      };
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
   }
   const publication = await client.deleteRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY);
   if (!publication.success && !isNotFoundError(publication.error)) return publication;
-  return { success: true, data: { deletedPosts: rkeys.length } };
+  return { success: true, data: { deletedPosts } };
 }
 
 export async function restoreLinkblog(session: Session, env: Env): Promise<void> {

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -15,6 +15,7 @@ import {
   type PutRecordResponse,
 } from './pds-client';
 import { resolveHandle } from './oauth';
+import { OFFPRINT_SCOPES, PCKT_SCOPES } from '../config/scopes';
 import { parseHandleTokens, buildMentionFacet, type MentionFacet } from '../utils/mention-facets';
 
 // Cap on the number of distinct handles we resolve per note. Each unique handle
@@ -1048,58 +1049,170 @@ async function deleteRecordBatch(
   return { success: true, data: undefined };
 }
 
+// Upper bound on pages walked in one delete. listRecords' cursor is the rkey of
+// the last record returned and is an exclusive key bound, not an offset: a PDS
+// hands back the same page for a cursor whose record no longer exists (verified
+// against a live PDS). So deleting as we page can neither invalidate the cursor
+// nor shift a record past it, and the walk is linear in the size of the repo's
+// document collection. The cap is a backstop against a PDS that keeps returning
+// records we just deleted, not a ceiling on a real linkblog: at 100 records a
+// page it covers 10k documents for 100 subrequests.
+const MAX_DELETE_PAGES = 100;
+
+// Companion collections we can only touch while the session still holds the
+// host app's scope (see COMPANION_SCOPES in routes/linkblog.ts, which gates the
+// write the same way). Deleting from a collection we were never granted costs a
+// guaranteed-failing applyWrites plus, because companion deletes are best-effort,
+// one deleteRecord per rkey behind it — enough to exhaust the Worker's
+// subrequest budget partway through a large linkblog.
+const COMPANION_SCOPES: Partial<Record<ContentFormat, string[]>> = {
+  pckt: PCKT_SCOPES,
+  offprint: OFFPRINT_SCOPES,
+};
+
+function canWriteCompanion(session: Session, format: ContentFormat): boolean {
+  const required = COMPANION_SCOPES[format];
+  if (!required) return false;
+  const granted = new Set((session.grantedScopes ?? '').split(' '));
+  return required.every((scope) => granted.has(scope));
+}
+
+// The companion deletes a page of documents actually calls for, keyed by
+// collection. Only the format a record was written in gets one, so an offprint
+// linkblog never addresses blog.pckt.document, and a leaflet or markpub share —
+// which has no companion at all — costs nothing.
+function companionDeletes(
+  session: Session,
+  records: Array<{ rkey: string; value: DocumentRecord }>
+): Map<string, string[]> {
+  const byCollection = new Map<string, string[]>();
+  const unauthorized = new Set<string>();
+  for (const { rkey, value } of records) {
+    const format = contentFormatOf(value.content);
+    const collection = format ? COMPANION_COLLECTIONS[format] : undefined;
+    if (!format || !collection) continue;
+    if (!canWriteCompanion(session, format)) {
+      // The grant is gone (revoked, or an older session): the document goes, and
+      // its companion is left pointing at nothing. Worth a line — it's the one
+      // way this path leaves the user's repo untidy.
+      unauthorized.add(collection);
+      continue;
+    }
+    const existing = byCollection.get(collection);
+    if (existing) existing.push(rkey);
+    else byCollection.set(collection, [rkey]);
+  }
+  for (const collection of unauthorized) {
+    console.warn(`[linkblog] no scope for ${collection}; leaving its companions orphaned`);
+  }
+  return byCollection;
+}
+
+// How far a delete got before it failed. `deletedPosts` is what separates "the
+// user's linkblog is untouched" from "it's already half gone", which is what the
+// caller needs to decide whether disabling it can be taken back.
+type PurgeResult =
+  | { success: true; deletedPosts: number }
+  | { success: false; error: string; retryable: boolean; deletedPosts: number };
+
+async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
+  const client = createPDSClient(session);
+  let cursor: string | undefined;
+  let deletedPosts = 0;
+
+  for (let page = 0; page < MAX_DELETE_PAGES; page++) {
+    const listed = await client.listRecords<DocumentRecord>(DOCUMENT_COLLECTION, cursor);
+    if (!listed.success) {
+      return { success: false, error: listed.error, retryable: !!listed.retryable, deletedPosts };
+    }
+    const ours = listed.data.records
+      .filter((record) => isSkyreaderShareRecord(session.did, record.value))
+      .map((record) => ({ rkey: record.uri.split('/').pop() ?? '', value: record.value }))
+      .filter((record) => record.rkey);
+    if (ours.length > 0) {
+      const rkeys = ours.map((record) => record.rkey);
+      const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
+      if (!documents.success) {
+        return {
+          success: false,
+          error: documents.error,
+          retryable: !!documents.retryable,
+          deletedPosts,
+        };
+      }
+      for (const [collection, companionRkeys] of companionDeletes(session, ours)) {
+        await deleteRecordBatch(client, collection, companionRkeys, true);
+      }
+      deletedPosts += rkeys.length;
+    }
+
+    const nextCursor = listed.data.cursor || undefined;
+    if (!nextCursor || listed.data.records.length === 0) {
+      const publication = await client.deleteRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY);
+      if (!publication.success && !isNotFoundError(publication.error)) {
+        return {
+          success: false,
+          error: publication.error,
+          retryable: !!publication.retryable,
+          deletedPosts,
+        };
+      }
+      return { success: true, deletedPosts };
+    }
+    cursor = nextCursor;
+  }
+
+  return {
+    success: false,
+    error: 'Too many document pages while deleting linkblog',
+    retryable: true,
+    deletedPosts,
+  };
+}
+
+// Delete every link post, then the publication record. Returns the publication
+// the linkblog pointed at, so the caller can move followers off it.
 export async function deleteLinkblog(
   session: Session,
   env: Env
-): Promise<PDSResult<{ deletedPosts: number }>> {
+): Promise<PDSResult<{ deletedPosts: number; previousSiteUri: string }>> {
   const now = Math.floor(Date.now() / 1000);
+  const previous = await getLinkblogTarget(env, session.did);
+
+  // Disable first: every write path checks the flag, so this is what stops a
+  // share racing the walk and landing a document behind it. The connected
+  // publication is deliberately NOT cleared yet — it's the one setting a failed
+  // delete could not give back (restore doesn't know it), so it waits until the
+  // PDS side is actually gone.
   await env.DB.prepare(
     `INSERT INTO user_settings (user_did, linkblog_disabled, created_at, updated_at)
      VALUES (?, 1, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_disabled = 1,
-     linkblog_publication = NULL, linkblog_content_format = NULL, updated_at = excluded.updated_at`
+     updated_at = excluded.updated_at`
   )
     .bind(session.did, now, now)
     .run();
 
-  const client = createPDSClient(session);
-  let cursor: string | undefined;
-  let deletedPosts = 0;
-  const seenCursors = new Set<string>();
-  while (true) {
-    const page = await client.listRecords<DocumentRecord>(DOCUMENT_COLLECTION, cursor);
-    if (!page.success) return page;
-    const rkeys = page.data.records
-      .filter((record) => isSkyreaderShareRecord(session.did, record.value))
-      .map((record) => record.uri.split('/').pop()!)
-      .filter(Boolean);
-    if (rkeys.length > 0) {
-      const documents = await deleteRecordBatch(client, DOCUMENT_COLLECTION, rkeys, false);
-      if (!documents.success) return documents;
-      for (const collection of new Set(Object.values(COMPANION_COLLECTIONS))) {
-        await deleteRecordBatch(client, collection, rkeys, true);
-      }
-      deletedPosts += rkeys.length;
-      // Mutating a collection can invalidate its cursor. Restarting guarantees
-      // that records shifted across page boundaries cannot be skipped.
-      cursor = undefined;
-      seenCursors.clear();
-      continue;
-    }
-    const nextCursor = page.data.cursor || undefined;
-    if (!nextCursor) break;
-    if (seenCursors.has(nextCursor)) {
-      return {
-        success: false,
-        error: 'PDS returned a repeated cursor while deleting linkblog',
-        retryable: true,
-      };
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
+  const purged = await purgeLinkblogRecords(session);
+  if (!purged.success) {
+    // Nothing went yet, so the linkblog is exactly as the user left it: take the
+    // flag back rather than strand them with a live blog that every write path
+    // rejects. A partial purge keeps the flag — that blog is already half gone,
+    // and retrying the delete resumes where this one stopped.
+    if (purged.deletedPosts === 0) await restoreLinkblog(session, env);
+    return { success: false, error: purged.error, retryable: purged.retryable };
   }
-  const publication = await client.deleteRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY);
-  if (!publication.success && !isNotFoundError(publication.error)) return publication;
-  return { success: true, data: { deletedPosts } };
+
+  await env.DB.prepare(
+    `UPDATE user_settings SET linkblog_publication = NULL, linkblog_content_format = NULL,
+     updated_at = ? WHERE user_did = ?`
+  )
+    .bind(now, session.did)
+    .run();
+
+  return {
+    success: true,
+    data: { deletedPosts: purged.deletedPosts, previousSiteUri: previous.siteUri },
+  };
 }
 
 export async function restoreLinkblog(session: Session, env: Env): Promise<void> {

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  deleteLinkblog,
   deleteLinkblogShare,
   updateLinkblogShareNote,
   LINKBLOG_MARKER_URL,
   publicationUri,
 } from '../src/services/linkblog-sync';
-import type { Session } from '../src/types';
+import type { Env, Session } from '../src/types';
 
 // A connected linkblog publishes into a publication its HOME app owns, which also
 // holds that app's own posts — and an essay that links out is shaped exactly like
@@ -140,5 +141,52 @@ describe('linkblog share guards', () => {
     expect((put?.body as { record: { skyreaderLinkblog?: string } }).record.skyreaderLinkblog).toBe(
       LINKBLOG_MARKER_URL
     );
+  });
+
+  it('continues deleting across pages and restarts after mutating the collection', async () => {
+    const cursors: Array<string | null> = [];
+    let deleted = false;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString());
+      const endpoint = url.pathname.split('/xrpc/')[1];
+      if (endpoint === 'com.atproto.repo.listRecords') {
+        const cursor = url.searchParams.get('cursor');
+        cursors.push(cursor);
+        if (!cursor) {
+          return Response.json({
+            records: [
+              {
+                uri: `at://${DID}/site.standard.document/foreign`,
+                cid: 'a',
+                value: documentRecord(),
+              },
+            ],
+            cursor: 'next',
+          });
+        }
+        if (!deleted) {
+          return Response.json({
+            records: [
+              {
+                uri: `at://${DID}/site.standard.document/ours`,
+                cid: 'b',
+                value: documentRecord({ skyreaderLinkblog: LINKBLOG_MARKER_URL }),
+              },
+            ],
+            cursor: 'more',
+          });
+        }
+        return Response.json({ records: [] });
+      }
+      if (endpoint === 'com.atproto.repo.applyWrites') deleted = true;
+      return Response.json({});
+    }) as unknown as typeof fetch;
+    const statement = { bind: vi.fn(() => statement), run: vi.fn(async () => ({})) };
+    const env = { DB: { prepare: vi.fn(() => statement) } } as unknown as Env;
+
+    const result = await deleteLinkblog(SESSION, env);
+
+    expect(result).toEqual({ success: true, data: { deletedPosts: 1 } });
+    expect(cursors).toEqual([null, 'next', null, 'next']);
   });
 });

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -6,6 +6,7 @@ import {
   LINKBLOG_MARKER_URL,
   publicationUri,
 } from '../src/services/linkblog-sync';
+import { OFFPRINT_SCOPES } from '../src/config/scopes';
 import type { Env, Session } from '../src/types';
 
 // A connected linkblog publishes into a publication its HOME app owns, which also
@@ -85,6 +86,61 @@ function stubPds(record: Record<string, unknown> | 'missing') {
   return calls;
 }
 
+// One of OUR link posts: carries the provenance marker, so the delete walk picks
+// it up out of a connected publication that also holds the home app's own posts.
+function ourShare(overrides: Record<string, unknown> = {}) {
+  return documentRecord({ skyreaderLinkblog: LINKBLOG_MARKER_URL, ...overrides });
+}
+
+function record(rkey: string, value: Record<string, unknown>) {
+  return { uri: `at://${DID}/site.standard.document/${rkey}`, cid: 'bafy', value };
+}
+
+interface ListPage {
+  records: Array<{ uri: string; cid: string; value: Record<string, unknown> }>;
+  cursor?: string;
+}
+
+// Stub the PDS for a full-linkblog delete: `page` answers each listRecords call
+// by cursor, and every applyWrites body is handed to `onApplyWrites` so a test
+// can assert which collections were addressed.
+function stubDeleteWalk(
+  page: (cursor: string | null) => ListPage,
+  options: { onApplyWrites?: (body: { writes: Array<{ collection: string }> }) => void } = {}
+) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    const endpoint = url.pathname.split('/xrpc/')[1];
+    if (endpoint === 'com.atproto.repo.listRecords') {
+      return Response.json(page(url.searchParams.get('cursor')));
+    }
+    if (endpoint === 'com.atproto.repo.applyWrites') {
+      options.onApplyWrites?.(JSON.parse((init?.body as string) ?? '{"writes":[]}'));
+    }
+    return Response.json({});
+  }) as unknown as typeof fetch;
+}
+
+// A D1 stub that records the SQL it was handed, so a test can assert which
+// settings a failed delete did and didn't touch.
+function dbStub() {
+  const sql: string[] = [];
+  const statement = {
+    bind: vi.fn(() => statement),
+    run: vi.fn(async () => ({})),
+    first: vi.fn(async () => null),
+  };
+  const env = {
+    DB: {
+      prepare: vi.fn((query: string) => {
+        sql.push(query);
+        return statement;
+      }),
+    },
+  } as unknown as Env;
+  return { env, sql };
+}
+
 describe('linkblog share guards', () => {
   let originalFetch: typeof fetch;
 
@@ -143,50 +199,99 @@ describe('linkblog share guards', () => {
     );
   });
 
-  it('continues deleting across pages and restarts after mutating the collection', async () => {
+  it('walks the collection once, deleting as it pages', async () => {
+    // listRecords' cursor is an exclusive rkey bound, not an offset, so deleting
+    // a page can't shift a later record past the cursor. The walk stays linear:
+    // no page is ever fetched twice.
     const cursors: Array<string | null> = [];
     let deleted = false;
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = new URL(typeof input === 'string' ? input : input.toString());
-      const endpoint = url.pathname.split('/xrpc/')[1];
-      if (endpoint === 'com.atproto.repo.listRecords') {
-        const cursor = url.searchParams.get('cursor');
+    stubDeleteWalk(
+      (cursor) => {
         cursors.push(cursor);
-        if (!cursor) {
-          return Response.json({
-            records: [
-              {
-                uri: `at://${DID}/site.standard.document/foreign`,
-                cid: 'a',
-                value: documentRecord(),
-              },
-            ],
-            cursor: 'next',
-          });
-        }
-        if (!deleted) {
-          return Response.json({
-            records: [
-              {
-                uri: `at://${DID}/site.standard.document/ours`,
-                cid: 'b',
-                value: documentRecord({ skyreaderLinkblog: LINKBLOG_MARKER_URL }),
-              },
-            ],
-            cursor: 'more',
-          });
-        }
-        return Response.json({ records: [] });
+        if (!cursor) return { records: [record('foreign', documentRecord())], cursor: 'next' };
+        if (!deleted) return { records: [record('ours', ourShare())], cursor: 'more' };
+        return { records: [] };
+      },
+      {
+        onApplyWrites: () => {
+          deleted = true;
+        },
       }
-      if (endpoint === 'com.atproto.repo.applyWrites') deleted = true;
-      return Response.json({});
-    }) as unknown as typeof fetch;
-    const statement = { bind: vi.fn(() => statement), run: vi.fn(async () => ({})) };
-    const env = { DB: { prepare: vi.fn(() => statement) } } as unknown as Env;
+    );
+    const { env } = dbStub();
 
     const result = await deleteLinkblog(SESSION, env);
 
-    expect(result).toEqual({ success: true, data: { deletedPosts: 1 } });
-    expect(cursors).toEqual([null, 'next', null, 'next']);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.deletedPosts).toBe(1);
+    expect(cursors).toEqual([null, 'next', 'more']);
+  });
+
+  it('deletes only the companion the record was actually written in', async () => {
+    // Both companion collections used to be addressed for every rkey. Neither is
+    // in LINKBLOG_SCOPES, so on a large linkblog that was two guaranteed-failing
+    // applyWrites plus a per-record fallback behind each — enough to burn the
+    // Worker's subrequest budget before the delete finished.
+    const collections: string[] = [];
+    stubDeleteWalk(
+      (cursor) =>
+        cursor
+          ? { records: [] }
+          : {
+              records: [
+                record('offprint-share', ourShare({ content: { $type: 'app.offprint.content' } })),
+                record('leaflet-share', ourShare()),
+              ],
+            },
+      { onApplyWrites: (body) => collections.push(body.writes[0].collection) }
+    );
+    const { env } = dbStub();
+
+    const session = { ...SESSION, grantedScopes: OFFPRINT_SCOPES.join(' ') } as Session;
+    const result = await deleteLinkblog(session, env);
+
+    expect(result.success).toBe(true);
+    expect(collections).toEqual(['site.standard.document', 'app.offprint.document.article']);
+    expect(collections).not.toContain('blog.pckt.document');
+  });
+
+  it('skips the companion entirely when the session never held that app’s scope', async () => {
+    const collections: string[] = [];
+    stubDeleteWalk(
+      (cursor) =>
+        cursor
+          ? { records: [] }
+          : {
+              records: [
+                record('offprint-share', ourShare({ content: { $type: 'app.offprint.content' } })),
+              ],
+            },
+      { onApplyWrites: (body) => collections.push(body.writes[0].collection) }
+    );
+    const { env } = dbStub();
+
+    const result = await deleteLinkblog(SESSION, env);
+
+    expect(result.success).toBe(true);
+    expect(collections).toEqual(['site.standard.document']);
+  });
+
+  it('puts the disabled flag back when the walk fails before deleting anything', async () => {
+    // The flag goes on first so a share can't race the walk. If the PDS side
+    // never happened, leaving it on would strand the user with a live linkblog
+    // that every write path rejects.
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ error: 'InternalServerError' }, { status: 500 })
+    ) as unknown as typeof fetch;
+    const { env, sql } = dbStub();
+
+    const result = await deleteLinkblog(SESSION, env);
+
+    expect(result.success).toBe(false);
+    expect(sql.filter((s) => /linkblog_disabled = 1/.test(s))).toHaveLength(1);
+    expect(sql.filter((s) => /linkblog_disabled = 0/.test(s))).toHaveLength(1);
+    // The connected publication is the one thing a restore can't give back, so a
+    // failed delete must not clear it.
+    expect(sql.some((s) => /linkblog_publication = NULL/.test(s))).toBe(false);
   });
 });

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -122,13 +122,15 @@ function stubDeleteWalk(
 }
 
 // A D1 stub that records the SQL it was handed, so a test can assert which
-// settings a failed delete did and didn't touch.
-function dbStub() {
+// settings a failed delete did and didn't touch. `row` is what every `.first()`
+// returns — enough to stand in for the user_settings lookups the delete makes
+// (its own disabled flag, and the linkblog target).
+function dbStub(row: Record<string, unknown> | null = null) {
   const sql: string[] = [];
   const statement = {
     bind: vi.fn(() => statement),
     run: vi.fn(async () => ({})),
-    first: vi.fn(async () => null),
+    first: vi.fn(async () => row),
   };
   const env = {
     DB: {
@@ -276,6 +278,54 @@ describe('linkblog share guards', () => {
     expect(collections).toEqual(['site.standard.document']);
   });
 
+  it('caps the per-record companion fallback across the whole walk', async () => {
+    // A companion batch that keeps failing degrades to one deleteRecord per
+    // record. Unbounded that's a subrequest per companion for every page, which
+    // exhausts the Worker's budget and strands the delete half-done. Documents
+    // still go; the leftover companions are orphaned on purpose.
+    const PAGES = 6;
+    const PER_PAGE = 100;
+    let deleteRecordCalls = 0;
+    let page = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString());
+      const endpoint = url.pathname.split('/xrpc/')[1];
+      if (endpoint === 'com.atproto.repo.listRecords') {
+        if (page >= PAGES) return Response.json({ records: [] });
+        const records = Array.from({ length: PER_PAGE }, (_, i) =>
+          record(`r${page}-${i}`, ourShare({ content: { $type: 'app.offprint.content' } }))
+        );
+        page++;
+        return Response.json({ records, cursor: `page-${page}` });
+      }
+      if (endpoint === 'com.atproto.repo.applyWrites') {
+        const body = JSON.parse((init?.body as string) ?? '{"writes":[]}');
+        // Documents succeed; the companion collection fails every time.
+        if (body.writes[0]?.collection !== 'site.standard.document') {
+          return Response.json({ error: 'InvalidRequest' }, { status: 400 });
+        }
+      }
+      if (endpoint === 'com.atproto.repo.deleteRecord') {
+        // Count only the companion fallback, not the single publication-record
+        // delete that closes out a successful walk.
+        const body = JSON.parse((init?.body as string) ?? '{}');
+        if (body.collection !== 'site.standard.publication') deleteRecordCalls++;
+      }
+      return Response.json({});
+    }) as unknown as typeof fetch;
+    const { env } = dbStub();
+
+    const session = { ...SESSION, grantedScopes: OFFPRINT_SCOPES.join(' ') } as Session;
+    const result = await deleteLinkblog(session, env);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.deletedPosts).toBe(PAGES * PER_PAGE);
+    // Bounded by the budget, not by the repo: without the cap this would be one
+    // call per companion record (600), and it grows with the linkblog.
+    expect(deleteRecordCalls).toBeLessThanOrEqual(200);
+    expect(deleteRecordCalls).toBeGreaterThan(0);
+  });
+
   it('puts the disabled flag back when the walk fails before deleting anything', async () => {
     // The flag goes on first so a share can't race the walk. If the PDS side
     // never happened, leaving it on would strand the user with a live linkblog
@@ -293,5 +343,22 @@ describe('linkblog share guards', () => {
     // The connected publication is the one thing a restore can't give back, so a
     // failed delete must not clear it.
     expect(sql.some((s) => /linkblog_publication = NULL/.test(s))).toBe(false);
+  });
+
+  it('keeps the flag when a retry of a partial delete fails having deleted nothing', async () => {
+    // A delete that got partway leaves the flag on. Retrying it can fail before
+    // deleting anything of its OWN — but the posts the first attempt took are
+    // still gone. Rolling back on this call's zero count would hand back a
+    // linkblog silently missing them, which is the one state the flag exists to
+    // prevent. Already-disabled on entry is what tells the two apart.
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ error: 'InternalServerError' }, { status: 500 })
+    ) as unknown as typeof fetch;
+    const { env, sql } = dbStub({ linkblog_disabled: 1 });
+
+    const result = await deleteLinkblog(SESSION, env);
+
+    expect(result.success).toBe(false);
+    expect(sql.some((s) => /linkblog_disabled = 0/.test(s))).toBe(false);
   });
 });

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -20,6 +20,22 @@ export default defineWorkersConfig({
         miniflare: {
           bindings: {
             CLIENT_SIGNING_KEY: TEST_CLIENT_SIGNING_KEY,
+            // Pin the ambient vars the suite depends on. Without these, tests
+            // inherit wrangler.toml's PRODUCTION values in CI and whatever the
+            // developer's .dev.vars says locally — so the same test can pass in
+            // one place and fail in the other.
+            //
+            // FEED_PROXY_URL pointed at the live Fly proxy in CI, and the save
+            // path extracts article content through it inside ctx.waitUntil.
+            // waitOnExecutionContext blocks on that, so a slow proxy (it is
+            // known-overloaded) blew the 5s test timeout and took the whole
+            // file's isolated storage down with it. A refused port fails
+            // instantly and keeps unit tests off the network entirely; any test
+            // that needs a proxy response stubs fetch itself.
+            FEED_PROXY_URL: 'http://127.0.0.1:1',
+            // Assertions hardcode the production linkblog base, which only held
+            // on a machine with no .dev.vars.
+            LINKBLOG_PUBLIC_URL: 'https://linkblogs.skyreader.app',
           },
         },
       },

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -101,7 +101,7 @@
       description: 'Linkblog',
       category: 'Views',
       action: () => goto('/linkblog'),
-      condition: () => auth.isAuthenticated,
+      condition: () => auth.isAuthenticated && !preferences.linkblogDisabled,
     });
 
     keyboardStore.register({

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -42,12 +42,11 @@
   import { socialStore } from '$lib/stores/social.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
-  import { shareDestination } from '$lib/utils/linkblogTargets';
   import { socialContextStore } from '$lib/stores/socialContext.svelte';
   import { profileService } from '$lib/services/profiles';
   import { auth } from '$lib/stores/auth.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
-  import Modal from '$lib/components/common/Modal.svelte';
+  import ShareConfirmModal from './feed/ShareConfirmModal.svelte';
   import ArticleCardView from './ArticleCardView.svelte';
   import { useAtmosphere } from '$lib/hooks/useAtmosphere.svelte';
   import type { LaneId } from './articleCardView.types';
@@ -477,16 +476,9 @@
   );
   let seededQuote = $derived(formatQuoteSeed(shareQuoteSource));
 
-  // First-share confirmation: sharing publishes to a public linkblog, which is
-  // irreversible-feeling and easy to do by accident. We gate the very first share
-  // on a one-time "this is public" dialog; "Don't ask again" persists in prefs.
-  // It names the publication the share actually lands in — a connected one, if
-  // the user switched, not the Skyreader linkblog they no longer publish to.
+  // The very first share is gated on the "this is public" dialog
+  // (ShareConfirmModal owns the copy, the acknowledgment and the target).
   let showShareConfirm = $state(false);
-  let dontAskAgain = $state(false);
-  let shareTarget = $derived(
-    shareDestination(myLinkblogStore.publication, myLinkblogStore.publicUrl())
-  );
 
   // Fire the share for the current mode (the Blogs lane [+]), seeding the note
   // with the article's quote so it lands in the persistent note box ready to
@@ -506,7 +498,6 @@
 
   function shareNow() {
     if (!preferences.linkblogShareConfirmed) {
-      dontAskAgain = false;
       showShareConfirm = true;
       return;
     }
@@ -514,7 +505,6 @@
   }
 
   function confirmShare() {
-    if (dontAskAgain) preferences.confirmLinkblogShare();
     showShareConfirm = false;
     performShare();
   }
@@ -1002,77 +992,8 @@
   {/if}
 {/if}
 
-<Modal
+<ShareConfirmModal
   open={showShareConfirm}
-  onclose={() => (showShareConfirm = false)}
-  title="Share to your linkblog?"
-  maxWidth="420px"
->
-  <p class="share-confirm-text">
-    This publishes to {#if shareTarget.external}<strong>{shareTarget.name}</strong>{:else}your
-      public linkblog{/if}{#if shareTarget.address}
-      at
-      <a href={shareTarget.url} target="_blank" rel="noopener noreferrer" class="share-confirm-link"
-        >{shareTarget.address}</a
-      >{/if}. Anyone can read it.
-  </p>
-  {#if shareTarget.external && shareTarget.linkblogUrl}
-    <p class="share-confirm-aside">
-      It shows on
-      <a
-        href={shareTarget.linkblogUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="share-confirm-link">your linkblog page</a
-      > too.
-    </p>
-  {/if}
-  <label class="share-confirm-remember">
-    <input type="checkbox" bind:checked={dontAskAgain} />
-    <span>Don't ask again</span>
-  </label>
-  {#snippet footer()}
-    <button class="btn btn-secondary" onclick={() => (showShareConfirm = false)}>Cancel</button>
-    <button class="btn btn-primary" onclick={confirmShare}>Share</button>
-  {/snippet}
-</Modal>
-
-<style>
-  .share-confirm-text {
-    margin: 0 0 1rem;
-    color: var(--color-text);
-    line-height: var(--leading-normal);
-  }
-
-  .share-confirm-aside {
-    margin: -0.5rem 0 1rem;
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-    line-height: var(--leading-normal);
-  }
-
-  .share-confirm-link {
-    color: var(--color-primary);
-    text-decoration: none;
-    word-break: break-all;
-  }
-
-  .share-confirm-link:hover {
-    text-decoration: underline;
-  }
-
-  .share-confirm-remember {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: var(--text-md);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-  }
-
-  .share-confirm-remember input {
-    width: 1rem;
-    height: 1rem;
-    cursor: pointer;
-  }
-</style>
+  onconfirm={confirmShare}
+  oncancel={() => (showShareConfirm = false)}
+/>

--- a/frontend/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/frontend/src/lib/components/KeyboardShortcutsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { keyboardStore } from '$lib/stores/keyboard.svelte';
   import Modal from '$lib/components/common/Modal.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
 
   const shortcuts = [
     // Navigation
@@ -15,7 +16,9 @@
     { category: 'Views', key: '0', description: 'Home' },
     { category: 'Views', key: '1', description: 'Feeds' },
     { category: 'Views', key: '2', description: 'Saved' },
-    { category: 'Views', key: '3', description: 'Linkblog' },
+    ...(!preferences.linkblogDisabled
+      ? [{ category: 'Views', key: '3', description: 'Linkblog' }]
+      : []),
     { category: 'Views', key: '4', description: 'Highlights' },
     { category: 'Views', key: '5', description: 'Discover' },
     { category: 'Views', key: '6', description: 'Manage Sources' },
@@ -27,7 +30,9 @@
 
     // Article actions
     { category: 'Article', key: 's', description: 'Toggle save' },
-    { category: 'Article', key: 'S', description: 'Share/unshare' },
+    ...(!preferences.linkblogDisabled
+      ? [{ category: 'Article', key: 'S', description: 'Share/unshare' }]
+      : []),
     { category: 'Article', key: 'm', description: 'Mark read/unread' },
     { category: 'Article', key: 'A', description: 'Mark all as read' },
     { category: 'Article', key: 't', description: 'Tag item' },

--- a/frontend/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/frontend/src/lib/components/KeyboardShortcutsModal.svelte
@@ -3,7 +3,10 @@
   import Modal from '$lib/components/common/Modal.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
 
-  const shortcuts = [
+  // Derived, not a const: the modal is mounted once for the app's lifetime, so a
+  // plain array would be built before `linkblogDisabled` is hydrated from the
+  // server and would keep listing linkblog keys for a deleted one.
+  const shortcuts = $derived([
     // Navigation
     { category: 'Navigation', key: '/', description: 'Open switcher' },
     { category: 'Navigation', key: 'j', description: 'Next item' },
@@ -48,7 +51,7 @@
     { category: 'Other', key: 'a', description: 'Toggle add menu' },
     { category: 'Other', key: '?', description: 'Show shortcuts' },
     { category: 'Other', key: 'Esc', description: 'Close modal / Deselect' },
-  ];
+  ]);
 
   const categories = ['Navigation', 'Views', 'Feed', 'Article', 'Other'];
 </script>

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -9,6 +9,7 @@
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
   import { channelPath, feedPath, FEEDS_PATH, SAVED_PATH } from '$lib/utils/viewNav';
   import Icon from './Icon.svelte';
   import AddDropdownMenu from './AddDropdownMenu.svelte';
@@ -230,7 +231,9 @@
       icon: 'bookmark',
     };
     const otherViews: NavItem[] = [
-      { type: 'utility', id: 'linkblog', label: 'Linkblog', icon: 'share' },
+      ...(!preferences.linkblogDisabled
+        ? [{ type: 'utility' as const, id: 'linkblog', label: 'Linkblog', icon: 'share' as const }]
+        : []),
       { type: 'utility', id: 'highlights', label: 'Highlights', icon: 'highlighter' },
       { type: 'utility', id: 'discover', label: 'Discover', icon: 'users' },
       { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' },

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -320,201 +320,203 @@
   <!-- Navigation items -->
   <nav class="sidebar-nav">
     <!-- Home: the default landing surface (a route, not a feed filter) -->
-    {#if !preferences.linkblogDisabled}<a
-        href="/home"
-        class="nav-item nav-link"
-        class:active={$page.url.pathname === '/home'}
-        onclick={() => sidebarStore.closeMobile()}
-      >
-        <span class="nav-icon"><Icon name="home" /></span>
-        <span class="nav-label">Home</span>
-      </a>
+    <a
+      href="/home"
+      class="nav-item nav-link"
+      class:active={$page.url.pathname === '/home'}
+      onclick={() => sidebarStore.closeMobile()}
+    >
+      <span class="nav-icon"><Icon name="home" /></span>
+      <span class="nav-label">Home</span>
+    </a>
 
-      <!-- Everything: top-level filter + nested source channels -->
-      <div class="nav-group" class:expanded={sidebarStore.expandedSections.everything}>
-        <div class="nav-row" class:active={currentFilter().type === 'all'}>
-          <button class="nav-row-main" onclick={() => selectFilter('all')}>
-            <span class="nav-icon"><Icon name="inbox" /></span>
-            <span class="nav-label">Feeds</span>
-          </button>
-          <button
-            class="row-add-btn"
-            onclick={(e) => {
-              e.stopPropagation();
-              openChannelModal(null, 'feed');
-            }}
-            title="New channel"
-          >
-            <Icon name="plus" size={14} strokeWidth={2} />
-          </button>
-          {#if totalUnread > 0}
-            <span class="nav-count">{totalUnread}</span>
-          {/if}
-          <button
-            class="row-disclosure-btn"
-            onclick={(e) => {
-              e.stopPropagation();
-              sidebarStore.toggleSection('everything');
-            }}
-            aria-label="Toggle channels"
-          >
-            <Icon
-              name={sidebarStore.expandedSections.everything ? 'chevron-down' : 'chevron-right'}
-              size={14}
-              strokeWidth={2.5}
-            />
-          </button>
-        </div>
-        {#if sidebarStore.expandedSections.everything}
-          <div class="nav-children">
-            {#each sourceChannels as view (view.uuid)}
-              <ViewItem
-                {view}
-                isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
-                isRenaming={renamingViewId === view.id}
-                unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-                onSelect={() => selectFilter('view', view.uuid)}
-                onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-                onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-                onTouchEnd={handleViewTouchEnd}
-                onTouchMove={handleViewTouchMove}
-                onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-                onRename={async (name) => {
-                  if (view.id != null) {
-                    await filteredViewsStore.update(view.id, { name });
-                  }
-                  renamingViewId = null;
-                }}
-                onRenameCancel={() => (renamingViewId = null)}
-              />
-            {/each}
-            {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
-              <div class="suggestion-item">
-                <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
-                  <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-                  <span class="suggestion-name">{suggestion.name}</span>
-                </button>
-                <Tooltip text={suggestion.description} />
-                <button
-                  class="suggestion-dismiss"
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    channelSuggestions.dismiss(suggestion.id);
-                  }}
-                  title="Dismiss"
-                >
-                  <Icon name="x" size={12} />
-                </button>
-              </div>
-            {/each}
-            {#if sourceChannels.length === 0 && channelSuggestions.suggestions.length === 0}
-              <div class="empty-section">No channels yet</div>
-            {/if}
-            <a
-              href="/channels/discover"
-              class="more-suggestions-link"
-              onclick={() => sidebarStore.closeMobile()}
-            >
-              More channel ideas
-              <Icon name="arrow-right" size={12} />
-            </a>
-          </div>
+    <!-- Everything: top-level filter + nested source channels -->
+    <div class="nav-group" class:expanded={sidebarStore.expandedSections.everything}>
+      <div class="nav-row" class:active={currentFilter().type === 'all'}>
+        <button class="nav-row-main" onclick={() => selectFilter('all')}>
+          <span class="nav-icon"><Icon name="inbox" /></span>
+          <span class="nav-label">Feeds</span>
+        </button>
+        <button
+          class="row-add-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            openChannelModal(null, 'feed');
+          }}
+          title="New channel"
+        >
+          <Icon name="plus" size={14} strokeWidth={2} />
+        </button>
+        {#if totalUnread > 0}
+          <span class="nav-count">{totalUnread}</span>
         {/if}
+        <button
+          class="row-disclosure-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            sidebarStore.toggleSection('everything');
+          }}
+          aria-label="Toggle channels"
+        >
+          <Icon
+            name={sidebarStore.expandedSections.everything ? 'chevron-down' : 'chevron-right'}
+            size={14}
+            strokeWidth={2.5}
+          />
+        </button>
       </div>
-
-      <!-- Saved: top-level filter + nested saved channels -->
-      <div class="nav-group" class:expanded={sidebarStore.expandedSections.saved}>
-        <div class="nav-row" class:active={currentFilter().type === 'saved'}>
-          <button class="nav-row-main" onclick={() => selectFilter('saved')}>
-            <span class="nav-icon"><Icon name="bookmark" /></span>
-            <span class="nav-label">Saved</span>
-          </button>
-          <button
-            class="row-add-btn"
-            onclick={(e) => {
-              e.stopPropagation();
-              openChannelModal(null, 'saved');
-            }}
-            title="New saved channel"
-          >
-            <Icon name="plus" size={14} strokeWidth={2} />
-          </button>
-          {#if itemLabelsStore.inboxCount > 0}
-            <span class="nav-count">{itemLabelsStore.inboxCount}</span>
-          {/if}
-          <button
-            class="row-disclosure-btn"
-            onclick={(e) => {
-              e.stopPropagation();
-              sidebarStore.toggleSection('saved');
-            }}
-            aria-label="Toggle saved channels"
-          >
-            <Icon
-              name={sidebarStore.expandedSections.saved ? 'chevron-down' : 'chevron-right'}
-              size={14}
-              strokeWidth={2.5}
+      {#if sidebarStore.expandedSections.everything}
+        <div class="nav-children">
+          {#each sourceChannels as view (view.uuid)}
+            <ViewItem
+              {view}
+              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+              isRenaming={renamingViewId === view.id}
+              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+              onSelect={() => selectFilter('view', view.uuid)}
+              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+              onTouchEnd={handleViewTouchEnd}
+              onTouchMove={handleViewTouchMove}
+              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onRename={async (name) => {
+                if (view.id != null) {
+                  await filteredViewsStore.update(view.id, { name });
+                }
+                renamingViewId = null;
+              }}
+              onRenameCancel={() => (renamingViewId = null)}
             />
-          </button>
-        </div>
-        {#if sidebarStore.expandedSections.saved}
-          <div class="nav-children">
-            {#each savedChannels as view (view.uuid)}
-              <ViewItem
-                {view}
-                isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
-                isRenaming={renamingViewId === view.id}
-                unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-                onSelect={() => selectFilter('view', view.uuid)}
-                onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-                onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-                onTouchEnd={handleViewTouchEnd}
-                onTouchMove={handleViewTouchMove}
-                onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-                onRename={async (name) => {
-                  if (view.id != null) {
-                    await filteredViewsStore.update(view.id, { name });
-                  }
-                  renamingViewId = null;
+          {/each}
+          {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+            <div class="suggestion-item">
+              <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                <span class="suggestion-name">{suggestion.name}</span>
+              </button>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  channelSuggestions.dismiss(suggestion.id);
                 }}
-                onRenameCancel={() => (renamingViewId = null)}
-              />
-            {/each}
-            {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
-              <div class="suggestion-item">
-                <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
-                  <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-                  <span class="suggestion-name">{suggestion.name}</span>
-                </button>
-                <Tooltip text={suggestion.description} />
-                <button
-                  class="suggestion-dismiss"
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    savedChannelSuggestions.dismiss(suggestion.id);
-                  }}
-                  title="Dismiss"
-                >
-                  <Icon name="x" size={12} />
-                </button>
-              </div>
-            {/each}
-            {#if savedChannels.length === 0 && savedChannelSuggestions.suggestions.length === 0}
-              <div class="empty-section">No saved channels yet</div>
-            {/if}
-            <a
-              href="/channels/discover"
-              class="more-suggestions-link"
-              onclick={() => sidebarStore.closeMobile()}
-            >
-              More channel ideas
-              <Icon name="arrow-right" size={12} />
-            </a>
-          </div>
-        {/if}
-      </div>
+                title="Dismiss"
+              >
+                <Icon name="x" size={12} />
+              </button>
+            </div>
+          {/each}
+          {#if sourceChannels.length === 0 && channelSuggestions.suggestions.length === 0}
+            <div class="empty-section">No channels yet</div>
+          {/if}
+          <a
+            href="/channels/discover"
+            class="more-suggestions-link"
+            onclick={() => sidebarStore.closeMobile()}
+          >
+            More channel ideas
+            <Icon name="arrow-right" size={12} />
+          </a>
+        </div>
+      {/if}
+    </div>
 
-      <!-- Bottom nav -->
+    <!-- Saved: top-level filter + nested saved channels -->
+    <div class="nav-group" class:expanded={sidebarStore.expandedSections.saved}>
+      <div class="nav-row" class:active={currentFilter().type === 'saved'}>
+        <button class="nav-row-main" onclick={() => selectFilter('saved')}>
+          <span class="nav-icon"><Icon name="bookmark" /></span>
+          <span class="nav-label">Saved</span>
+        </button>
+        <button
+          class="row-add-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            openChannelModal(null, 'saved');
+          }}
+          title="New saved channel"
+        >
+          <Icon name="plus" size={14} strokeWidth={2} />
+        </button>
+        {#if itemLabelsStore.inboxCount > 0}
+          <span class="nav-count">{itemLabelsStore.inboxCount}</span>
+        {/if}
+        <button
+          class="row-disclosure-btn"
+          onclick={(e) => {
+            e.stopPropagation();
+            sidebarStore.toggleSection('saved');
+          }}
+          aria-label="Toggle saved channels"
+        >
+          <Icon
+            name={sidebarStore.expandedSections.saved ? 'chevron-down' : 'chevron-right'}
+            size={14}
+            strokeWidth={2.5}
+          />
+        </button>
+      </div>
+      {#if sidebarStore.expandedSections.saved}
+        <div class="nav-children">
+          {#each savedChannels as view (view.uuid)}
+            <ViewItem
+              {view}
+              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+              isRenaming={renamingViewId === view.id}
+              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+              onSelect={() => selectFilter('view', view.uuid)}
+              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+              onTouchEnd={handleViewTouchEnd}
+              onTouchMove={handleViewTouchMove}
+              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+              onRename={async (name) => {
+                if (view.id != null) {
+                  await filteredViewsStore.update(view.id, { name });
+                }
+                renamingViewId = null;
+              }}
+              onRenameCancel={() => (renamingViewId = null)}
+            />
+          {/each}
+          {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+            <div class="suggestion-item">
+              <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
+                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                <span class="suggestion-name">{suggestion.name}</span>
+              </button>
+              <Tooltip text={suggestion.description} />
+              <button
+                class="suggestion-dismiss"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  savedChannelSuggestions.dismiss(suggestion.id);
+                }}
+                title="Dismiss"
+              >
+                <Icon name="x" size={12} />
+              </button>
+            </div>
+          {/each}
+          {#if savedChannels.length === 0 && savedChannelSuggestions.suggestions.length === 0}
+            <div class="empty-section">No saved channels yet</div>
+          {/if}
+          <a
+            href="/channels/discover"
+            class="more-suggestions-link"
+            onclick={() => sidebarStore.closeMobile()}
+          >
+            More channel ideas
+            <Icon name="arrow-right" size={12} />
+          </a>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Bottom nav. The linkblog entry hides once the user deletes their
+         linkblog; the rest of the nav is unrelated to it and always shows. -->
+    {#if !preferences.linkblogDisabled}
       <a
         href="/linkblog"
         class="nav-item nav-link"
@@ -523,7 +525,8 @@
       >
         <span class="nav-icon"><Icon name="share" /></span>
         <span class="nav-label">Linkblog</span>
-      </a>{/if}
+      </a>
+    {/if}
 
     <a
       href="/highlights"

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -31,6 +31,7 @@
   import Tooltip from './Tooltip.svelte';
   import { feedStatusStore } from '$lib/stores/feedStatus.svelte';
   import { fetchSingleFeed } from '$lib/services/feedFetcher';
+  import { preferences } from '$lib/stores/preferences.svelte';
 
   function handleFeedContextMenu(e: MouseEvent, feedId: number) {
     e.preventDefault();
@@ -319,210 +320,210 @@
   <!-- Navigation items -->
   <nav class="sidebar-nav">
     <!-- Home: the default landing surface (a route, not a feed filter) -->
-    <a
-      href="/home"
-      class="nav-item nav-link"
-      class:active={$page.url.pathname === '/home'}
-      onclick={() => sidebarStore.closeMobile()}
-    >
-      <span class="nav-icon"><Icon name="home" /></span>
-      <span class="nav-label">Home</span>
-    </a>
+    {#if !preferences.linkblogDisabled}<a
+        href="/home"
+        class="nav-item nav-link"
+        class:active={$page.url.pathname === '/home'}
+        onclick={() => sidebarStore.closeMobile()}
+      >
+        <span class="nav-icon"><Icon name="home" /></span>
+        <span class="nav-label">Home</span>
+      </a>
 
-    <!-- Everything: top-level filter + nested source channels -->
-    <div class="nav-group" class:expanded={sidebarStore.expandedSections.everything}>
-      <div class="nav-row" class:active={currentFilter().type === 'all'}>
-        <button class="nav-row-main" onclick={() => selectFilter('all')}>
-          <span class="nav-icon"><Icon name="inbox" /></span>
-          <span class="nav-label">Feeds</span>
-        </button>
-        <button
-          class="row-add-btn"
-          onclick={(e) => {
-            e.stopPropagation();
-            openChannelModal(null, 'feed');
-          }}
-          title="New channel"
-        >
-          <Icon name="plus" size={14} strokeWidth={2} />
-        </button>
-        {#if totalUnread > 0}
-          <span class="nav-count">{totalUnread}</span>
-        {/if}
-        <button
-          class="row-disclosure-btn"
-          onclick={(e) => {
-            e.stopPropagation();
-            sidebarStore.toggleSection('everything');
-          }}
-          aria-label="Toggle channels"
-        >
-          <Icon
-            name={sidebarStore.expandedSections.everything ? 'chevron-down' : 'chevron-right'}
-            size={14}
-            strokeWidth={2.5}
-          />
-        </button>
-      </div>
-      {#if sidebarStore.expandedSections.everything}
-        <div class="nav-children">
-          {#each sourceChannels as view (view.uuid)}
-            <ViewItem
-              {view}
-              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
-              isRenaming={renamingViewId === view.id}
-              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-              onSelect={() => selectFilter('view', view.uuid)}
-              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-              onTouchEnd={handleViewTouchEnd}
-              onTouchMove={handleViewTouchMove}
-              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-              onRename={async (name) => {
-                if (view.id != null) {
-                  await filteredViewsStore.update(view.id, { name });
-                }
-                renamingViewId = null;
-              }}
-              onRenameCancel={() => (renamingViewId = null)}
-            />
-          {/each}
-          {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
-            <div class="suggestion-item">
-              <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
-                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-                <span class="suggestion-name">{suggestion.name}</span>
-              </button>
-              <Tooltip text={suggestion.description} />
-              <button
-                class="suggestion-dismiss"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  channelSuggestions.dismiss(suggestion.id);
-                }}
-                title="Dismiss"
-              >
-                <Icon name="x" size={12} />
-              </button>
-            </div>
-          {/each}
-          {#if sourceChannels.length === 0 && channelSuggestions.suggestions.length === 0}
-            <div class="empty-section">No channels yet</div>
-          {/if}
-          <a
-            href="/channels/discover"
-            class="more-suggestions-link"
-            onclick={() => sidebarStore.closeMobile()}
+      <!-- Everything: top-level filter + nested source channels -->
+      <div class="nav-group" class:expanded={sidebarStore.expandedSections.everything}>
+        <div class="nav-row" class:active={currentFilter().type === 'all'}>
+          <button class="nav-row-main" onclick={() => selectFilter('all')}>
+            <span class="nav-icon"><Icon name="inbox" /></span>
+            <span class="nav-label">Feeds</span>
+          </button>
+          <button
+            class="row-add-btn"
+            onclick={(e) => {
+              e.stopPropagation();
+              openChannelModal(null, 'feed');
+            }}
+            title="New channel"
           >
-            More channel ideas
-            <Icon name="arrow-right" size={12} />
-          </a>
-        </div>
-      {/if}
-    </div>
-
-    <!-- Saved: top-level filter + nested saved channels -->
-    <div class="nav-group" class:expanded={sidebarStore.expandedSections.saved}>
-      <div class="nav-row" class:active={currentFilter().type === 'saved'}>
-        <button class="nav-row-main" onclick={() => selectFilter('saved')}>
-          <span class="nav-icon"><Icon name="bookmark" /></span>
-          <span class="nav-label">Saved</span>
-        </button>
-        <button
-          class="row-add-btn"
-          onclick={(e) => {
-            e.stopPropagation();
-            openChannelModal(null, 'saved');
-          }}
-          title="New saved channel"
-        >
-          <Icon name="plus" size={14} strokeWidth={2} />
-        </button>
-        {#if itemLabelsStore.inboxCount > 0}
-          <span class="nav-count">{itemLabelsStore.inboxCount}</span>
-        {/if}
-        <button
-          class="row-disclosure-btn"
-          onclick={(e) => {
-            e.stopPropagation();
-            sidebarStore.toggleSection('saved');
-          }}
-          aria-label="Toggle saved channels"
-        >
-          <Icon
-            name={sidebarStore.expandedSections.saved ? 'chevron-down' : 'chevron-right'}
-            size={14}
-            strokeWidth={2.5}
-          />
-        </button>
-      </div>
-      {#if sidebarStore.expandedSections.saved}
-        <div class="nav-children">
-          {#each savedChannels as view (view.uuid)}
-            <ViewItem
-              {view}
-              isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
-              isRenaming={renamingViewId === view.id}
-              unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
-              onSelect={() => selectFilter('view', view.uuid)}
-              onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-              onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
-              onTouchEnd={handleViewTouchEnd}
-              onTouchMove={handleViewTouchMove}
-              onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
-              onRename={async (name) => {
-                if (view.id != null) {
-                  await filteredViewsStore.update(view.id, { name });
-                }
-                renamingViewId = null;
-              }}
-              onRenameCancel={() => (renamingViewId = null)}
-            />
-          {/each}
-          {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
-            <div class="suggestion-item">
-              <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
-                <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
-                <span class="suggestion-name">{suggestion.name}</span>
-              </button>
-              <Tooltip text={suggestion.description} />
-              <button
-                class="suggestion-dismiss"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  savedChannelSuggestions.dismiss(suggestion.id);
-                }}
-                title="Dismiss"
-              >
-                <Icon name="x" size={12} />
-              </button>
-            </div>
-          {/each}
-          {#if savedChannels.length === 0 && savedChannelSuggestions.suggestions.length === 0}
-            <div class="empty-section">No saved channels yet</div>
+            <Icon name="plus" size={14} strokeWidth={2} />
+          </button>
+          {#if totalUnread > 0}
+            <span class="nav-count">{totalUnread}</span>
           {/if}
-          <a
-            href="/channels/discover"
-            class="more-suggestions-link"
-            onclick={() => sidebarStore.closeMobile()}
+          <button
+            class="row-disclosure-btn"
+            onclick={(e) => {
+              e.stopPropagation();
+              sidebarStore.toggleSection('everything');
+            }}
+            aria-label="Toggle channels"
           >
-            More channel ideas
-            <Icon name="arrow-right" size={12} />
-          </a>
+            <Icon
+              name={sidebarStore.expandedSections.everything ? 'chevron-down' : 'chevron-right'}
+              size={14}
+              strokeWidth={2.5}
+            />
+          </button>
         </div>
-      {/if}
-    </div>
+        {#if sidebarStore.expandedSections.everything}
+          <div class="nav-children">
+            {#each sourceChannels as view (view.uuid)}
+              <ViewItem
+                {view}
+                isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+                isRenaming={renamingViewId === view.id}
+                unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+                onSelect={() => selectFilter('view', view.uuid)}
+                onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+                onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+                onTouchEnd={handleViewTouchEnd}
+                onTouchMove={handleViewTouchMove}
+                onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+                onRename={async (name) => {
+                  if (view.id != null) {
+                    await filteredViewsStore.update(view.id, { name });
+                  }
+                  renamingViewId = null;
+                }}
+                onRenameCancel={() => (renamingViewId = null)}
+              />
+            {/each}
+            {#each channelSuggestions.suggestions as suggestion (suggestion.id)}
+              <div class="suggestion-item">
+                <button class="suggestion-accept" onclick={() => acceptSuggestion(suggestion)}>
+                  <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                  <span class="suggestion-name">{suggestion.name}</span>
+                </button>
+                <Tooltip text={suggestion.description} />
+                <button
+                  class="suggestion-dismiss"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    channelSuggestions.dismiss(suggestion.id);
+                  }}
+                  title="Dismiss"
+                >
+                  <Icon name="x" size={12} />
+                </button>
+              </div>
+            {/each}
+            {#if sourceChannels.length === 0 && channelSuggestions.suggestions.length === 0}
+              <div class="empty-section">No channels yet</div>
+            {/if}
+            <a
+              href="/channels/discover"
+              class="more-suggestions-link"
+              onclick={() => sidebarStore.closeMobile()}
+            >
+              More channel ideas
+              <Icon name="arrow-right" size={12} />
+            </a>
+          </div>
+        {/if}
+      </div>
 
-    <!-- Bottom nav -->
-    <a
-      href="/linkblog"
-      class="nav-item nav-link"
-      class:active={$page.url.pathname === '/linkblog'}
-      onclick={() => sidebarStore.closeMobile()}
-    >
-      <span class="nav-icon"><Icon name="share" /></span>
-      <span class="nav-label">Linkblog</span>
-    </a>
+      <!-- Saved: top-level filter + nested saved channels -->
+      <div class="nav-group" class:expanded={sidebarStore.expandedSections.saved}>
+        <div class="nav-row" class:active={currentFilter().type === 'saved'}>
+          <button class="nav-row-main" onclick={() => selectFilter('saved')}>
+            <span class="nav-icon"><Icon name="bookmark" /></span>
+            <span class="nav-label">Saved</span>
+          </button>
+          <button
+            class="row-add-btn"
+            onclick={(e) => {
+              e.stopPropagation();
+              openChannelModal(null, 'saved');
+            }}
+            title="New saved channel"
+          >
+            <Icon name="plus" size={14} strokeWidth={2} />
+          </button>
+          {#if itemLabelsStore.inboxCount > 0}
+            <span class="nav-count">{itemLabelsStore.inboxCount}</span>
+          {/if}
+          <button
+            class="row-disclosure-btn"
+            onclick={(e) => {
+              e.stopPropagation();
+              sidebarStore.toggleSection('saved');
+            }}
+            aria-label="Toggle saved channels"
+          >
+            <Icon
+              name={sidebarStore.expandedSections.saved ? 'chevron-down' : 'chevron-right'}
+              size={14}
+              strokeWidth={2.5}
+            />
+          </button>
+        </div>
+        {#if sidebarStore.expandedSections.saved}
+          <div class="nav-children">
+            {#each savedChannels as view (view.uuid)}
+              <ViewItem
+                {view}
+                isActive={currentFilter().type === 'view' && currentFilter().id === view.uuid}
+                isRenaming={renamingViewId === view.id}
+                unreadCount={view.id != null ? (unreadCounts.channelCounts.get(view.id) ?? 0) : 0}
+                onSelect={() => selectFilter('view', view.uuid)}
+                onContextMenu={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+                onTouchStart={(e) => view.id != null && handleViewTouchStart(e, view.id)}
+                onTouchEnd={handleViewTouchEnd}
+                onTouchMove={handleViewTouchMove}
+                onMoreClick={(e) => view.id != null && handleViewContextMenu(e, view.id)}
+                onRename={async (name) => {
+                  if (view.id != null) {
+                    await filteredViewsStore.update(view.id, { name });
+                  }
+                  renamingViewId = null;
+                }}
+                onRenameCancel={() => (renamingViewId = null)}
+              />
+            {/each}
+            {#each savedChannelSuggestions.suggestions as suggestion (suggestion.id)}
+              <div class="suggestion-item">
+                <button class="suggestion-accept" onclick={() => acceptSavedSuggestion(suggestion)}>
+                  <span class="suggestion-icon"><Icon name="plus" size={12} /></span>
+                  <span class="suggestion-name">{suggestion.name}</span>
+                </button>
+                <Tooltip text={suggestion.description} />
+                <button
+                  class="suggestion-dismiss"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    savedChannelSuggestions.dismiss(suggestion.id);
+                  }}
+                  title="Dismiss"
+                >
+                  <Icon name="x" size={12} />
+                </button>
+              </div>
+            {/each}
+            {#if savedChannels.length === 0 && savedChannelSuggestions.suggestions.length === 0}
+              <div class="empty-section">No saved channels yet</div>
+            {/if}
+            <a
+              href="/channels/discover"
+              class="more-suggestions-link"
+              onclick={() => sidebarStore.closeMobile()}
+            >
+              More channel ideas
+              <Icon name="arrow-right" size={12} />
+            </a>
+          </div>
+        {/if}
+      </div>
+
+      <!-- Bottom nav -->
+      <a
+        href="/linkblog"
+        class="nav-item nav-link"
+        class:active={$page.url.pathname === '/linkblog'}
+        onclick={() => sidebarStore.closeMobile()}
+      >
+        <span class="nav-icon"><Icon name="share" /></span>
+        <span class="nav-label">Linkblog</span>
+      </a>{/if}
 
     <a
       href="/highlights"

--- a/frontend/src/lib/components/common/Modal.svelte
+++ b/frontend/src/lib/components/common/Modal.svelte
@@ -34,6 +34,21 @@
       onclose();
     }
   }
+
+  // Portal to <body>. A modal opened from deep in the page (an article card, the
+  // reader) would otherwise be trapped in an ancestor's stacking context, and
+  // `z-index` can't climb out of one: the sticky page header (z-index 10, but in
+  // a context that outranks the card's) kept painting over the backdrop while
+  // everything around it dimmed. As a direct child of body the backdrop competes
+  // at the root, so it covers the whole app whatever opened it.
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -42,6 +57,7 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="modal-backdrop"
+    use:portal
     onclick={handleBackdropClick}
     onkeydown={handleKeydown}
     role="dialog"

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -8,6 +8,7 @@
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
   import {
     channelSuggestions,
     type ChannelSuggestion,
@@ -194,12 +195,16 @@
       icon: 'bookmark',
     };
     const otherItems: NavItem[] = [
-      {
-        type: 'utility',
-        id: 'linkblog',
-        label: 'Linkblog',
-        icon: 'share' as IconName,
-      },
+      ...(!preferences.linkblogDisabled
+        ? [
+            {
+              type: 'utility',
+              id: 'linkblog',
+              label: 'Linkblog',
+              icon: 'share' as IconName,
+            } as NavItem,
+          ]
+        : []),
       {
         type: 'utility',
         id: 'highlights',

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -54,7 +54,7 @@
   );
   let sharedNow = $derived(linkblogStore.isShared(itemUrl));
   let currentShareNote = $derived(linkblogStore.getNote(itemUrl));
-  let canShareLinkblog = $derived(Boolean(auth.user));
+  let canShareLinkblog = $derived(Boolean(auth.user) && !preferences.linkblogDisabled);
   let shareHighlights = $derived(itemLabelsStore.getHighlights(readerItem.key));
 
   let shareTarget = $derived.by((): { article: Article; repostUri?: string } | null => {

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -8,10 +8,12 @@
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
   import { useAtmosphere } from '$lib/hooks/useAtmosphere.svelte';
   import { getExternalArticleLink, formatQuoteSeed } from '$lib/utils/linkPost';
   import { normalizeDisplayItem } from '$lib/utils/displayItem';
   import AtmospherePanel from './AtmospherePanel.svelte';
+  import ShareConfirmModal from './ShareConfirmModal.svelte';
   import Icon from '$lib/components/Icon.svelte';
 
   let {
@@ -97,10 +99,22 @@
 
   let seededQuote = $derived(formatQuoteSeed(shareTarget?.article.summary));
 
-  async function shareNow() {
+  async function performShare() {
     const target = shareTarget;
     if (!target) return;
     await linkblogStore.shareLink(target.article, seededQuote ?? '', target.repostUri);
+  }
+
+  // Sharing from the reader publishes exactly as publicly as sharing from a
+  // card, so it takes the same first-share confirmation.
+  let showShareConfirm = $state(false);
+
+  function shareNow() {
+    if (!preferences.linkblogShareConfirmed) {
+      showShareConfirm = true;
+      return;
+    }
+    void performShare();
   }
 
   function laneCanCreate(id: LaneId): boolean {
@@ -118,7 +132,7 @@
 
   function createInLane(id: LaneId) {
     if (id === 'linkblog') {
-      if (!sharedNow) void shareNow();
+      if (!sharedNow) shareNow();
     } else if (id === 'semble') {
       onSaveToSemble?.();
     } else if (id === 'margin') {
@@ -136,7 +150,7 @@
 <section class="reader-discussion" aria-label="Discussion">
   <div class="reader-discussion-divider"></div>
   {#if !sharedNow && canShareLinkblog}
-    <button type="button" class="reader-share-cta" onclick={() => void shareNow()}>
+    <button type="button" class="reader-share-cta" onclick={shareNow}>
       <Icon name="share" size={16} />
       <span>Share to your linkblog</span>
     </button>
@@ -167,6 +181,15 @@
     {/snippet}
   </AtmospherePanel>
 </section>
+
+<ShareConfirmModal
+  open={showShareConfirm}
+  onconfirm={() => {
+    showShareConfirm = false;
+    void performShare();
+  }}
+  oncancel={() => (showShareConfirm = false)}
+/>
 
 <style>
   .reader-discussion {

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -8,6 +8,7 @@
   import { savesStore } from '$lib/stores/saves.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { auth } from '$lib/stores/auth.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
   import { formatQuoteSeed } from '$lib/utils/linkPost';
   import type { Article } from '$lib/types';
   import { db } from '$lib/services/db';
@@ -15,6 +16,7 @@
   import Icon from '$lib/components/Icon.svelte';
   import PopoverMenu from '$lib/components/PopoverMenu.svelte';
   import TagMenu from '$lib/components/feed/TagMenu.svelte';
+  import ShareConfirmModal from '$lib/components/feed/ShareConfirmModal.svelte';
 
   let {
     displayItem,
@@ -343,7 +345,7 @@
   // card and reader use. Discussion counts stay a reader-only concern; the saved
   // list keeps just the share toggle, so the row stays quiet.
   let isShared = $derived(Boolean(url) && linkblogStore.isShared(url));
-  let canShare = $derived(Boolean(auth.user) && Boolean(url));
+  let canShare = $derived(Boolean(auth.user) && Boolean(url) && !preferences.linkblogDisabled);
 
   // The article record to share, built from whichever item type this card shows.
   // A document carries its recordUri as repostUri so a reshare credits the original.
@@ -385,14 +387,26 @@
     };
   }
 
-  async function toggleShare() {
-    if (isShared) {
-      await linkblogStore.unshare(url);
-      return;
-    }
+  async function performShare() {
     const t = buildShareTarget();
     if (!t) return;
     await linkblogStore.shareLink(t.article, formatQuoteSeed(t.article.summary) ?? '', t.repostUri);
+  }
+
+  // A share from the saved list is as public as one from a feed card or the
+  // reader, so it takes the same first-share confirmation.
+  let showShareConfirm = $state(false);
+
+  function toggleShare() {
+    if (isShared) {
+      void linkblogStore.unshare(url);
+      return;
+    }
+    if (!preferences.linkblogShareConfirmed) {
+      showShareConfirm = true;
+      return;
+    }
+    void performShare();
   }
 
   let popoverMenuItems = $derived.by(() => {
@@ -545,6 +559,15 @@
     />
   {/if}
 </article>
+
+<ShareConfirmModal
+  open={showShareConfirm}
+  onconfirm={() => {
+    showShareConfirm = false;
+    void performShare();
+  }}
+  oncancel={() => (showShareConfirm = false)}
+/>
 
 <style>
   .bookmark-card {

--- a/frontend/src/lib/components/feed/ShareConfirmModal.svelte
+++ b/frontend/src/lib/components/feed/ShareConfirmModal.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  // First-share confirmation: sharing publishes to a public linkblog, which is
+  // irreversible-feeling and easy to do by accident. Every surface that can
+  // start a share routes through this dialog until the account acknowledges it
+  // ("Don't ask again" persists per account) — a share from the reader is as
+  // public as one from a card, so neither may skip it.
+  //
+  // It names the publication the share actually lands in: a connected one, if
+  // the user switched, not the Skyreader linkblog they no longer publish to.
+  import Modal from '$lib/components/common/Modal.svelte';
+  import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
+  import { shareDestination } from '$lib/utils/linkblogTargets';
+
+  let {
+    open,
+    onconfirm,
+    oncancel,
+  }: {
+    open: boolean;
+    onconfirm: () => void;
+    oncancel: () => void;
+  } = $props();
+
+  let dontAskAgain = $state(false);
+  let target = $derived(shareDestination(myLinkblogStore.publication, myLinkblogStore.publicUrl()));
+
+  // Each opening starts unchecked: a dismissed dialog must not leave the box
+  // ticked for the next share the user is only half sure about.
+  $effect(() => {
+    if (open) dontAskAgain = false;
+  });
+
+  function confirm() {
+    if (dontAskAgain) preferences.confirmLinkblogShare();
+    onconfirm();
+  }
+</script>
+
+<Modal {open} onclose={oncancel} title="Share to your linkblog?" maxWidth="420px">
+  <p class="share-confirm-text">
+    This publishes to {#if target.external}<strong>{target.name}</strong>{:else}your public linkblog{/if}{#if target.address}
+      at
+      <a href={target.url} target="_blank" rel="noopener noreferrer" class="share-confirm-link"
+        >{target.address}</a
+      >{/if}. Anyone can read it.
+  </p>
+  {#if target.external && target.linkblogUrl}
+    <p class="share-confirm-aside">
+      It shows on
+      <a
+        href={target.linkblogUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="share-confirm-link">your linkblog page</a
+      > too.
+    </p>
+  {/if}
+  <label class="share-confirm-remember">
+    <input type="checkbox" bind:checked={dontAskAgain} />
+    <span>Don't ask again</span>
+  </label>
+  {#snippet footer()}
+    <button class="btn btn-secondary" onclick={oncancel}>Cancel</button>
+    <button class="btn btn-primary" onclick={confirm}>Share</button>
+  {/snippet}
+</Modal>
+
+<style>
+  .share-confirm-text {
+    margin: 0 0 1rem;
+    color: var(--color-text);
+    line-height: var(--leading-normal);
+  }
+
+  .share-confirm-aside {
+    margin: -0.5rem 0 1rem;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+  }
+
+  .share-confirm-link {
+    color: var(--color-primary);
+    text-decoration: none;
+    word-break: break-all;
+  }
+
+  .share-confirm-link:hover {
+    text-decoration: underline;
+  }
+
+  .share-confirm-remember {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: var(--text-md);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .share-confirm-remember input {
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/components/settings/DeleteLinkblogModal.svelte
+++ b/frontend/src/lib/components/settings/DeleteLinkblogModal.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  // Typed confirmation for the one linkblog action that destroys PDS records.
+  // The typed word is the point: deletion walks the user's whole document
+  // collection and nothing comes back, so it takes more than a misclickable
+  // button. (This replaced a native `prompt()`, which renders as a system sheet
+  // in an installed PWA and can't say any of this.)
+  import Modal from '$lib/components/common/Modal.svelte';
+
+  let {
+    open,
+    busy = false,
+    onconfirm,
+    oncancel,
+  }: {
+    open: boolean;
+    busy?: boolean;
+    onconfirm: () => void;
+    oncancel: () => void;
+  } = $props();
+
+  const REQUIRED = 'DELETE';
+  let typed = $state('');
+  let confirmed = $derived(typed.trim() === REQUIRED);
+
+  // Each opening starts empty, so a dismissed dialog can't leave the word primed
+  // for a later, less deliberate click.
+  $effect(() => {
+    if (open) typed = '';
+  });
+
+  function confirm() {
+    if (!confirmed || busy) return;
+    onconfirm();
+  }
+</script>
+
+<Modal {open} onclose={oncancel} title="Delete your linkblog?" maxWidth="420px">
+  <p class="delete-linkblog-text">
+    Every link post will be deleted from your PDS. Your page goes blank and subscribers stop
+    receiving it. This cannot be undone.
+  </p>
+  <label class="delete-linkblog-field">
+    <span>Type <strong>{REQUIRED}</strong> to continue</span>
+    <input
+      type="text"
+      bind:value={typed}
+      autocomplete="off"
+      autocapitalize="characters"
+      spellcheck="false"
+      disabled={busy}
+      onkeydown={(e) => {
+        if (e.key === 'Enter') confirm();
+      }}
+    />
+  </label>
+  {#snippet footer()}
+    <button class="btn btn-secondary" onclick={oncancel} disabled={busy}>Cancel</button>
+    <button class="btn btn-danger" onclick={confirm} disabled={!confirmed || busy}>
+      {busy ? 'Deleting…' : 'Delete linkblog'}
+    </button>
+  {/snippet}
+</Modal>
+
+<style>
+  .delete-linkblog-text {
+    margin: 0 0 1rem;
+    color: var(--color-text);
+    line-height: var(--leading-normal);
+  }
+
+  .delete-linkblog-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .delete-linkblog-field input {
+    padding: 0.5rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    background: var(--color-bg);
+    color: var(--color-text);
+    /* 16px floor: anything smaller triggers Safari iOS auto-zoom on focus. */
+    font-size: 1rem;
+  }
+
+  .delete-linkblog-field input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+</style>

--- a/frontend/src/lib/components/settings/LinkblogTargetPicker.svelte
+++ b/frontend/src/lib/components/settings/LinkblogTargetPicker.svelte
@@ -39,7 +39,7 @@
   const FORMATS: Array<{ value: Format; label: string }> = [
     { value: 'leaflet', label: 'Leaflet blocks' },
     { value: 'offprint', label: 'Offprint blocks' },
-    { value: 'markpub', label: 'Markdown' },
+    { value: 'markpub', label: 'Markdown (markpub.at)' },
   ];
 
   const formatLabel = (format: Format) =>

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -15,6 +15,7 @@ import type { IconName } from '$lib/components/Icon.svelte';
 import type { LaneId, LaneRowVM, ExpandedLaneItemsVM } from '$lib/components/articleCardView.types';
 import { articleMentionsStore } from '$lib/stores/articleMentions.svelte';
 import { mentionLaneItemsStore } from '$lib/stores/mentionLaneItems.svelte';
+import { preferences } from '$lib/stores/preferences.svelte';
 
 // Per-lane display metadata. The count + verb come from the network breakdown;
 // this fixes the icon, name, and the create-affordance label per lane.
@@ -109,6 +110,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     const shared = opts.isShared();
     const rows: LaneRowVM[] = [];
     for (const id of LANE_ORDER) {
+      if (id === 'linkblog' && preferences.linkblogDisabled) continue;
       const data = mentionLaneMap.get(id);
       const count = data?.count ?? 0;
       const canCreate = opts.canCreate(id);

--- a/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
+++ b/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
@@ -7,6 +7,7 @@ import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
 import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
 import { linkblogStore } from '$lib/stores/linkblog.svelte';
 import { linkPostContentStore } from '$lib/stores/linkPostContent.svelte';
+import { preferences } from '$lib/stores/preferences.svelte';
 import type { Article, Subscription } from '$lib/types';
 
 interface KeyboardShortcutsParams {
@@ -128,6 +129,7 @@ export function useFeedKeyboardShortcuts(params: KeyboardShortcutsParams) {
 
   // Share/unshare selected item to the linkblog (article items only)
   function toggleSelectedShare() {
+    if (preferences.linkblogDisabled) return;
     const selected = getSelectedArticle();
     if (!selected) return;
 

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -597,6 +597,14 @@ class ApiClient {
     });
   }
 
+  async deleteLinkblog(): Promise<{ success: true; deletedPosts: number }> {
+    return this.fetch('/api/linkblog/publication', { method: 'DELETE' });
+  }
+
+  async restoreLinkblog(): Promise<LinkblogPublication> {
+    return this.fetch('/api/linkblog/publication', { method: 'POST' });
+  }
+
   async listLinkblogPublications(): Promise<{
     publications: import('$lib/types').LinkblogPublicationChoice[];
   }> {
@@ -870,6 +878,7 @@ class ApiClient {
     pdsSyncEnabled: boolean;
     lastPdsSyncSubscriptions: number | null;
     backing: SaveBacking;
+    linkblogDisabled: boolean;
     createdAt: number;
     updatedAt: number;
   }> {

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -48,8 +48,7 @@ function createMyLinkblogStore() {
   const scopeResults = new Map<string, { documents: SocialDocument[]; complete: boolean }>();
 
   async function load(force = false) {
-    if (preferences.linkblogDisabled) return;
-    if ((loaded || loading) && !force) return;
+    if (loading) return;
     const user = auth.user;
     if (!user) return;
 
@@ -69,6 +68,10 @@ function createMyLinkblogStore() {
           return;
         }
       }
+      // The disabled preference is device-global, so publication metadata must
+      // be refreshed before honoring the in-memory document cache. This also
+      // corrects state after switching accounts or restoring on another device.
+      if (loaded && !force) return;
       const target = pub ?? publication;
       const defaultUri = publicationUri(user.did);
       const scopes = [...new Set([target?.uri || defaultUri, defaultUri])];

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -47,8 +47,27 @@ function createMyLinkblogStore() {
   // drop its documents while the other scope refreshes.
   const scopeResults = new Map<string, { documents: SocialDocument[]; complete: boolean }>();
 
+  // A forced load has to await the pull in flight rather than return past it:
+  // callers chain reconcile() onto load(true), and resolving early runs the
+  // prune against whatever state the unfinished pull hasn't written yet.
+  let inFlight: Promise<void> | null = null;
+
   async function load(force = false) {
-    if (loading) return;
+    // An unforced load piggybacks on the pull already running. A forced one can't:
+    // that pull may itself be unforced and skip the refresh (`loaded && !force`),
+    // so wait for it to settle and then do the real thing.
+    while (inFlight) {
+      if (!force) return;
+      await inFlight.catch(() => {});
+    }
+    const run = loadOnce(force);
+    inFlight = run.finally(() => {
+      inFlight = null;
+    });
+    await inFlight;
+  }
+
+  async function loadOnce(force = false) {
     const user = auth.user;
     if (!user) return;
 
@@ -65,6 +84,13 @@ function createMyLinkblogStore() {
         if (pub.disabled) {
           documents = [];
           loaded = true;
+          // A deleted linkblog is an authoritative empty set, not an unfinished
+          // pull: the posts are gone from the PDS. Say so, or reconcile() bails
+          // on a stale `false` and leaves every share sitting in IndexedDB,
+          // still rendering its card as shared.
+          lastPullComplete = true;
+          scopeResults.clear();
+          optimisticUris.clear();
           return;
         }
       }

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -19,6 +19,7 @@ import { buildOptimisticLinkPost, getExternalArticleLink } from '$lib/utils/link
 import { noteToLeafletBlocks } from '$lib/utils/linkPostNote';
 import { loadDigests, saveDigests, scopeKey } from '$lib/services/documentDigests';
 import type { LinkblogPublication, SocialDocument } from '$lib/types';
+import { preferences } from '$lib/stores/preferences.svelte';
 
 const PUBLICATION_COLLECTION = 'site.standard.publication';
 const LINKBLOG_RKEY = 'skyreader-links';
@@ -47,6 +48,7 @@ function createMyLinkblogStore() {
   const scopeResults = new Map<string, { documents: SocialDocument[]; complete: boolean }>();
 
   async function load(force = false) {
+    if (preferences.linkblogDisabled) return;
     if ((loaded || loading) && !force) return;
     const user = auth.user;
     if (!user) return;
@@ -58,7 +60,15 @@ function createMyLinkblogStore() {
       // scoped to the default alone would come back (completely) empty for a user
       // who has switched.
       const pub = await api.getLinkblogPublication().catch(() => null);
-      if (pub) publication = pub;
+      if (pub) {
+        publication = pub;
+        preferences.setLinkblogDisabled(pub.disabled);
+        if (pub.disabled) {
+          documents = [];
+          loaded = true;
+          return;
+        }
+      }
       const target = pub ?? publication;
       const defaultUri = publicationUri(user.did);
       const scopes = [...new Set([target?.uri || defaultUri, defaultUri])];

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { auth } from '$lib/stores/auth.svelte';
 
 export type ArticleFont = 'sans-serif' | 'serif' | 'mono' | 'literata';
 // Reader body size, in CSS pixels. Was a fixed xs…xl scale (12–20px); now a
@@ -59,9 +60,14 @@ interface PreferencesState {
   scrollToMarkAsRead: boolean;
   expandAllItems: boolean;
   sortOrder: BaseSortOrder;
-  // Set once the user has acknowledged the first-share "this is public" confirmation.
-  linkblogShareConfirmed: boolean;
-  linkblogDisabled: boolean;
+  // Accounts (by DID) that have acknowledged the first-share "this is public"
+  // confirmation, and accounts whose linkblog is deleted. Both are per-account
+  // facts living in a device-global blob that logout doesn't clear, so they're
+  // keyed by DID: a second account on the same browser must not inherit the
+  // first account's acknowledgment (it would publish publicly with no warning)
+  // or its deleted linkblog.
+  linkblogShareConfirmedDids: string[];
+  linkblogDisabledDids: string[];
   // Which surface a cold app load lands on (consumed by the `/` redirector).
   defaultView: DefaultView;
   // How tightly the Home lane tiles are packed.
@@ -72,6 +78,12 @@ interface PreferencesState {
 
 const STORAGE_KEY = 'skyreader-preferences';
 
+// localStorage is user-editable and carries whatever an older build wrote, so a
+// DID list is only trusted once it's actually a list of strings.
+function didList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((did): did is string => typeof did === 'string') : [];
+}
+
 function createPreferencesStore() {
   let state = $state<PreferencesState>({
     articleFont: 'serif',
@@ -80,8 +92,8 @@ function createPreferencesStore() {
     scrollToMarkAsRead: false,
     expandAllItems: true,
     sortOrder: 'newest',
-    linkblogShareConfirmed: false,
-    linkblogDisabled: false,
+    linkblogShareConfirmedDids: [],
+    linkblogDisabledDids: [],
     defaultView: 'home',
     cardDensity: 'cozy',
     dailyMagazineMinutes: 20,
@@ -113,10 +125,13 @@ function createPreferencesStore() {
         if (parsed.sortOrder) {
           state.sortOrder = parsed.sortOrder;
         }
-        if (parsed.linkblogShareConfirmed !== undefined) {
-          state.linkblogShareConfirmed = parsed.linkblogShareConfirmed;
-        }
-        if (parsed.linkblogDisabled !== undefined) state.linkblogDisabled = parsed.linkblogDisabled;
+        // Legacy device-global booleans are intentionally NOT migrated: they
+        // can't be attributed to an account. The disabled flag re-derives from
+        // the server on the next publication fetch, and an un-attributable
+        // share acknowledgment falls back to showing the warning once more —
+        // the safe direction for something that publishes publicly.
+        state.linkblogShareConfirmedDids = didList(parsed.linkblogShareConfirmedDids);
+        state.linkblogDisabledDids = didList(parsed.linkblogDisabledDids);
         if (
           parsed.defaultView === 'home' ||
           parsed.defaultView === 'feeds' ||
@@ -211,12 +226,18 @@ function createPreferencesStore() {
   }
 
   function confirmLinkblogShare() {
-    state.linkblogShareConfirmed = true;
+    const did = auth.user?.did;
+    if (!did || state.linkblogShareConfirmedDids.includes(did)) return;
+    state.linkblogShareConfirmedDids = [...state.linkblogShareConfirmedDids, did];
     save();
   }
 
   function setLinkblogDisabled(disabled: boolean) {
-    state.linkblogDisabled = disabled;
+    const did = auth.user?.did;
+    if (!did || disabled === state.linkblogDisabledDids.includes(did)) return;
+    state.linkblogDisabledDids = disabled
+      ? [...state.linkblogDisabledDids, did]
+      : state.linkblogDisabledDids.filter((d) => d !== did);
     save();
   }
 
@@ -261,11 +282,15 @@ function createPreferencesStore() {
     get sortOrder() {
       return state.sortOrder;
     },
+    // Both read the CURRENT account. Logged out, neither is true: no account
+    // has acknowledged anything, and nothing should be hidden as deleted.
     get linkblogShareConfirmed() {
-      return state.linkblogShareConfirmed;
+      const did = auth.user?.did;
+      return !!did && state.linkblogShareConfirmedDids.includes(did);
     },
     get linkblogDisabled() {
-      return state.linkblogDisabled;
+      const did = auth.user?.did;
+      return !!did && state.linkblogDisabledDids.includes(did);
     },
     get defaultView() {
       return state.defaultView;

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -61,6 +61,7 @@ interface PreferencesState {
   sortOrder: BaseSortOrder;
   // Set once the user has acknowledged the first-share "this is public" confirmation.
   linkblogShareConfirmed: boolean;
+  linkblogDisabled: boolean;
   // Which surface a cold app load lands on (consumed by the `/` redirector).
   defaultView: DefaultView;
   // How tightly the Home lane tiles are packed.
@@ -80,6 +81,7 @@ function createPreferencesStore() {
     expandAllItems: true,
     sortOrder: 'newest',
     linkblogShareConfirmed: false,
+    linkblogDisabled: false,
     defaultView: 'home',
     cardDensity: 'cozy',
     dailyMagazineMinutes: 20,
@@ -114,6 +116,7 @@ function createPreferencesStore() {
         if (parsed.linkblogShareConfirmed !== undefined) {
           state.linkblogShareConfirmed = parsed.linkblogShareConfirmed;
         }
+        if (parsed.linkblogDisabled !== undefined) state.linkblogDisabled = parsed.linkblogDisabled;
         if (
           parsed.defaultView === 'home' ||
           parsed.defaultView === 'feeds' ||
@@ -212,6 +215,11 @@ function createPreferencesStore() {
     save();
   }
 
+  function setLinkblogDisabled(disabled: boolean) {
+    state.linkblogDisabled = disabled;
+    save();
+  }
+
   function setDefaultView(view: DefaultView) {
     state.defaultView = view;
     save();
@@ -256,6 +264,9 @@ function createPreferencesStore() {
     get linkblogShareConfirmed() {
       return state.linkblogShareConfirmed;
     },
+    get linkblogDisabled() {
+      return state.linkblogDisabled;
+    },
     get defaultView() {
       return state.defaultView;
     },
@@ -269,6 +280,7 @@ function createPreferencesStore() {
       return state.dailyMagazineOrder;
     },
     confirmLinkblogShare,
+    setLinkblogDisabled,
     setDefaultView,
     setCardDensity,
     setDailyMagazineMinutes,

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -798,6 +798,7 @@ export interface LinkblogPublication {
   exists: boolean;
   external: boolean;
   format: 'leaflet' | 'pckt' | 'offprint' | 'markpub';
+  disabled: boolean;
   // For a connected publication only: its own site (e.g. https://leaflet.pub/…).
   // Informational — `url` above is always the Skyreader linkblog page, which
   // renders the connected publication's link posts too.

--- a/frontend/src/routes/linkblog/+page.svelte
+++ b/frontend/src/routes/linkblog/+page.svelte
@@ -4,12 +4,16 @@
   import { api } from '$lib/services/api';
 
   let restoring = $state(false);
+  let restoreError = $state<string | null>(null);
   async function restore() {
     restoring = true;
+    restoreError = null;
     try {
       await api.restoreLinkblog();
       preferences.setLinkblogDisabled(false);
       location.reload();
+    } catch {
+      restoreError = 'Could not restore your linkblog. Try again.';
     } finally {
       restoring = false;
     }
@@ -27,6 +31,9 @@
     <button onclick={restore} disabled={restoring}
       >{restoring ? 'Restoring…' : 'Restore linkblog'}</button
     >
+    {#if restoreError}
+      <p class="error" role="alert">{restoreError}</p>
+    {/if}
   </section>
 {:else}
   <FeedPage mode="linkblog" />
@@ -40,17 +47,24 @@
     text-align: center;
   }
   h1 {
-    font-size: 1.35rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
   }
   p {
-    color: var(--text-secondary);
+    color: var(--color-text-secondary);
   }
   button {
     border: 0;
     border-radius: 0.4rem;
     padding: 0.65rem 1rem;
-    background: #0066cc;
+    background: var(--color-primary);
     color: white;
     cursor: pointer;
+  }
+  .error {
+    margin-top: 0.75rem;
+    color: var(--color-error);
   }
 </style>

--- a/frontend/src/routes/linkblog/+page.svelte
+++ b/frontend/src/routes/linkblog/+page.svelte
@@ -1,9 +1,56 @@
 <script lang="ts">
   import FeedPage from '$lib/components/feed/FeedPage.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
+  import { api } from '$lib/services/api';
+
+  let restoring = $state(false);
+  async function restore() {
+    restoring = true;
+    try {
+      await api.restoreLinkblog();
+      preferences.setLinkblogDisabled(false);
+      location.reload();
+    } finally {
+      restoring = false;
+    }
+  }
 </script>
 
 <svelte:head>
   <title>Linkblog - Skyreader</title>
 </svelte:head>
 
-<FeedPage mode="linkblog" />
+{#if preferences.linkblogDisabled}
+  <section class="deleted-linkblog">
+    <h1>Your linkblog is deleted.</h1>
+    <p>Restore it to share links again. Deleted posts won’t come back.</p>
+    <button onclick={restore} disabled={restoring}
+      >{restoring ? 'Restoring…' : 'Restore linkblog'}</button
+    >
+  </section>
+{:else}
+  <FeedPage mode="linkblog" />
+{/if}
+
+<style>
+  .deleted-linkblog {
+    max-width: 36rem;
+    margin: 5rem auto;
+    padding: 2rem;
+    text-align: center;
+  }
+  h1 {
+    font-size: 1.35rem;
+  }
+  p {
+    color: var(--text-secondary);
+  }
+  button {
+    border: 0;
+    border-radius: 0.4rem;
+    padding: 0.65rem 1rem;
+    background: #0066cc;
+    color: white;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/routes/linkblog/+page.svelte
+++ b/frontend/src/routes/linkblog/+page.svelte
@@ -26,13 +26,15 @@
 
 {#if preferences.linkblogDisabled}
   <section class="deleted-linkblog">
-    <h1>Your linkblog is deleted.</h1>
-    <p>Restore it to share links again. Deleted posts won’t come back.</p>
-    <button onclick={restore} disabled={restoring}
-      >{restoring ? 'Restoring…' : 'Restore linkblog'}</button
-    >
+    <h1 class="deleted-linkblog-title">Your linkblog is deleted.</h1>
+    <p class="deleted-linkblog-text">
+      Restore it to share links again. Deleted posts won’t come back.
+    </p>
+    <button class="btn btn-primary" onclick={restore} disabled={restoring}>
+      {restoring ? 'Restoring…' : 'Restore linkblog'}
+    </button>
     {#if restoreError}
-      <p class="error" role="alert">{restoreError}</p>
+      <p class="deleted-linkblog-error" role="alert">{restoreError}</p>
     {/if}
   </section>
 {:else}
@@ -40,30 +42,28 @@
 {/if}
 
 <style>
+  /* Classes, not bare element selectors: these leaked to every h1/p/button the
+     route renders. The button is the shared .btn .btn-primary so it stays on the
+     one interaction blue rather than re-deriving its own. */
   .deleted-linkblog {
     max-width: 36rem;
     margin: 5rem auto;
     padding: 2rem;
     text-align: center;
   }
-  h1 {
-    font-size: 1.25rem;
+
+  .deleted-linkblog-title {
+    font-size: var(--text-2xl);
     font-weight: 600;
-    line-height: 1.3;
+    line-height: var(--leading-tight);
     letter-spacing: -0.01em;
   }
-  p {
+
+  .deleted-linkblog-text {
     color: var(--color-text-secondary);
   }
-  button {
-    border: 0;
-    border-radius: 0.4rem;
-    padding: 0.65rem 1rem;
-    background: var(--color-primary);
-    color: white;
-    cursor: pointer;
-  }
-  .error {
+
+  .deleted-linkblog-error {
     margin-top: 0.75rem;
     color: var(--color-error);
   }

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -128,6 +128,7 @@
         api.listLinkblogPublications(),
       ]);
       linkblogPub = pub;
+      preferences.setLinkblogDisabled(pub.disabled);
       linkblogChoices = choices.publications;
       linkblogName = pub.name;
       linkblogDescription = pub.description ?? '';
@@ -135,6 +136,44 @@
       console.error('Failed to load linkblog publication:', error);
     } finally {
       isLinkblogLoading = false;
+    }
+  }
+
+  async function handleDeleteLinkblog() {
+    if (isSavingLinkblog || !syncStore.isOnline) {
+      linkblogError = 'You are offline. Connect to the internet to delete your linkblog.';
+      return;
+    }
+    const confirmation = prompt(
+      'Every link post will be deleted from your PDS. Your page will go blank and subscribers will stop receiving it. This cannot be undone. Type DELETE to continue.'
+    );
+    if (confirmation !== 'DELETE') return;
+    isSavingLinkblog = true;
+    linkblogError = null;
+    try {
+      const result = await api.deleteLinkblog();
+      preferences.setLinkblogDisabled(true);
+      if (linkblogPub) linkblogPub = { ...linkblogPub, disabled: true, exists: false };
+      linkblogSuccess = `Linkblog deleted. ${result.deletedPosts} post${result.deletedPosts === 1 ? '' : 's'} removed.`;
+    } catch (error) {
+      linkblogError = error instanceof Error ? error.message : 'Could not delete your linkblog.';
+    } finally {
+      isSavingLinkblog = false;
+    }
+  }
+
+  async function handleRestoreLinkblog() {
+    if (isSavingLinkblog || !syncStore.isOnline) return;
+    isSavingLinkblog = true;
+    linkblogError = null;
+    try {
+      linkblogPub = await api.restoreLinkblog();
+      preferences.setLinkblogDisabled(false);
+      linkblogSuccess = 'Linkblog restored. Deleted posts do not come back.';
+    } catch (error) {
+      linkblogError = error instanceof Error ? error.message : 'Could not restore your linkblog.';
+    } finally {
+      isSavingLinkblog = false;
     }
   }
 
@@ -574,6 +613,11 @@
     </p>
     {#if isLinkblogLoading}
       <p class="loading">Loading linkblog…</p>
+    {:else if linkblogPub?.disabled}
+      <p class="setting-description">Your linkblog is deleted. Deleted posts cannot be restored.</p>
+      <button class="btn btn-secondary" onclick={handleRestoreLinkblog} disabled={isSavingLinkblog}>
+        {isSavingLinkblog ? 'Restoring…' : 'Restore linkblog'}
+      </button>
     {:else}
       {#if linkblogPub}
         <p class="setting-description" style="margin-top: 0;">
@@ -636,6 +680,15 @@
       {#if linkblogSuccess}
         <p class="sync-success">{linkblogSuccess}</p>
       {/if}
+      <hr />
+      <h3 class="subhead">Delete linkblog</h3>
+      <p class="setting-description">
+        Deletes every link post from your PDS and removes the linkblog from Skyreader. This cannot
+        be undone.
+      </p>
+      <button class="btn btn-danger" onclick={handleDeleteLinkblog} disabled={isSavingLinkblog}>
+        Delete linkblog
+      </button>
     {/if}
   </section>
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -15,7 +15,10 @@
   import ImportOPMLModal from '$lib/components/ImportOPMLModal.svelte';
   import SaveBackingPicker from '$lib/components/settings/SaveBackingPicker.svelte';
   import LinkblogTargetPicker from '$lib/components/settings/LinkblogTargetPicker.svelte';
+  import DeleteLinkblogModal from '$lib/components/settings/DeleteLinkblogModal.svelte';
   import StaticPageChrome from '$lib/components/feed/StaticPageChrome.svelte';
+  import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
+  import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { downloadOPML } from '$lib/utils/opml-exporter';
   import { api, RateLimitError } from '$lib/services/api';
   import { syncStore } from '$lib/stores/sync.svelte';
@@ -103,6 +106,7 @@
   let linkblogError = $state<string | null>(null);
   let linkblogSuccess = $state<string | null>(null);
   let linkblogChoices = $state<LinkblogPublicationChoice[]>([]);
+  let showDeleteLinkblogConfirm = $state(false);
 
   onMount(async () => {
     if (!auth.isAuthenticated) {
@@ -139,16 +143,19 @@
     }
   }
 
-  async function handleDeleteLinkblog() {
+  function handleDeleteLinkblog() {
     if (isSavingLinkblog) return;
+    linkblogSuccess = null;
     if (!syncStore.isOnline) {
       linkblogError = 'You are offline. Connect to the internet to delete your linkblog.';
       return;
     }
-    const confirmation = prompt(
-      'Every link post will be deleted from your PDS. Your page will go blank and subscribers will stop receiving it. This cannot be undone. Type DELETE to continue.'
-    );
-    if (confirmation !== 'DELETE') return;
+    linkblogError = null;
+    showDeleteLinkblogConfirm = true;
+  }
+
+  async function confirmDeleteLinkblog() {
+    if (isSavingLinkblog) return;
     isSavingLinkblog = true;
     linkblogError = null;
     try {
@@ -156,15 +163,33 @@
       preferences.setLinkblogDisabled(true);
       if (linkblogPub) linkblogPub = { ...linkblogPub, disabled: true, exists: false };
       linkblogSuccess = `Linkblog deleted. ${result.deletedPosts} post${result.deletedPosts === 1 ? '' : 's'} removed.`;
+      showDeleteLinkblogConfirm = false;
+      // The posts are gone from the PDS, but every card still holds its local
+      // share state: without this they keep rendering as shared, with a Remove
+      // that would address a record that no longer exists. Same pair the app
+      // runs on boot — do it now rather than leaving the window open until then.
+      await myLinkblogStore.load(true);
+      await linkblogStore.reconcile();
     } catch (error) {
+      // A delete that fails partway leaves the linkblog disabled server-side, so
+      // re-read the publication rather than trusting the pre-delete copy: the
+      // section then shows the deleted state (and its Restore) instead of
+      // offering edits that every write path now rejects.
       linkblogError = error instanceof Error ? error.message : 'Could not delete your linkblog.';
+      showDeleteLinkblogConfirm = false;
+      await loadLinkblog();
     } finally {
       isSavingLinkblog = false;
     }
   }
 
   async function handleRestoreLinkblog() {
-    if (isSavingLinkblog || !syncStore.isOnline) return;
+    if (isSavingLinkblog) return;
+    linkblogSuccess = null;
+    if (!syncStore.isOnline) {
+      linkblogError = 'You are offline. Connect to the internet to restore your linkblog.';
+      return;
+    }
     isSavingLinkblog = true;
     linkblogError = null;
     try {
@@ -244,6 +269,10 @@
       const settings = await api.getSettings();
       pdsSyncEnabled = settings.pdsSyncEnabled;
       lastSyncSubscriptions = settings.lastPdsSyncSubscriptions;
+      // Runs before loadLinkblog and doesn't touch the PDS, so on a device that
+      // has never seen this account the linkblog nav hides a beat sooner —
+      // and still corrects itself if the publication fetch disagrees.
+      preferences.setLinkblogDisabled(settings.linkblogDisabled);
     } catch (error) {
       console.error('Failed to load sync settings:', error);
     } finally {
@@ -675,12 +704,6 @@
           {#if isSavingLinkblog}Saving…{:else}Save{/if}
         </button>
       {/if}
-      {#if linkblogError}
-        <p class="sync-error">{linkblogError}</p>
-      {/if}
-      {#if linkblogSuccess}
-        <p class="sync-success">{linkblogSuccess}</p>
-      {/if}
       <div class="danger-section">
         <h3 class="subhead">Delete linkblog</h3>
         <p class="setting-description">
@@ -691,6 +714,15 @@
           Delete linkblog
         </button>
       </div>
+    {/if}
+    <!-- Outside the branches above: delete and restore both report here, and each
+         one switches which branch is rendered. Nested in either, the delete's
+         "N posts removed" and a failed restore's error would never be seen. -->
+    {#if linkblogError}
+      <p class="sync-error">{linkblogError}</p>
+    {/if}
+    {#if linkblogSuccess}
+      <p class="sync-success">{linkblogSuccess}</p>
     {/if}
   </section>
 
@@ -898,6 +930,13 @@
 </div>
 
 <ImportOPMLModal open={showImportModal} onclose={() => (showImportModal = false)} />
+
+<DeleteLinkblogModal
+  open={showDeleteLinkblogConfirm}
+  busy={isSavingLinkblog}
+  onconfirm={confirmDeleteLinkblog}
+  oncancel={() => (showDeleteLinkblogConfirm = false)}
+/>
 
 <style>
   .settings-page {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -140,7 +140,8 @@
   }
 
   async function handleDeleteLinkblog() {
-    if (isSavingLinkblog || !syncStore.isOnline) {
+    if (isSavingLinkblog) return;
+    if (!syncStore.isOnline) {
       linkblogError = 'You are offline. Connect to the internet to delete your linkblog.';
       return;
     }

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -680,15 +680,16 @@
       {#if linkblogSuccess}
         <p class="sync-success">{linkblogSuccess}</p>
       {/if}
-      <hr />
-      <h3 class="subhead">Delete linkblog</h3>
-      <p class="setting-description">
-        Deletes every link post from your PDS and removes the linkblog from Skyreader. This cannot
-        be undone.
-      </p>
-      <button class="btn btn-danger" onclick={handleDeleteLinkblog} disabled={isSavingLinkblog}>
-        Delete linkblog
-      </button>
+      <div class="danger-section">
+        <h3 class="subhead">Delete linkblog</h3>
+        <p class="setting-description">
+          Deletes every link post from your PDS and removes the linkblog from Skyreader. This cannot
+          be undone.
+        </p>
+        <button class="btn btn-danger" onclick={handleDeleteLinkblog} disabled={isSavingLinkblog}>
+          Delete linkblog
+        </button>
+      </div>
     {/if}
   </section>
 
@@ -1369,6 +1370,21 @@
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--color-border);
+  }
+
+  /* Sets the destructive action apart from the settings above it, on the same
+     divider rhythm as .about-links / .sync-toggle-section. (It replaced a bare
+     <hr>, which drew the UA's grooved 2px line on ~8px of margin — too tight
+     above, and the wrong rule.) The subhead drops its own top margin so the
+     spacing is the section's, not the sum of both. */
+  .danger-section {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .danger-section .subhead {
+    margin-top: 0;
   }
 
   .sync-status {


### PR DESCRIPTION
Adds an irreversible linkblog delete flow with restore, PDS record teardown, discovery exclusion, and persisted UI gating.

This update addresses review findings by refreshing server-owned disabled state before cached UI exits, deleting Skyreader posts through the complete paginated PDS collection, and filtering disabled authors against every actual discovery candidate without a global cap.

Followers’ subscriptions are intentionally left in place; a deleted linkblog simply stops publishing.

Checks: backend `npm run check`; frontend `npm run check`; focused linkblog guard tests (7/7).

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-e3nyipf35zwdni2yzzqlvtau)