### PR TITLE
Observability phases 0–4 with review follow-ups

### DIFF
--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -75,6 +75,14 @@ jobs:
           command: pages deploy .svelte-kit/cloudflare --project-name=skyreader-admin-staging --commit-dirty=true
           workingDirectory: admin
 
+      # Hits the pages.dev origin on purpose: if the admin is later put behind
+      # Cloudflare Access on a custom domain, an unauthenticated check there would
+      # follow the login redirect and go red for the wrong reason.
+      - name: Smoke check staging
+        env:
+          SMOKE_URL: https://skyreader-admin-staging.pages.dev
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'
+
   deploy-production:
     name: Deploy to Production
     needs: typecheck
@@ -110,3 +118,8 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy .svelte-kit/cloudflare --project-name=skyreader-admin --branch=main --commit-dirty=true
           workingDirectory: admin
+
+      - name: Smoke check production
+        env:
+          SMOKE_URL: https://skyreader-admin.pages.dev
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Smoke check staging
         env:
           SMOKE_URL: https://skyreader-admin-staging.pages.dev
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'
 
   deploy-production:
     name: Deploy to Production
@@ -122,4 +124,6 @@ jobs:
       - name: Smoke check production
         env:
           SMOKE_URL: https://skyreader-admin.pages.dev
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader Admin'

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   typecheck:
-    name: Type Check
+    name: Type Check & Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,6 +38,9 @@ jobs:
 
       - name: Run type check
         run: npm run check
+
+      - name: Run tests
+        run: npm test
 
   deploy-staging:
     name: Deploy to Staging

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -75,8 +75,17 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env staging
+          command: deploy --env staging --var GIT_COMMIT_SHA:${{ github.sha }}
           workingDirectory: backend
+
+      # Smoke check against production reality, not test-suite reality: asserts the
+      # deployed Worker answers AND that it's serving *this* commit. A deploy that
+      # passes tests but 500s (or silently didn't roll out) now turns the run red.
+      - name: Smoke check staging
+        env:
+          HEALTH_URL: https://api-staging.skyreader.app/api/health
+          EXPECTED_SHA: ${{ github.sha }}
+        run: node ../scripts/smoke-check.mjs "$HEALTH_URL" --version "$EXPECTED_SHA"
 
   deploy-production:
     name: Deploy to Production
@@ -114,5 +123,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: deploy --var GIT_COMMIT_SHA:${{ github.sha }}
           workingDirectory: backend
+
+      - name: Smoke check production
+        env:
+          HEALTH_URL: https://api.skyreader.app/api/health
+          EXPECTED_SHA: ${{ github.sha }}
+        run: node ../scripts/smoke-check.mjs "$HEALTH_URL" --version "$EXPECTED_SHA"

--- a/.github/workflows/feed-proxy-deploy.yml
+++ b/.github/workflows/feed-proxy-deploy.yml
@@ -68,6 +68,15 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --build-arg GIT_COMMIT_SHA=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # Asserts the machine is answering AND running this commit. The proxy is a
+      # singleton, so "deployed but wedged" is a total feed outage — worth failing
+      # the workflow over.
+      - name: Smoke check
+        env:
+          HEALTH_URL: https://skyreader-feed-proxy.fly.dev/health
+          EXPECTED_SHA: ${{ github.sha }}
+        run: node ../scripts/smoke-check.mjs "$HEALTH_URL" --version "$EXPECTED_SHA"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -37,6 +37,29 @@ jobs:
       - name: Run type check
         run: npm run check
 
+  # The unit suite existed before CI ran it. Client error reporting is the first
+  # thing here whose whole job is to behave correctly on a page that's already
+  # broken — untested restraints (sampling, caps, offline) are no restraints.
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -79,13 +79,17 @@ jobs:
           command: pages deploy --project-name=skyreader-staging --commit-dirty=true
           workingDirectory: frontend
 
-      # Pages deploys can't carry a version stamp the way the Workers do, so this
-      # is a liveness + "the shell actually rendered" check: a build that deploys
-      # but serves a broken/empty document goes red here instead of in a bug report.
+      # Two assertions, because they catch different failures. `/_app/version.json`
+      # carries `kit.version.name`, which svelte.config.js stamps with the deployed
+      # SHA — matching it proves *this build* is serving, the same proof the Workers
+      # smoke check gives. The content sniff then proves the shell actually renders;
+      # a deploy that serves a broken/empty document goes red here, not in a bug report.
       - name: Smoke check staging
         env:
           SMOKE_URL: https://staging.skyreader.app
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
 
   deploy-staging-prod:
     name: Deploy Staging (Prod Backend)
@@ -129,7 +133,9 @@ jobs:
       - name: Smoke check staging-prod
         env:
           SMOKE_URL: https://staging-prod.skyreader.app
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
 
   deploy-production:
     name: Deploy to Production
@@ -173,4 +179,6 @@ jobs:
       - name: Smoke check production
         env:
           SMOKE_URL: https://skyreader.app
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -79,6 +79,14 @@ jobs:
           command: pages deploy --project-name=skyreader-staging --commit-dirty=true
           workingDirectory: frontend
 
+      # Pages deploys can't carry a version stamp the way the Workers do, so this
+      # is a liveness + "the shell actually rendered" check: a build that deploys
+      # but serves a broken/empty document goes red here instead of in a bug report.
+      - name: Smoke check staging
+        env:
+          SMOKE_URL: https://staging.skyreader.app
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
+
   deploy-staging-prod:
     name: Deploy Staging (Prod Backend)
     needs: typecheck
@@ -118,6 +126,11 @@ jobs:
           command: pages deploy --project-name=skyreader-staging-prod --commit-dirty=true
           workingDirectory: frontend
 
+      - name: Smoke check staging-prod
+        env:
+          SMOKE_URL: https://staging-prod.skyreader.app
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'
+
   deploy-production:
     name: Deploy to Production
     needs: typecheck
@@ -156,3 +169,8 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy --project-name=skyreader --branch=main --commit-dirty=true
           workingDirectory: frontend
+
+      - name: Smoke check production
+        env:
+          SMOKE_URL: https://skyreader.app
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains '<title>Skyreader</title>'

--- a/.github/workflows/linkblog-deploy.yml
+++ b/.github/workflows/linkblog-deploy.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Smoke check staging
         env:
           SMOKE_URL: https://staging-linkblogs.skyreader.app
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'
 
   deploy-production:
     name: Deploy to Production
@@ -113,4 +115,6 @@ jobs:
       - name: Smoke check production
         env:
           SMOKE_URL: https://linkblogs.skyreader.app
-        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'
+        run: |
+          node ../scripts/smoke-check.mjs "$SMOKE_URL/_app/version.json" --version "$GITHUB_SHA"
+          node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'

--- a/.github/workflows/linkblog-deploy.yml
+++ b/.github/workflows/linkblog-deploy.yml
@@ -72,6 +72,13 @@ jobs:
           command: pages deploy --project-name=skyreader-linkblog-staging --commit-dirty=true
           workingDirectory: linkblog-site
 
+      # The bare subdomain renders the "linkblogs live at /<handle>" placeholder;
+      # a 200 containing it means SSR is alive, not just that Pages answered.
+      - name: Smoke check staging
+        env:
+          SMOKE_URL: https://staging-linkblogs.skyreader.app
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'
+
   deploy-production:
     name: Deploy to Production
     needs: typecheck
@@ -102,3 +109,8 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy --project-name=skyreader-linkblog --branch=main --commit-dirty=true
           workingDirectory: linkblog-site
+
+      - name: Smoke check production
+        env:
+          SMOKE_URL: https://linkblogs.skyreader.app
+        run: node ../scripts/smoke-check.mjs "$SMOKE_URL" --contains 'Skyreader'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,14 @@ These are **separate** from the main E2E suite (`playwright.pwa.config.ts`, spec
 - **What's covered:** `build-output.spec.ts` (the built SW precaches the shell as `/` not `index.html`, every precache URL exists, custom handlers present — fast disk-only checks), `service-worker.spec.ts` (registers → full precache → activated → controls; no-skew invariant), `offline.spec.ts` (offline reload + deep-link still render the shell; recovery overlay stays hidden).
 - **webkit caveat:** Playwright webkit throws an internal error when navigating with `setOffline(true)`, so the offline-navigation tests are chromium-only (guarded with `test.skip`). webkit still verifies SW lifecycle + healthy load. True installed iOS Safari PWA behavior still needs manual device testing.
 
+## Operations
+
+[`docs/RUNBOOK.md`](docs/RUNBOOK.md) is the operational source of truth: health
+endpoints, the external check list and thresholds, dead-man's-switch heartbeats,
+error-tracking setup, and per-alert response procedures. Read it before changing
+anything under `backend/src/observability/`, the health routes, or a deploy
+workflow's smoke-check step.
+
 ## Architecture Overview
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,8 +213,9 @@ AT Protocol (Bluesky PDS) + Fly.io Feed Proxy + Jetstream Firehose
 - **Framework:** SvelteKit 2.x with Svelte 5 runes
 - **Runtime:** Cloudflare Pages
 - **Database:** D1 (SQLite) - reads the same database as the backend
-- **Features:** System metrics dashboard, user management, feed health monitoring, search/sort/pagination
-- **Pages:** Dashboard (metrics overview), Users (list + detail), Feeds (health + error tracking)
+- **Features:** Ops panel (cron liveness, firehose lag, proxy cache health) with 30-day trend
+  sparklines, system metrics, user management, feed health monitoring, search/sort/pagination
+- **Pages:** Dashboard (ops + metrics + trends), Users (list + detail), Feeds (health + error tracking)
 - **Deploy:** Cloudflare Pages via GitHub Actions (staging on push to main, production on release)
 
 ### Key Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,9 +179,11 @@ These are **separate** from the main E2E suite (`playwright.pwa.config.ts`, spec
 
 [`docs/RUNBOOK.md`](docs/RUNBOOK.md) is the operational source of truth: health
 endpoints, the external check list and thresholds, dead-man's-switch heartbeats,
-error-tracking setup, and per-alert response procedures. Read it before changing
-anything under `backend/src/observability/`, the health routes, or a deploy
-workflow's smoke-check step.
+error-tracking setup, per-alert response procedures, the SLOs those thresholds
+answer to, and the alert-pruning ritual that keeps "silence means healthy" true.
+Read it before changing anything under `backend/src/observability/`, the health or
+telemetry routes, the client error reporter (`frontend/src/lib/services/telemetry.ts`),
+or a deploy workflow's smoke-check step.
 
 ## Architecture Overview
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -17,6 +17,7 @@
         "svelte-check": "^4.3.4",
         "typescript": "^5.9.3",
         "vite": "^7.2.6",
+        "vitest": "^3.2.7",
         "wrangler": "^3.0.0"
       }
     },
@@ -1554,10 +1555,28 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1574,6 +1593,131 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1618,6 +1762,16 @@
         "printable-characters": "^1.0.42"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1634,6 +1788,43 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -1727,6 +1918,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1759,6 +1978,13 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1853,6 +2079,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -1929,6 +2165,13 @@
         "@types/estree": "^1.0.6"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1943,6 +2186,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2028,6 +2278,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -2088,6 +2345,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2359,6 +2626,13 @@
         "@img/sharp-win32-x64": "0.33.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -2413,6 +2687,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
@@ -2424,6 +2705,13 @@
         "get-source": "^2.0.12"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -2433,6 +2721,19 @@
       "engines": {
         "node": ">=4",
         "npm": ">=6"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/svelte": {
@@ -2487,6 +2788,20 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2502,6 +2817,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2643,6 +2988,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -3130,6 +3498,96 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -8,6 +8,7 @@
     "preview": "wrangler pages dev .svelte-kit/cloudflare",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && prettier --check .",
     "check:types": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "deploy": "npm run build && wrangler pages deploy .svelte-kit/cloudflare"
@@ -22,6 +23,7 @@
     "svelte-check": "^4.3.4",
     "typescript": "^5.9.3",
     "vite": "^7.2.6",
+    "vitest": "^3.2.7",
     "wrangler": "^3.0.0"
   },
   "type": "module"

--- a/admin/src/lib/components/Sparkline.svelte
+++ b/admin/src/lib/components/Sparkline.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TrendSeries } from '$lib/metrics/ops';
+  import { sparklineGeometry } from './sparkline';
 
   interface Props {
     series: TrendSeries;
@@ -10,36 +11,14 @@
   const WIDTH = 240;
   const HEIGHT = 40;
 
-  // Nulls are gaps, not zeroes — a stretch where the cron never recorded a value
-  // must not be drawn as a plunge to the axis. Points keep their x position so a
-  // gap reads as a gap.
-  const drawn = $derived(
-    series.points
-      .map((value, index) => ({ value, index }))
-      .filter((p): p is { value: number; index: number } => p.value !== null)
+  // Nulls are gaps, not zeroes — an hour the cron never recorded must not be
+  // drawn as a plunge to the axis, and must not be bridged by a line either. See
+  // ./sparkline.ts, where that rule is tested.
+  const geometry = $derived(sparklineGeometry(series.points, WIDTH, HEIGHT));
+  const latest = $derived(geometry.latest);
+  const change = $derived(
+    geometry.latest !== null && geometry.first !== null ? geometry.latest - geometry.first : null
   );
-
-  const latest = $derived(drawn.length ? drawn[drawn.length - 1].value : null);
-  const first = $derived(drawn.length ? drawn[0].value : null);
-  const change = $derived(latest !== null && first !== null ? latest - first : null);
-
-  const path = $derived.by(() => {
-    if (drawn.length < 2) return '';
-    const values = drawn.map((p) => p.value);
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const span = max - min || 1;
-    const lastIndex = series.points.length - 1 || 1;
-
-    return drawn
-      .map((point, i) => {
-        const x = (point.index / lastIndex) * WIDTH;
-        // Flat series sit on the mid-line rather than pinned to the floor.
-        const y = HEIGHT - ((point.value - min) / span) * (HEIGHT - 4) - 2;
-        return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
-      })
-      .join(' ');
-  });
 
   function format(value: number): string {
     if (Number.isInteger(value)) return value.toLocaleString();
@@ -57,17 +36,23 @@
     </span>
   </div>
 
-  {#if path}
+  {#if geometry.path || geometry.dots.length}
     <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none" role="presentation">
-      <path d={path} fill="none" stroke="var(--color-primary)" stroke-width="1.5" />
+      {#if geometry.path}
+        <path d={geometry.path} fill="none" stroke="var(--color-primary)" stroke-width="1.5" />
+      {/if}
+      <!-- An hour recorded with no recorded neighbour has no line to belong to. -->
+      {#each geometry.dots as dot (dot.x)}
+        <circle cx={dot.x} cy={dot.y} r="1.2" fill="var(--color-primary)" />
+      {/each}
     </svg>
   {:else}
     <p class="empty">Not enough history yet</p>
   {/if}
 
-  {#if change !== null && drawn.length > 1}
+  {#if change !== null && geometry.spanHours > 0}
     <div class="change">
-      {change > 0 ? '+' : ''}{format(change)} over {drawn.length}h
+      {change > 0 ? '+' : ''}{format(change)} over {geometry.spanHours}h
     </div>
   {/if}
 </div>

--- a/admin/src/lib/components/Sparkline.svelte
+++ b/admin/src/lib/components/Sparkline.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import type { TrendSeries } from '$lib/metrics/ops';
+
+  interface Props {
+    series: TrendSeries;
+  }
+
+  let { series }: Props = $props();
+
+  const WIDTH = 240;
+  const HEIGHT = 40;
+
+  // Nulls are gaps, not zeroes — a stretch where the cron never recorded a value
+  // must not be drawn as a plunge to the axis. Points keep their x position so a
+  // gap reads as a gap.
+  const drawn = $derived(
+    series.points
+      .map((value, index) => ({ value, index }))
+      .filter((p): p is { value: number; index: number } => p.value !== null)
+  );
+
+  const latest = $derived(drawn.length ? drawn[drawn.length - 1].value : null);
+  const first = $derived(drawn.length ? drawn[0].value : null);
+  const change = $derived(latest !== null && first !== null ? latest - first : null);
+
+  const path = $derived.by(() => {
+    if (drawn.length < 2) return '';
+    const values = drawn.map((p) => p.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const span = max - min || 1;
+    const lastIndex = series.points.length - 1 || 1;
+
+    return drawn
+      .map((point, i) => {
+        const x = (point.index / lastIndex) * WIDTH;
+        // Flat series sit on the mid-line rather than pinned to the floor.
+        const y = HEIGHT - ((point.value - min) / span) * (HEIGHT - 4) - 2;
+        return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+  });
+
+  function format(value: number): string {
+    if (Number.isInteger(value)) return value.toLocaleString();
+    return value.toFixed(1);
+  }
+</script>
+
+<div class="card trend">
+  <div class="head">
+    <span class="label">{series.label}</span>
+    <span class="value">
+      {latest === null ? '—' : format(latest)}{#if series.unit && latest !== null}<span class="unit"
+          >{series.unit}</span
+        >{/if}
+    </span>
+  </div>
+
+  {#if path}
+    <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none" role="presentation">
+      <path d={path} fill="none" stroke="var(--color-primary)" stroke-width="1.5" />
+    </svg>
+  {:else}
+    <p class="empty">Not enough history yet</p>
+  {/if}
+
+  {#if change !== null && drawn.length > 1}
+    <div class="change">
+      {change > 0 ? '+' : ''}{format(change)} over {drawn.length}h
+    </div>
+  {/if}
+</div>
+
+<style>
+  .trend {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .label {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+  }
+
+  .value {
+    font-size: 1.1rem;
+    font-weight: 700;
+  }
+
+  .unit {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    margin-left: 0.15rem;
+  }
+
+  svg {
+    width: 100%;
+    height: 40px;
+    display: block;
+  }
+
+  .empty,
+  .change {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/admin/src/lib/components/sparkline.test.ts
+++ b/admin/src/lib/components/sparkline.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { sparklineGeometry } from './sparkline';
+
+// The failure these guard against is a chart that reads as continuous collection
+// when it isn't: one line drawn straight across the hours nobody recorded.
+
+const WIDTH = 240;
+const HEIGHT = 40;
+const geometry = (points: (number | null)[]) => sparklineGeometry(points, WIDTH, HEIGHT);
+
+// "M12.3,4.5 L…" → ['M12.3,4.5 L…'] per subpath
+const subpaths = (path: string) =>
+  path
+    .split('M')
+    .filter(Boolean)
+    .map((s) => `M${s.trim()}`);
+
+describe('sparkline geometry', () => {
+  it('breaks the line at a missing value instead of drawing through it', () => {
+    const { path } = geometry([1000, 1500, null, 2000, 3000]);
+    // Two runs of two, not one line of four drawn through the missing hour.
+    expect(subpaths(path)).toHaveLength(2);
+    expect(path.match(/L/g)).toHaveLength(2);
+  });
+
+  it('draws one continuous subpath when nothing is missing', () => {
+    const { path } = geometry([1, 2, 3, 4]);
+    expect(subpaths(path)).toHaveLength(1);
+    expect(path.match(/L/g)).toHaveLength(3);
+  });
+
+  it('keeps x anchored to the hour, so a gap occupies its own width', () => {
+    const { path, dots } = geometry([1000, 1100, null, null, 2000, 2100]);
+    // Six hours: the second run starts at hour 4 of 5, i.e. 80% across. Dropping
+    // the nulls instead would have put it at 50%.
+    expect(dots).toHaveLength(0);
+    expect(subpaths(path)[1]).toContain(`M${((4 / 5) * WIDTH).toFixed(1)},`);
+  });
+
+  it('marks a lone recorded hour that has no neighbour to connect to', () => {
+    const { path, dots } = geometry([null, 1000, null, 2000, 3000]);
+    expect(dots).toHaveLength(1);
+    expect(subpaths(path)).toHaveLength(1);
+  });
+
+  it('has nothing to draw when nothing was ever recorded', () => {
+    expect(geometry([null, null])).toEqual({
+      path: '',
+      dots: [],
+      spanHours: 0,
+      first: null,
+      latest: null,
+    });
+    expect(geometry([])).toMatchObject({ path: '', latest: null });
+  });
+
+  it('spans the change over the hours between the endpoints, not the sample count', () => {
+    // Two recorded values 5 hours apart: "+1000 over 5h", never "over 2h".
+    const { first, latest, spanHours } = geometry([1000, null, null, null, null, 2000]);
+    expect({ first, latest, spanHours }).toEqual({ first: 1000, latest: 2000, spanHours: 5 });
+  });
+
+  it('puts a flat series on the mid-line rather than on the floor', () => {
+    const { path } = geometry([5, 5, 5]);
+    const ys = [...path.matchAll(/[ML][\d.]+,([\d.]+)/g)].map((m) => Number(m[1]));
+    expect(new Set(ys).size).toBe(1);
+    expect(ys[0]).toBeGreaterThan(1);
+    expect(ys[0]).toBeLessThan(HEIGHT - 1);
+  });
+});

--- a/admin/src/lib/components/sparkline.ts
+++ b/admin/src/lib/components/sparkline.ts
@@ -1,0 +1,89 @@
+// Geometry for the trend sparklines, kept out of the component so the one thing
+// that can silently lie — drawing a line across hours nobody recorded — is unit
+// testable rather than eyeballed.
+//
+// A gap is any hour whose value is null: either the metric was unavailable that
+// hour (a stale source is recorded as null, never as its last value) or the
+// snapshot row is missing entirely (cron down — see `trendsFrom`). Both mean the
+// same thing to a reader, so both break the line.
+
+export interface SparklinePoint {
+  x: number;
+  y: number;
+}
+
+export interface SparklineGeometry {
+  /** One `M…L…` subpath per unbroken run of recorded hours. `''` if none. */
+  path: string;
+  /** Recorded hours with no recorded neighbour: a line can't render them. */
+  dots: SparklinePoint[];
+  /** Hours between the first and last recorded value — what `change` spans. */
+  spanHours: number;
+  first: number | null;
+  latest: number | null;
+}
+
+export function sparklineGeometry(
+  points: (number | null)[],
+  width: number,
+  height: number
+): SparklineGeometry {
+  const recorded = points
+    .map((value, index) => ({ value, index }))
+    .filter((p): p is { value: number; index: number } => p.value !== null);
+
+  if (recorded.length === 0) {
+    return { path: '', dots: [], spanHours: 0, first: null, latest: null };
+  }
+
+  const first = recorded[0];
+  const last = recorded[recorded.length - 1];
+  const values = recorded.map((p) => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  // x stays anchored to the hour, not to the point's position among the recorded
+  // ones — that's what makes a gap occupy the width of the time it covers.
+  const lastIndex = points.length - 1 || 1;
+
+  const at = (p: { value: number; index: number }): SparklinePoint => ({
+    x: (p.index / lastIndex) * width,
+    // Flat series sit on the mid-line rather than pinned to the floor.
+    y: height - ((p.value - min) / span) * (height - 4) - 2,
+  });
+
+  const subpaths: string[] = [];
+  const dots: SparklinePoint[] = [];
+  let run: { value: number; index: number }[] = [];
+
+  const flush = () => {
+    if (run.length === 1) {
+      dots.push(at(run[0]));
+    } else if (run.length > 1) {
+      subpaths.push(
+        run
+          .map((p, i) => {
+            const { x, y } = at(p);
+            return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+          })
+          .join(' ')
+      );
+    }
+    run = [];
+  };
+
+  for (const point of recorded) {
+    const previous = run[run.length - 1];
+    if (previous && point.index !== previous.index + 1) flush();
+    run.push(point);
+  }
+  flush();
+
+  return {
+    path: subpaths.join(' '),
+    dots,
+    spanHours: last.index - first.index,
+    first: first.value,
+    latest: last.value,
+  };
+}

--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { opsMetricsFrom, trendsFrom, formatAge } from './ops';
+import type { OpsStatus, SnapshotRow } from '$lib/queries/ops';
+
+// The ops tiles are read during an incident, so the failure that matters is a
+// confident-looking number that is actually old. These pin the staleness rules.
+
+const NOW = 1_700_000_000_000;
+const MINUTE = 60 * 1000;
+
+const status = (overrides: Partial<OpsStatus> = {}): OpsStatus => ({
+  cron: {
+    updatedAt: NOW - 30 * 1000,
+    value: {
+      at: NOW - 30 * 1000,
+      cron: '* * * * *',
+      healthy: true,
+      durationMs: 90,
+      version: 'abc',
+    },
+  },
+  poller: {
+    updatedAt: NOW - 30 * 1000,
+    value: {
+      lagMs: 20_000,
+      subscriptionsLagMs: 20_000,
+      documentsLagMs: 15_000,
+      lastPollAt: NOW - 45 * 1000,
+      lastPollDurationMs: 4200,
+      processed: 12,
+      errors: 0,
+      alarmScheduled: true,
+    },
+  },
+  proxy: {
+    updatedAt: NOW - 2 * MINUTE,
+    value: {
+      total: 400,
+      fresh: 390,
+      stale: 8,
+      freshPct: 97.5,
+      inFlight: 1,
+      feedsInError: 0,
+      feedsInBackoff: 0,
+      feedsPermanentlyFailed: 0,
+      cacheTtlSeconds: 900,
+    },
+  },
+  ...overrides,
+});
+
+const tile = (metrics: ReturnType<typeof opsMetricsFrom>, label: string) =>
+  metrics.find((m) => m.label === label)!;
+
+describe('ops tiles', () => {
+  it('reads healthy across the board on a live system', () => {
+    const metrics = opsMetricsFrom(status(), NOW);
+    expect(metrics.every((m) => m.status === 'healthy')).toBe(true);
+    expect(tile(metrics, 'Cron Last Run').value).toBe('30s ago');
+  });
+
+  it('flags a cron that ran recently but failed', () => {
+    const s = status();
+    s.cron!.value.healthy = false;
+    expect(tile(opsMetricsFrom(s, NOW), 'Cron Last Run').status).toBe('error');
+  });
+
+  it('escalates the cron tile as the gap grows', () => {
+    const stale = (ageMs: number) => {
+      const s = status();
+      s.cron!.value.at = NOW - ageMs;
+      return tile(opsMetricsFrom(s, NOW), 'Cron Last Run').status;
+    };
+    expect(stale(2 * MINUTE)).toBe('healthy');
+    expect(stale(5 * MINUTE)).toBe('warning');
+    expect(stale(30 * MINUTE)).toBe('error');
+  });
+
+  it('turns red at the same lag the backend alerts on', () => {
+    const lag = (lagMs: number | null) => {
+      const s = status();
+      s.poller!.value.lagMs = lagMs;
+      return tile(opsMetricsFrom(s, NOW), 'Firehose Lag');
+    };
+    expect(lag(60_000).status).toBe('healthy');
+    expect(lag(6 * MINUTE).status).toBe('warning');
+    expect(lag(20 * MINUTE).status).toBe('error');
+    // No cursor yet is unknown, not zero.
+    expect(lag(null).value).toBe('—');
+  });
+
+  it('says "stale" instead of showing proxy numbers nobody refreshed', () => {
+    const s = status();
+    s.proxy!.updatedAt = NOW - 40 * MINUTE;
+    const metrics = opsMetricsFrom(s, NOW);
+    expect(tile(metrics, 'Proxy Cache Fresh').status).toBe('error');
+    expect(String(tile(metrics, 'Proxy Cache Fresh').value)).toContain('Stale');
+  });
+
+  it('grades cache freshness against the 95% SLO', () => {
+    const fresh = (pct: number | null) => {
+      const s = status();
+      s.proxy!.value.freshPct = pct;
+      return tile(opsMetricsFrom(s, NOW), 'Proxy Cache Fresh').status;
+    };
+    expect(fresh(99)).toBe('healthy');
+    expect(fresh(90)).toBe('warning');
+    expect(fresh(50)).toBe('error');
+    // An empty cache has no percentage to grade.
+    expect(fresh(null)).toBe('warning');
+  });
+
+  it('renders a full set of tiles before the cron has ever run', () => {
+    const metrics = opsMetricsFrom({ cron: null, poller: null, proxy: null }, NOW);
+    expect(metrics).toHaveLength(6);
+    expect(metrics.every((m) => m.status === 'error')).toBe(true);
+  });
+});
+
+describe('trend series', () => {
+  const row = (capturedAt: number, overrides: Partial<SnapshotRow> = {}): SnapshotRow => ({
+    captured_at: capturedAt,
+    users: 10,
+    feeds: 20,
+    feed_items: 30,
+    subscriptions: 40,
+    saved_articles: 50,
+    feeds_with_errors: 1,
+    active_sessions: 5,
+    firehose_lag_ms: 1000,
+    proxy_fresh_pct: 98,
+    ...overrides,
+  });
+
+  it('keeps a missing value as a gap rather than a zero', () => {
+    const { series } = trendsFrom([
+      row(1),
+      row(2, { firehose_lag_ms: null }),
+      row(3, { firehose_lag_ms: 2000 }),
+    ]);
+    const lag = series.find((s) => s.key === 'firehose_lag_ms')!;
+    expect(lag.points).toEqual([1000, null, 2000]);
+  });
+
+  it('is empty but well-formed with no history', () => {
+    const trends = trendsFrom([]);
+    expect(trends.from).toBeNull();
+    expect(trends.series.every((s) => s.points.length === 0)).toBe(true);
+  });
+});
+
+describe('formatAge', () => {
+  it('picks a unit a human reads at a glance', () => {
+    expect(formatAge(30_000)).toBe('30s');
+    expect(formatAge(5 * MINUTE)).toBe('5m');
+    expect(formatAge(3 * 60 * MINUTE)).toBe('3h');
+    expect(formatAge(5 * 24 * 60 * MINUTE)).toBe('5d');
+  });
+});

--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -89,6 +89,24 @@ describe('ops tiles', () => {
     expect(lag(null).value).toBe('—');
   });
 
+  it('says "stale" instead of showing poller numbers nobody refreshed', () => {
+    // The cron is alive but its DO /status fetch has been failing for an hour, so
+    // the row still holds an hour-old lag of 20s. The tiles must not read green.
+    const s = status();
+    s.poller!.updatedAt = NOW - 60 * MINUTE;
+    const metrics = opsMetricsFrom(s, NOW);
+    for (const label of ['Firehose Lag', 'Last Poll', 'Poll Errors (last cycle)']) {
+      expect(tile(metrics, label).status).toBe('error');
+      expect(String(tile(metrics, label).value)).toContain('Stale');
+    }
+  });
+
+  it('tolerates a single missed poller write', () => {
+    const s = status();
+    s.poller!.updatedAt = NOW - 2 * MINUTE;
+    expect(tile(opsMetricsFrom(s, NOW), 'Firehose Lag').status).toBe('healthy');
+  });
+
   it('says "stale" instead of showing proxy numbers nobody refreshed', () => {
     const s = status();
     s.proxy!.updatedAt = NOW - 40 * MINUTE;
@@ -132,14 +150,36 @@ describe('trend series', () => {
     ...overrides,
   });
 
+  const HOUR = 60 * MINUTE;
+  const lagOf = (rows: SnapshotRow[]) =>
+    trendsFrom(rows).series.find((s) => s.key === 'firehose_lag_ms')!.points;
+
   it('keeps a missing value as a gap rather than a zero', () => {
-    const { series } = trendsFrom([
-      row(1),
-      row(2, { firehose_lag_ms: null }),
-      row(3, { firehose_lag_ms: 2000 }),
+    expect(
+      lagOf([
+        row(NOW),
+        row(NOW + HOUR, { firehose_lag_ms: null }),
+        row(NOW + 2 * HOUR, { firehose_lag_ms: 2000 }),
+      ])
+    ).toEqual([1000, null, 2000]);
+  });
+
+  it('keeps an hour with no snapshot at all as a gap', () => {
+    // The cron was down for two hours: three rows, but five hours of timeline.
+    expect(lagOf([row(NOW), row(NOW + 3 * HOUR), row(NOW + 4 * HOUR)])).toEqual([
+      1000,
+      null,
+      null,
+      1000,
+      1000,
     ]);
-    const lag = series.find((s) => s.key === 'firehose_lag_ms')!;
-    expect(lag.points).toEqual([1000, null, 2000]);
+  });
+
+  it('reports the real span of the history it holds', () => {
+    const trends = trendsFrom([row(NOW), row(NOW + 5 * HOUR)]);
+    expect(trends.from).toBe(NOW);
+    expect(trends.to).toBe(NOW + 5 * HOUR);
+    expect(trends.series[0].points).toHaveLength(6);
   });
 
   it('is empty but well-formed with no history', () => {

--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -192,6 +192,12 @@ describe('trend series', () => {
     ]);
   });
 
+  it('does not open a bucket for an hour that has not happened yet', () => {
+    // Healthy collector, 45 minutes into the newest hour: the timeline ends at
+    // the hour we're in, not the next one, so there is no trailing gap.
+    expect(lagOf([row(NOW), row(NOW + HOUR)], NOW + HOUR + 45 * MINUTE)).toEqual([1000, 1000]);
+  });
+
   it('is empty but well-formed with no history', () => {
     const trends = trendsFrom([]);
     expect(trends.from).toBeNull();

--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -151,8 +151,8 @@ describe('trend series', () => {
   });
 
   const HOUR = 60 * MINUTE;
-  const lagOf = (rows: SnapshotRow[]) =>
-    trendsFrom(rows).series.find((s) => s.key === 'firehose_lag_ms')!.points;
+  const lagOf = (rows: SnapshotRow[], now = rows.at(-1)?.captured_at ?? NOW) =>
+    trendsFrom(rows, now).series.find((s) => s.key === 'firehose_lag_ms')!.points;
 
   it('keeps a missing value as a gap rather than a zero', () => {
     expect(
@@ -176,10 +176,20 @@ describe('trend series', () => {
   });
 
   it('reports the real span of the history it holds', () => {
-    const trends = trendsFrom([row(NOW), row(NOW + 5 * HOUR)]);
+    const trends = trendsFrom([row(NOW), row(NOW + 5 * HOUR)], NOW + 5 * HOUR);
     expect(trends.from).toBe(NOW);
     expect(trends.to).toBe(NOW + 5 * HOUR);
     expect(trends.series[0].points).toHaveLength(6);
+  });
+
+  it('shows missing trailing snapshots as a gap through the current hour', () => {
+    expect(lagOf([row(NOW), row(NOW + HOUR)], NOW + 4 * HOUR)).toEqual([
+      1000,
+      1000,
+      null,
+      null,
+      null,
+    ]);
   });
 
   it('is empty but well-formed with no history', () => {

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -16,6 +16,15 @@ const LAG_ERROR_MS = 15 * 60 * 1000;
 /** Mirrors POLLER_STALE_MS in the backend's deep health check. */
 const POLL_STALE_MS = 5 * 60 * 1000;
 
+/**
+ * How old the `poller_status` *row* may be before its numbers stop being facts.
+ * The cron rewrites it every minute, so this catches the case the tile values
+ * can't see themselves: the cron is alive but its DO `/status` fetch keeps
+ * failing, leaving yesterday's lag sitting in D1 looking green. Same 5 minutes
+ * as POLL_STALE_MS — one missed minute is a blip, five is a broken collector.
+ */
+const POLLER_ROW_STALE_MS = 5 * 60 * 1000;
+
 /** Proxy stats refresh every 5 minutes; past this the numbers are history. */
 const PROXY_STALE_MS = 15 * 60 * 1000;
 
@@ -39,6 +48,10 @@ const unknown = (label: string, note = 'No data'): MetricValue => ({
   status: 'error',
 });
 
+/** The one thing these tiles must never do: show a number nobody refreshed. */
+const stale = (label: string, ageMs: number): MetricValue =>
+  unknown(label, `Stale (${formatAge(ageMs)})`);
+
 function cronMetric(status: OpsStatus, now: number): MetricValue {
   const cron = status.cron;
   if (!cron) return unknown('Cron Last Run', 'Never');
@@ -54,11 +67,18 @@ function cronMetric(status: OpsStatus, now: number): MetricValue {
   };
 }
 
+const POLLER_LABELS = ['Firehose Lag', 'Last Poll', 'Poll Errors (last cycle)'] as const;
+
 function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
   const poller = status.poller;
-  if (!poller) {
-    return [unknown('Firehose Lag'), unknown('Last Poll'), unknown('Poll Errors')];
-  }
+  if (!poller) return POLLER_LABELS.map((label) => unknown(label));
+
+  // Age of the row, not of the values inside it. `Last Poll` carries its own
+  // timestamp and would eventually go red on its own, but `Firehose Lag` and
+  // `Poll Errors` are frozen snapshots: if the collector stopped, they keep
+  // reading green forever. Grade all three on the row instead.
+  const rowAge = now - poller.updatedAt;
+  if (rowAge > POLLER_ROW_STALE_MS) return POLLER_LABELS.map((label) => stale(label, rowAge));
 
   const { lagMs, lastPollAt, errors } = poller.value;
   const lag: MetricValue =
@@ -84,7 +104,7 @@ function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
     lag,
     lastPoll,
     {
-      label: 'Poll Errors (last cycle)',
+      label: POLLER_LABELS[2],
       value: errors,
       status: errors > 0 ? 'warning' : 'healthy',
     },
@@ -96,12 +116,9 @@ function proxyMetrics(status: OpsStatus, now: number): MetricValue[] {
   if (!proxy) return [unknown('Proxy Cache Fresh'), unknown('Proxy Feeds in Error')];
 
   // Nobody refreshed these, so don't dress them up as current.
-  if (now - proxy.updatedAt > PROXY_STALE_MS) {
-    const age = formatAge(now - proxy.updatedAt);
-    return [
-      { label: 'Proxy Cache Fresh', value: `Stale (${age})`, status: 'error' },
-      { label: 'Proxy Feeds in Error', value: `Stale (${age})`, status: 'error' },
-    ];
+  const rowAge = now - proxy.updatedAt;
+  if (rowAge > PROXY_STALE_MS) {
+    return [stale('Proxy Cache Fresh', rowAge), stale('Proxy Feeds in Error', rowAge)];
   }
 
   const { freshPct, total, feedsInError, feedsPermanentlyFailed } = proxy.value;
@@ -152,19 +169,55 @@ const seriesDefinitions: { key: keyof SnapshotRow; label: string; unit?: string 
   { key: 'proxy_fresh_pct', label: 'Proxy Cache Fresh', unit: '%' },
 ];
 
+const HOUR_MS = 60 * 60 * 1000;
+
+/** 30 days of hourly points is what the query asks for; refuse to allocate past a
+ *  sane ceiling if a stray `captured_at` ever lands in the future. */
+const MAX_BUCKETS = 24 * 45;
+
+/**
+ * One point per hour between the oldest and newest snapshot — including the hours
+ * that have no row at all.
+ *
+ * Mapping rows straight to points would draw an hour the cron missed as no point
+ * rather than as a gap, so a two-day outage would render as an unbroken line
+ * between the snapshots on either side of it. The whole reason these charts are
+ * worth having is that a flat line means "nothing changed" and not "nobody
+ * looked"; only a timeline with holes in it can tell those apart.
+ */
 export function trendsFrom(rows: SnapshotRow[]): {
   from: number | null;
   to: number | null;
   series: TrendSeries[];
 } {
+  const from = rows[0]?.captured_at ?? null;
+  const to = rows[rows.length - 1]?.captured_at ?? null;
+
+  const empty = seriesDefinitions.map(({ key, label, unit }) => ({
+    key,
+    label,
+    unit,
+    points: [] as (number | null)[],
+  }));
+  if (from === null || to === null) return { from, to, series: empty };
+
+  // captured_at is already bucketed to the top of the hour by the cron that
+  // writes it, so this index is exact rather than approximate.
+  const bucketOf = (capturedAt: number) => Math.round((capturedAt - from) / HOUR_MS);
+  const count = Math.min(bucketOf(to) + 1, MAX_BUCKETS);
+  const byBucket = new Map(rows.map((row) => [bucketOf(row.captured_at), row]));
+
   return {
-    from: rows[0]?.captured_at ?? null,
-    to: rows[rows.length - 1]?.captured_at ?? null,
+    from,
+    to,
     series: seriesDefinitions.map(({ key, label, unit }) => ({
       key,
       label,
       unit,
-      points: rows.map((row) => row[key] as number | null),
+      points: Array.from({ length: count }, (_, bucket) => {
+        const row = byBucket.get(bucket);
+        return row ? ((row[key] as number | null) ?? null) : null;
+      }),
     })),
   };
 }

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -1,0 +1,188 @@
+import type { MetricValue } from '$lib/types';
+import { getOpsStatus, getSnapshots, type OpsStatus, type SnapshotRow } from '$lib/queries/ops';
+
+// The "is Skyreader healthy right now" tiles. Everything here comes from rows the
+// every-minute cron writes, so a value that stops moving is itself the signal:
+// staleness is treated as an error rather than rendered as a confident number.
+
+/** The cron runs every minute; two missed runs is a problem, ten is an outage. */
+const CRON_WARN_MS = 3 * 60 * 1000;
+const CRON_ERROR_MS = 10 * 60 * 1000;
+
+/** Mirrors the backend's alert threshold (FIREHOSE_LAG_ALERT_MS) and the 5-min SLO. */
+const LAG_WARN_MS = 5 * 60 * 1000;
+const LAG_ERROR_MS = 15 * 60 * 1000;
+
+/** Mirrors POLLER_STALE_MS in the backend's deep health check. */
+const POLL_STALE_MS = 5 * 60 * 1000;
+
+/** Proxy stats refresh every 5 minutes; past this the numbers are history. */
+const PROXY_STALE_MS = 15 * 60 * 1000;
+
+/** The plan's starter SLO: ≥95% of cached feeds within TTL. */
+const FRESH_WARN_PCT = 95;
+const FRESH_ERROR_PCT = 80;
+
+export function formatAge(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 90) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 90) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+const unknown = (label: string, note = 'No data'): MetricValue => ({
+  label,
+  value: note,
+  status: 'error',
+});
+
+function cronMetric(status: OpsStatus, now: number): MetricValue {
+  const cron = status.cron;
+  if (!cron) return unknown('Cron Last Run', 'Never');
+
+  const age = now - cron.value.at;
+  const stale = age > CRON_ERROR_MS;
+  return {
+    label: 'Cron Last Run',
+    value: `${formatAge(age)} ago`,
+    // A run that finished with failures is as interesting as one that never
+    // happened — it's the same condition the dead-man's switch withholds on.
+    status: stale || !cron.value.healthy ? 'error' : age > CRON_WARN_MS ? 'warning' : 'healthy',
+  };
+}
+
+function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
+  const poller = status.poller;
+  if (!poller) {
+    return [unknown('Firehose Lag'), unknown('Last Poll'), unknown('Poll Errors')];
+  }
+
+  const { lagMs, lastPollAt, errors } = poller.value;
+  const lag: MetricValue =
+    lagMs === null
+      ? { label: 'Firehose Lag', value: '—', status: 'warning' }
+      : {
+          label: 'Firehose Lag',
+          value: formatAge(lagMs),
+          status: lagMs >= LAG_ERROR_MS ? 'error' : lagMs >= LAG_WARN_MS ? 'warning' : 'healthy',
+        };
+
+  const pollAge = lastPollAt === null ? null : now - lastPollAt;
+  const lastPoll: MetricValue =
+    pollAge === null
+      ? { label: 'Last Poll', value: 'Never', status: 'warning' }
+      : {
+          label: 'Last Poll',
+          value: `${formatAge(pollAge)} ago`,
+          status: pollAge > POLL_STALE_MS ? 'error' : 'healthy',
+        };
+
+  return [
+    lag,
+    lastPoll,
+    {
+      label: 'Poll Errors (last cycle)',
+      value: errors,
+      status: errors > 0 ? 'warning' : 'healthy',
+    },
+  ];
+}
+
+function proxyMetrics(status: OpsStatus, now: number): MetricValue[] {
+  const proxy = status.proxy;
+  if (!proxy) return [unknown('Proxy Cache Fresh'), unknown('Proxy Feeds in Error')];
+
+  // Nobody refreshed these, so don't dress them up as current.
+  if (now - proxy.updatedAt > PROXY_STALE_MS) {
+    const age = formatAge(now - proxy.updatedAt);
+    return [
+      { label: 'Proxy Cache Fresh', value: `Stale (${age})`, status: 'error' },
+      { label: 'Proxy Feeds in Error', value: `Stale (${age})`, status: 'error' },
+    ];
+  }
+
+  const { freshPct, total, feedsInError, feedsPermanentlyFailed } = proxy.value;
+  return [
+    freshPct === null
+      ? { label: 'Proxy Cache Fresh', value: 'Empty cache', status: 'warning' }
+      : {
+          label: 'Proxy Cache Fresh',
+          value: freshPct,
+          unit: `% of ${total}`,
+          status:
+            freshPct < FRESH_ERROR_PCT
+              ? 'error'
+              : freshPct < FRESH_WARN_PCT
+                ? 'warning'
+                : 'healthy',
+        },
+    {
+      label: 'Proxy Feeds in Error',
+      value: feedsInError,
+      unit: feedsPermanentlyFailed > 0 ? `${feedsPermanentlyFailed} permanent` : undefined,
+      status: feedsPermanentlyFailed > 0 ? 'error' : feedsInError > 0 ? 'warning' : 'healthy',
+    },
+  ];
+}
+
+export function opsMetricsFrom(status: OpsStatus, now = Date.now()): MetricValue[] {
+  return [cronMetric(status, now), ...pollerMetrics(status, now), ...proxyMetrics(status, now)];
+}
+
+export interface TrendSeries {
+  key: string;
+  label: string;
+  unit?: string;
+  /** Hourly points, oldest first. Null means "not recorded", not zero. */
+  points: (number | null)[];
+}
+
+const seriesDefinitions: { key: keyof SnapshotRow; label: string; unit?: string }[] = [
+  { key: 'users', label: 'Users' },
+  { key: 'active_sessions', label: 'Active Sessions' },
+  { key: 'feeds', label: 'Feeds' },
+  { key: 'feeds_with_errors', label: 'Feeds with Errors' },
+  { key: 'subscriptions', label: 'Subscriptions' },
+  { key: 'saved_articles', label: 'Saved Articles' },
+  { key: 'feed_items', label: 'Feed Items' },
+  { key: 'firehose_lag_ms', label: 'Firehose Lag', unit: 'ms' },
+  { key: 'proxy_fresh_pct', label: 'Proxy Cache Fresh', unit: '%' },
+];
+
+export function trendsFrom(rows: SnapshotRow[]): {
+  from: number | null;
+  to: number | null;
+  series: TrendSeries[];
+} {
+  return {
+    from: rows[0]?.captured_at ?? null,
+    to: rows[rows.length - 1]?.captured_at ?? null,
+    series: seriesDefinitions.map(({ key, label, unit }) => ({
+      key,
+      label,
+      unit,
+      points: rows.map((row) => row[key] as number | null),
+    })),
+  };
+}
+
+export interface OpsData {
+  /** False when migration 0067 hasn't reached this database yet. */
+  available: boolean;
+  metrics: MetricValue[];
+  trends: ReturnType<typeof trendsFrom>;
+}
+
+export async function loadOps(db: D1Database): Promise<OpsData> {
+  try {
+    const [status, snapshots] = await Promise.all([getOpsStatus(db), getSnapshots(db)]);
+    return { available: true, metrics: opsMetricsFrom(status), trends: trendsFrom(snapshots) };
+  } catch {
+    // Almost always "no such table": the admin deploys independently of the
+    // backend's migrations. Say so on the page rather than showing zeroes.
+    return { available: false, metrics: [], trends: { from: null, to: null, series: [] } };
+  }
+}

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -209,7 +209,13 @@ export function trendsFrom(
   const bucketOf = (capturedAt: number) => Math.round((capturedAt - from) / HOUR_MS);
   // End at the current hour, not the newest row. Otherwise collection stopping
   // is invisible until it resumes: an old value still sits at the chart edge.
-  const count = Math.min(Math.max(bucketOf(now), bucketOf(to)) + 1, MAX_BUCKETS);
+  //
+  // `now` is a wall clock instant rather than a bucketed timestamp, so it floors
+  // to the hour it falls in. Rounding it would open a bucket for an hour that
+  // hasn't happened yet from :30 onward — a trailing gap on a healthy collector,
+  // which is the opposite of what the gap is supposed to mean.
+  const nowBucket = Math.floor((now - from) / HOUR_MS);
+  const count = Math.min(Math.max(nowBucket, bucketOf(to)) + 1, MAX_BUCKETS);
   const byBucket = new Map(rows.map((row) => [bucketOf(row.captured_at), row]));
 
   return {

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -185,7 +185,10 @@ const MAX_BUCKETS = 24 * 45;
  * worth having is that a flat line means "nothing changed" and not "nobody
  * looked"; only a timeline with holes in it can tell those apart.
  */
-export function trendsFrom(rows: SnapshotRow[]): {
+export function trendsFrom(
+  rows: SnapshotRow[],
+  now = Date.now()
+): {
   from: number | null;
   to: number | null;
   series: TrendSeries[];
@@ -204,7 +207,9 @@ export function trendsFrom(rows: SnapshotRow[]): {
   // captured_at is already bucketed to the top of the hour by the cron that
   // writes it, so this index is exact rather than approximate.
   const bucketOf = (capturedAt: number) => Math.round((capturedAt - from) / HOUR_MS);
-  const count = Math.min(bucketOf(to) + 1, MAX_BUCKETS);
+  // End at the current hour, not the newest row. Otherwise collection stopping
+  // is invisible until it resumes: an old value still sits at the chart edge.
+  const count = Math.min(Math.max(bucketOf(now), bucketOf(to)) + 1, MAX_BUCKETS);
   const byBucket = new Map(rows.map((row) => [bucketOf(row.captured_at), row]));
 
   return {

--- a/admin/src/lib/queries/ops.ts
+++ b/admin/src/lib/queries/ops.ts
@@ -1,0 +1,99 @@
+// Reads of the two tables the backend cron writes (`system_status`,
+// `metrics_snapshots`, migration 0067). The admin already reads this database
+// read-only, so the ops view needs no API token and no production-only path — it
+// works the moment the cron has run once, including in local dev.
+//
+// The shapes here mirror `backend/src/observability/ops-metrics.ts`. They are
+// separate packages, so this is a copy by necessity; the values are JSON in a D1
+// column and every field is treated as possibly absent, which is what keeps a
+// backend that adds or drops a field from breaking the dashboard.
+
+export interface PollerStatusValue {
+  lagMs: number | null;
+  subscriptionsLagMs: number | null;
+  documentsLagMs: number | null;
+  lastPollAt: number | null;
+  lastPollDurationMs: number | null;
+  processed: number;
+  errors: number;
+  alarmScheduled: boolean;
+}
+
+export interface CronLastRunValue {
+  at: number;
+  cron: string;
+  healthy: boolean;
+  durationMs: number;
+  version: string;
+}
+
+export interface ProxyStatsValue {
+  total: number;
+  fresh: number;
+  stale: number;
+  freshPct: number | null;
+  inFlight: number;
+  feedsInError: number;
+  feedsInBackoff: number;
+  feedsPermanentlyFailed: number;
+  cacheTtlSeconds: number | null;
+}
+
+export interface StatusRow<T> {
+  value: T;
+  updatedAt: number;
+}
+
+export interface OpsStatus {
+  cron: StatusRow<CronLastRunValue> | null;
+  poller: StatusRow<PollerStatusValue> | null;
+  proxy: StatusRow<ProxyStatsValue> | null;
+}
+
+function parse<T>(row: { value: string; updated_at: number } | undefined): StatusRow<T> | null {
+  if (!row) return null;
+  try {
+    return { value: JSON.parse(row.value) as T, updatedAt: row.updated_at };
+  } catch {
+    return null;
+  }
+}
+
+export async function getOpsStatus(db: D1Database): Promise<OpsStatus> {
+  const result = await db
+    .prepare('SELECT key, value, updated_at FROM system_status')
+    .all<{ key: string; value: string; updated_at: number }>();
+
+  const byKey = new Map(result.results.map((r) => [r.key, r]));
+  return {
+    cron: parse<CronLastRunValue>(byKey.get('cron_last_run')),
+    poller: parse<PollerStatusValue>(byKey.get('poller_status')),
+    proxy: parse<ProxyStatsValue>(byKey.get('proxy_stats')),
+  };
+}
+
+export interface SnapshotRow {
+  captured_at: number;
+  users: number;
+  feeds: number;
+  feed_items: number;
+  subscriptions: number;
+  saved_articles: number;
+  feeds_with_errors: number;
+  active_sessions: number;
+  firehose_lag_ms: number | null;
+  proxy_fresh_pct: number | null;
+}
+
+/**
+ * Hourly points, oldest first. 30 days by default: enough to see a trend, few
+ * enough points (~720) that the sparklines stay a cheap inline SVG.
+ */
+export async function getSnapshots(db: D1Database, days = 30): Promise<SnapshotRow[]> {
+  const since = Date.now() - days * 24 * 60 * 60 * 1000;
+  const result = await db
+    .prepare('SELECT * FROM metrics_snapshots WHERE captured_at >= ? ORDER BY captured_at ASC')
+    .bind(since)
+    .all<SnapshotRow>();
+  return result.results;
+}

--- a/admin/src/routes/+page.server.ts
+++ b/admin/src/routes/+page.server.ts
@@ -1,8 +1,9 @@
 import { loadAllMetrics } from '$lib/metrics';
+import { loadOps } from '$lib/metrics/ops';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ platform }) => {
   const db = platform!.env.DB;
-  const groups = await loadAllMetrics(db);
-  return { groups };
+  const [groups, ops] = await Promise.all([loadAllMetrics(db), loadOps(db)]);
+  return { groups, ops };
 };

--- a/admin/src/routes/+page.svelte
+++ b/admin/src/routes/+page.svelte
@@ -32,6 +32,7 @@
 {#if data.ops.available}
   <section>
     <h2>Trends (30 days, hourly)</h2>
+    <p class="note">A break in a line is an hour with no recorded value, not a drop to zero.</p>
     <div class="grid">
       {#each data.ops.trends.series as series (series.key)}
         <Sparkline {series} />
@@ -56,6 +57,12 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 0.75rem;
+  }
+
+  .note {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+    margin: -0.4rem 0 0.75rem;
   }
 
   .grid {

--- a/admin/src/routes/+page.svelte
+++ b/admin/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MetricGrid from '$lib/components/MetricGrid.svelte';
+  import Sparkline from '$lib/components/Sparkline.svelte';
 
   let { data } = $props();
 </script>
@@ -10,12 +11,61 @@
 
 <h1>Dashboard</h1>
 
+<!-- Ops first: "is it healthy right now" outranks "how big is it". -->
+{#if data.ops.available}
+  <MetricGrid category="Ops" metrics={data.ops.metrics} />
+{:else}
+  <section class="unavailable">
+    <h2>Ops</h2>
+    <p class="card">
+      No <code>system_status</code> table in this database yet — apply the backend migrations (<code
+        >0067_system_status.sql</code
+      >) and wait one cron run.
+    </p>
+  </section>
+{/if}
+
 {#each data.groups as group}
   <MetricGrid category={group.category} metrics={group.metrics} />
 {/each}
 
+{#if data.ops.available}
+  <section>
+    <h2>Trends (30 days, hourly)</h2>
+    <div class="grid">
+      {#each data.ops.trends.series as series (series.key)}
+        <Sparkline {series} />
+      {/each}
+    </div>
+  </section>
+{/if}
+
 <style>
   h1 {
     margin-bottom: 1.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+
+  .unavailable p {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
   }
 </style>

--- a/admin/svelte.config.js
+++ b/admin/svelte.config.js
@@ -4,6 +4,10 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
   preprocess: vitePreprocess(),
   kit: {
+    // Deployed commit, served at `/_app/version.json` so the post-deploy smoke
+    // check can assert this build is the one actually serving (see
+    // frontend/svelte.config.js for the full rationale).
+    ...(process.env.GITHUB_SHA ? { version: { name: process.env.GITHUB_SHA } } : {}),
     adapter: adapter({
       platformProxy: {
         persist: {

--- a/admin/vitest.config.ts
+++ b/admin/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Deliberately not the SvelteKit vite config: these are plain unit tests over the
+// metric/query modules, and loading the kit plugin starts a dev server that then
+// refuses to shut down after the run. `$lib` is the only thing the plugin
+// provided that the tests need.
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -75,16 +75,18 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 
 ### Observability
 
-| File                             | Purpose                                                        |
-| -------------------------------- | -------------------------------------------------------------- |
-| `src/observability/sentry.ts`    | SDK options + the `reportError()` wrapper every call site uses |
-| `src/observability/scrub.ts`     | `beforeSend` credential scrubbing (keeps DIDs, drops tokens)   |
-| `src/observability/heartbeat.ts` | Dead-man's-switch ping for the every-minute cron               |
-| `src/utils/logger.ts`            | `log.info('event', { … })` — structured, queryable log lines   |
-| `src/utils/request-context.ts`   | Request id / route / DID in AsyncLocalStorage                  |
+| File                               | Purpose                                                        |
+| ---------------------------------- | -------------------------------------------------------------- |
+| `src/observability/sentry.ts`      | SDK options + the `reportError()` wrapper every call site uses |
+| `src/observability/scrub.ts`       | `beforeSend` credential scrubbing (keeps DIDs, drops tokens)   |
+| `src/observability/heartbeat.ts`   | Dead-man's-switch ping for the every-minute cron               |
+| `src/observability/ops-metrics.ts` | What the cron records to D1 for the admin's ops panel          |
+| `src/utils/logger.ts`              | `log.info('event', { … })` — structured, queryable log lines   |
+| `src/utils/request-context.ts`     | Request id / route / DID in AsyncLocalStorage                  |
 
-Error reporting goes through `reportError()`, never `Sentry.captureException`
-directly, so the vendor stays a one-file decision.
+Error reporting goes through `reportError()` (exceptions) or `reportMessage()`
+(threshold crossings, with a fingerprint so a persistent condition is one issue),
+never `Sentry.captureException` directly, so the vendor stays a one-file decision.
 
 Logging: use `log.*` with a stable low-cardinality `event` slug and put the details
 in fields. Workers Logs indexes the fields of a logged object but treats a string
@@ -95,6 +97,12 @@ redaction layer on this path.
 The request id is ambient (`getRequestId()`), so nothing has to thread it: it lands
 on every log line, every `reportError()` tag, the `X-Request-Id` response header,
 and outbound feed-proxy calls.
+
+The every-minute cron also _records_: poller lag and cron liveness to
+`system_status`, the proxy's cache stats every 5th minute, and an hourly row in
+`metrics_snapshots` (pruned at 90 days). The admin renders those tables directly.
+Recording failures never withhold the cron heartbeat — losing a data point is not
+an outage; see the note on `runRecordingStep()`.
 
 Alert thresholds, secrets, log queries, and incident procedures:
 [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
@@ -126,6 +134,8 @@ Key tables:
 - `user_settings` - User preferences
 - `rate_limits` - Per-user rate limiting
 - `sync_state` - Jetstream cursor and other sync state
+- `system_status` - Cron-written health board (cron liveness, poller lag, proxy stats)
+- `metrics_snapshots` - Hourly trend points behind the admin's sparklines (90-day retention)
 
 ## Common Tasks
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -57,6 +57,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/routes/settings.ts`      | User settings                                         |
 | `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status         |
 | `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons        |
+| `src/routes/health.ts`        | `/api/health` (shallow) + `/api/health/deep` (gated)  |
 
 ### Services
 
@@ -71,6 +72,18 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/services/subscription-sync.ts` | Sync subscriptions to/from PDS                    |
 | `src/services/rate-limit.ts`        | Per-user per-endpoint rate limiting (D1-backed)   |
 | `src/services/user-tier.ts`         | Tier lookup (free/supporter)                      |
+
+### Observability
+
+| File                             | Purpose                                                        |
+| -------------------------------- | -------------------------------------------------------------- |
+| `src/observability/sentry.ts`    | SDK options + the `reportError()` wrapper every call site uses |
+| `src/observability/scrub.ts`     | `beforeSend` credential scrubbing (keeps DIDs, drops tokens)   |
+| `src/observability/heartbeat.ts` | Dead-man's-switch ping for the every-minute cron               |
+
+Error reporting goes through `reportError()`, never `Sentry.captureException`
+directly, so the vendor stays a one-file decision. Alert thresholds, secrets, and
+incident procedures: [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 ### Durable Objects
 
@@ -129,8 +142,16 @@ FRONTEND_URL = "https://skyreader.app"
 ALLOWED_ORIGINS = "https://skyreader.app,https://staging.skyreader.app,..."
 FEED_PROXY_URL = "https://skyreader-feed-proxy.fly.dev"
 
+SENTRY_ENVIRONMENT = "production"   # "staging" in [env.staging]
+
 # Secrets (set via `wrangler secret put`):
-# FEED_PROXY_SECRET - authenticates with the Fly.io feed proxy
+# FEED_PROXY_SECRET   - authenticates with the Fly.io feed proxy
+# SENTRY_DSN          - error reporting (unset ⇒ silent no-op)
+# HEARTBEAT_URL       - dead-man ping for the every-minute cron
+# HEALTH_CHECK_SECRET - gates /api/health/deep (X-Health-Secret header)
+#
+# GIT_COMMIT_SHA is passed by CI at deploy time (`--var GIT_COMMIT_SHA:<sha>`)
+# and reported by /api/health; a manual deploy reports "dev".
 ```
 
 ## Local Development Setup

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -106,7 +106,8 @@ Recording failures never withhold the cron heartbeat — losing a data point is 
 an outage; see the note on `runRecordingStep()`.
 
 The browser reports its own errors to `/api/telemetry/error` (unauthenticated by
-design — an error on the login screen counts). That route is the only thing that
+design — an error on the login screen counts, and the route is answered before
+session resolution so a degraded D1 can't turn the report into a 500). That route is the only thing that
 talks to Sentry on the client's behalf: no SDK ships in the frontend bundle, and
 every field the client sends is length-capped and validated against a closed set
 of `kind`s before it becomes a log line or a Sentry tag.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -80,10 +80,24 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/observability/sentry.ts`    | SDK options + the `reportError()` wrapper every call site uses |
 | `src/observability/scrub.ts`     | `beforeSend` credential scrubbing (keeps DIDs, drops tokens)   |
 | `src/observability/heartbeat.ts` | Dead-man's-switch ping for the every-minute cron               |
+| `src/utils/logger.ts`            | `log.info('event', { … })` — structured, queryable log lines   |
+| `src/utils/request-context.ts`   | Request id / route / DID in AsyncLocalStorage                  |
 
 Error reporting goes through `reportError()`, never `Sentry.captureException`
-directly, so the vendor stays a one-file decision. Alert thresholds, secrets, and
-incident procedures: [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
+directly, so the vendor stays a one-file decision.
+
+Logging: use `log.*` with a stable low-cardinality `event` slug and put the details
+in fields. Workers Logs indexes the fields of a logged object but treats a string
+as opaque text, so `log.info('feed_fetched', { feedCount })` is queryable and an
+interpolated `console.log` sentence is not. Never log a credential — there is no
+redaction layer on this path.
+
+The request id is ambient (`getRequestId()`), so nothing has to thread it: it lands
+on every log line, every `reportError()` tag, the `X-Request-Id` response header,
+and outbound feed-proxy calls.
+
+Alert thresholds, secrets, log queries, and incident procedures:
+[`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 ### Durable Objects
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -58,6 +58,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status         |
 | `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons        |
 | `src/routes/health.ts`        | `/api/health` (shallow) + `/api/health/deep` (gated)  |
+| `src/routes/telemetry.ts`     | `/api/telemetry/error` — sampled client error reports |
 
 ### Services
 
@@ -104,8 +105,14 @@ The every-minute cron also _records_: poller lag and cron liveness to
 Recording failures never withhold the cron heartbeat — losing a data point is not
 an outage; see the note on `runRecordingStep()`.
 
-Alert thresholds, secrets, log queries, and incident procedures:
-[`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
+The browser reports its own errors to `/api/telemetry/error` (unauthenticated by
+design — an error on the login screen counts). That route is the only thing that
+talks to Sentry on the client's behalf: no SDK ships in the frontend bundle, and
+every field the client sends is length-capped and validated against a closed set
+of `kind`s before it becomes a log line or a Sentry tag.
+
+Alert thresholds, SLOs, alert policy, secrets, log queries, and incident
+procedures: [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 ### Durable Objects
 

--- a/backend/migrations/0067_system_status.sql
+++ b/backend/migrations/0067_system_status.sql
@@ -1,0 +1,32 @@
+-- Observability phase 2. Two tables, two jobs.
+--
+-- `system_status` is the point-in-time board: one row per key, overwritten by the
+-- every-minute cron. It exists so the admin — which already reads this database
+-- read-only — can show cron liveness, firehose lag and proxy cache health with no
+-- new API, no new token, and no behaviour that only works in production.
+--
+-- `metrics_snapshots` is the history behind it: one row per hour, pruned at 90
+-- days by the same job that writes it. `captured_at` is the *start of the hour* in
+-- unix ms and the INTEGER PRIMARY KEY (so it is the rowid — range scans by time
+-- are free and need no second index), which makes an hourly write idempotent: a
+-- cron that runs twice in one hour replaces its row instead of duplicating it.
+-- Nullable columns are the values that can genuinely be unknown (no cursor yet,
+-- proxy unreachable) — recording a null is honest, recording a 0 is a lie.
+CREATE TABLE system_status (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE metrics_snapshots (
+  captured_at INTEGER PRIMARY KEY,
+  users INTEGER NOT NULL,
+  feeds INTEGER NOT NULL,
+  feed_items INTEGER NOT NULL,
+  subscriptions INTEGER NOT NULL,
+  saved_articles INTEGER NOT NULL,
+  feeds_with_errors INTEGER NOT NULL,
+  active_sessions INTEGER NOT NULL,
+  firehose_lag_ms INTEGER,
+  proxy_fresh_pct REAL
+);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@noble/curves": "^2.2.0",
         "@scure/base": "^2.2.0",
+        "@sentry/cloudflare": "^10.70.0",
         "fast-xml-parser": "^5.2.0"
       },
       "devDependencies": {
@@ -21,11 +22,60 @@
         "wrangler": "^4.58.0"
       }
     },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -685,7 +735,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -698,7 +748,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1151,7 +1200,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1278,7 +1327,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1295,7 +1343,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1426,7 +1473,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1449,7 +1495,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1584,7 +1629,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1641,7 +1685,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1651,14 +1695,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1692,11 +1735,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -1706,7 +1758,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -1718,7 +1770,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2080,11 +2132,75 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.70.0.tgz",
+      "integrity": "sha512-jlr9txw3lQrbc6KQn9FzlpgC1KcB36u7aIGSlUhXAZ2MB93DgwjuTnHF20qQHxmHbZylg7CtHoMq3rGiTXAgpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "magic-string": "~0.30.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x || ^5.x",
+        "wrangler": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "wrangler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2097,7 +2213,7 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/@types/chai": {
@@ -2122,7 +2238,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -2273,6 +2388,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/birpc": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
@@ -2287,7 +2411,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cac": {
@@ -2383,7 +2507,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2397,7 +2521,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2432,7 +2555,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2449,7 +2572,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2502,6 +2625,27 @@
         "@esbuild/win32-arm64": "0.27.2",
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -2584,7 +2728,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2620,7 +2763,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2637,10 +2780,18 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/mime": {
@@ -2693,11 +2844,16 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2730,14 +2886,14 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -2860,11 +3016,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2928,6 +3090,15 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -2994,7 +3165,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3068,7 +3239,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -3107,7 +3277,7 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -3326,7 +3496,7 @@
       "version": "4.59.3",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.3.tgz",
       "integrity": "sha512-zl+nqoGzWJ4K+NEMjy4GiaIi9ix59FkOzd7UsDb8CQADwy3li1DSNAzHty/BWYa3ZvMxr/G4pogMBb5vcSrNvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
@@ -3361,7 +3531,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
       "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -3380,7 +3550,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3397,7 +3566,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3414,7 +3582,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3431,7 +3598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3448,7 +3614,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3465,7 +3630,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3482,7 +3646,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3499,7 +3662,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3516,7 +3678,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3533,7 +3694,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3550,7 +3710,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3567,7 +3726,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3584,7 +3742,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3601,7 +3758,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3618,7 +3774,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3635,7 +3790,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3652,7 +3806,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3669,7 +3822,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,7 +3838,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3703,7 +3854,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3720,7 +3870,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3737,7 +3886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3754,7 +3902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3771,7 +3918,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3788,7 +3934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3805,7 +3950,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3822,7 +3966,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3839,7 +3982,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3856,7 +3998,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3873,7 +4014,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3890,7 +4030,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3907,7 +4046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3930,7 +4068,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3953,7 +4090,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3970,7 +4106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3987,7 +4122,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4004,7 +4138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4021,7 +4154,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4038,7 +4170,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4055,7 +4186,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4072,7 +4202,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4089,7 +4218,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4112,7 +4240,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4135,7 +4262,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4158,7 +4284,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4181,7 +4306,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4204,7 +4328,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4227,7 +4350,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4247,7 +4369,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4267,7 +4388,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4284,7 +4404,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4326,7 +4446,7 @@
       "version": "4.20260116.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260116.0.tgz",
       "integrity": "sha512-fCU1thOdiKfcauYp/gAchhesOTqTPy3K7xY6g72RiJ2xkna18QJ3Mh5sgDmnqlOEqSW9vpmYeK8vd/aqkrtlUA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -4348,7 +4468,7 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4393,7 +4513,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
       "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4403,7 +4523,7 @@
       "version": "1.20260116.0",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260116.0.tgz",
       "integrity": "sha512-tVdBes3qkZKm9ntrgSDlvKzk4g2mcMp4bNM1+UgZMpTesb0x7e59vYYcKclbSNypmVkdLWpEc2TOpO0WF/rrZw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4424,7 +4544,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4446,7 +4566,7 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -4460,7 +4580,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
@@ -4471,7 +4591,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@noble/curves": "^2.2.0",
     "@scure/base": "^2.2.0",
+    "@sentry/cloudflare": "^10.70.0",
     "fast-xml-parser": "^5.2.0"
   },
   "devDependencies": {

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/cloudflare';
 import type { Env } from '../types';
 import { resolveCanonicalUrl } from '../utils/canonical-url';
 import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
+import { sentryOptions, reportError } from '../observability/sentry';
 
 // Jetstream event types
 interface JetstreamEvent {
@@ -49,7 +51,7 @@ const POLL_TIMEOUT_MS = 8000; // 8 seconds per stream
 const IDLE_TIMEOUT_MS = 2000; // 2 seconds without events = caught up
 const ALARM_INTERVAL_MS = 60000; // 60 seconds between polls
 
-export class JetstreamPoller implements DurableObject {
+class JetstreamPollerBase implements DurableObject {
   private state: DurableObjectState;
   private env: Env;
 
@@ -150,6 +152,7 @@ export class JetstreamPoller implements DurableObject {
         stats.documents = documentsResult;
       } catch (error) {
         console.error('[JetstreamPoller] Error during poll cycle:', error);
+        reportError(error, { tags: { source: 'jetstream-poller', phase: 'poll-cycle' } });
       }
 
       stats.duration = Date.now() - startTime;
@@ -170,12 +173,16 @@ export class JetstreamPoller implements DurableObject {
     } catch (error) {
       // Catch-all for any unexpected errors
       console.error('[JetstreamPoller] UNEXPECTED ERROR in alarm handler:', error);
+      reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm' } });
     } finally {
       // ALWAYS schedule next poll - this runs even if an error occurred above
       try {
         await this.state.storage.setAlarm(Date.now() + ALARM_INTERVAL_MS);
       } catch (error) {
+        // The firehose stops here until the next cron /start ping revives it, so
+        // this one is worth a page rather than a log line.
         console.error('[JetstreamPoller] CRITICAL: Error scheduling next alarm:', error);
+        reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm-scheduling' } });
       }
     }
   }
@@ -577,3 +584,17 @@ export class JetstreamPoller implements DurableObject {
     return new Set(result.results.map((r) => r.did));
   }
 }
+
+// Instrumented at the export so exceptions escaping `fetch`/`alarm` reach Sentry,
+// and — just as importantly — so the SDK is initialized inside this DO's isolate,
+// which is what makes the `reportError()` calls above actually send. The cast
+// bridges the ambient `DurableObject` interface this class implements to the
+// `cloudflare:workers` base class the instrumenter's types expect; the runtime
+// contract (constructor(state, env) + fetch/alarm) is identical.
+export const JetstreamPoller = Sentry.instrumentDurableObjectWithSentry(
+  sentryOptions,
+  JetstreamPollerBase as unknown as new (
+    state: DurableObjectState,
+    env: Env
+  ) => InstanceType<typeof JetstreamPollerBase> & { ctx: DurableObjectState; env: Env }
+) as unknown as typeof JetstreamPollerBase;

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -3,6 +3,8 @@ import type { Env } from '../types';
 import { resolveCanonicalUrl } from '../utils/canonical-url';
 import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
 import { sentryOptions, reportError } from '../observability/sentry';
+import { log, serializeError } from '../utils/logger';
+import { runWithRequestContext } from '../utils/request-context';
 
 // Jetstream event types
 interface JetstreamEvent {
@@ -51,6 +53,13 @@ const POLL_TIMEOUT_MS = 8000; // 8 seconds per stream
 const IDLE_TIMEOUT_MS = 2000; // 2 seconds without events = caught up
 const ALARM_INTERVAL_MS = 60000; // 60 seconds between polls
 
+// How long after an alarm *started* we still consider the poller alive without a
+// scheduled alarm. `getAlarm()` returns null while the handler runs, so both
+// `/start` (don't double-start) and `/status` consumers (don't cry wedged) need
+// this window. Two alarm intervals: long enough to cover a slow cycle, short
+// enough that a genuinely dead poller is caught within a couple of minutes.
+export const ALARM_ACTIVE_WINDOW_MS = 2 * ALARM_INTERVAL_MS;
+
 class JetstreamPollerBase implements DurableObject {
   private state: DurableObjectState;
   private env: Env;
@@ -72,7 +81,7 @@ class JetstreamPollerBase implements DurableObject {
         this.state.storage.get<number>('last_alarm_start'),
       ]);
 
-      const recentlyActive = lastAlarmStart && Date.now() - lastAlarmStart < 120000; // 2 minutes
+      const recentlyActive = lastAlarmStart && Date.now() - lastAlarmStart < ALARM_ACTIVE_WINDOW_MS;
 
       if (!alarmTime && !recentlyActive) {
         // No alarm scheduled and none ran recently - start fresh
@@ -95,12 +104,14 @@ class JetstreamPollerBase implements DurableObject {
     }
 
     if (url.pathname === '/status') {
-      const [subscriptionsCursor, documentsCursor, lastStats, alarmTime] = await Promise.all([
-        this.state.storage.get<string>('cursor_subscriptions'),
-        this.state.storage.get<string>('cursor_documents'),
-        this.state.storage.get<PollStats>('last_stats'),
-        this.state.storage.getAlarm(),
-      ]);
+      const [subscriptionsCursor, documentsCursor, lastStats, alarmTime, lastAlarmStart] =
+        await Promise.all([
+          this.state.storage.get<string>('cursor_subscriptions'),
+          this.state.storage.get<string>('cursor_documents'),
+          this.state.storage.get<PollStats>('last_stats'),
+          this.state.storage.getAlarm(),
+          this.state.storage.get<number>('last_alarm_start'),
+        ]);
 
       return new Response(
         JSON.stringify({
@@ -110,7 +121,14 @@ class JetstreamPollerBase implements DurableObject {
           },
           lastStats,
           nextPoll: alarmTime,
+          // `getAlarm()` returns null *while the alarm handler is running*, and a
+          // poll cycle occupies a real fraction of every minute (two streams, each
+          // 2–8s). A caller that reads `isRunning` alone would see false during
+          // that window and conclude the firehose is dead — so surface
+          // `lastAlarmStart` too and let it apply the same recency rule /start
+          // uses (see above). Callers: routes/health.ts.
           isRunning: !!alarmTime,
+          lastAlarmStart: lastAlarmStart ?? null,
         }),
         {
           headers: { 'Content-Type': 'application/json' },
@@ -122,6 +140,14 @@ class JetstreamPollerBase implements DurableObject {
   }
 
   async alarm(): Promise<void> {
+    // Every line and every Sentry event from this poll cycle shares one id, so a
+    // bad cycle can be read end to end from a single filter.
+    return runWithRequestContext({ requestId: crypto.randomUUID(), route: 'jetstream-poll' }, () =>
+      this.runPollCycle()
+    );
+  }
+
+  private async runPollCycle(): Promise<void> {
     // Record when this alarm started to prevent race conditions with /start
     // (cron calls /start every minute, but getAlarm() returns null while running)
     await this.state.storage.put('last_alarm_start', Date.now());
@@ -130,7 +156,7 @@ class JetstreamPollerBase implements DurableObject {
     // The finally block ensures we always schedule the next alarm
     try {
       const startTime = Date.now();
-      console.log('[JetstreamPoller] Starting poll cycle');
+      log.info('jetstream_poll_start');
 
       const stats: PollStats = {
         subscriptions: { processed: 0, errors: 0 },
@@ -142,16 +168,14 @@ class JetstreamPollerBase implements DurableObject {
       try {
         // Poll streams sequentially to reduce peak CPU usage
         // 1. Subscriptions (app.skyreader.feed.subscription) - global watch, filter by sync-enabled
-        console.log('[JetstreamPoller] Polling subscriptions stream');
         const subscriptionsResult = await this.pollSubscriptionsStream();
         stats.subscriptions = subscriptionsResult;
 
         // 2. Documents (site.standard.document) - filter to followed users
-        console.log('[JetstreamPoller] Polling documents stream');
         const documentsResult = await this.pollDocumentsStream();
         stats.documents = documentsResult;
       } catch (error) {
-        console.error('[JetstreamPoller] Error during poll cycle:', error);
+        log.error('jetstream_poll_failed', { ...serializeError(error) });
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'poll-cycle' } });
       }
 
@@ -164,15 +188,27 @@ class JetstreamPollerBase implements DurableObject {
         console.error('[JetstreamPoller] Error saving stats:', error);
       }
 
-      console.log(
-        `[JetstreamPoller] Poll complete: ` +
-          `subscriptions=${stats.subscriptions.processed}/${stats.subscriptions.errors}, ` +
-          `documents=${stats.documents.processed}/${stats.documents.errors}, ` +
-          `duration=${stats.duration}ms`
-      );
+      // Jetstream cursors are microsecond timestamps, so `now - cursor` is how far
+      // behind the firehose we are. Logging it every cycle turns "the firehose is
+      // stalled" from something you notice when shares stop appearing into a
+      // number with a history.
+      const [subscriptionsLagMs, documentsLagMs] = await Promise.all([
+        this.cursorLagMs('cursor_subscriptions'),
+        this.cursorLagMs('cursor_documents'),
+      ]);
+
+      log.info('jetstream_poll', {
+        subscriptionsProcessed: stats.subscriptions.processed,
+        subscriptionsErrors: stats.subscriptions.errors,
+        documentsProcessed: stats.documents.processed,
+        documentsErrors: stats.documents.errors,
+        subscriptionsLagMs,
+        documentsLagMs,
+        durationMs: stats.duration,
+      });
     } catch (error) {
       // Catch-all for any unexpected errors
-      console.error('[JetstreamPoller] UNEXPECTED ERROR in alarm handler:', error);
+      log.error('jetstream_alarm_failed', { ...serializeError(error) });
       reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm' } });
     } finally {
       // ALWAYS schedule next poll - this runs even if an error occurred above
@@ -184,6 +220,24 @@ class JetstreamPollerBase implements DurableObject {
         console.error('[JetstreamPoller] CRITICAL: Error scheduling next alarm:', error);
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm-scheduling' } });
       }
+    }
+  }
+
+  /**
+   * How far behind real time the stored cursor is, in ms. Null when the stream
+   * has no cursor yet (first ever poll) — that's "unknown", not "zero lag".
+   */
+  private async cursorLagMs(
+    key: 'cursor_subscriptions' | 'cursor_documents'
+  ): Promise<number | null> {
+    try {
+      const cursor = await this.state.storage.get<string>(key);
+      if (!cursor) return null;
+      const cursorUs = Number(cursor);
+      if (!Number.isFinite(cursorUs) || cursorUs <= 0) return null;
+      return Math.max(0, Date.now() - Math.round(cursorUs / 1000));
+    } catch {
+      return null;
     }
   }
 

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -104,20 +104,37 @@ class JetstreamPollerBase implements DurableObject {
     }
 
     if (url.pathname === '/status') {
-      const [subscriptionsCursor, documentsCursor, lastStats, alarmTime, lastAlarmStart] =
-        await Promise.all([
-          this.state.storage.get<string>('cursor_subscriptions'),
-          this.state.storage.get<string>('cursor_documents'),
-          this.state.storage.get<PollStats>('last_stats'),
-          this.state.storage.getAlarm(),
-          this.state.storage.get<number>('last_alarm_start'),
-        ]);
+      const [
+        subscriptionsCursor,
+        documentsCursor,
+        lastStats,
+        alarmTime,
+        lastAlarmStart,
+        subscriptionsLagMs,
+        documentsLagMs,
+      ] = await Promise.all([
+        this.state.storage.get<string>('cursor_subscriptions'),
+        this.state.storage.get<string>('cursor_documents'),
+        this.state.storage.get<PollStats>('last_stats'),
+        this.state.storage.getAlarm(),
+        this.state.storage.get<number>('last_alarm_start'),
+        this.cursorLagMs('cursor_subscriptions'),
+        this.cursorLagMs('cursor_documents'),
+      ]);
 
       return new Response(
         JSON.stringify({
           cursors: {
             subscriptions: subscriptionsCursor,
             documents: documentsCursor,
+          },
+          // Lag is derived here rather than by each caller: turning a cursor into
+          // a number of milliseconds behind real time takes knowing that Jetstream
+          // cursors are microsecond timestamps, and that knowledge should live in
+          // exactly one place. Null means "no cursor yet", not "zero lag".
+          lag: {
+            subscriptionsMs: subscriptionsLagMs,
+            documentsMs: documentsLagMs,
           },
           lastStats,
           nextPoll: alarmTime,

--- a/backend/src/env.d.ts
+++ b/backend/src/env.d.ts
@@ -2,6 +2,18 @@
 declare namespace Cloudflare {
   interface Env {
     FEED_PROXY_SECRET: string;
+    // Observability. All optional: unset means "that signal is off", which is the
+    // correct behavior in local dev, tests, and CI.
+    //   SENTRY_DSN          - secret; error reporting is a no-op without it
+    //   SENTRY_ENVIRONMENT  - [vars]; "production" / "staging"
+    //   GIT_COMMIT_SHA      - passed by CI (`--var GIT_COMMIT_SHA:...`); the /api/health version
+    //   HEARTBEAT_URL       - secret; dead-man's-switch ping URL for the every-minute cron
+    //   HEALTH_CHECK_SECRET - secret; gates /api/health/deep via the X-Health-Secret header
+    SENTRY_DSN?: string;
+    SENTRY_ENVIRONMENT?: string;
+    GIT_COMMIT_SHA?: string;
+    HEARTBEAT_URL?: string;
+    HEALTH_CHECK_SECRET?: string;
     // Public base for users' linkblogs (linkblogs.skyreader.app). A [vars] entry,
     // so cf-typegen also emits it; declared here too for envs typed without it.
     LINKBLOG_PUBLIC_URL?: string;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -98,8 +98,10 @@ import { handleHealth, handleDeepHealth } from './routes/health';
 import { resolveSessionFromRequest, updateUserActivity } from './services/oauth';
 import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './services/rate-limit';
 import * as Sentry from '@sentry/cloudflare';
-import { sentryOptions, reportError } from './observability/sentry';
+import { sentryOptions, reportError, tagRequestId } from './observability/sentry';
 import { pingHeartbeat } from './observability/heartbeat';
+import { log, serializeError } from './utils/logger';
+import { classifyRoute, runWithRequestContext, setContextDid } from './utils/request-context';
 
 export { JetstreamPoller } from './durable-objects/jetstream-poller';
 
@@ -116,6 +118,9 @@ function corsHeaders(origin: string | null, env: Env): HeadersInit {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Access-Control-Allow-Credentials': 'true',
+    // So a browser client can read the correlation id off a failed response and
+    // quote it in a bug report.
+    'Access-Control-Expose-Headers': 'X-Request-Id',
   };
 }
 
@@ -159,574 +164,636 @@ function isHealthPath(pathname: string): boolean {
   return pathname === '/api/health' || pathname === '/api/health/deep';
 }
 
+// The routed request. Wrapped by `fetch` below, which owns the request context,
+// the summary log line, and the X-Request-Id echo.
+async function serveRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  const url = new URL(request.url);
+  const origin = request.headers.get('Origin');
+  const headers = corsHeaders(origin, env);
+
+  // Handle CORS preflight
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { headers });
+  }
+
+  if (isHealthPath(url.pathname)) {
+    const health =
+      url.pathname === '/api/health' ? handleHealth(env) : await handleDeepHealth(request, env);
+    const healthHeaders = new Headers(health.headers);
+    Object.entries(headers).forEach(([key, value]) => healthHeaders.set(key, value as string));
+    return new Response(health.body, { status: health.status, headers: healthHeaders });
+  }
+
+  // Track user activity for authenticated requests (non-blocking)
+  const sessionResult = await resolveSessionFromRequest(request, env);
+  const session = sessionResult.session;
+  if (session) {
+    // Correlation key for every subsequent log line and Sentry event on this
+    // request. A DID is a public identifier — see observability/scrub.ts.
+    setContextDid(session.did);
+    ctx.waitUntil(updateUserActivity(env, session.did));
+
+    // Check rate limit for authenticated requests
+    const rateLimit = await checkRateLimit(env, session.did, url.pathname);
+    if (!rateLimit.allowed) {
+      const config = getRateLimitConfig(url.pathname);
+      return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
+        status: 429,
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+          'Retry-After': String(rateLimit.retryAfter || 60),
+          'X-RateLimit-Limit': String(config.limit),
+          'X-RateLimit-Remaining': '0',
+        },
+      });
+    }
+  } else if (sessionResult.reason === 'transient' && !isPublicPath(url.pathname)) {
+    // The user still has a valid session, we just couldn't refresh its token in
+    // time (e.g. concurrent request burst right after a deploy). Tell the client to
+    // retry instead of returning the 401 that would tear down its auth.
+    return sessionRetryResponse(headers);
+  }
+
+  try {
+    let response: Response;
+
+    // Route matching
+    switch (true) {
+      // Test-only D1 exec endpoint (e2e seed/cleanup). Mounted only when
+      // E2E_TEST_MODE is set, so it's unreachable in production.
+      case url.pathname === '/api/test/exec' && env.E2E_TEST_MODE === 'true':
+        response = await handleTestExec(request, env);
+        break;
+
+      // OAuth client metadata
+      case url.pathname === '/.well-known/client-metadata':
+        response = await handleClientMetadata(request, env);
+        break;
+
+      // Lexicon schemas
+      case url.pathname === '/.well-known/lexicons':
+        response = handleLexiconIndex();
+        break;
+      case url.pathname.startsWith('/.well-known/lexicons/'):
+        response = handleLexicon(request);
+        break;
+
+      // Auth routes
+      case url.pathname === '/api/auth/login':
+        response = await handleAuthLogin(request, env);
+        break;
+      case url.pathname === '/api/auth/callback':
+        response = await handleAuthCallback(request, env, ctx);
+        break;
+      case url.pathname === '/api/auth/logout':
+        response = await handleAuthLogout(request, env);
+        break;
+      case url.pathname === '/api/auth/me':
+        response = await handleAuthMe(request, env);
+        break;
+
+      // Feed routes (v2 via Fly.io proxy)
+      case url.pathname === '/api/v2/feeds/fetch':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2FeedFetch(request, env);
+        break;
+      case url.pathname === '/api/v2/feeds/batch':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2BatchFeedFetch(request, env, session);
+        break;
+      case url.pathname === '/api/v2/feeds/discover':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2FeedDiscover(request, env);
+        break;
+      case url.pathname === '/api/v2/documents/batch':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2BatchDocumentFetch(request, env, session);
+        break;
+      case url.pathname === '/api/v2/documents/get':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2GetDocument(request, env, session);
+        break;
+      case url.pathname === '/api/v2/social-context':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2SocialContext(request, env);
+        break;
+      case url.pathname === '/api/v2/mentions':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2Mentions(request, env);
+        break;
+      case url.pathname === '/api/v2/mention-lane':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleV2MentionLane(request, env);
+        break;
+
+      // Social routes
+      case url.pathname === '/api/social/detect-content':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleDetectContent(request, env);
+        break;
+      // Linkblog discovery — find friends with linkblogs / browse all (Phase 6)
+      case url.pathname === '/api/linkblog/discover/friends':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleDiscoverFriends(request, env);
+        break;
+      case url.pathname === '/api/linkblog/discover':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleDiscover(request, env);
+        break;
+
+      // Linkblog endpoints — sharing as portable site.standard.document records
+      case url.pathname === '/api/linkblog/share':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleCreateLinkblogShare(request, env);
+        break;
+      case url.pathname.startsWith('/api/linkblog/share/'):
+        if (!session) return unauthorizedResponse(headers);
+        response =
+          request.method === 'PATCH'
+            ? await handleUpdateLinkblogShare(request, env)
+            : await handleDeleteLinkblogShare(request, env);
+        break;
+      case url.pathname === '/api/linkblog/publication':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'GET') {
+          response = await handleGetPublication(request, env);
+        } else if (request.method === 'DELETE') {
+          response = await handleDeletePublication(request, env);
+        } else if (request.method === 'POST') {
+          response = await handleRestorePublication(request, env);
+        } else {
+          response = await handleUpdatePublication(request, env);
+        }
+        break;
+      case url.pathname === '/api/linkblog/publications':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleListPublications(request, env);
+        break;
+      case url.pathname === '/api/linkblog/publication/connect':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleConnectPublication(request, env);
+        break;
+      case url.pathname.startsWith('/api/linkblog/resolve/'):
+        response = await handleResolvePublication(request, env);
+        break;
+
+      // Subscribe via the Atmosphere — writes the portable
+      // site.standard.graph.subscription record, and (for a signed-in user)
+      // also creates the matching local reader subscription.
+      case url.pathname === '/api/atmosphere/subscription':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleAtmosphereSubscription(request, env, ctx);
+        break;
+
+      // Subscriptions endpoints (new)
+      case url.pathname === '/api/subscriptions':
+        if (!session) return unauthorizedResponse(headers);
+        response =
+          request.method === 'GET'
+            ? await handleListSubscriptions(request, env)
+            : await handleCreateSubscription(request, env, ctx);
+        break;
+      case url.pathname === '/api/subscriptions/bulk':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleBulkCreateSubscriptions(request, env, ctx);
+        break;
+      case url.pathname === '/api/subscriptions/bulk-update':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleBulkUpdateSubscriptions(request, env, ctx);
+        break;
+      case url.pathname === '/api/subscriptions/bulk-delete':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleBulkDeleteSubscriptions(request, env, ctx);
+        break;
+      case url.pathname === '/api/subscriptions/parked':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleListParkedSubscriptions(request, env);
+        break;
+      case url.pathname.endsWith('/activate') && url.pathname.startsWith('/api/subscriptions/'):
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSetSubscriptionActive(request, env, true);
+        break;
+      case url.pathname.endsWith('/park') && url.pathname.startsWith('/api/subscriptions/'):
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSetSubscriptionActive(request, env, false);
+        break;
+      case url.pathname.startsWith('/api/subscriptions/'):
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'DELETE') {
+          response = await handleDeleteSubscription(request, env, ctx);
+        } else if (request.method === 'PATCH') {
+          response = await handleUpdateSubscription(request, env, ctx);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+
+      // Record list route (sync routes removed - use dedicated endpoints)
+      case url.pathname === '/api/records/list':
+        response = await handleRecordsList(request, env);
+        break;
+
+      // Reading routes (read positions)
+      case url.pathname === '/api/reading/positions':
+        response = await handleGetReadPositions(request, env);
+        break;
+      case url.pathname === '/api/reading/mark-read':
+        response = await handleMarkAsRead(request, env);
+        break;
+      case url.pathname === '/api/reading/mark-unread':
+        response = await handleMarkAsUnread(request, env);
+        break;
+      case url.pathname === '/api/reading/mark-read-bulk':
+        response = await handleBulkMarkAsRead(request, env);
+        break;
+
+      // Labels routes (unified item labels)
+      case url.pathname === '/api/labels':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'GET') {
+          response = await handleGetLabels(request, env);
+        } else if (request.method === 'POST') {
+          response = await handleAddLabel(request, env);
+        } else if (request.method === 'DELETE') {
+          response = await handleDeleteLabel(request, env);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+      case url.pathname === '/api/labels/bulk':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleBulkAddLabels(request, env);
+        break;
+
+      // Article extraction route (fetch + Defuddle via the feed proxy)
+      case url.pathname === '/api/extract':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleExtract(request, env);
+        break;
+
+      // Saved routes
+      case url.pathname === '/api/saved':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'GET') {
+          response = await handleGetSaved(request, env, ctx);
+        } else if (request.method === 'POST') {
+          response = await handleCreateSaved(request, env, ctx);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+      case url.pathname === '/api/saved/status':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSavedStatus(request, env);
+        break;
+      case url.pathname.startsWith('/api/saved/by-guid/'):
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleDeleteSavedByGuid(request, env, ctx);
+        break;
+      case url.pathname === '/api/saved/backing':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSetBacking(request, env);
+        break;
+      case url.pathname === '/api/saved/bodies':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleGetSavedBodies(request, env);
+        break;
+      case url.pathname.startsWith('/api/saved/'):
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'PATCH') {
+          response = await handleUpdateSaved(request, env);
+        } else {
+          response = await handleDeleteSaved(request, env, ctx);
+        }
+        break;
+
+      // Settings routes
+      case url.pathname === '/api/settings':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'PUT') {
+          response = await handleUpdateSettings(request, env);
+        } else {
+          response = await handleGetSettings(request, env);
+        }
+        break;
+
+      // Magazine routes (durable, cross-device reading issues)
+      case url.pathname === '/api/magazines':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'GET') {
+          response = await handleGetMagazines(request, env);
+        } else if (request.method === 'POST') {
+          response = await handleUpsertMagazine(request, env);
+        } else if (request.method === 'DELETE') {
+          response = await handleDeleteMagazine(request, env);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+      case url.pathname === '/api/magazines/position':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'PATCH') {
+          response = await handleUpdateMagazinePosition(request, env);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+
+      // Integration routes
+      case url.pathname === '/api/integrations/status':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleIntegrationStatus(request, env);
+        break;
+      case url.pathname === '/api/integrations/semble/cards':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method !== 'POST') {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        } else {
+          response = await handleCreateSembleCard(request, env);
+        }
+        break;
+      case url.pathname === '/api/integrations/semble/collections':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleListSembleCollections(request, env);
+        break;
+      case url.pathname === '/api/integrations/margin/bookmarks':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method !== 'POST') {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        } else {
+          response = await handleCreateMarginBookmark(request, env);
+        }
+        break;
+      case url.pathname === '/api/integrations/margin/collections':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleListMarginCollections(request, env);
+        break;
+      case url.pathname === '/api/integrations/margin/notes':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method !== 'POST') {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        } else {
+          response = await handleCreateMarginNote(request, env);
+        }
+        break;
+      case url.pathname.startsWith('/api/integrations/margin/notes/'):
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'DELETE') {
+          response = await handleDeleteMarginNote(request, env);
+        } else if (request.method === 'PUT') {
+          response = await handleUpdateMarginNote(request, env);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+
+      // Channels routes
+      case url.pathname === '/api/channels':
+        if (!session) return unauthorizedResponse(headers);
+        if (request.method === 'GET') {
+          response = await handleGetChannels(request, env);
+        } else if (request.method === 'PUT') {
+          response = await handleSyncChannels(request, env);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+      case url.pathname.startsWith('/api/channels/'): {
+        if (!session) return unauthorizedResponse(headers);
+        const channelUuid = url.pathname.split('/').pop()!;
+        if (request.method === 'PUT') {
+          response = await handleUpsertChannel(request, env, channelUuid);
+        } else if (request.method === 'DELETE') {
+          response = await handleDeleteChannel(request, env, channelUuid);
+        } else {
+          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        break;
+      }
+
+      // Sync routes
+      case url.pathname === '/api/sync/full':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleFullSync(request, env, ctx);
+        break;
+      case url.pathname === '/api/sync/subscriptions':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSyncSubscriptions(request, env);
+        break;
+      case url.pathname === '/api/sync/status':
+        if (!session) return unauthorizedResponse(headers);
+        response = await handleSyncStatus(request, env);
+        break;
+
+      // AT Intents service endpoints (XRPC procedures). No top-level session guard:
+      // the handlers return XRPC-shaped `{ error, message }` auth errors themselves.
+      case url.pathname === '/xrpc/app.skyreader.feed.save':
+        response = await handleXrpcSave(request, env, ctx);
+        break;
+      case url.pathname === '/xrpc/app.skyreader.feed.subscribe':
+        response = await handleXrpcSubscribe(request, env, ctx);
+        break;
+      case url.pathname === '/xrpc/app.skyreader.linkblog.share':
+        response = await handleXrpcLinkblogShare(request, env);
+        break;
+
+      default:
+        response = new Response(JSON.stringify({ error: 'Not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+    }
+
+    // Add CORS headers to response
+    const newHeaders = new Headers(response.headers);
+    Object.entries(headers).forEach(([key, value]) => {
+      newHeaders.set(key, value);
+    });
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: newHeaders,
+    });
+  } catch (error) {
+    // Workers Logs stays the quick-look tool; Sentry is what groups, dedupes,
+    // and notifies. Both, deliberately — and both carry the request id, which
+    // is what lets a Sentry event find its log line.
+    log.error('request_error', { method: request.method, ...serializeError(error) });
+    reportError(error, {
+      tags: { source: 'fetch', route: classifyRoute(url.pathname) },
+      extra: { method: request.method, path: url.pathname },
+    });
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+  }
+}
+
 const handler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
-    const origin = request.headers.get('Origin');
-    const headers = corsHeaders(origin, env);
+    const requestId = crypto.randomUUID();
+    const started = Date.now();
 
-    // Handle CORS preflight
-    if (request.method === 'OPTIONS') {
-      return new Response(null, { headers });
-    }
+    // Minted here, never accepted from the client: a caller that sent a constant
+    // id would silently merge unrelated requests in the logs. The response header
+    // is how a client (or a bug report) learns the id it should quote.
+    return runWithRequestContext(
+      { requestId, route: classifyRoute(url.pathname), method: request.method },
+      async () => {
+        tagRequestId(requestId);
+        const response = await serveRequest(request, env, ctx);
 
-    if (isHealthPath(url.pathname)) {
-      const health =
-        url.pathname === '/api/health' ? handleHealth(env) : await handleDeepHealth(request, env);
-      const healthHeaders = new Headers(health.headers);
-      Object.entries(headers).forEach(([key, value]) => healthHeaders.set(key, value as string));
-      return new Response(health.body, { status: health.status, headers: healthHeaders });
-    }
-
-    // Track user activity for authenticated requests (non-blocking)
-    const sessionResult = await resolveSessionFromRequest(request, env);
-    const session = sessionResult.session;
-    if (session) {
-      ctx.waitUntil(updateUserActivity(env, session.did));
-
-      // Check rate limit for authenticated requests
-      const rateLimit = await checkRateLimit(env, session.did, url.pathname);
-      if (!rateLimit.allowed) {
-        const config = getRateLimitConfig(url.pathname);
-        return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
-          status: 429,
-          headers: {
-            ...headers,
-            'Content-Type': 'application/json',
-            'Retry-After': String(rateLimit.retryAfter || 60),
-            'X-RateLimit-Limit': String(config.limit),
-            'X-RateLimit-Remaining': '0',
-          },
-        });
-      }
-    } else if (sessionResult.reason === 'transient' && !isPublicPath(url.pathname)) {
-      // The user still has a valid session, we just couldn't refresh its token in
-      // time (e.g. concurrent request burst right after a deploy). Tell the client to
-      // retry instead of returning the 401 that would tear down its auth.
-      return sessionRetryResponse(headers);
-    }
-
-    try {
-      let response: Response;
-
-      // Route matching
-      switch (true) {
-        // Test-only D1 exec endpoint (e2e seed/cleanup). Mounted only when
-        // E2E_TEST_MODE is set, so it's unreachable in production.
-        case url.pathname === '/api/test/exec' && env.E2E_TEST_MODE === 'true':
-          response = await handleTestExec(request, env);
-          break;
-
-        // OAuth client metadata
-        case url.pathname === '/.well-known/client-metadata':
-          response = await handleClientMetadata(request, env);
-          break;
-
-        // Lexicon schemas
-        case url.pathname === '/.well-known/lexicons':
-          response = handleLexiconIndex();
-          break;
-        case url.pathname.startsWith('/.well-known/lexicons/'):
-          response = handleLexicon(request);
-          break;
-
-        // Auth routes
-        case url.pathname === '/api/auth/login':
-          response = await handleAuthLogin(request, env);
-          break;
-        case url.pathname === '/api/auth/callback':
-          response = await handleAuthCallback(request, env, ctx);
-          break;
-        case url.pathname === '/api/auth/logout':
-          response = await handleAuthLogout(request, env);
-          break;
-        case url.pathname === '/api/auth/me':
-          response = await handleAuthMe(request, env);
-          break;
-
-        // Feed routes (v2 via Fly.io proxy)
-        case url.pathname === '/api/v2/feeds/fetch':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2FeedFetch(request, env);
-          break;
-        case url.pathname === '/api/v2/feeds/batch':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2BatchFeedFetch(request, env, session);
-          break;
-        case url.pathname === '/api/v2/feeds/discover':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2FeedDiscover(request, env);
-          break;
-        case url.pathname === '/api/v2/documents/batch':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2BatchDocumentFetch(request, env, session);
-          break;
-        case url.pathname === '/api/v2/documents/get':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2GetDocument(request, env, session);
-          break;
-        case url.pathname === '/api/v2/social-context':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2SocialContext(request, env);
-          break;
-        case url.pathname === '/api/v2/mentions':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2Mentions(request, env);
-          break;
-        case url.pathname === '/api/v2/mention-lane':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleV2MentionLane(request, env);
-          break;
-
-        // Social routes
-        case url.pathname === '/api/social/detect-content':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleDetectContent(request, env);
-          break;
-        // Linkblog discovery — find friends with linkblogs / browse all (Phase 6)
-        case url.pathname === '/api/linkblog/discover/friends':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleDiscoverFriends(request, env);
-          break;
-        case url.pathname === '/api/linkblog/discover':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleDiscover(request, env);
-          break;
-
-        // Linkblog endpoints — sharing as portable site.standard.document records
-        case url.pathname === '/api/linkblog/share':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleCreateLinkblogShare(request, env);
-          break;
-        case url.pathname.startsWith('/api/linkblog/share/'):
-          if (!session) return unauthorizedResponse(headers);
-          response =
-            request.method === 'PATCH'
-              ? await handleUpdateLinkblogShare(request, env)
-              : await handleDeleteLinkblogShare(request, env);
-          break;
-        case url.pathname === '/api/linkblog/publication':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'GET') {
-            response = await handleGetPublication(request, env);
-          } else if (request.method === 'DELETE') {
-            response = await handleDeletePublication(request, env);
-          } else if (request.method === 'POST') {
-            response = await handleRestorePublication(request, env);
-          } else {
-            response = await handleUpdatePublication(request, env);
-          }
-          break;
-        case url.pathname === '/api/linkblog/publications':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleListPublications(request, env);
-          break;
-        case url.pathname === '/api/linkblog/publication/connect':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleConnectPublication(request, env);
-          break;
-        case url.pathname.startsWith('/api/linkblog/resolve/'):
-          response = await handleResolvePublication(request, env);
-          break;
-
-        // Subscribe via the Atmosphere — writes the portable
-        // site.standard.graph.subscription record, and (for a signed-in user)
-        // also creates the matching local reader subscription.
-        case url.pathname === '/api/atmosphere/subscription':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleAtmosphereSubscription(request, env, ctx);
-          break;
-
-        // Subscriptions endpoints (new)
-        case url.pathname === '/api/subscriptions':
-          if (!session) return unauthorizedResponse(headers);
-          response =
-            request.method === 'GET'
-              ? await handleListSubscriptions(request, env)
-              : await handleCreateSubscription(request, env, ctx);
-          break;
-        case url.pathname === '/api/subscriptions/bulk':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleBulkCreateSubscriptions(request, env, ctx);
-          break;
-        case url.pathname === '/api/subscriptions/bulk-update':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleBulkUpdateSubscriptions(request, env, ctx);
-          break;
-        case url.pathname === '/api/subscriptions/bulk-delete':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleBulkDeleteSubscriptions(request, env, ctx);
-          break;
-        case url.pathname === '/api/subscriptions/parked':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleListParkedSubscriptions(request, env);
-          break;
-        case url.pathname.endsWith('/activate') && url.pathname.startsWith('/api/subscriptions/'):
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSetSubscriptionActive(request, env, true);
-          break;
-        case url.pathname.endsWith('/park') && url.pathname.startsWith('/api/subscriptions/'):
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSetSubscriptionActive(request, env, false);
-          break;
-        case url.pathname.startsWith('/api/subscriptions/'):
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'DELETE') {
-            response = await handleDeleteSubscription(request, env, ctx);
-          } else if (request.method === 'PATCH') {
-            response = await handleUpdateSubscription(request, env, ctx);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-
-        // Record list route (sync routes removed - use dedicated endpoints)
-        case url.pathname === '/api/records/list':
-          response = await handleRecordsList(request, env);
-          break;
-
-        // Reading routes (read positions)
-        case url.pathname === '/api/reading/positions':
-          response = await handleGetReadPositions(request, env);
-          break;
-        case url.pathname === '/api/reading/mark-read':
-          response = await handleMarkAsRead(request, env);
-          break;
-        case url.pathname === '/api/reading/mark-unread':
-          response = await handleMarkAsUnread(request, env);
-          break;
-        case url.pathname === '/api/reading/mark-read-bulk':
-          response = await handleBulkMarkAsRead(request, env);
-          break;
-
-        // Labels routes (unified item labels)
-        case url.pathname === '/api/labels':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'GET') {
-            response = await handleGetLabels(request, env);
-          } else if (request.method === 'POST') {
-            response = await handleAddLabel(request, env);
-          } else if (request.method === 'DELETE') {
-            response = await handleDeleteLabel(request, env);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-        case url.pathname === '/api/labels/bulk':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleBulkAddLabels(request, env);
-          break;
-
-        // Article extraction route (fetch + Defuddle via the feed proxy)
-        case url.pathname === '/api/extract':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleExtract(request, env);
-          break;
-
-        // Saved routes
-        case url.pathname === '/api/saved':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'GET') {
-            response = await handleGetSaved(request, env, ctx);
-          } else if (request.method === 'POST') {
-            response = await handleCreateSaved(request, env, ctx);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-        case url.pathname === '/api/saved/status':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSavedStatus(request, env);
-          break;
-        case url.pathname.startsWith('/api/saved/by-guid/'):
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleDeleteSavedByGuid(request, env, ctx);
-          break;
-        case url.pathname === '/api/saved/backing':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSetBacking(request, env);
-          break;
-        case url.pathname === '/api/saved/bodies':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleGetSavedBodies(request, env);
-          break;
-        case url.pathname.startsWith('/api/saved/'):
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'PATCH') {
-            response = await handleUpdateSaved(request, env);
-          } else {
-            response = await handleDeleteSaved(request, env, ctx);
-          }
-          break;
-
-        // Settings routes
-        case url.pathname === '/api/settings':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'PUT') {
-            response = await handleUpdateSettings(request, env);
-          } else {
-            response = await handleGetSettings(request, env);
-          }
-          break;
-
-        // Magazine routes (durable, cross-device reading issues)
-        case url.pathname === '/api/magazines':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'GET') {
-            response = await handleGetMagazines(request, env);
-          } else if (request.method === 'POST') {
-            response = await handleUpsertMagazine(request, env);
-          } else if (request.method === 'DELETE') {
-            response = await handleDeleteMagazine(request, env);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-        case url.pathname === '/api/magazines/position':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'PATCH') {
-            response = await handleUpdateMagazinePosition(request, env);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-
-        // Integration routes
-        case url.pathname === '/api/integrations/status':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleIntegrationStatus(request, env);
-          break;
-        case url.pathname === '/api/integrations/semble/cards':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method !== 'POST') {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          } else {
-            response = await handleCreateSembleCard(request, env);
-          }
-          break;
-        case url.pathname === '/api/integrations/semble/collections':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleListSembleCollections(request, env);
-          break;
-        case url.pathname === '/api/integrations/margin/bookmarks':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method !== 'POST') {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          } else {
-            response = await handleCreateMarginBookmark(request, env);
-          }
-          break;
-        case url.pathname === '/api/integrations/margin/collections':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleListMarginCollections(request, env);
-          break;
-        case url.pathname === '/api/integrations/margin/notes':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method !== 'POST') {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          } else {
-            response = await handleCreateMarginNote(request, env);
-          }
-          break;
-        case url.pathname.startsWith('/api/integrations/margin/notes/'):
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'DELETE') {
-            response = await handleDeleteMarginNote(request, env);
-          } else if (request.method === 'PUT') {
-            response = await handleUpdateMarginNote(request, env);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-
-        // Channels routes
-        case url.pathname === '/api/channels':
-          if (!session) return unauthorizedResponse(headers);
-          if (request.method === 'GET') {
-            response = await handleGetChannels(request, env);
-          } else if (request.method === 'PUT') {
-            response = await handleSyncChannels(request, env);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
-        case url.pathname.startsWith('/api/channels/'): {
-          if (!session) return unauthorizedResponse(headers);
-          const channelUuid = url.pathname.split('/').pop()!;
-          if (request.method === 'PUT') {
-            response = await handleUpsertChannel(request, env, channelUuid);
-          } else if (request.method === 'DELETE') {
-            response = await handleDeleteChannel(request, env, channelUuid);
-          } else {
-            response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-              status: 405,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          }
-          break;
+        // One summary line per request — route class, status, duration. This is
+        // the raw material for "what's slow" and "what's erroring" until metrics
+        // land, and it's why the log is worth querying at all.
+        //
+        // The shallow health check is exempt: an uptime poller hits it every 30s
+        // forever and the line carries no information the check's own history
+        // doesn't already have.
+        if (url.pathname !== '/api/health') {
+          log.info('request', {
+            method: request.method,
+            status: response.status,
+            durationMs: Date.now() - started,
+          });
         }
 
-        // Sync routes
-        case url.pathname === '/api/sync/full':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleFullSync(request, env, ctx);
-          break;
-        case url.pathname === '/api/sync/subscriptions':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSyncSubscriptions(request, env);
-          break;
-        case url.pathname === '/api/sync/status':
-          if (!session) return unauthorizedResponse(headers);
-          response = await handleSyncStatus(request, env);
-          break;
-
-        // AT Intents service endpoints (XRPC procedures). No top-level session guard:
-        // the handlers return XRPC-shaped `{ error, message }` auth errors themselves.
-        case url.pathname === '/xrpc/app.skyreader.feed.save':
-          response = await handleXrpcSave(request, env, ctx);
-          break;
-        case url.pathname === '/xrpc/app.skyreader.feed.subscribe':
-          response = await handleXrpcSubscribe(request, env, ctx);
-          break;
-        case url.pathname === '/xrpc/app.skyreader.linkblog.share':
-          response = await handleXrpcLinkblogShare(request, env);
-          break;
-
-        default:
-          response = new Response(JSON.stringify({ error: 'Not found' }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          });
+        const headers = new Headers(response.headers);
+        headers.set('X-Request-Id', requestId);
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
       }
-
-      // Add CORS headers to response
-      const newHeaders = new Headers(response.headers);
-      Object.entries(headers).forEach(([key, value]) => {
-        newHeaders.set(key, value);
-      });
-
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
-    } catch (error) {
-      // Workers Logs stays the quick-look tool; Sentry is what groups, dedupes,
-      // and notifies. Both, deliberately.
-      console.error('Request error:', error);
-      reportError(error, {
-        tags: { source: 'fetch', route: url.pathname },
-        extra: { method: request.method },
-      });
-      return new Response(JSON.stringify({ error: 'Internal server error' }), {
-        status: 500,
-        headers: { ...headers, 'Content-Type': 'application/json' },
-      });
-    }
+    );
   },
 
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    const cronStart = Date.now();
-    const minute = new Date().getMinutes();
-    const isEveryMinuteCron = controller.cron === '* * * * *';
+    // A cron run gets a correlation id too: every line it emits — and every
+    // Sentry event from a failing phase — carries the same `requestId`, so one
+    // filter shows the whole run.
+    return runWithRequestContext(
+      { requestId: crypto.randomUUID(), route: `cron ${controller.cron}` },
+      () => runScheduled(controller, env, ctx)
+    );
+  },
+} satisfies ExportedHandler<Env>;
 
-    console.log(`[Cron] Started: ${controller.cron}, minute=${minute}`);
+async function runScheduled(
+  controller: ScheduledController,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<void> {
+  const cronStart = Date.now();
+  const minute = new Date().getMinutes();
+  const isEveryMinuteCron = controller.cron === '* * * * *';
 
-    // Tracks whether this run did its job. The heartbeat at the end only fires on
-    // a clean run, so "cron throwing every minute" looks the same to the monitor
-    // as "cron never fired" — both are outages.
-    let cronHealthy = true;
+  log.info('cron_start', { cron: controller.cron, minute });
 
-    // Every minute: Cleanup tasks and ensure JetstreamPoller is running
-    if (isEveryMinuteCron) {
-      // Phase 1: Ensure JetstreamPoller DO is running
+  // Tracks whether this run did its job. The heartbeat at the end only fires on
+  // a clean run, so "cron throwing every minute" looks the same to the monitor
+  // as "cron never fired" — both are outages.
+  let cronHealthy = true;
+
+  // Every minute: Cleanup tasks and ensure JetstreamPoller is running
+  if (isEveryMinuteCron) {
+    // Phase 1: Ensure JetstreamPoller DO is running
+    try {
+      const pollerId = env.JETSTREAM_POLLER.idFromName('main-v2');
+      const poller = env.JETSTREAM_POLLER.get(pollerId);
+      const response = await poller.fetch('http://internal/start');
+      const result = (await response.json()) as { status: string };
+      log.info('cron_poller_ping', { pollerStatus: result.status });
+    } catch (error) {
+      log.error('cron_phase_failed', { phase: 'poller-start', ...serializeError(error) });
+      reportError(error, { tags: { source: 'cron', phase: 'poller-start' } });
+      cronHealthy = false;
+    }
+
+    // Phase 2: Clean up rate limit records
+    let rateLimitDuration = 0;
+    let rateLimitDeleted = 0;
+    try {
+      const result = await cleanupRateLimits(env);
+      rateLimitDeleted = result.deleted;
+      rateLimitDuration = result.duration;
+      if (rateLimitDeleted > 0) {
+        log.info('cron_rate_limit_cleanup', {
+          deleted: rateLimitDeleted,
+          durationMs: rateLimitDuration,
+        });
+      }
+    } catch (error) {
+      log.error('cron_phase_failed', { phase: 'rate-limit-cleanup', ...serializeError(error) });
+      reportError(error, { tags: { source: 'cron', phase: 'rate-limit-cleanup' } });
+      cronHealthy = false;
+    }
+
+    // Phase 3: Clean up expired D1 data (once per hour)
+    let d1CleanupDuration = 0;
+    if (minute === 0) {
+      log.info('cron_d1_cleanup_start');
+      const cleanupStart = Date.now();
+      const now = Date.now();
+      const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
+
+      let oauthDeleted = 0;
+      let sessionsDeleted = 0;
+      let labelTombstonesDeleted = 0;
+
+      // Clean up expired OAuth states
       try {
-        const pollerId = env.JETSTREAM_POLLER.idFromName('main-v2');
-        const poller = env.JETSTREAM_POLLER.get(pollerId);
-        const response = await poller.fetch('http://internal/start');
-        const result = (await response.json()) as { status: string };
-        console.log(`[Cron] JetstreamPoller: ${result.status}`);
+        const oauthResult = await env.DB.prepare('DELETE FROM oauth_state WHERE expires_at < ?')
+          .bind(now)
+          .run();
+        oauthDeleted = oauthResult.meta?.changes || 0;
       } catch (error) {
-        console.error('[Cron] Failed to start JetstreamPoller:', error);
-        reportError(error, { tags: { source: 'cron', phase: 'poller-start' } });
-        cronHealthy = false;
+        log.error('cron_phase_failed', { phase: 'oauth-state-cleanup', ...serializeError(error) });
+        reportError(error, { tags: { source: 'cron', phase: 'oauth-state-cleanup' } });
       }
 
-      // Phase 2: Clean up rate limit records
-      let rateLimitDuration = 0;
-      let rateLimitDeleted = 0;
+      // Clean up failed/expired sessions
       try {
-        const result = await cleanupRateLimits(env);
-        rateLimitDeleted = result.deleted;
-        rateLimitDuration = result.duration;
-        if (rateLimitDeleted > 0) {
-          console.log(
-            `[Cron] Rate limit cleanup: deleted ${rateLimitDeleted} records, ${rateLimitDuration}ms`
-          );
-        }
-      } catch (error) {
-        console.error('[Cron] Rate limit cleanup error:', error);
-        reportError(error, { tags: { source: 'cron', phase: 'rate-limit-cleanup' } });
-        cronHealthy = false;
-      }
-
-      // Phase 3: Clean up expired D1 data (once per hour)
-      let d1CleanupDuration = 0;
-      if (minute === 0) {
-        console.log('[Cron] Starting D1 cleanup');
-        const cleanupStart = Date.now();
-        const now = Date.now();
-        const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
-
-        let oauthDeleted = 0;
-        let sessionsDeleted = 0;
-        let labelTombstonesDeleted = 0;
-
-        // Clean up expired OAuth states
-        try {
-          const oauthResult = await env.DB.prepare('DELETE FROM oauth_state WHERE expires_at < ?')
-            .bind(now)
-            .run();
-          oauthDeleted = oauthResult.meta?.changes || 0;
-        } catch (error) {
-          console.error('[Cron] D1 WRITE ERROR deleting expired oauth_state:', error);
-          reportError(error, { tags: { source: 'cron', phase: 'oauth-state-cleanup' } });
-        }
-
-        // Clean up failed/expired sessions
-        try {
-          const sessionsResult = await env.DB.prepare(
-            `
+        const sessionsResult = await env.DB.prepare(
+          `
               DELETE FROM sessions
               WHERE (
                 refresh_failures >= 5
@@ -734,68 +801,84 @@ const handler = {
               )
               OR expires_at < ?
             `
-          )
-            .bind(now, thirtyDaysAgo)
-            .run();
-          sessionsDeleted = sessionsResult.meta?.changes || 0;
-        } catch (error) {
-          console.error('[Cron] D1 WRITE ERROR deleting expired sessions:', error);
-          reportError(error, { tags: { source: 'cron', phase: 'session-cleanup' } });
-        }
-
-        // Purge old label tombstones (soft-deleted archived/tagged AND read
-        // rows — un-read is now a soft-delete that rides the forward read delta).
-        // The retention must outlast any realistic delta-cursor staleness so a
-        // client offline for a while still replays the deletion; 90 days. The
-        // sweep is label- and type-agnostic, so read tombstones are covered with
-        // no change. deleted_at is unix seconds.
-        try {
-          const tombstoneCutoff = Math.floor(now / 1000) - 90 * 24 * 60 * 60;
-          const tombstoneResult = await env.DB.prepare(
-            'DELETE FROM item_labels_cache WHERE deleted_at IS NOT NULL AND deleted_at < ?'
-          )
-            .bind(tombstoneCutoff)
-            .run();
-          labelTombstonesDeleted = tombstoneResult.meta?.changes || 0;
-        } catch (error) {
-          console.error('[Cron] D1 WRITE ERROR purging label tombstones:', error);
-          reportError(error, { tags: { source: 'cron', phase: 'label-tombstone-purge' } });
-        }
-
-        // Purge old magazine tombstones (same 90-day retention as labels so a
-        // long-offline client still replays the deletion via its `?since=` delta).
-        try {
-          const magazineCutoff = Math.floor(now / 1000) - 90 * 24 * 60 * 60;
-          await env.DB.prepare(
-            'DELETE FROM magazines WHERE deleted_at IS NOT NULL AND deleted_at < ?'
-          )
-            .bind(magazineCutoff)
-            .run();
-        } catch (error) {
-          console.error('[Cron] D1 WRITE ERROR purging magazine tombstones:', error);
-          reportError(error, { tags: { source: 'cron', phase: 'magazine-tombstone-purge' } });
-        }
-
-        d1CleanupDuration = Date.now() - cleanupStart;
-        console.log(
-          `[Cron] D1 cleanup: deleted ${oauthDeleted} OAuth states, ${sessionsDeleted} sessions, ${labelTombstonesDeleted} label tombstones, ${d1CleanupDuration}ms`
-        );
+        )
+          .bind(now, thirtyDaysAgo)
+          .run();
+        sessionsDeleted = sessionsResult.meta?.changes || 0;
+      } catch (error) {
+        log.error('cron_phase_failed', { phase: 'session-cleanup', ...serializeError(error) });
+        reportError(error, { tags: { source: 'cron', phase: 'session-cleanup' } });
       }
 
-      const totalDuration = Date.now() - cronStart;
-      console.log(`[Cron] Every-minute complete: total=${totalDuration}ms`);
-
-      // Dead-man's switch. Fire-and-forget so a slow monitor can never extend or
-      // fail the cron. Skipped on a failed run so the monitor's grace period
-      // expires and pages — that's the whole point of the switch.
-      if (cronHealthy) {
-        ctx.waitUntil(pingHeartbeat(env.HEARTBEAT_URL, 'cron'));
-      } else {
-        console.warn('[Cron] Skipping heartbeat: run had failures');
+      // Purge old label tombstones (soft-deleted archived/tagged AND read
+      // rows — un-read is now a soft-delete that rides the forward read delta).
+      // The retention must outlast any realistic delta-cursor staleness so a
+      // client offline for a while still replays the deletion; 90 days. The
+      // sweep is label- and type-agnostic, so read tombstones are covered with
+      // no change. deleted_at is unix seconds.
+      try {
+        const tombstoneCutoff = Math.floor(now / 1000) - 90 * 24 * 60 * 60;
+        const tombstoneResult = await env.DB.prepare(
+          'DELETE FROM item_labels_cache WHERE deleted_at IS NOT NULL AND deleted_at < ?'
+        )
+          .bind(tombstoneCutoff)
+          .run();
+        labelTombstonesDeleted = tombstoneResult.meta?.changes || 0;
+      } catch (error) {
+        log.error('cron_phase_failed', {
+          phase: 'label-tombstone-purge',
+          ...serializeError(error),
+        });
+        reportError(error, { tags: { source: 'cron', phase: 'label-tombstone-purge' } });
       }
+
+      // Purge old magazine tombstones (same 90-day retention as labels so a
+      // long-offline client still replays the deletion via its `?since=` delta).
+      try {
+        const magazineCutoff = Math.floor(now / 1000) - 90 * 24 * 60 * 60;
+        await env.DB.prepare(
+          'DELETE FROM magazines WHERE deleted_at IS NOT NULL AND deleted_at < ?'
+        )
+          .bind(magazineCutoff)
+          .run();
+      } catch (error) {
+        log.error('cron_phase_failed', {
+          phase: 'magazine-tombstone-purge',
+          ...serializeError(error),
+        });
+        reportError(error, { tags: { source: 'cron', phase: 'magazine-tombstone-purge' } });
+      }
+
+      d1CleanupDuration = Date.now() - cleanupStart;
+      log.info('cron_d1_cleanup', {
+        oauthStatesDeleted: oauthDeleted,
+        sessionsDeleted,
+        labelTombstonesDeleted,
+        durationMs: d1CleanupDuration,
+      });
     }
-  },
-} satisfies ExportedHandler<Env>;
+
+    // The run summary. `durationMs` is the number to watch as the cron takes on
+    // more work (see the cron-budget risk in the observability plan): it has a
+    // hard 60s ceiling before runs start overlapping.
+    log.info('cron_run', {
+      cron: controller.cron,
+      healthy: cronHealthy,
+      durationMs: Date.now() - cronStart,
+      d1CleanupDurationMs: d1CleanupDuration,
+      rateLimitDeleted,
+    });
+
+    // Dead-man's switch. Fire-and-forget so a slow monitor can never extend or
+    // fail the cron. Skipped on a failed run so the monitor's grace period
+    // expires and pages — that's the whole point of the switch.
+    if (cronHealthy) {
+      ctx.waitUntil(pingHeartbeat(env.HEARTBEAT_URL, 'cron'));
+    } else {
+      log.warn('cron_heartbeat_skipped', { reason: 'run had failures' });
+    }
+  }
+}
 
 // Wrapping the exported handler instruments both `fetch` and `scheduled`; the
 // JetstreamPoller DO is instrumented separately at its own export.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -101,6 +101,13 @@ import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './service
 import * as Sentry from '@sentry/cloudflare';
 import { sentryOptions, reportError, tagRequestId } from './observability/sentry';
 import { pingHeartbeat } from './observability/heartbeat';
+import {
+  recordPollerStatus,
+  recordProxyStats,
+  recordCronRun,
+  writeMetricsSnapshot,
+  runRecordingStep,
+} from './observability/ops-metrics';
 import { log, serializeError } from './utils/logger';
 import { classifyRoute, runWithRequestContext, setContextDid } from './utils/request-context';
 
@@ -753,6 +760,19 @@ async function runScheduled(
       cronHealthy = false;
     }
 
+    // Phase 1b: Record what the poller knows. The /start ping above only asks
+    // "are you alive"; /status carries the firehose lag, the last cycle's error
+    // counts and the alarm state — all of which were being discarded. Storing it
+    // is what lets the admin show poller health, and what makes the lag threshold
+    // alert possible at all.
+    await runRecordingStep('poller-status', () => recordPollerStatus(env));
+
+    // Every 5th minute: the proxy's cache stats. Its own cadence because it's a
+    // cross-cloud fetch and the cron has a 60s ceiling to respect.
+    if (minute % 5 === 0) {
+      await runRecordingStep('proxy-stats', () => recordProxyStats(env));
+    }
+
     // Phase 2: Clean up rate limit records
     let rateLimitDuration = 0;
     let rateLimitDeleted = 0;
@@ -861,18 +881,35 @@ async function runScheduled(
         labelTombstonesDeleted,
         durationMs: d1CleanupDuration,
       });
+
+      // Hourly trend point. Runs after the proxy-stats refresh above (minute 0 is
+      // a multiple of 5), so the snapshot reads fresh values rather than
+      // five-minute-old ones. Prunes its own tail at 90 days.
+      await runRecordingStep('metrics-snapshot', () => writeMetricsSnapshot(env));
     }
 
     // The run summary. `durationMs` is the number to watch as the cron takes on
     // more work (see the cron-budget risk in the observability plan): it has a
     // hard 60s ceiling before runs start overlapping.
+    const cronDuration = Date.now() - cronStart;
     log.info('cron_run', {
       cron: controller.cron,
       healthy: cronHealthy,
-      durationMs: Date.now() - cronStart,
+      durationMs: cronDuration,
       d1CleanupDurationMs: d1CleanupDuration,
       rateLimitDeleted,
     });
+
+    // The same fact the heartbeat pushes to the monitor, kept locally: the admin
+    // shows "last run 40s ago" from this row, which works in staging and local dev
+    // where no monitor is configured at all.
+    await runRecordingStep('cron-last-run', () =>
+      recordCronRun(env, {
+        cron: controller.cron,
+        healthy: cronHealthy,
+        durationMs: cronDuration,
+      })
+    );
 
     // Dead-man's switch. Fire-and-forget so a slow monitor can never extend or
     // fail the cron. Skipped on a failed run so the monitor's grace period

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,6 +96,7 @@ import {
 } from './routes/channels';
 import { handleTestExec } from './routes/test-utils';
 import { handleHealth, handleDeepHealth } from './routes/health';
+import { handleTelemetryError } from './routes/telemetry';
 import { resolveSessionFromRequest, updateUserActivity } from './services/oauth';
 import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './services/rate-limit';
 import * as Sentry from '@sentry/cloudflare';
@@ -184,6 +185,36 @@ async function serveRequest(request: Request, env: Env, ctx: ExecutionContext): 
     return new Response(null, { headers });
   }
 
+  // The try opens here rather than after session resolution: a D1 blip inside
+  // `resolveSessionFromRequest` or the rate-limit check used to escape the whole
+  // handler, which meant no summary line, no `request_error`, no CORS headers and
+  // no X-Request-Id on the runtime's bare 500 — the one class of failure you most
+  // want correlated.
+  try {
+    return await route(request, env, ctx, url, headers);
+  } catch (error) {
+    // Workers Logs stays the quick-look tool; Sentry is what groups, dedupes,
+    // and notifies. Both, deliberately — and both carry the request id, which
+    // is what lets a Sentry event find its log line.
+    log.error('request_error', { method: request.method, ...serializeError(error) });
+    reportError(error, {
+      tags: { source: 'fetch', route: classifyRoute(url.pathname) },
+      extra: { method: request.method, path: url.pathname },
+    });
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+async function route(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  url: URL,
+  headers: HeadersInit
+): Promise<Response> {
   if (isHealthPath(url.pathname)) {
     const health =
       url.pathname === '/api/health' ? handleHealth(env) : await handleDeepHealth(request, env);
@@ -223,458 +254,451 @@ async function serveRequest(request: Request, env: Env, ctx: ExecutionContext): 
     return sessionRetryResponse(headers);
   }
 
-  try {
-    let response: Response;
+  let response: Response;
 
-    // Route matching
-    switch (true) {
-      // Test-only D1 exec endpoint (e2e seed/cleanup). Mounted only when
-      // E2E_TEST_MODE is set, so it's unreachable in production.
-      case url.pathname === '/api/test/exec' && env.E2E_TEST_MODE === 'true':
-        response = await handleTestExec(request, env);
-        break;
+  // Route matching
+  switch (true) {
+    // Test-only D1 exec endpoint (e2e seed/cleanup). Mounted only when
+    // E2E_TEST_MODE is set, so it's unreachable in production.
+    case url.pathname === '/api/test/exec' && env.E2E_TEST_MODE === 'true':
+      response = await handleTestExec(request, env);
+      break;
 
-      // OAuth client metadata
-      case url.pathname === '/.well-known/client-metadata':
-        response = await handleClientMetadata(request, env);
-        break;
+    // OAuth client metadata
+    case url.pathname === '/.well-known/client-metadata':
+      response = await handleClientMetadata(request, env);
+      break;
 
-      // Lexicon schemas
-      case url.pathname === '/.well-known/lexicons':
-        response = handleLexiconIndex();
-        break;
-      case url.pathname.startsWith('/.well-known/lexicons/'):
-        response = handleLexicon(request);
-        break;
+    // Lexicon schemas
+    case url.pathname === '/.well-known/lexicons':
+      response = handleLexiconIndex();
+      break;
+    case url.pathname.startsWith('/.well-known/lexicons/'):
+      response = handleLexicon(request);
+      break;
 
-      // Auth routes
-      case url.pathname === '/api/auth/login':
-        response = await handleAuthLogin(request, env);
-        break;
-      case url.pathname === '/api/auth/callback':
-        response = await handleAuthCallback(request, env, ctx);
-        break;
-      case url.pathname === '/api/auth/logout':
-        response = await handleAuthLogout(request, env);
-        break;
-      case url.pathname === '/api/auth/me':
-        response = await handleAuthMe(request, env);
-        break;
+    // Auth routes
+    case url.pathname === '/api/auth/login':
+      response = await handleAuthLogin(request, env);
+      break;
+    case url.pathname === '/api/auth/callback':
+      response = await handleAuthCallback(request, env, ctx);
+      break;
+    case url.pathname === '/api/auth/logout':
+      response = await handleAuthLogout(request, env);
+      break;
+    case url.pathname === '/api/auth/me':
+      response = await handleAuthMe(request, env);
+      break;
 
-      // Feed routes (v2 via Fly.io proxy)
-      case url.pathname === '/api/v2/feeds/fetch':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2FeedFetch(request, env);
-        break;
-      case url.pathname === '/api/v2/feeds/batch':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2BatchFeedFetch(request, env, session);
-        break;
-      case url.pathname === '/api/v2/feeds/discover':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2FeedDiscover(request, env);
-        break;
-      case url.pathname === '/api/v2/documents/batch':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2BatchDocumentFetch(request, env, session);
-        break;
-      case url.pathname === '/api/v2/documents/get':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2GetDocument(request, env, session);
-        break;
-      case url.pathname === '/api/v2/social-context':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2SocialContext(request, env);
-        break;
-      case url.pathname === '/api/v2/mentions':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2Mentions(request, env);
-        break;
-      case url.pathname === '/api/v2/mention-lane':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleV2MentionLane(request, env);
-        break;
+    // Client error reports. Deliberately session-free: an error on the login
+    // screen, or one thrown before auth resolves, is exactly the kind worth
+    // having. The handler rate-limits by DID when there is one, by IP when
+    // there isn't.
+    case url.pathname === '/api/telemetry/error':
+      response = await handleTelemetryError(request, env, session?.did);
+      break;
 
-      // Social routes
-      case url.pathname === '/api/social/detect-content':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleDetectContent(request, env);
-        break;
-      // Linkblog discovery — find friends with linkblogs / browse all (Phase 6)
-      case url.pathname === '/api/linkblog/discover/friends':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleDiscoverFriends(request, env);
-        break;
-      case url.pathname === '/api/linkblog/discover':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleDiscover(request, env);
-        break;
+    // Feed routes (v2 via Fly.io proxy)
+    case url.pathname === '/api/v2/feeds/fetch':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2FeedFetch(request, env);
+      break;
+    case url.pathname === '/api/v2/feeds/batch':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2BatchFeedFetch(request, env, session);
+      break;
+    case url.pathname === '/api/v2/feeds/discover':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2FeedDiscover(request, env);
+      break;
+    case url.pathname === '/api/v2/documents/batch':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2BatchDocumentFetch(request, env, session);
+      break;
+    case url.pathname === '/api/v2/documents/get':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2GetDocument(request, env, session);
+      break;
+    case url.pathname === '/api/v2/social-context':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2SocialContext(request, env);
+      break;
+    case url.pathname === '/api/v2/mentions':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2Mentions(request, env);
+      break;
+    case url.pathname === '/api/v2/mention-lane':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2MentionLane(request, env);
+      break;
 
-      // Linkblog endpoints — sharing as portable site.standard.document records
-      case url.pathname === '/api/linkblog/share':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleCreateLinkblogShare(request, env);
-        break;
-      case url.pathname.startsWith('/api/linkblog/share/'):
-        if (!session) return unauthorizedResponse(headers);
-        response =
-          request.method === 'PATCH'
-            ? await handleUpdateLinkblogShare(request, env)
-            : await handleDeleteLinkblogShare(request, env);
-        break;
-      case url.pathname === '/api/linkblog/publication':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'GET') {
-          response = await handleGetPublication(request, env);
-        } else if (request.method === 'DELETE') {
-          response = await handleDeletePublication(request, env);
-        } else if (request.method === 'POST') {
-          response = await handleRestorePublication(request, env);
-        } else {
-          response = await handleUpdatePublication(request, env);
-        }
-        break;
-      case url.pathname === '/api/linkblog/publications':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleListPublications(request, env);
-        break;
-      case url.pathname === '/api/linkblog/publication/connect':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleConnectPublication(request, env);
-        break;
-      case url.pathname === '/api/linkblog/publication/visibility':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSetPageVisibility(request, env);
-        break;
-      case url.pathname.startsWith('/api/linkblog/resolve/'):
-        response = await handleResolvePublication(request, env);
-        break;
+    // Social routes
+    case url.pathname === '/api/social/detect-content':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleDetectContent(request, env);
+      break;
+    // Linkblog discovery — find friends with linkblogs / browse all (Phase 6)
+    case url.pathname === '/api/linkblog/discover/friends':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleDiscoverFriends(request, env);
+      break;
+    case url.pathname === '/api/linkblog/discover':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleDiscover(request, env);
+      break;
 
-      // Subscribe via the Atmosphere — writes the portable
-      // site.standard.graph.subscription record, and (for a signed-in user)
-      // also creates the matching local reader subscription.
-      case url.pathname === '/api/atmosphere/subscription':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleAtmosphereSubscription(request, env, ctx);
-        break;
-
-      // Subscriptions endpoints (new)
-      case url.pathname === '/api/subscriptions':
-        if (!session) return unauthorizedResponse(headers);
-        response =
-          request.method === 'GET'
-            ? await handleListSubscriptions(request, env)
-            : await handleCreateSubscription(request, env, ctx);
-        break;
-      case url.pathname === '/api/subscriptions/bulk':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleBulkCreateSubscriptions(request, env, ctx);
-        break;
-      case url.pathname === '/api/subscriptions/bulk-update':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleBulkUpdateSubscriptions(request, env, ctx);
-        break;
-      case url.pathname === '/api/subscriptions/bulk-delete':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleBulkDeleteSubscriptions(request, env, ctx);
-        break;
-      case url.pathname === '/api/subscriptions/parked':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleListParkedSubscriptions(request, env);
-        break;
-      case url.pathname.endsWith('/activate') && url.pathname.startsWith('/api/subscriptions/'):
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSetSubscriptionActive(request, env, true);
-        break;
-      case url.pathname.endsWith('/park') && url.pathname.startsWith('/api/subscriptions/'):
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSetSubscriptionActive(request, env, false);
-        break;
-      case url.pathname.startsWith('/api/subscriptions/'):
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'DELETE') {
-          response = await handleDeleteSubscription(request, env, ctx);
-        } else if (request.method === 'PATCH') {
-          response = await handleUpdateSubscription(request, env, ctx);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-
-      // Record list route (sync routes removed - use dedicated endpoints)
-      case url.pathname === '/api/records/list':
-        response = await handleRecordsList(request, env);
-        break;
-
-      // Reading routes (read positions)
-      case url.pathname === '/api/reading/positions':
-        response = await handleGetReadPositions(request, env);
-        break;
-      case url.pathname === '/api/reading/mark-read':
-        response = await handleMarkAsRead(request, env);
-        break;
-      case url.pathname === '/api/reading/mark-unread':
-        response = await handleMarkAsUnread(request, env);
-        break;
-      case url.pathname === '/api/reading/mark-read-bulk':
-        response = await handleBulkMarkAsRead(request, env);
-        break;
-
-      // Labels routes (unified item labels)
-      case url.pathname === '/api/labels':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'GET') {
-          response = await handleGetLabels(request, env);
-        } else if (request.method === 'POST') {
-          response = await handleAddLabel(request, env);
-        } else if (request.method === 'DELETE') {
-          response = await handleDeleteLabel(request, env);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-      case url.pathname === '/api/labels/bulk':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleBulkAddLabels(request, env);
-        break;
-
-      // Article extraction route (fetch + Defuddle via the feed proxy)
-      case url.pathname === '/api/extract':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleExtract(request, env);
-        break;
-
-      // Saved routes
-      case url.pathname === '/api/saved':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'GET') {
-          response = await handleGetSaved(request, env, ctx);
-        } else if (request.method === 'POST') {
-          response = await handleCreateSaved(request, env, ctx);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-      case url.pathname === '/api/saved/status':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSavedStatus(request, env);
-        break;
-      case url.pathname.startsWith('/api/saved/by-guid/'):
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleDeleteSavedByGuid(request, env, ctx);
-        break;
-      case url.pathname === '/api/saved/backing':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSetBacking(request, env);
-        break;
-      case url.pathname === '/api/saved/bodies':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleGetSavedBodies(request, env);
-        break;
-      case url.pathname.startsWith('/api/saved/'):
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'PATCH') {
-          response = await handleUpdateSaved(request, env);
-        } else {
-          response = await handleDeleteSaved(request, env, ctx);
-        }
-        break;
-
-      // Settings routes
-      case url.pathname === '/api/settings':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'PUT') {
-          response = await handleUpdateSettings(request, env);
-        } else {
-          response = await handleGetSettings(request, env);
-        }
-        break;
-
-      // Magazine routes (durable, cross-device reading issues)
-      case url.pathname === '/api/magazines':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'GET') {
-          response = await handleGetMagazines(request, env);
-        } else if (request.method === 'POST') {
-          response = await handleUpsertMagazine(request, env);
-        } else if (request.method === 'DELETE') {
-          response = await handleDeleteMagazine(request, env);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-      case url.pathname === '/api/magazines/position':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'PATCH') {
-          response = await handleUpdateMagazinePosition(request, env);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-
-      // Integration routes
-      case url.pathname === '/api/integrations/status':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleIntegrationStatus(request, env);
-        break;
-      case url.pathname === '/api/integrations/semble/cards':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method !== 'POST') {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        } else {
-          response = await handleCreateSembleCard(request, env);
-        }
-        break;
-      case url.pathname === '/api/integrations/semble/collections':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleListSembleCollections(request, env);
-        break;
-      case url.pathname === '/api/integrations/margin/bookmarks':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method !== 'POST') {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        } else {
-          response = await handleCreateMarginBookmark(request, env);
-        }
-        break;
-      case url.pathname === '/api/integrations/margin/collections':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleListMarginCollections(request, env);
-        break;
-      case url.pathname === '/api/integrations/margin/notes':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method !== 'POST') {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        } else {
-          response = await handleCreateMarginNote(request, env);
-        }
-        break;
-      case url.pathname.startsWith('/api/integrations/margin/notes/'):
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'DELETE') {
-          response = await handleDeleteMarginNote(request, env);
-        } else if (request.method === 'PUT') {
-          response = await handleUpdateMarginNote(request, env);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-
-      // Channels routes
-      case url.pathname === '/api/channels':
-        if (!session) return unauthorizedResponse(headers);
-        if (request.method === 'GET') {
-          response = await handleGetChannels(request, env);
-        } else if (request.method === 'PUT') {
-          response = await handleSyncChannels(request, env);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
-      case url.pathname.startsWith('/api/channels/'): {
-        if (!session) return unauthorizedResponse(headers);
-        const channelUuid = url.pathname.split('/').pop()!;
-        if (request.method === 'PUT') {
-          response = await handleUpsertChannel(request, env, channelUuid);
-        } else if (request.method === 'DELETE') {
-          response = await handleDeleteChannel(request, env, channelUuid);
-        } else {
-          response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
-            status: 405,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        break;
+    // Linkblog endpoints — sharing as portable site.standard.document records
+    case url.pathname === '/api/linkblog/share':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleCreateLinkblogShare(request, env);
+      break;
+    case url.pathname.startsWith('/api/linkblog/share/'):
+      if (!session) return unauthorizedResponse(headers);
+      response =
+        request.method === 'PATCH'
+          ? await handleUpdateLinkblogShare(request, env)
+          : await handleDeleteLinkblogShare(request, env);
+      break;
+    case url.pathname === '/api/linkblog/publication':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetPublication(request, env);
+      } else if (request.method === 'DELETE') {
+        response = await handleDeletePublication(request, env);
+      } else if (request.method === 'POST') {
+        response = await handleRestorePublication(request, env);
+      } else {
+        response = await handleUpdatePublication(request, env);
       }
+      break;
+    case url.pathname === '/api/linkblog/publications':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleListPublications(request, env);
+      break;
+    case url.pathname === '/api/linkblog/publication/connect':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleConnectPublication(request, env);
+      break;
+    case url.pathname === '/api/linkblog/publication/visibility':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSetPageVisibility(request, env);
+      break;
+    case url.pathname.startsWith('/api/linkblog/resolve/'):
+      response = await handleResolvePublication(request, env);
+      break;
 
-      // Sync routes
-      case url.pathname === '/api/sync/full':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleFullSync(request, env, ctx);
-        break;
-      case url.pathname === '/api/sync/subscriptions':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSyncSubscriptions(request, env);
-        break;
-      case url.pathname === '/api/sync/status':
-        if (!session) return unauthorizedResponse(headers);
-        response = await handleSyncStatus(request, env);
-        break;
+    // Subscribe via the Atmosphere — writes the portable
+    // site.standard.graph.subscription record, and (for a signed-in user)
+    // also creates the matching local reader subscription.
+    case url.pathname === '/api/atmosphere/subscription':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleAtmosphereSubscription(request, env, ctx);
+      break;
 
-      // AT Intents service endpoints (XRPC procedures). No top-level session guard:
-      // the handlers return XRPC-shaped `{ error, message }` auth errors themselves.
-      case url.pathname === '/xrpc/app.skyreader.feed.save':
-        response = await handleXrpcSave(request, env, ctx);
-        break;
-      case url.pathname === '/xrpc/app.skyreader.feed.subscribe':
-        response = await handleXrpcSubscribe(request, env, ctx);
-        break;
-      case url.pathname === '/xrpc/app.skyreader.linkblog.share':
-        response = await handleXrpcLinkblogShare(request, env);
-        break;
-
-      default:
-        response = new Response(JSON.stringify({ error: 'Not found' }), {
-          status: 404,
+    // Subscriptions endpoints (new)
+    case url.pathname === '/api/subscriptions':
+      if (!session) return unauthorizedResponse(headers);
+      response =
+        request.method === 'GET'
+          ? await handleListSubscriptions(request, env)
+          : await handleCreateSubscription(request, env, ctx);
+      break;
+    case url.pathname === '/api/subscriptions/bulk':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleBulkCreateSubscriptions(request, env, ctx);
+      break;
+    case url.pathname === '/api/subscriptions/bulk-update':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleBulkUpdateSubscriptions(request, env, ctx);
+      break;
+    case url.pathname === '/api/subscriptions/bulk-delete':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleBulkDeleteSubscriptions(request, env, ctx);
+      break;
+    case url.pathname === '/api/subscriptions/parked':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleListParkedSubscriptions(request, env);
+      break;
+    case url.pathname.endsWith('/activate') && url.pathname.startsWith('/api/subscriptions/'):
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSetSubscriptionActive(request, env, true);
+      break;
+    case url.pathname.endsWith('/park') && url.pathname.startsWith('/api/subscriptions/'):
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSetSubscriptionActive(request, env, false);
+      break;
+    case url.pathname.startsWith('/api/subscriptions/'):
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'DELETE') {
+        response = await handleDeleteSubscription(request, env, ctx);
+      } else if (request.method === 'PATCH') {
+        response = await handleUpdateSubscription(request, env, ctx);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
           headers: { 'Content-Type': 'application/json' },
         });
+      }
+      break;
+
+    // Record list route (sync routes removed - use dedicated endpoints)
+    case url.pathname === '/api/records/list':
+      response = await handleRecordsList(request, env);
+      break;
+
+    // Reading routes (read positions)
+    case url.pathname === '/api/reading/positions':
+      response = await handleGetReadPositions(request, env);
+      break;
+    case url.pathname === '/api/reading/mark-read':
+      response = await handleMarkAsRead(request, env);
+      break;
+    case url.pathname === '/api/reading/mark-unread':
+      response = await handleMarkAsUnread(request, env);
+      break;
+    case url.pathname === '/api/reading/mark-read-bulk':
+      response = await handleBulkMarkAsRead(request, env);
+      break;
+
+    // Labels routes (unified item labels)
+    case url.pathname === '/api/labels':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetLabels(request, env);
+      } else if (request.method === 'POST') {
+        response = await handleAddLabel(request, env);
+      } else if (request.method === 'DELETE') {
+        response = await handleDeleteLabel(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+    case url.pathname === '/api/labels/bulk':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleBulkAddLabels(request, env);
+      break;
+
+    // Article extraction route (fetch + Defuddle via the feed proxy)
+    case url.pathname === '/api/extract':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleExtract(request, env);
+      break;
+
+    // Saved routes
+    case url.pathname === '/api/saved':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetSaved(request, env, ctx);
+      } else if (request.method === 'POST') {
+        response = await handleCreateSaved(request, env, ctx);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+    case url.pathname === '/api/saved/status':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSavedStatus(request, env);
+      break;
+    case url.pathname.startsWith('/api/saved/by-guid/'):
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleDeleteSavedByGuid(request, env, ctx);
+      break;
+    case url.pathname === '/api/saved/backing':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSetBacking(request, env);
+      break;
+    case url.pathname === '/api/saved/bodies':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleGetSavedBodies(request, env);
+      break;
+    case url.pathname.startsWith('/api/saved/'):
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'PATCH') {
+        response = await handleUpdateSaved(request, env);
+      } else {
+        response = await handleDeleteSaved(request, env, ctx);
+      }
+      break;
+
+    // Settings routes
+    case url.pathname === '/api/settings':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'PUT') {
+        response = await handleUpdateSettings(request, env);
+      } else {
+        response = await handleGetSettings(request, env);
+      }
+      break;
+
+    // Magazine routes (durable, cross-device reading issues)
+    case url.pathname === '/api/magazines':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetMagazines(request, env);
+      } else if (request.method === 'POST') {
+        response = await handleUpsertMagazine(request, env);
+      } else if (request.method === 'DELETE') {
+        response = await handleDeleteMagazine(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+    case url.pathname === '/api/magazines/position':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'PATCH') {
+        response = await handleUpdateMagazinePosition(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+
+    // Integration routes
+    case url.pathname === '/api/integrations/status':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleIntegrationStatus(request, env);
+      break;
+    case url.pathname === '/api/integrations/semble/cards':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method !== 'POST') {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } else {
+        response = await handleCreateSembleCard(request, env);
+      }
+      break;
+    case url.pathname === '/api/integrations/semble/collections':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleListSembleCollections(request, env);
+      break;
+    case url.pathname === '/api/integrations/margin/bookmarks':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method !== 'POST') {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } else {
+        response = await handleCreateMarginBookmark(request, env);
+      }
+      break;
+    case url.pathname === '/api/integrations/margin/collections':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleListMarginCollections(request, env);
+      break;
+    case url.pathname === '/api/integrations/margin/notes':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method !== 'POST') {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } else {
+        response = await handleCreateMarginNote(request, env);
+      }
+      break;
+    case url.pathname.startsWith('/api/integrations/margin/notes/'):
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'DELETE') {
+        response = await handleDeleteMarginNote(request, env);
+      } else if (request.method === 'PUT') {
+        response = await handleUpdateMarginNote(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+
+    // Channels routes
+    case url.pathname === '/api/channels':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetChannels(request, env);
+      } else if (request.method === 'PUT') {
+        response = await handleSyncChannels(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
+    case url.pathname.startsWith('/api/channels/'): {
+      if (!session) return unauthorizedResponse(headers);
+      const channelUuid = url.pathname.split('/').pop()!;
+      if (request.method === 'PUT') {
+        response = await handleUpsertChannel(request, env, channelUuid);
+      } else if (request.method === 'DELETE') {
+        response = await handleDeleteChannel(request, env, channelUuid);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      break;
     }
 
-    // Add CORS headers to response
-    const newHeaders = new Headers(response.headers);
-    Object.entries(headers).forEach(([key, value]) => {
-      newHeaders.set(key, value);
-    });
+    // Sync routes
+    case url.pathname === '/api/sync/full':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleFullSync(request, env, ctx);
+      break;
+    case url.pathname === '/api/sync/subscriptions':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSyncSubscriptions(request, env);
+      break;
+    case url.pathname === '/api/sync/status':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSyncStatus(request, env);
+      break;
 
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: newHeaders,
-    });
-  } catch (error) {
-    // Workers Logs stays the quick-look tool; Sentry is what groups, dedupes,
-    // and notifies. Both, deliberately — and both carry the request id, which
-    // is what lets a Sentry event find its log line.
-    log.error('request_error', { method: request.method, ...serializeError(error) });
-    reportError(error, {
-      tags: { source: 'fetch', route: classifyRoute(url.pathname) },
-      extra: { method: request.method, path: url.pathname },
-    });
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { ...headers, 'Content-Type': 'application/json' },
-    });
+    // AT Intents service endpoints (XRPC procedures). No top-level session guard:
+    // the handlers return XRPC-shaped `{ error, message }` auth errors themselves.
+    case url.pathname === '/xrpc/app.skyreader.feed.save':
+      response = await handleXrpcSave(request, env, ctx);
+      break;
+    case url.pathname === '/xrpc/app.skyreader.feed.subscribe':
+      response = await handleXrpcSubscribe(request, env, ctx);
+      break;
+    case url.pathname === '/xrpc/app.skyreader.linkblog.share':
+      response = await handleXrpcLinkblogShare(request, env);
+      break;
+
+    default:
+      response = new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
   }
+
+  // Add CORS headers to response
+  const newHeaders = new Headers(response.headers);
+  Object.entries(headers).forEach(([key, value]) => {
+    newHeaders.set(key, value);
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
 }
 
 const handler = {
@@ -690,30 +714,39 @@ const handler = {
       { requestId, route: classifyRoute(url.pathname), method: request.method },
       async () => {
         tagRequestId(requestId);
-        const response = await serveRequest(request, env, ctx);
 
         // One summary line per request — route class, status, duration. This is
         // the raw material for "what's slow" and "what's erroring" until metrics
         // land, and it's why the log is worth querying at all.
         //
+        // In a `finally` so that "every request produces a line" survives a throw
+        // that somehow gets past serveRequest's catch: the line then reports the
+        // 500 the runtime is about to serve.
+        //
         // The shallow health check is exempt: an uptime poller hits it every 30s
         // forever and the line carries no information the check's own history
         // doesn't already have.
-        if (url.pathname !== '/api/health') {
-          log.info('request', {
-            method: request.method,
-            status: response.status,
-            durationMs: Date.now() - started,
-          });
-        }
+        let status = 500;
+        try {
+          const response = await serveRequest(request, env, ctx);
+          status = response.status;
 
-        const headers = new Headers(response.headers);
-        headers.set('X-Request-Id', requestId);
-        return new Response(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers,
-        });
+          const headers = new Headers(response.headers);
+          headers.set('X-Request-Id', requestId);
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          });
+        } finally {
+          if (url.pathname !== '/api/health') {
+            log.info('request', {
+              method: request.method,
+              status,
+              durationMs: Date.now() - started,
+            });
+          }
+        }
       }
     );
   },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -162,7 +162,8 @@ function isPublicPath(pathname: string): boolean {
     pathname.startsWith('/.well-known/') ||
     pathname === '/api/auth/login' ||
     pathname === '/api/auth/callback' ||
-    pathname === '/api/auth/logout'
+    pathname === '/api/auth/logout' ||
+    pathname === '/api/telemetry/error'
   );
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,7 +96,7 @@ import {
 } from './routes/channels';
 import { handleTestExec } from './routes/test-utils';
 import { handleHealth, handleDeepHealth } from './routes/health';
-import { handleTelemetryError } from './routes/telemetry';
+import { handleTelemetryError, TELEMETRY_PATH } from './routes/telemetry';
 import { resolveSessionFromRequest, updateUserActivity } from './services/oauth';
 import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './services/rate-limit';
 import * as Sentry from '@sentry/cloudflare';
@@ -162,8 +162,7 @@ function isPublicPath(pathname: string): boolean {
     pathname.startsWith('/.well-known/') ||
     pathname === '/api/auth/login' ||
     pathname === '/api/auth/callback' ||
-    pathname === '/api/auth/logout' ||
-    pathname === '/api/telemetry/error'
+    pathname === '/api/auth/logout'
   );
 }
 
@@ -172,6 +171,18 @@ function isPublicPath(pathname: string): boolean {
 // session, and the shallow check must stay free of D1 work (see routes/health.ts).
 function isHealthPath(pathname: string): boolean {
   return pathname === '/api/health' || pathname === '/api/health/deep';
+}
+
+// Every response leaving route() carries the CORS headers computed for the
+// request's Origin, including the ones answered before the switch.
+function withCors(response: Response, headers: HeadersInit): Response {
+  const merged = new Headers(response.headers);
+  Object.entries(headers).forEach(([key, value]) => merged.set(key, value as string));
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: merged,
+  });
 }
 
 // The routed request. Wrapped by `fetch` below, which owns the request context,
@@ -222,6 +233,18 @@ async function route(
     const healthHeaders = new Headers(health.headers);
     Object.entries(headers).forEach(([key, value]) => healthHeaders.set(key, value as string));
     return new Response(health.body, { status: health.status, headers: healthHeaders });
+  }
+
+  // Client error reports, answered before session resolution — deliberately, and
+  // for a stronger reason than "no session required": the reports worth having
+  // most are the ones sent while auth is broken. Behind `resolveSessionFromRequest`
+  // a D1 read failure would become the 500 from serveRequest's catch, and a session
+  // mid-refresh would wait out the concurrent-refresh poll, before the report was
+  // ever parsed — and the reporter never retries (frontend/src/lib/services/telemetry.ts).
+  // The cost is that an authenticated report is rate-limited by IP rather than by
+  // DID; the handler owns that limit, so this also stops paying for two.
+  if (url.pathname === TELEMETRY_PATH) {
+    return withCors(await handleTelemetryError(request, env), headers);
   }
 
   // Track user activity for authenticated requests (non-blocking)
@@ -290,14 +313,6 @@ async function route(
       break;
     case url.pathname === '/api/auth/me':
       response = await handleAuthMe(request, env);
-      break;
-
-    // Client error reports. Deliberately session-free: an error on the login
-    // screen, or one thrown before auth resolves, is exactly the kind worth
-    // having. The handler rate-limits by DID when there is one, by IP when
-    // there isn't.
-    case url.pathname === '/api/telemetry/error':
-      response = await handleTelemetryError(request, env, session?.did);
       break;
 
     // Feed routes (v2 via Fly.io proxy)
@@ -689,17 +704,7 @@ async function route(
       });
   }
 
-  // Add CORS headers to response
-  const newHeaders = new Headers(response.headers);
-  Object.entries(headers).forEach(([key, value]) => {
-    newHeaders.set(key, value);
-  });
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: newHeaders,
-  });
+  return withCors(response, headers);
 }
 
 const handler = {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -92,8 +92,12 @@ import {
   handleDeleteChannel,
 } from './routes/channels';
 import { handleTestExec } from './routes/test-utils';
+import { handleHealth, handleDeepHealth } from './routes/health';
 import { resolveSessionFromRequest, updateUserActivity } from './services/oauth';
 import { checkRateLimit, cleanupRateLimits, getRateLimitConfig } from './services/rate-limit';
+import * as Sentry from '@sentry/cloudflare';
+import { sentryOptions, reportError } from './observability/sentry';
+import { pingHeartbeat } from './observability/heartbeat';
 
 export { JetstreamPoller } from './durable-objects/jetstream-poller';
 
@@ -146,7 +150,14 @@ function isPublicPath(pathname: string): boolean {
   );
 }
 
-export default {
+// The other set of session-free routes. Health endpoints are answered *before*
+// session resolution rather than via isPublicPath: an uptime poller has no
+// session, and the shallow check must stay free of D1 work (see routes/health.ts).
+function isHealthPath(pathname: string): boolean {
+  return pathname === '/api/health' || pathname === '/api/health/deep';
+}
+
+const handler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const origin = request.headers.get('Origin');
@@ -155,6 +166,14 @@ export default {
     // Handle CORS preflight
     if (request.method === 'OPTIONS') {
       return new Response(null, { headers });
+    }
+
+    if (isHealthPath(url.pathname)) {
+      const health =
+        url.pathname === '/api/health' ? handleHealth(env) : await handleDeepHealth(request, env);
+      const healthHeaders = new Headers(health.headers);
+      Object.entries(headers).forEach(([key, value]) => healthHeaders.set(key, value as string));
+      return new Response(health.body, { status: health.status, headers: healthHeaders });
     }
 
     // Track user activity for authenticated requests (non-blocking)
@@ -616,7 +635,13 @@ export default {
         headers: newHeaders,
       });
     } catch (error) {
+      // Workers Logs stays the quick-look tool; Sentry is what groups, dedupes,
+      // and notifies. Both, deliberately.
       console.error('Request error:', error);
+      reportError(error, {
+        tags: { source: 'fetch', route: url.pathname },
+        extra: { method: request.method },
+      });
       return new Response(JSON.stringify({ error: 'Internal server error' }), {
         status: 500,
         headers: { ...headers, 'Content-Type': 'application/json' },
@@ -631,6 +656,11 @@ export default {
 
     console.log(`[Cron] Started: ${controller.cron}, minute=${minute}`);
 
+    // Tracks whether this run did its job. The heartbeat at the end only fires on
+    // a clean run, so "cron throwing every minute" looks the same to the monitor
+    // as "cron never fired" — both are outages.
+    let cronHealthy = true;
+
     // Every minute: Cleanup tasks and ensure JetstreamPoller is running
     if (isEveryMinuteCron) {
       // Phase 1: Ensure JetstreamPoller DO is running
@@ -642,6 +672,8 @@ export default {
         console.log(`[Cron] JetstreamPoller: ${result.status}`);
       } catch (error) {
         console.error('[Cron] Failed to start JetstreamPoller:', error);
+        reportError(error, { tags: { source: 'cron', phase: 'poller-start' } });
+        cronHealthy = false;
       }
 
       // Phase 2: Clean up rate limit records
@@ -658,6 +690,8 @@ export default {
         }
       } catch (error) {
         console.error('[Cron] Rate limit cleanup error:', error);
+        reportError(error, { tags: { source: 'cron', phase: 'rate-limit-cleanup' } });
+        cronHealthy = false;
       }
 
       // Phase 3: Clean up expired D1 data (once per hour)
@@ -680,6 +714,7 @@ export default {
           oauthDeleted = oauthResult.meta?.changes || 0;
         } catch (error) {
           console.error('[Cron] D1 WRITE ERROR deleting expired oauth_state:', error);
+          reportError(error, { tags: { source: 'cron', phase: 'oauth-state-cleanup' } });
         }
 
         // Clean up failed/expired sessions
@@ -699,6 +734,7 @@ export default {
           sessionsDeleted = sessionsResult.meta?.changes || 0;
         } catch (error) {
           console.error('[Cron] D1 WRITE ERROR deleting expired sessions:', error);
+          reportError(error, { tags: { source: 'cron', phase: 'session-cleanup' } });
         }
 
         // Purge old label tombstones (soft-deleted archived/tagged AND read
@@ -717,6 +753,7 @@ export default {
           labelTombstonesDeleted = tombstoneResult.meta?.changes || 0;
         } catch (error) {
           console.error('[Cron] D1 WRITE ERROR purging label tombstones:', error);
+          reportError(error, { tags: { source: 'cron', phase: 'label-tombstone-purge' } });
         }
 
         // Purge old magazine tombstones (same 90-day retention as labels so a
@@ -730,6 +767,7 @@ export default {
             .run();
         } catch (error) {
           console.error('[Cron] D1 WRITE ERROR purging magazine tombstones:', error);
+          reportError(error, { tags: { source: 'cron', phase: 'magazine-tombstone-purge' } });
         }
 
         d1CleanupDuration = Date.now() - cleanupStart;
@@ -740,6 +778,19 @@ export default {
 
       const totalDuration = Date.now() - cronStart;
       console.log(`[Cron] Every-minute complete: total=${totalDuration}ms`);
+
+      // Dead-man's switch. Fire-and-forget so a slow monitor can never extend or
+      // fail the cron. Skipped on a failed run so the monitor's grace period
+      // expires and pages — that's the whole point of the switch.
+      if (cronHealthy) {
+        ctx.waitUntil(pingHeartbeat(env.HEARTBEAT_URL, 'cron'));
+      } else {
+        console.warn('[Cron] Skipping heartbeat: run had failures');
+      }
     }
   },
-};
+} satisfies ExportedHandler<Env>;
+
+// Wrapping the exported handler instruments both `fetch` and `scheduled`; the
+// JetstreamPoller DO is instrumented separately at its own export.
+export default Sentry.withSentry(sentryOptions, handler);

--- a/backend/src/observability/heartbeat.ts
+++ b/backend/src/observability/heartbeat.ts
@@ -1,0 +1,30 @@
+// Dead-man's switch ping. The every-minute cron is what keeps the JetstreamPoller
+// alive, so a cron that stops firing (or throws every run) silently kills the
+// firehose. A monitor that alerts on the *absence* of this ping is the only thing
+// that notices.
+//
+// Fire-and-forget by contract: call it inside `ctx.waitUntil()`, never `await` it
+// on the critical path, and it swallows every failure — a slow or broken monitor
+// must never fail or extend the cron.
+
+const HEARTBEAT_TIMEOUT_MS = 5000;
+
+/**
+ * Ping a heartbeat URL (Healthchecks.io / Better Stack). No-op when `url` is
+ * unset, which keeps local dev and staging quiet without an env-name check.
+ */
+export async function pingHeartbeat(url: string | undefined, source: string): Promise<void> {
+  if (!url) return;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      console.warn(`[Heartbeat] ${source} ping returned ${response.status}`);
+    }
+  } catch (error) {
+    console.warn(`[Heartbeat] ${source} ping failed:`, error);
+  }
+}

--- a/backend/src/observability/ops-metrics.ts
+++ b/backend/src/observability/ops-metrics.ts
@@ -1,0 +1,369 @@
+import type { Env } from '../types';
+import { log, serializeError } from '../utils/logger';
+import { reportError, reportMessage } from './sentry';
+
+// The cron's second job: leave behind what it learned.
+//
+// Every minute the cron already talks to the JetstreamPoller DO. That call knows
+// the firehose lag, the last poll's error counts and whether the alarm is armed —
+// and until now it threw all of it away. Here it lands in D1, where the admin
+// (already a read-only reader of this database) can render it without a new API,
+// a new token, or an integration that only works against production.
+//
+// Two shapes, deliberately different:
+//   - `system_status` — the current board. One row per key, overwritten each run.
+//     Reading it answers "is it healthy *now*".
+//   - `metrics_snapshots` — one row per hour, pruned at 90 days. Reading it
+//     answers "which way is it trending", the question point-in-time counts can't.
+//
+// Nothing here may fail the cron. A recording failure is a loss of visibility,
+// not of service; callers log it and move on (see the note at the cron site).
+
+export type SystemStatusKey = 'cron_last_run' | 'poller_status' | 'proxy_stats';
+
+/** Lag past this and the firehose is not "catching up", it's stuck. */
+export const FIREHOSE_LAG_ALERT_MS = 15 * 60 * 1000;
+
+/**
+ * The cron re-checks lag every minute; without this, a stuck firehose would send
+ * an event a minute for as long as it stayed stuck. One event, then a reminder
+ * every half hour while the condition persists.
+ */
+export const FIREHOSE_LAG_REALERT_MS = 30 * 60 * 1000;
+
+/** The proxy is a different host on a different cloud; fail fast, don't hang. */
+const PROXY_STATS_TIMEOUT_MS = 3000;
+
+const HOUR_MS = 60 * 60 * 1000;
+export const SNAPSHOT_RETENTION_MS = 90 * 24 * HOUR_MS;
+
+/**
+ * How stale a `system_status` row may be before a snapshot records null instead
+ * of its value. Poller status is written every minute and proxy stats every five,
+ * so anything older than this is a value nobody refreshed — carrying it into an
+ * hourly point would draw a flat line through an outage.
+ */
+const SNAPSHOT_MAX_AGE_MS = 15 * 60 * 1000;
+
+export interface StatusRow<T> {
+  value: T;
+  updatedAt: number;
+}
+
+export interface PollerStatusValue {
+  /** The worse of the two streams — the number that means "how far behind are we". */
+  lagMs: number | null;
+  subscriptionsLagMs: number | null;
+  documentsLagMs: number | null;
+  lastPollAt: number | null;
+  lastPollDurationMs: number | null;
+  processed: number;
+  errors: number;
+  alarmScheduled: boolean;
+  /** When the lag alert last fired. Dedupe state, not a display value. */
+  lagAlertAt: number | null;
+}
+
+export interface CronLastRunValue {
+  at: number;
+  cron: string;
+  healthy: boolean;
+  durationMs: number;
+  version: string;
+}
+
+export interface ProxyStatsValue {
+  total: number;
+  fresh: number;
+  stale: number;
+  freshPct: number | null;
+  inFlight: number;
+  feedsInError: number;
+  feedsInBackoff: number;
+  feedsPermanentlyFailed: number;
+  cacheTtlSeconds: number | null;
+}
+
+export async function writeSystemStatus(
+  env: Env,
+  key: SystemStatusKey,
+  value: unknown,
+  now = Date.now()
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO system_status (key, value, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+  )
+    .bind(key, JSON.stringify(value), now)
+    .run();
+}
+
+export async function readSystemStatus<T>(
+  env: Env,
+  key: SystemStatusKey
+): Promise<StatusRow<T> | null> {
+  const row = await env.DB.prepare('SELECT value, updated_at FROM system_status WHERE key = ?')
+    .bind(key)
+    .first<{ value: string; updated_at: number }>();
+  if (!row) return null;
+  try {
+    return { value: JSON.parse(row.value) as T, updatedAt: row.updated_at };
+  } catch {
+    // A row we can't parse is a row we can't trust; treat it as absent rather
+    // than throwing inside a cron phase.
+    return null;
+  }
+}
+
+interface PollerStatusResponse {
+  lag?: { subscriptionsMs?: number | null; documentsMs?: number | null };
+  lastStats?: {
+    subscriptions?: { processed?: number; errors?: number };
+    documents?: { processed?: number; errors?: number };
+    duration?: number;
+    lastPollAt?: number;
+  };
+  nextPoll?: number | null;
+  isRunning?: boolean;
+}
+
+/** The worse of two lags, ignoring streams that have no cursor yet. */
+export function worstLagMs(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}
+
+export interface LagAlertDecision {
+  /** Send an event now. */
+  alert: boolean;
+  /** Lag was high last time we looked and no longer is. */
+  recovered: boolean;
+  /** The dedupe stamp to persist. */
+  lagAlertAt: number | null;
+}
+
+/**
+ * Pure so the "alerts once, reminds at the re-alert interval, resets on recovery"
+ * behaviour can be tested without a clock or a database.
+ */
+export function decideLagAlert(
+  lagMs: number | null,
+  previousAlertAt: number | null,
+  now: number
+): LagAlertDecision {
+  // Unknown lag (no cursor yet) is not high lag. A DO that has never polled
+  // should not page; the cron heartbeat and deep health cover "poller is dead".
+  if (lagMs === null || lagMs <= FIREHOSE_LAG_ALERT_MS) {
+    return { alert: false, recovered: previousAlertAt !== null, lagAlertAt: null };
+  }
+  if (previousAlertAt === null || now - previousAlertAt >= FIREHOSE_LAG_REALERT_MS) {
+    return { alert: true, recovered: false, lagAlertAt: now };
+  }
+  return { alert: false, recovered: false, lagAlertAt: previousAlertAt };
+}
+
+/**
+ * Read the poller's own status, store it, and push an alert when the firehose has
+ * fallen far enough behind that waiting for someone to open the admin isn't good
+ * enough.
+ */
+export async function recordPollerStatus(env: Env, now = Date.now()): Promise<PollerStatusValue> {
+  const pollerId = env.JETSTREAM_POLLER.idFromName('main-v2');
+  const poller = env.JETSTREAM_POLLER.get(pollerId);
+  const response = await poller.fetch('http://internal/status');
+  if (!response.ok) {
+    throw new Error(`JetstreamPoller /status returned ${response.status}`);
+  }
+  const status = (await response.json()) as PollerStatusResponse;
+
+  const subscriptionsLagMs = status.lag?.subscriptionsMs ?? null;
+  const documentsLagMs = status.lag?.documentsMs ?? null;
+  const lagMs = worstLagMs(subscriptionsLagMs, documentsLagMs);
+
+  const previous = await readSystemStatus<PollerStatusValue>(env, 'poller_status');
+  const decision = decideLagAlert(lagMs, previous?.value.lagAlertAt ?? null, now);
+
+  const value: PollerStatusValue = {
+    lagMs,
+    subscriptionsLagMs,
+    documentsLagMs,
+    lastPollAt: status.lastStats?.lastPollAt ?? null,
+    lastPollDurationMs: status.lastStats?.duration ?? null,
+    processed:
+      (status.lastStats?.subscriptions?.processed ?? 0) +
+      (status.lastStats?.documents?.processed ?? 0),
+    errors:
+      (status.lastStats?.subscriptions?.errors ?? 0) + (status.lastStats?.documents?.errors ?? 0),
+    alarmScheduled: Boolean(status.isRunning),
+    lagAlertAt: decision.lagAlertAt,
+  };
+
+  await writeSystemStatus(env, 'poller_status', value, now);
+
+  if (decision.alert) {
+    log.error('firehose_lag_high', {
+      lagMs,
+      subscriptionsLagMs,
+      documentsLagMs,
+      thresholdMs: FIREHOSE_LAG_ALERT_MS,
+      lastPollAt: value.lastPollAt,
+    });
+    reportMessage(`Firehose lag above ${Math.round(FIREHOSE_LAG_ALERT_MS / 60000)}m`, {
+      level: 'error',
+      // One issue for the condition, not one per occurrence.
+      fingerprint: ['firehose-lag-high'],
+      tags: { source: 'cron', check: 'firehose-lag' },
+      extra: { lagMs, subscriptionsLagMs, documentsLagMs, lastPollAt: value.lastPollAt },
+    });
+  } else if (decision.recovered) {
+    log.info('firehose_lag_recovered', { lagMs, thresholdMs: FIREHOSE_LAG_ALERT_MS });
+  }
+
+  return value;
+}
+
+interface ProxyStatsResponse {
+  total?: number;
+  fresh?: number;
+  stale?: number;
+  inFlight?: number;
+  cacheTtlSeconds?: number;
+  errors?: { total?: number; inBackoff?: number; permanent?: number };
+}
+
+/**
+ * Pull the proxy's cache stats across. Runs on its own cadence rather than every
+ * minute — it's a cross-cloud fetch, and the cron's minute is not infinite (see
+ * the cron-budget risk in the plan).
+ */
+export async function recordProxyStats(env: Env, now = Date.now()): Promise<ProxyStatsValue> {
+  if (!env.FEED_PROXY_URL) {
+    throw new Error('FEED_PROXY_URL is not set');
+  }
+  const headers: Record<string, string> = {};
+  if (env.FEED_PROXY_SECRET) headers['X-Proxy-Secret'] = env.FEED_PROXY_SECRET;
+
+  const response = await fetch(`${env.FEED_PROXY_URL}/stats`, {
+    headers,
+    signal: AbortSignal.timeout(PROXY_STATS_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`feed proxy /stats returned ${response.status}`);
+  }
+  const stats = (await response.json()) as ProxyStatsResponse;
+
+  const total = stats.total ?? 0;
+  const fresh = stats.fresh ?? 0;
+  const value: ProxyStatsValue = {
+    total,
+    fresh,
+    stale: stats.stale ?? 0,
+    // Percentage of a zero-feed cache is undefined, not 0% and not 100%.
+    freshPct: total > 0 ? Math.round((fresh / total) * 1000) / 10 : null,
+    inFlight: stats.inFlight ?? 0,
+    feedsInError: stats.errors?.total ?? 0,
+    feedsInBackoff: stats.errors?.inBackoff ?? 0,
+    feedsPermanentlyFailed: stats.errors?.permanent ?? 0,
+    cacheTtlSeconds: stats.cacheTtlSeconds ?? null,
+  };
+
+  await writeSystemStatus(env, 'proxy_stats', value, now);
+  return value;
+}
+
+export async function recordCronRun(
+  env: Env,
+  run: { cron: string; healthy: boolean; durationMs: number },
+  now = Date.now()
+): Promise<void> {
+  const value: CronLastRunValue = {
+    at: now,
+    cron: run.cron,
+    healthy: run.healthy,
+    durationMs: run.durationMs,
+    version: env.GIT_COMMIT_SHA || 'dev',
+  };
+  await writeSystemStatus(env, 'cron_last_run', value, now);
+}
+
+/**
+ * One row per hour: the counts the admin shows as tiles, plus the two health
+ * numbers that only exist in `system_status`. Same job prunes the tail, so the
+ * table can't grow without an owner.
+ */
+export async function writeMetricsSnapshot(env: Env, now = Date.now()): Promise<void> {
+  // Bucket to the top of the hour so a cron that fires twice in one hour replaces
+  // its point instead of drawing two.
+  const capturedAt = Math.floor(now / HOUR_MS) * HOUR_MS;
+  const sessionCutoff = Math.floor(now / 1000);
+
+  const counts = await env.DB.batch<{ count: number }>([
+    env.DB.prepare('SELECT COUNT(*) AS count FROM users'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM feed_metadata'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM feed_items'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM subscriptions_cache'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM saved_articles'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM feed_metadata WHERE error_count > 0'),
+    env.DB.prepare('SELECT COUNT(*) AS count FROM sessions WHERE expires_at > ?').bind(
+      sessionCutoff
+    ),
+  ]);
+  const at = (index: number) => counts[index]?.results?.[0]?.count ?? 0;
+
+  const [poller, proxy] = await Promise.all([
+    readSystemStatus<PollerStatusValue>(env, 'poller_status'),
+    readSystemStatus<ProxyStatsValue>(env, 'proxy_stats'),
+  ]);
+  const usable = <T>(row: StatusRow<T> | null): T | null =>
+    row && now - row.updatedAt <= SNAPSHOT_MAX_AGE_MS ? row.value : null;
+
+  await env.DB.prepare(
+    `INSERT OR REPLACE INTO metrics_snapshots
+       (captured_at, users, feeds, feed_items, subscriptions, saved_articles,
+        feeds_with_errors, active_sessions, firehose_lag_ms, proxy_fresh_pct)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      capturedAt,
+      at(0),
+      at(1),
+      at(2),
+      at(3),
+      at(4),
+      at(5),
+      at(6),
+      usable(poller)?.lagMs ?? null,
+      usable(proxy)?.freshPct ?? null
+    )
+    .run();
+
+  const pruned = await env.DB.prepare('DELETE FROM metrics_snapshots WHERE captured_at < ?')
+    .bind(capturedAt - SNAPSHOT_RETENTION_MS)
+    .run();
+
+  log.info('metrics_snapshot', {
+    capturedAt,
+    users: at(0),
+    feeds: at(1),
+    feedsWithErrors: at(5),
+    prunedRows: pruned.meta?.changes ?? 0,
+  });
+}
+
+/**
+ * Run one recording step. Visibility work never decides whether the cron was
+ * healthy: a failed D1 write here loses a data point, and paging for that would
+ * be the alert fatigue the plan warns about. The error still reaches Sentry and
+ * the logs, and a D1 outage broad enough to matter fails the cleanup phases,
+ * which *do* withhold the heartbeat.
+ */
+export async function runRecordingStep(name: string, work: () => Promise<unknown>): Promise<void> {
+  try {
+    await work();
+  } catch (error) {
+    log.error('ops_metrics_failed', { step: name, ...serializeError(error) });
+    reportError(error, { tags: { source: 'cron', phase: `ops-metrics:${name}` } });
+  }
+}

--- a/backend/src/observability/scrub.ts
+++ b/backend/src/observability/scrub.ts
@@ -158,9 +158,13 @@ export function scrubEvent<T extends Event>(event: T): T {
     if (request.data !== undefined) request.data = scrubBody(request.data);
   }
 
-  if (event.extra) scrubValue(event.extra);
-  if (event.contexts) scrubValue(event.contexts);
-  if (event.tags) scrubValue(event.tags);
+  // Assigned rather than called for their side effect: scrubValue can't redact a
+  // top-level string or array in place, so discarding the result would make the
+  // scrub a silent no-op for those shapes — the worst failure mode for a control
+  // whose caller swallows exceptions.
+  if (event.extra) event.extra = scrubValue(event.extra) as typeof event.extra;
+  if (event.contexts) event.contexts = scrubValue(event.contexts) as typeof event.contexts;
+  if (event.tags) event.tags = scrubValue(event.tags) as typeof event.tags;
 
   // Breadcrumbs are the widest unstructured channel: whatever a call site logged
   // before the throw rides along verbatim. The Console integration is disabled
@@ -168,7 +172,7 @@ export function scrubEvent<T extends Event>(event: T): T {
   // `addBreadcrumb()` adds still passes through here.
   for (const breadcrumb of event.breadcrumbs ?? []) {
     if (typeof breadcrumb.message === 'string') breadcrumb.message = scrubText(breadcrumb.message);
-    if (breadcrumb.data) scrubValue(breadcrumb.data);
+    if (breadcrumb.data) breadcrumb.data = scrubValue(breadcrumb.data) as typeof breadcrumb.data;
   }
 
   // An exception's own message is free text and routinely quotes the URL that

--- a/backend/src/observability/scrub.ts
+++ b/backend/src/observability/scrub.ts
@@ -37,6 +37,42 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_PARAMS.has(lower) || SENSITIVE_KEY.test(lower);
 }
 
+// --- Free text -------------------------------------------------------------
+//
+// Breadcrumbs, exception messages and log-ish strings carry credentials inline,
+// where there is no key to match on: a tokenized URL, an `Authorization: Bearer
+// …` echoed into an error, a `code_verifier=…` pasted into a message. These
+// three patterns cover what this codebase actually produces.
+
+// A URL with a query string, anywhere inside a longer string.
+const URL_WITH_QUERY = /\bhttps?:\/\/[^\s"'<>]*\?[^\s"'<>]*/gi;
+// `Bearer <token>` / `DPoP <proof>` / `Basic <creds>`.
+const AUTH_SCHEME_VALUE = /\b(Bearer|DPoP|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+// `key=value` / `key: value` pairs, so the key can be tested with the same rule
+// used for structured fields.
+const INLINE_PAIR = /([A-Za-z0-9_.-]+)(\s*[=:]\s*)(["']?)([^\s,;&"']+)\3/g;
+
+/**
+ * Redact credentials embedded in an arbitrary string. Conservative: it rewrites
+ * only what matches a credential shape, so ordinary prose survives intact.
+ */
+export function scrubText(text: string): string {
+  return (
+    text
+      .replace(URL_WITH_QUERY, (url) => {
+        const [base, query] = splitOnce(url, '?');
+        return `${base}?${scrubQueryString(query)}`;
+      })
+      .replace(AUTH_SCHEME_VALUE, (_match, scheme: string) => `${scheme} ${REDACTED}`)
+      .replace(INLINE_PAIR, (match, key: string, separator: string, quote: string) =>
+        isSensitiveKey(key) ? `${key}${separator}${quote}${REDACTED}${quote}` : match
+      )
+      // `Authorization: Bearer <jwt>` matches two rules in a row and comes out as
+      // `[redacted] [redacted]`. Same safety, less noise.
+      .replace(/(?:\[redacted\]\s+)+\[redacted\]/g, REDACTED)
+  );
+}
+
 function scrubHeaders(headers: Record<string, unknown>): Record<string, unknown> {
   for (const key of Object.keys(headers)) {
     const lower = key.toLowerCase();
@@ -67,6 +103,8 @@ function scrubQueryString(queryString: string): string {
 }
 
 function scrubValue(value: unknown, depth = 0): unknown {
+  // A non-sensitive key can still hold a sensitive string ("url", "message").
+  if (typeof value === 'string') return scrubText(value);
   if (depth > MAX_DEPTH || value === null || typeof value !== 'object') return value;
 
   if (Array.isArray(value)) {
@@ -94,7 +132,7 @@ function scrubBody(data: unknown): unknown {
     }
   }
   if (trimmed.includes('=')) return scrubQueryString(trimmed);
-  return data;
+  return scrubText(data);
 }
 
 /**
@@ -123,6 +161,23 @@ export function scrubEvent<T extends Event>(event: T): T {
   if (event.extra) scrubValue(event.extra);
   if (event.contexts) scrubValue(event.contexts);
   if (event.tags) scrubValue(event.tags);
+
+  // Breadcrumbs are the widest unstructured channel: whatever a call site logged
+  // before the throw rides along verbatim. The Console integration is disabled
+  // for exactly that reason (see ./sentry.ts), but anything the SDK or a future
+  // `addBreadcrumb()` adds still passes through here.
+  for (const breadcrumb of event.breadcrumbs ?? []) {
+    if (typeof breadcrumb.message === 'string') breadcrumb.message = scrubText(breadcrumb.message);
+    if (breadcrumb.data) scrubValue(breadcrumb.data);
+  }
+
+  // An exception's own message is free text and routinely quotes the URL that
+  // failed — including its query string.
+  for (const exception of event.exception?.values ?? []) {
+    if (typeof exception.value === 'string') exception.value = scrubText(exception.value);
+  }
+  if (typeof event.message === 'string') event.message = scrubText(event.message);
+  if (event.logentry?.message) event.logentry.message = scrubText(event.logentry.message);
 
   return event;
 }

--- a/backend/src/observability/scrub.ts
+++ b/backend/src/observability/scrub.ts
@@ -1,0 +1,128 @@
+import type { Event } from '@sentry/cloudflare';
+
+// Sentry event scrubbing. Runs in `beforeSend` (see ./sentry.ts) so nothing
+// leaves the Worker with a credential attached.
+//
+// What we keep on purpose: DIDs. They're public identifiers and the single most
+// useful correlation key when chasing "which user hit this". What we strip:
+// anything that could be replayed — OAuth codes/tokens, DPoP proofs, cookies,
+// session ids, and our own shared secrets.
+
+const REDACTED = '[redacted]';
+
+// Matched case-insensitively against header names.
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'dpop',
+  'x-proxy-secret',
+  'x-health-secret',
+  'x-api-key',
+]);
+
+// Matched against query-string params and body keys. Broad on purpose: a false
+// positive costs one redacted debugging field, a false negative leaks a token.
+const SENSITIVE_KEY =
+  /(token|secret|password|passphrase|authorization|cookie|dpop|private[_-]?key|client[_-]?assertion|code[_-]?verifier|session[_-]?id|jwk|signature)/i;
+
+// Single-use OAuth credentials whose names don't match the pattern above.
+const SENSITIVE_PARAMS = new Set(['code', 'state', 'id_token']);
+
+const MAX_DEPTH = 6;
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SENSITIVE_PARAMS.has(lower) || SENSITIVE_KEY.test(lower);
+}
+
+function scrubHeaders(headers: Record<string, unknown>): Record<string, unknown> {
+  for (const key of Object.keys(headers)) {
+    const lower = key.toLowerCase();
+    if (SENSITIVE_HEADERS.has(lower) || SENSITIVE_KEY.test(lower)) {
+      headers[key] = REDACTED;
+    }
+  }
+  return headers;
+}
+
+function splitOnce(value: string, separator: string): [string, string] {
+  const index = value.indexOf(separator);
+  return [value.slice(0, index), value.slice(index + separator.length)];
+}
+
+function scrubQueryString(queryString: string): string {
+  // URLSearchParams round-trips both `a=1&b=2` and `?a=1&b=2` shapes.
+  const leading = queryString.startsWith('?') ? '?' : '';
+  const params = new URLSearchParams(leading ? queryString.slice(1) : queryString);
+  let changed = false;
+  for (const key of [...params.keys()]) {
+    if (isSensitiveKey(key)) {
+      params.set(key, REDACTED);
+      changed = true;
+    }
+  }
+  return changed ? leading + params.toString() : queryString;
+}
+
+function scrubValue(value: unknown, depth = 0): unknown {
+  if (depth > MAX_DEPTH || value === null || typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubValue(entry, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    record[key] = isSensitiveKey(key) ? REDACTED : scrubValue(record[key], depth + 1);
+  }
+  return record;
+}
+
+// Request bodies reach Sentry as either a parsed object or the raw string. Handle
+// both so a JSON or form-encoded token payload can't slip through as text.
+function scrubBody(data: unknown): unknown {
+  if (typeof data !== 'string') return scrubValue(data);
+
+  const trimmed = data.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.stringify(scrubValue(JSON.parse(trimmed)));
+    } catch {
+      // Not actually JSON — fall through to the form-encoded attempt.
+    }
+  }
+  if (trimmed.includes('=')) return scrubQueryString(trimmed);
+  return data;
+}
+
+/**
+ * Strip credentials from a Sentry event in place, returning the same event.
+ */
+export function scrubEvent<T extends Event>(event: T): T {
+  const request = event.request;
+  if (request) {
+    if (request.headers) scrubHeaders(request.headers as Record<string, unknown>);
+    // The SDK usually splits the query into `query_string`, but not always — an
+    // OAuth callback URL carries the single-use `code` right in `url`.
+    if (typeof request.url === 'string' && request.url.includes('?')) {
+      const [path, query] = splitOnce(request.url, '?');
+      request.url = `${path}?${scrubQueryString(query)}`;
+    }
+    // Cookies are never useful in a stack trace and always carry the session.
+    delete request.cookies;
+    if (typeof request.query_string === 'string') {
+      request.query_string = scrubQueryString(request.query_string);
+    } else if (request.query_string) {
+      request.query_string = scrubValue(request.query_string) as typeof request.query_string;
+    }
+    if (request.data !== undefined) request.data = scrubBody(request.data);
+  }
+
+  if (event.extra) scrubValue(event.extra);
+  if (event.contexts) scrubValue(event.contexts);
+  if (event.tags) scrubValue(event.tags);
+
+  return event;
+}

--- a/backend/src/observability/sentry.ts
+++ b/backend/src/observability/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/cloudflare';
 import type { CloudflareOptions } from '@sentry/cloudflare';
 import type { Env } from '../types';
 import { scrubEvent } from './scrub';
+import { getRequestContext } from '../utils/request-context';
 
 // Error reporting for the Worker. Everything goes through `reportError()` rather
 // than calling `Sentry.captureException` at call sites: the vendor is then a
@@ -26,7 +27,18 @@ export function sentryOptions(env: Env): CloudflareOptions {
     // feed proxy, DID resolution, Jetstream). Measured in `test/xrpc.spec.ts`: the
     // background extraction fetch went 124ms → ~17s with it enabled. Not worth it
     // for breadcrumbs we don't need.
-    integrations: (defaults) => defaults.filter((integration) => integration.name !== 'Fetch'),
+    //
+    // Drop the Console integration too, for a different reason: it turns every
+    // `console.*` call preceding an error into a breadcrumb, verbatim. This
+    // codebase logs raw identifiers on failure paths (session ids, OAuth state),
+    // and no scrubber can reliably tell a credential from prose once it's been
+    // interpolated into a sentence — so the safe move is not to ship the channel
+    // at all. `scrubEvent` still scrubs breadcrumbs defensively in case one gets
+    // added another way. Workers Logs keeps the console output where it belongs.
+    integrations: (defaults) =>
+      defaults.filter(
+        (integration) => integration.name !== 'Fetch' && integration.name !== 'Console'
+      ),
     // Never let the SDK attach bodies/headers on its own judgement; scrubEvent
     // is the only thing that decides what ships.
     sendDefaultPii: false,
@@ -44,11 +56,39 @@ export interface ReportContext {
 /**
  * Report an error to the error tracker. Never throws: an observability failure
  * must not turn into a request failure.
+ *
+ * The request id is attached here rather than at call sites, so every report is
+ * correlatable with the Workers Logs lines for the same request without any
+ * caller having to remember.
  */
 export function reportError(error: unknown, context?: ReportContext): void {
   try {
-    Sentry.captureException(error, { tags: context?.tags, extra: context?.extra });
+    const requestContext = getRequestContext();
+    Sentry.captureException(error, {
+      tags: {
+        ...(requestContext?.requestId ? { requestId: requestContext.requestId } : {}),
+        ...(requestContext?.route ? { route: requestContext.route } : {}),
+        ...context?.tags,
+      },
+      extra: context?.extra,
+      // A DID is a public identifier and the one thing that turns "someone hit
+      // this" into "this account hits this" (see ./scrub.ts).
+      user: requestContext?.did ? { id: requestContext.did } : undefined,
+    });
   } catch (reportingError) {
     console.error('[Observability] Failed to report error:', reportingError);
+  }
+}
+
+/**
+ * Tag the in-flight Sentry scope with the request id, so an exception the SDK
+ * captures on its own (one that escapes our own try/catch) is still correlatable.
+ * No-op when Sentry isn't initialized.
+ */
+export function tagRequestId(requestId: string): void {
+  try {
+    Sentry.getCurrentScope().setTag('requestId', requestId);
+  } catch {
+    // Scope access before init, or a vendor swap that doesn't have scopes.
   }
 }

--- a/backend/src/observability/sentry.ts
+++ b/backend/src/observability/sentry.ts
@@ -81,6 +81,35 @@ export function reportError(error: unknown, context?: ReportContext): void {
 }
 
 /**
+ * Report a condition that nothing threw for — a threshold crossing, not a crash.
+ *
+ * `fingerprint` is the grouping key: every "firehose lag is high" event lands in
+ * one issue rather than opening a new one each time the condition is re-checked.
+ * Callers are still responsible for *when* to send (see the re-alert interval in
+ * ops-metrics.ts); the fingerprint only controls grouping once sent.
+ */
+export function reportMessage(
+  message: string,
+  options: ReportContext & { level?: 'warning' | 'error'; fingerprint?: string[] } = {}
+): void {
+  try {
+    const requestContext = getRequestContext();
+    Sentry.captureMessage(message, {
+      level: options.level ?? 'warning',
+      fingerprint: options.fingerprint,
+      tags: {
+        ...(requestContext?.requestId ? { requestId: requestContext.requestId } : {}),
+        ...(requestContext?.route ? { route: requestContext.route } : {}),
+        ...options.tags,
+      },
+      extra: options.extra,
+    });
+  } catch (reportingError) {
+    console.error('[Observability] Failed to report message:', reportingError);
+  }
+}
+
+/**
  * Tag the in-flight Sentry scope with the request id, so an exception the SDK
  * captures on its own (one that escapes our own try/catch) is still correlatable.
  * No-op when Sentry isn't initialized.

--- a/backend/src/observability/sentry.ts
+++ b/backend/src/observability/sentry.ts
@@ -103,6 +103,9 @@ export function reportMessage(
         ...options.tags,
       },
       extra: options.extra,
+      // Same reasoning as reportError: a DID is public, and it's what turns a
+      // client error report into "which account is seeing this".
+      user: requestContext?.did ? { id: requestContext.did } : undefined,
     });
   } catch (reportingError) {
     console.error('[Observability] Failed to report message:', reportingError);
@@ -116,7 +119,13 @@ export function reportMessage(
  */
 export function tagRequestId(requestId: string): void {
   try {
-    Sentry.getCurrentScope().setTag('requestId', requestId);
+    // The *isolation* scope, not the current one. `@sentry/cloudflare` forks an
+    // isolation scope per invocation (fetch — including OPTIONS/HEAD — scheduled,
+    // and the DO), but only clones the current scope on the request path that
+    // runs `continueTrace`, which it skips for preflights. Tagging the current
+    // scope there would write to the isolate-global singleton, and a later
+    // SDK-captured exception would inherit some unrelated preflight's id.
+    Sentry.getIsolationScope().setTag('requestId', requestId);
   } catch {
     // Scope access before init, or a vendor swap that doesn't have scopes.
   }

--- a/backend/src/observability/sentry.ts
+++ b/backend/src/observability/sentry.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/cloudflare';
+import type { CloudflareOptions } from '@sentry/cloudflare';
+import type { Env } from '../types';
+import { scrubEvent } from './scrub';
+
+// Error reporting for the Worker. Everything goes through `reportError()` rather
+// than calling `Sentry.captureException` at call sites: the vendor is then a
+// one-file decision (swap the SDK for GlitchTip, or for a hand-rolled envelope
+// POST if `@sentry/cloudflare` ever stops coexisting with our compat flags)
+// without touching a single caller.
+//
+// Errors-only, matching the feed proxy: `tracesSampleRate: 0`. When SENTRY_DSN is
+// unset — local dev, tests, staging before the secret is added — init is a no-op
+// and nothing is sent.
+
+export function sentryOptions(env: Env): CloudflareOptions {
+  return {
+    dsn: env.SENTRY_DSN,
+    environment: env.SENTRY_ENVIRONMENT || 'development',
+    // Set by CI (`--var GIT_COMMIT_SHA:...`), so an event points at a commit.
+    release: env.GIT_COMMIT_SHA,
+    tracesSampleRate: 0,
+    // Drop the Fetch integration. It exists to turn outbound requests into spans
+    // and breadcrumbs, and with tracing off the spans are dead weight — but the
+    // wrapper still sits in front of every outbound call this Worker makes (PDS,
+    // feed proxy, DID resolution, Jetstream). Measured in `test/xrpc.spec.ts`: the
+    // background extraction fetch went 124ms → ~17s with it enabled. Not worth it
+    // for breadcrumbs we don't need.
+    integrations: (defaults) => defaults.filter((integration) => integration.name !== 'Fetch'),
+    // Never let the SDK attach bodies/headers on its own judgement; scrubEvent
+    // is the only thing that decides what ships.
+    sendDefaultPii: false,
+    beforeSend(event) {
+      return scrubEvent(event);
+    },
+  };
+}
+
+export interface ReportContext {
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * Report an error to the error tracker. Never throws: an observability failure
+ * must not turn into a request failure.
+ */
+export function reportError(error: unknown, context?: ReportContext): void {
+  try {
+    Sentry.captureException(error, { tags: context?.tags, extra: context?.extra });
+  } catch (reportingError) {
+    console.error('[Observability] Failed to report error:', reportingError);
+  }
+}

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../types';
 import { checkRateLimit } from '../services/rate-limit';
+import { ALARM_ACTIVE_WINDOW_MS } from '../durable-objects/jetstream-poller';
 
 // Two health endpoints with deliberately different jobs:
 //
@@ -109,6 +110,7 @@ async function checkPoller(env: Env): Promise<CheckResult> {
       lastStats?: { lastPollAt?: number; duration?: number };
       nextPoll?: number | null;
       isRunning?: boolean;
+      lastAlarmStart?: number | null;
     };
 
     const lastPollAt = status.lastStats?.lastPollAt;
@@ -117,9 +119,20 @@ async function checkPoller(env: Env): Promise<CheckResult> {
     // and not yet run" as healthy rather than paging on a cold start.
     const fresh = lastPollAgeMs === null || lastPollAgeMs < POLLER_STALE_MS;
 
+    // `isRunning` is `!!getAlarm()`, which the DO reports as false for the whole
+    // time the alarm handler is executing — 5–16s of every 60s cycle. Probing in
+    // that window is likely, not exotic, so mirror the recency rule the DO's own
+    // /start branch uses instead of paging on a healthy poller mid-poll. Staleness
+    // is still caught: lastPollAgeMs is the signal that actually means "wedged".
+    const alarmStart = typeof status.lastAlarmStart === 'number' ? status.lastAlarmStart : null;
+    const recentlyActive = alarmStart !== null && Date.now() - alarmStart < ALARM_ACTIVE_WINDOW_MS;
+    const running = Boolean(status.isRunning) || recentlyActive;
+
     return {
-      ok: Boolean(status.isRunning) && fresh,
-      isRunning: Boolean(status.isRunning),
+      ok: running && fresh,
+      isRunning: running,
+      alarmScheduled: Boolean(status.isRunning),
+      lastAlarmAgeMs: alarmStart === null ? null : Date.now() - alarmStart,
       lastPollAgeMs,
       nextPoll: status.nextPoll ?? null,
     };

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,201 @@
+import type { Env } from '../types';
+import { checkRateLimit } from '../services/rate-limit';
+
+// Two health endpoints with deliberately different jobs:
+//
+// - `/api/health` is shallow and unauthenticated. It touches nothing — no D1, no
+//   DO, no proxy — so an uptime poller can hit it every 30s forever without
+//   costing anything or becoming an amplification vector. It answers exactly one
+//   question: is this Worker serving, and which build is it serving?
+// - `/api/health/deep` does the real dependency checks and is therefore gated by
+//   a shared secret and rate-limited.
+
+const DEEP_HEALTH_PATH = '/api/health/deep';
+
+// The poller's alarm re-arms every 60s. Anything past 5 minutes without a
+// completed poll means it's wedged, not merely between cycles.
+const POLLER_STALE_MS = 5 * 60 * 1000;
+
+// Dependency checks are for a monitor with a timeout of its own; fail fast rather
+// than hang.
+const DEPENDENCY_TIMEOUT_MS = 3000;
+
+export function getVersion(env: Env): string {
+  return env.GIT_COMMIT_SHA || 'dev';
+}
+
+function json(body: unknown, status = 200, extraHeaders: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      // Health answers are never cacheable — a cached 200 defeats the point.
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+  });
+}
+
+/**
+ * Shallow liveness. Dependency-free by design — see the note above.
+ */
+export function handleHealth(env: Env): Response {
+  return json({
+    status: 'ok',
+    version: getVersion(env),
+    timestamp: Date.now(),
+  });
+}
+
+// Constant-time compare so the secret can't be recovered by timing the response.
+function secretsMatch(provided: string, expected: string): boolean {
+  if (provided.length !== expected.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < provided.length; i++) {
+    mismatch |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+interface CheckResult {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+function failed(error: unknown): CheckResult {
+  return { ok: false, error: error instanceof Error ? error.message : String(error) };
+}
+
+async function checkDatabase(env: Env): Promise<CheckResult> {
+  const start = Date.now();
+  try {
+    await withTimeout(env.DB.prepare('SELECT 1').first(), DEPENDENCY_TIMEOUT_MS, 'D1');
+    return { ok: true, durationMs: Date.now() - start };
+  } catch (error) {
+    return { ...failed(error), durationMs: Date.now() - start };
+  }
+}
+
+// The DO has maintained this state all along behind an internal /status endpoint
+// that nothing called. Reading it here is what turns firehose staleness into a
+// signal instead of a surprise.
+async function checkPoller(env: Env): Promise<CheckResult> {
+  try {
+    const pollerId = env.JETSTREAM_POLLER.idFromName('main-v2');
+    const poller = env.JETSTREAM_POLLER.get(pollerId);
+    const response = await withTimeout<Response>(
+      poller.fetch('http://internal/status'),
+      DEPENDENCY_TIMEOUT_MS,
+      'JetstreamPoller /status'
+    );
+    if (!response.ok) {
+      return { ok: false, error: `status endpoint returned ${response.status}` };
+    }
+
+    const status = (await response.json()) as {
+      lastStats?: { lastPollAt?: number; duration?: number };
+      nextPoll?: number | null;
+      isRunning?: boolean;
+    };
+
+    const lastPollAt = status.lastStats?.lastPollAt;
+    const lastPollAgeMs = typeof lastPollAt === 'number' ? Date.now() - lastPollAt : null;
+    // A DO that has just been created has no completed poll yet; treat "scheduled
+    // and not yet run" as healthy rather than paging on a cold start.
+    const fresh = lastPollAgeMs === null || lastPollAgeMs < POLLER_STALE_MS;
+
+    return {
+      ok: Boolean(status.isRunning) && fresh,
+      isRunning: Boolean(status.isRunning),
+      lastPollAgeMs,
+      nextPoll: status.nextPoll ?? null,
+    };
+  } catch (error) {
+    return failed(error);
+  }
+}
+
+async function checkFeedProxy(env: Env): Promise<CheckResult> {
+  const start = Date.now();
+  try {
+    const response = await fetch(`${env.FEED_PROXY_URL}/health`, {
+      signal: AbortSignal.timeout(DEPENDENCY_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `health returned ${response.status}`,
+        durationMs: Date.now() - start,
+      };
+    }
+    const body = (await response.json()) as { cachedFeeds?: number; version?: string };
+    return {
+      ok: true,
+      durationMs: Date.now() - start,
+      cachedFeeds: body.cachedFeeds ?? null,
+      version: body.version ?? null,
+    };
+  } catch (error) {
+    return { ...failed(error), durationMs: Date.now() - start };
+  }
+}
+
+/**
+ * Deep health: one URL that answers "is everything up". Returns 503 when any
+ * dependency is unhealthy so an uptime monitor alerts on it directly.
+ */
+export async function handleDeepHealth(request: Request, env: Env): Promise<Response> {
+  const expected = env.HEALTH_CHECK_SECRET;
+  if (!expected) {
+    // Fail closed. Without the secret this endpoint would be an unauthenticated
+    // way to make the Worker fan out to D1, a DO, and the proxy on every request.
+    return json({ status: 'unconfigured', error: 'HEALTH_CHECK_SECRET is not set' }, 503);
+  }
+
+  // Secret first, rate limit second: the secret check is pure CPU, so an
+  // unauthenticated flood is rejected without a single D1 write. Rate limiting
+  // then bounds how much real dependency work an authorized caller can trigger.
+  const provided = request.headers.get('X-Health-Secret') ?? '';
+  if (!secretsMatch(provided, expected)) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateLimit = await checkRateLimit(env, `health:${ip}`, DEEP_HEALTH_PATH);
+  if (!rateLimit.allowed) {
+    return json({ error: 'Rate limit exceeded' }, 429, {
+      'Retry-After': String(rateLimit.retryAfter || 60),
+    });
+  }
+
+  const [database, poller, feedProxy] = await Promise.all([
+    checkDatabase(env),
+    checkPoller(env),
+    checkFeedProxy(env),
+  ]);
+
+  const healthy = database.ok && poller.ok && feedProxy.ok;
+
+  return json(
+    {
+      status: healthy ? 'ok' : 'degraded',
+      version: getVersion(env),
+      timestamp: Date.now(),
+      checks: { database, poller, feedProxy },
+    },
+    healthy ? 200 : 503
+  );
+}

--- a/backend/src/routes/telemetry.ts
+++ b/backend/src/routes/telemetry.ts
@@ -1,0 +1,184 @@
+import type { Env } from '../types';
+import { checkRateLimit } from '../services/rate-limit';
+import { log } from '../utils/logger';
+import { reportMessage } from '../observability/sentry';
+
+// Client-side error reporting, deliberately minimal.
+//
+// The gap this closes: when a deploy breaks the PWA shell for real users, we
+// currently learn about it from a bug report. The gap it does NOT try to close is
+// per-user telemetry — there is no session replay, no breadcrumb trail, no page
+// analytics, and the client never talks to a third party. The browser posts here;
+// this Worker decides what reaches the error tracker.
+//
+// Everything the client sends is treated as hostile: this endpoint is
+// unauthenticated (an error on the login screen is exactly the kind we want), so
+// every field is length-capped, the `kind` is an allowlist, and the URL is
+// reduced to a path before it goes anywhere. The client samples before it sends
+// (see frontend/src/lib/services/telemetry.ts); the rate limit here is the floor
+// under a client that ignores its own sampling, not the primary control.
+
+const TELEMETRY_PATH = '/api/telemetry/error';
+
+/** Refuse to even read a body larger than this — nothing legitimate is close. */
+const MAX_BODY_BYTES = 16 * 1024;
+
+const MAX_MESSAGE_CHARS = 300;
+const MAX_STACK_CHARS = 2000;
+const MAX_NAME_CHARS = 100;
+const MAX_URL_CHARS = 200;
+const MAX_VERSION_CHARS = 64;
+
+/**
+ * What kind of failure the client is reporting. A closed set, because this is a
+ * Sentry tag and a log facet: an open one would let a client mint unbounded
+ * values in both.
+ */
+const KINDS = new Set([
+  // SvelteKit's handleError — an error during navigation or rendering.
+  'render',
+  // window.onerror — an uncaught exception anywhere else.
+  'uncaught',
+  // unhandledrejection — a promise nobody caught.
+  'rejection',
+  // The stale-chunk reload guard tripped twice: recovery itself failed, which is
+  // the "a deploy bricked the PWA" signal. Never sampled away by the client.
+  'preload_recovery_failed',
+]);
+
+interface ClientErrorReport {
+  kind: string;
+  name: string;
+  message: string;
+  stack?: string;
+  /** The frontend build (`$app/environment`'s version = the deploy's SHA). */
+  appVersion?: string;
+  /** Path only — the client strips the query string, and so do we. */
+  path?: string;
+  /** Client-side sampling rate, so a count here can be scaled back up. */
+  sampleRate?: number;
+}
+
+function text(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+/**
+ * Keep the path, drop everything that could carry a credential or an identifier:
+ * query strings (share tokens, OAuth params), fragments, and the origin.
+ */
+function safePath(value: unknown): string | undefined {
+  const raw = text(value, MAX_URL_CHARS * 4);
+  if (!raw) return undefined;
+  try {
+    return text(new URL(raw, 'https://skyreader.app').pathname, MAX_URL_CHARS);
+  } catch {
+    return text(raw.split(/[?#]/)[0], MAX_URL_CHARS);
+  }
+}
+
+function parseReport(body: unknown): ClientErrorReport | null {
+  if (!body || typeof body !== 'object') return null;
+  const input = body as Record<string, unknown>;
+
+  const kind = typeof input.kind === 'string' && KINDS.has(input.kind) ? input.kind : null;
+  if (!kind) return null;
+
+  const message = text(input.message, MAX_MESSAGE_CHARS);
+  if (!message) return null;
+
+  const sampleRate =
+    typeof input.sampleRate === 'number' && input.sampleRate > 0 && input.sampleRate <= 1
+      ? input.sampleRate
+      : undefined;
+
+  return {
+    kind,
+    name: text(input.name, MAX_NAME_CHARS) ?? 'Error',
+    message,
+    stack: text(input.stack, MAX_STACK_CHARS),
+    appVersion: text(input.appVersion, MAX_VERSION_CHARS),
+    path: safePath(input.path),
+    sampleRate,
+  };
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+}
+
+/**
+ * Accept one client error report.
+ *
+ * Answers before it does any work whenever it can: a browser is waiting on this
+ * during a page that is already broken, so nothing here is allowed to be slow or
+ * to fail loudly. Every outcome is a small JSON body the client ignores.
+ */
+export async function handleTelemetryError(
+  request: Request,
+  env: Env,
+  did?: string
+): Promise<Response> {
+  if (request.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  const declaredLength = Number(request.headers.get('Content-Length') ?? 0);
+  if (declaredLength > MAX_BODY_BYTES) return json({ error: 'Payload too large' }, 413);
+
+  // Anonymous clients are keyed by IP: an error on the login screen has no DID,
+  // and that's a report worth having.
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateLimit = await checkRateLimit(env, `telemetry:${did ?? ip}`, TELEMETRY_PATH);
+  if (!rateLimit.allowed) {
+    // 429 without Retry-After on purpose: a client in an error loop should drop
+    // the report, not schedule it. The frontend reporter never retries.
+    return json({ error: 'Rate limit exceeded' }, 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const report = parseReport(body);
+  if (!report) return json({ error: 'Invalid report' }, 400);
+
+  // Workers Logs gets the full picture (queryable by `event = client_error`);
+  // Sentry gets the grouped, notifiable version.
+  log.warn('client_error', {
+    kind: report.kind,
+    errorName: report.name,
+    errorMessage: report.message,
+    appVersion: report.appVersion,
+    path: report.path,
+    sampleRate: report.sampleRate,
+  });
+
+  reportMessage(`[client] ${report.name}: ${report.message}`, {
+    level: 'error',
+    // Group by kind + name + message rather than by the stack: the stack belongs
+    // to a client bundle this Sentry project has no source maps for, so letting
+    // the SDK group on it would scatter one bug across many issues.
+    fingerprint: ['client', report.kind, report.name, report.message],
+    tags: {
+      source: 'client',
+      kind: report.kind,
+      ...(report.appVersion ? { appVersion: report.appVersion } : {}),
+    },
+    extra: {
+      stack: report.stack,
+      path: report.path,
+      sampleRate: report.sampleRate,
+      userAgent: request.headers.get('User-Agent')?.slice(0, 200),
+    },
+  });
+
+  return new Response(null, { status: 204 });
+}

--- a/backend/src/routes/telemetry.ts
+++ b/backend/src/routes/telemetry.ts
@@ -18,7 +18,7 @@ import { reportMessage } from '../observability/sentry';
 // (see frontend/src/lib/services/telemetry.ts); the rate limit here is the floor
 // under a client that ignores its own sampling, not the primary control.
 
-const TELEMETRY_PATH = '/api/telemetry/error';
+export const TELEMETRY_PATH = '/api/telemetry/error';
 
 /** Refuse to even read a body larger than this — nothing legitimate is close. */
 const MAX_BODY_BYTES = 16 * 1024;
@@ -120,20 +120,18 @@ function json(body: unknown, status: number): Response {
  * during a page that is already broken, so nothing here is allowed to be slow or
  * to fail loudly. Every outcome is a small JSON body the client ignores.
  */
-export async function handleTelemetryError(
-  request: Request,
-  env: Env,
-  did?: string
-): Promise<Response> {
+export async function handleTelemetryError(request: Request, env: Env): Promise<Response> {
   if (request.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
 
   const declaredLength = Number(request.headers.get('Content-Length') ?? 0);
   if (declaredLength > MAX_BODY_BYTES) return json({ error: 'Payload too large' }, 413);
 
-  // Anonymous clients are keyed by IP: an error on the login screen has no DID,
-  // and that's a report worth having.
+  // Keyed by IP, never by DID: this route is answered before session resolution
+  // (see src/index.ts), so there is no session to key on — which is the point.
+  // An error on the login screen has no DID either, and that's a report worth
+  // having.
   const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
-  const rateLimit = await checkRateLimit(env, `telemetry:${did ?? ip}`, TELEMETRY_PATH);
+  const rateLimit = await checkRateLimit(env, `telemetry:${ip}`, TELEMETRY_PATH);
   if (!rateLimit.allowed) {
     // 429 without Retry-After on purpose: a client in an error loop should drop
     // the report, not schedule it. The frontend reporter never retries.

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -1,4 +1,11 @@
 import type { Env, FeedItem } from '../types';
+import { getRequestId } from '../utils/request-context';
+
+/** Stamp the in-flight request id on an outbound proxy call, when there is one. */
+function setRequestIdHeader(headers: Headers): void {
+  const requestId = getRequestId();
+  if (requestId) headers.set('X-Request-Id', requestId);
+}
 
 // Default ceiling on a single proxy round-trip. Generous because endpoints like
 // /extract legitimately fetch + parse large pages.
@@ -299,6 +306,10 @@ export class FeedProxyClient {
     const headers = new Headers(options.headers);
     headers.set('X-Proxy-Secret', this.proxySecret);
     headers.set('Content-Type', 'application/json');
+    // Cross-service correlation for the cost of one header: the proxy echoes this
+    // into its own logs and Sentry tags, so a slow or failing feed fetch can be
+    // followed from the Worker's request line into the proxy.
+    setRequestIdHeader(headers);
 
     // Hard ceiling on a single proxy round-trip. The proxy self-bounds each feed
     // in a batch (BATCH_INLINE_FETCH_BUDGET_MS), so under normal load it answers
@@ -598,6 +609,7 @@ export class FeedProxyClient {
     const headers = new Headers();
     headers.set('X-Proxy-Secret', this.proxySecret);
     headers.set('Content-Type', 'application/json');
+    setRequestIdHeader(headers);
 
     const response = await fetch(proxyUrl, {
       method: 'POST',

--- a/backend/src/services/rate-limit.ts
+++ b/backend/src/services/rate-limit.ts
@@ -20,6 +20,11 @@ const STANDARD_LIMIT: RateLimitConfig = { limit: 100, windowMs: 60000 };
 const LIGHT_LIMIT: RateLimitConfig = { limit: 300, windowMs: 60000 };
 
 const RATE_LIMITS: Record<string, RateLimitConfig> = {
+  // Deep health check. Keyed by client IP (not did) since callers are monitors,
+  // not users. Sized for a poll every 30s plus retries — anything above that is
+  // someone using our dependency fan-out as an amplifier.
+  '/api/health/deep': { limit: 10, windowMs: 60000 },
+
   // Expensive operations (external API calls, complex queries)
   '/api/social/feed': EXPENSIVE_LIMIT,
   '/api/social/sync-follows': EXPENSIVE_LIMIT,

--- a/backend/src/services/rate-limit.ts
+++ b/backend/src/services/rate-limit.ts
@@ -25,6 +25,12 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
   // someone using our dependency fan-out as an amplifier.
   '/api/health/deep': { limit: 10, windowMs: 60000 },
 
+  // Client error reports. Keyed by DID when the reporter has a session and by IP
+  // when it doesn't. Sized for a page that breaks in several ways at once, not
+  // for a client stuck in an error loop — the client samples before it sends, and
+  // anything above this is a bug in the client, not signal worth keeping.
+  '/api/telemetry/error': { limit: 20, windowMs: 60000 },
+
   // Expensive operations (external API calls, complex queries)
   '/api/social/feed': EXPENSIVE_LIMIT,
   '/api/social/sync-follows': EXPENSIVE_LIMIT,

--- a/backend/src/types/node-async-hooks.d.ts
+++ b/backend/src/types/node-async-hooks.d.ts
@@ -1,0 +1,15 @@
+// Ambient types for the slice of `node:async_hooks` that workerd exposes under
+// the `nodejs_als` compatibility flag (see wrangler.toml).
+//
+// Why not `@types/node`: it would declare Node's entire global surface — process,
+// Buffer, NodeJS.Timeout — inside a Workers project that deliberately doesn't
+// have it, quietly type-checking code that would fail at runtime. `AsyncLocalStorage`
+// is the only Node API this Worker uses, so it's the only one declared.
+declare module 'node:async_hooks' {
+  export class AsyncLocalStorage<T> {
+    run<R>(store: T, callback: () => R): R;
+    getStore(): T | undefined;
+    enterWith(store: T): void;
+    exit<R>(callback: () => R): R;
+  }
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,72 @@
+import { getRequestContext } from './request-context';
+
+// Structured logging for the Worker.
+//
+// Workers Logs indexes the *fields of an object* passed to `console.*` and treats
+// a string — even a JSON one — as an opaque message you can only text-match. So
+// this emits one object per line: `{ level, event, requestId, route, … }`, which
+// makes "every error on route X" and "every line for request Y" queries rather
+// than greps. `wrangler tail` prints the same object inline, so local debugging
+// doesn't get worse.
+//
+// Two rules for call sites:
+//   1. `event` is a stable, low-cardinality slug (`request`, `cron_run`,
+//      `jetstream_poll`) — it's the thing you filter on. Details go in fields.
+//   2. Never log a credential. Workers Logs is not a place where redaction can
+//      save you; log an id, a length, or a boolean instead.
+//
+// Existing `console.log` calls are left alone deliberately: converting ~240 leaf
+// call sites is churn without payoff. The high-value paths (request summary,
+// top-level error, cron, poll cycle) go through here.
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogFields {
+  [key: string]: unknown;
+}
+
+interface LogPayload extends LogFields {
+  level: LogLevel;
+  event: string;
+}
+
+/**
+ * Flatten an unknown thrown value into loggable fields. Stacks are kept — this
+ * is our own log sink, not a third party — but bounded, since a Workers Logs
+ * line has a size limit and a truncated stack still names the throw site.
+ */
+export function serializeError(error: unknown): LogFields {
+  if (error instanceof Error) {
+    return {
+      errorName: error.name,
+      errorMessage: error.message,
+      stack: error.stack?.slice(0, 2000),
+    };
+  }
+  return { errorMessage: String(error) };
+}
+
+function emit(level: LogLevel, event: string, fields: LogFields = {}): void {
+  const context = getRequestContext();
+  const payload: LogPayload = {
+    level,
+    event,
+    ...(context?.requestId ? { requestId: context.requestId } : {}),
+    ...(context?.route ? { route: context.route } : {}),
+    ...(context?.did ? { did: context.did } : {}),
+    ...fields,
+  };
+
+  // console.error/warn also route to Workers Logs' level facets, which is what
+  // makes "errors only" a one-click filter in the dashboard.
+  if (level === 'error') console.error(payload);
+  else if (level === 'warn') console.warn(payload);
+  else console.log(payload);
+}
+
+export const log = {
+  debug: (event: string, fields?: LogFields) => emit('debug', event, fields),
+  info: (event: string, fields?: LogFields) => emit('info', event, fields),
+  warn: (event: string, fields?: LogFields) => emit('warn', event, fields),
+  error: (event: string, fields?: LogFields) => emit('error', event, fields),
+};

--- a/backend/src/utils/request-context.ts
+++ b/backend/src/utils/request-context.ts
@@ -1,0 +1,82 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// Per-request (and per-cron-run, per-poll-cycle) context, carried in
+// AsyncLocalStorage rather than threaded through every function signature.
+//
+// Why ALS: the useful correlation key is the request id, and the places that
+// want it — a log line in a service, the outbound header on a feed-proxy call,
+// a Sentry tag inside `reportError()` — are three or four call frames below the
+// handler that minted it. Threading a parameter through all of them would touch
+// every route and service for one field. `nodejs_als` is already enabled for
+// @sentry/cloudflare (see wrangler.toml), so this costs nothing new.
+//
+// Nothing in here is required for correctness: every reader treats a missing
+// store as "no id", so code paths outside a context (module init, tests calling
+// a handler directly) work unchanged.
+
+export interface RequestContext {
+  /** Correlation id. Present on every log line and Sentry event from this task. */
+  requestId: string;
+  /** Route class, not raw path — see `classifyRoute()`. */
+  route?: string;
+  method?: string;
+  /** Set once the session resolves. DIDs are public identifiers; keeping one is
+   *  what turns "an error happened" into "this user hit it". */
+  did?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/** Run `fn` with `context` visible to everything it awaits. */
+export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+export function getRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}
+
+/** Attach the DID to the in-flight context once the session is known. */
+export function setContextDid(did: string): void {
+  const context = storage.getStore();
+  if (context) context.did = did;
+}
+
+/**
+ * Collapse a pathname to a route class so logs group by endpoint instead of by
+ * identifier. `/api/linkblog/share/3labc…` and `/api/linkblog/share/3lxyz…` are
+ * the same route and must aggregate as one.
+ *
+ * Deliberately a small allowlist of the prefix-matched routes in index.ts plus a
+ * generic guard: anything that reaches the default branch is a 404, and 404s on
+ * arbitrary paths must not mint unbounded distinct route values.
+ */
+export function classifyRoute(pathname: string): string {
+  const dynamicPrefixes = [
+    '/api/linkblog/share/',
+    '/api/linkblog/resolve/',
+    '/api/subscriptions/',
+    '/api/saved/by-guid/',
+    '/api/saved/',
+    '/api/integrations/margin/notes/',
+    '/api/channels/',
+    '/.well-known/lexicons/',
+  ];
+  for (const prefix of dynamicPrefixes) {
+    if (pathname.startsWith(prefix) && pathname.length > prefix.length) {
+      // Keep the verb-ish suffixes index.ts routes on (…/activate, …/park) —
+      // they're distinct endpoints, not identifiers.
+      const [, next] = pathname.slice(prefix.length).split('/');
+      return `${prefix}:id${next ? `/${next}` : ''}`;
+    }
+  }
+  // Cap the cardinality of everything else. Real routes in this app are at most
+  // four segments deep; anything longer is a probe or a typo.
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length > 4) return '/' + segments.slice(0, 4).join('/') + '/…';
+  return pathname;
+}

--- a/backend/src/utils/request-context.ts
+++ b/backend/src/utils/request-context.ts
@@ -74,8 +74,19 @@ export function classifyRoute(pathname: string): string {
       return `${prefix}:id${next ? `/${next}` : ''}`;
     }
   }
-  // Cap the cardinality of everything else. Real routes in this app are at most
-  // four segments deep; anything longer is a probe or a typo.
+  // Everything this Worker serves lives under one of three prefixes. A path
+  // outside them is a scanner (`/wp-login.php`, `/.env`, `/phpmyadmin`) — a 404
+  // that still gets an `event = request` line, so returning it verbatim would let
+  // anyone on the internet mint unbounded values of the field the runbook says to
+  // aggregate on. One value for the whole class instead; the raw path is still on
+  // the line's `path` field when a specific probe matters.
+  const known = ['/api/', '/xrpc/', '/.well-known/'];
+  if (!known.some((prefix) => pathname.startsWith(prefix))) return '/other';
+
+  // Cap the cardinality of what's left. Real routes in this app are at most four
+  // segments deep; anything longer is a probe or a typo. A scanner enumerating
+  // *inside* `/api/` can still mint a value per path — accepted, because
+  // collapsing those would also collapse the real 404s worth noticing.
   const segments = pathname.split('/').filter(Boolean);
   if (segments.length > 4) return '/' + segments.slice(0, 4).join('/') + '/…';
   return pathname;

--- a/backend/test/feed-proxy-client.spec.ts
+++ b/backend/test/feed-proxy-client.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FeedProxyClient, FeedProxyError } from '../src/services/feed-proxy-client';
 import type { Env } from '../src/types';
+import { runWithRequestContext } from '../src/utils/request-context';
 
 function createClient(): FeedProxyClient {
   return new FeedProxyClient({
@@ -188,6 +189,36 @@ describe('FeedProxyClient', () => {
         name: 'FeedProxyError',
         message: 'boom',
       });
+    });
+  });
+
+  // Cross-service correlation: the proxy adopts this header and tags its own logs
+  // and Sentry events with it, so one id spans both runtimes.
+  describe('request id propagation', () => {
+    it('sends X-Request-Id when there is an ambient request context', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ feeds: [] }), { status: 200 }));
+      globalThis.fetch = fetchMock;
+
+      await runWithRequestContext({ requestId: 'req-abc' }, () =>
+        createClient().discoverFeeds('https://example.com')
+      );
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(new Headers(init.headers).get('X-Request-Id')).toBe('req-abc');
+    });
+
+    it('omits the header outside a request context', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ feeds: [] }), { status: 200 }));
+      globalThis.fetch = fetchMock;
+
+      await createClient().discoverFeeds('https://example.com');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(new Headers(init.headers).get('X-Request-Id')).toBeNull();
     });
   });
 });

--- a/backend/test/health.spec.ts
+++ b/backend/test/health.spec.ts
@@ -8,7 +8,32 @@ interface HealthBody {
   status: string;
   version: string;
   timestamp: number;
-  checks?: Record<string, { ok: boolean; error?: string }>;
+  checks?: Record<string, { ok: boolean; error?: string; [key: string]: unknown }>;
+}
+
+// A stand-in for the JetstreamPoller namespace that answers /status with a fixed
+// body — the only way to drive the "alarm is mid-flight" window deterministically.
+function envWithPollerStatus(status: Record<string, unknown>) {
+  const namespace = {
+    idFromName: () => 'stub-id',
+    get: () => ({
+      fetch: async () =>
+        new Response(JSON.stringify(status), { headers: { 'Content-Type': 'application/json' } }),
+    }),
+  };
+  return {
+    ...env,
+    HEALTH_CHECK_SECRET: SECRET,
+    JETSTREAM_POLLER: namespace,
+  } as unknown as Parameters<typeof handleDeepHealth>[1];
+}
+
+async function pollerCheck(status: Record<string, unknown>) {
+  const response = await handleDeepHealth(
+    new Request('http://localhost/api/health/deep', { headers: { 'X-Health-Secret': SECRET } }),
+    envWithPollerStatus(status)
+  );
+  return ((await response.json()) as HealthBody).checks!.poller;
 }
 
 describe('health endpoints', () => {
@@ -90,6 +115,59 @@ describe('health endpoints', () => {
       const allOk = body.checks!.database.ok && body.checks!.poller.ok && body.checks!.feedProxy.ok;
       expect(body.status).toBe(allOk ? 'ok' : 'degraded');
       expect(response.status).toBe(allOk ? 200 : 503);
+    });
+
+    // The DO reports `isRunning: !!getAlarm()`, and getAlarm() is null for the
+    // whole time the alarm handler is executing — several seconds of every
+    // minute. Treating that as "poller down" would page during normal operation,
+    // which is exactly the false alert that teaches an operator to ignore the one
+    // signal that catches a dead firehose.
+    describe('poller freshness', () => {
+      it('stays healthy while the alarm is mid-cycle', async () => {
+        const poller = await pollerCheck({
+          isRunning: false,
+          nextPoll: null,
+          lastAlarmStart: Date.now() - 3000,
+          lastStats: { lastPollAt: Date.now() - 60_000 },
+        });
+
+        expect(poller.ok).toBe(true);
+        expect(poller.isRunning).toBe(true);
+        // …while still reporting the underlying fact, so the distinction is
+        // visible to a human reading the body.
+        expect(poller.alarmScheduled).toBe(false);
+      });
+
+      it('reports unhealthy when no alarm is scheduled and none ran recently', async () => {
+        const poller = await pollerCheck({
+          isRunning: false,
+          nextPoll: null,
+          lastAlarmStart: Date.now() - 10 * 60_000,
+          lastStats: { lastPollAt: Date.now() - 30_000 },
+        });
+
+        expect(poller.ok).toBe(false);
+        expect(poller.isRunning).toBe(false);
+      });
+
+      it('reports unhealthy when the last completed poll is stale', async () => {
+        const poller = await pollerCheck({
+          isRunning: true,
+          nextPoll: Date.now() + 30_000,
+          lastAlarmStart: Date.now() - 30_000,
+          lastStats: { lastPollAt: Date.now() - 10 * 60_000 },
+        });
+
+        expect(poller.ok).toBe(false);
+        expect(poller.lastPollAgeMs).toBeGreaterThan(5 * 60_000);
+      });
+
+      it('treats a cold DO with no completed poll as healthy', async () => {
+        const poller = await pollerCheck({ isRunning: true, nextPoll: Date.now() + 1000 });
+
+        expect(poller.ok).toBe(true);
+        expect(poller.lastPollAgeMs).toBeNull();
+      });
     });
   });
 });

--- a/backend/test/health.spec.ts
+++ b/backend/test/health.spec.ts
@@ -1,0 +1,95 @@
+import { env, SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import { handleDeepHealth } from '../src/routes/health';
+
+const SECRET = 'correct-horse-battery-staple';
+
+interface HealthBody {
+  status: string;
+  version: string;
+  timestamp: number;
+  checks?: Record<string, { ok: boolean; error?: string }>;
+}
+
+describe('health endpoints', () => {
+  describe('GET /api/health', () => {
+    it('is reachable without a session and reports status + version', async () => {
+      const response = await SELF.fetch('http://localhost/api/health');
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as HealthBody;
+      expect(body.status).toBe('ok');
+      // No GIT_COMMIT_SHA in tests, so the fallback stamp.
+      expect(body.version).toBe('dev');
+      expect(typeof body.timestamp).toBe('number');
+    });
+
+    it('is not cacheable', async () => {
+      const response = await SELF.fetch('http://localhost/api/health');
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    it('ignores a bogus Authorization header rather than 401ing', async () => {
+      const response = await SELF.fetch('http://localhost/api/health', {
+        headers: { Authorization: 'Bearer nonsense' },
+      });
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('GET /api/health/deep', () => {
+    it('fails closed when HEALTH_CHECK_SECRET is unset', async () => {
+      expect(env.HEALTH_CHECK_SECRET).toBeUndefined();
+
+      const response = await SELF.fetch('http://localhost/api/health/deep');
+      expect(response.status).toBe(503);
+      expect(((await response.json()) as HealthBody).status).toBe('unconfigured');
+    });
+
+    // The secret is a wrangler secret, not a test binding, so these drive the
+    // handler directly with an env that has one.
+    const configuredEnv = { ...env, HEALTH_CHECK_SECRET: SECRET } as unknown as Parameters<
+      typeof handleDeepHealth
+    >[1];
+
+    it('rejects a wrong secret with 401', async () => {
+      const response = await handleDeepHealth(
+        new Request('http://localhost/api/health/deep', {
+          headers: { 'X-Health-Secret': 'wrong' },
+        }),
+        configuredEnv
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it('rejects a missing secret with 401', async () => {
+      const response = await handleDeepHealth(
+        new Request('http://localhost/api/health/deep'),
+        configuredEnv
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it('runs the dependency checks with the right secret', async () => {
+      const response = await handleDeepHealth(
+        new Request('http://localhost/api/health/deep', {
+          headers: { 'X-Health-Secret': SECRET },
+        }),
+        configuredEnv
+      );
+
+      // The feed proxy isn't reachable from the test worker, so the aggregate
+      // verdict may well be degraded — what matters is that each dependency
+      // reports independently instead of the whole endpoint throwing.
+      const body = (await response.json()) as HealthBody;
+      expect([200, 503]).toContain(response.status);
+      expect(body.checks).toBeDefined();
+      expect(body.checks!.database.ok).toBe(true);
+      expect(body.checks!.poller).toBeDefined();
+      expect(body.checks!.feedProxy).toBeDefined();
+      const allOk = body.checks!.database.ok && body.checks!.poller.ok && body.checks!.feedProxy.ok;
+      expect(body.status).toBe(allOk ? 'ok' : 'degraded');
+      expect(response.status).toBe(allOk ? 200 : 503);
+    });
+  });
+});

--- a/backend/test/ops-metrics.spec.ts
+++ b/backend/test/ops-metrics.spec.ts
@@ -1,0 +1,319 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  decideLagAlert,
+  worstLagMs,
+  readSystemStatus,
+  writeSystemStatus,
+  recordPollerStatus,
+  recordProxyStats,
+  recordCronRun,
+  writeMetricsSnapshot,
+  runRecordingStep,
+  FIREHOSE_LAG_ALERT_MS,
+  FIREHOSE_LAG_REALERT_MS,
+  SNAPSHOT_RETENTION_MS,
+  type PollerStatusValue,
+  type ProxyStatsValue,
+  type CronLastRunValue,
+} from '../src/observability/ops-metrics';
+import type { Env } from '../src/types';
+
+// Phase 2 of the observability plan: the cron stops discarding what it learns.
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** A JetstreamPoller namespace whose /status answers with a fixed body. */
+function envWithPollerStatus(status: Record<string, unknown>): Env {
+  return {
+    ...env,
+    JETSTREAM_POLLER: {
+      idFromName: () => 'stub-id',
+      get: () => ({
+        fetch: async () =>
+          new Response(JSON.stringify(status), { headers: { 'Content-Type': 'application/json' } }),
+      }),
+    },
+  } as unknown as Env;
+}
+
+const pollerStatusBody = (lagMs: number | null) => ({
+  lag: { subscriptionsMs: lagMs, documentsMs: lagMs === null ? null : Math.max(0, lagMs - 1000) },
+  lastStats: {
+    subscriptions: { processed: 3, errors: 1 },
+    documents: { processed: 2, errors: 0 },
+    duration: 4200,
+    lastPollAt: 1_700_000_000_000,
+  },
+  isRunning: true,
+});
+
+beforeEach(async () => {
+  await env.DB.prepare('DELETE FROM system_status').run();
+  await env.DB.prepare('DELETE FROM metrics_snapshots').run();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('system_status storage', () => {
+  it('upserts rather than duplicating a key', async () => {
+    await writeSystemStatus(env as Env, 'cron_last_run', { at: 1 }, 1000);
+    await writeSystemStatus(env as Env, 'cron_last_run', { at: 2 }, 2000);
+
+    const row = await readSystemStatus<{ at: number }>(env as Env, 'cron_last_run');
+    expect(row).toEqual({ value: { at: 2 }, updatedAt: 2000 });
+
+    const count = await env.DB.prepare('SELECT COUNT(*) AS c FROM system_status').first<{
+      c: number;
+    }>();
+    expect(count?.c).toBe(1);
+  });
+
+  it('treats an unparseable row as absent instead of throwing mid-cron', async () => {
+    await env.DB.prepare('INSERT INTO system_status (key, value, updated_at) VALUES (?, ?, ?)')
+      .bind('poller_status', 'not json', 1000)
+      .run();
+
+    expect(await readSystemStatus(env as Env, 'poller_status')).toBeNull();
+  });
+});
+
+describe('firehose lag alerting', () => {
+  it('takes the worse of the two stream lags, ignoring a stream with no cursor', () => {
+    expect(worstLagMs(1000, 5000)).toBe(5000);
+    expect(worstLagMs(null, 5000)).toBe(5000);
+    expect(worstLagMs(1000, null)).toBe(1000);
+    expect(worstLagMs(null, null)).toBeNull();
+  });
+
+  it('does not alert on unknown lag — a poller with no cursor yet is not late', () => {
+    expect(decideLagAlert(null, null, 1000)).toEqual({
+      alert: false,
+      recovered: false,
+      lagAlertAt: null,
+    });
+  });
+
+  it('alerts once, then reminds only at the re-alert interval', () => {
+    const high = FIREHOSE_LAG_ALERT_MS + 1;
+    const now = 10_000_000;
+
+    const first = decideLagAlert(high, null, now);
+    expect(first.alert).toBe(true);
+    expect(first.lagAlertAt).toBe(now);
+
+    // A minute later the condition persists — no second event.
+    const nextMinute = decideLagAlert(high, first.lagAlertAt, now + 60_000);
+    expect(nextMinute.alert).toBe(false);
+    expect(nextMinute.lagAlertAt).toBe(now);
+
+    const afterInterval = decideLagAlert(high, first.lagAlertAt, now + FIREHOSE_LAG_REALERT_MS);
+    expect(afterInterval.alert).toBe(true);
+    expect(afterInterval.lagAlertAt).toBe(now + FIREHOSE_LAG_REALERT_MS);
+  });
+
+  it('clears the dedupe stamp on recovery so the next spike alerts immediately', () => {
+    const recovered = decideLagAlert(1000, 5_000_000, 6_000_000);
+    expect(recovered).toEqual({ alert: false, recovered: true, lagAlertAt: null });
+
+    const nextSpike = decideLagAlert(FIREHOSE_LAG_ALERT_MS + 1, recovered.lagAlertAt, 6_000_001);
+    expect(nextSpike.alert).toBe(true);
+  });
+});
+
+describe('recordPollerStatus', () => {
+  it('stores lag, last-cycle counts and alarm state', async () => {
+    const value = await recordPollerStatus(envWithPollerStatus(pollerStatusBody(30_000)), 5000);
+
+    expect(value.lagMs).toBe(30_000);
+    expect(value.subscriptionsLagMs).toBe(30_000);
+    expect(value.documentsLagMs).toBe(29_000);
+    expect(value.processed).toBe(5);
+    expect(value.errors).toBe(1);
+    expect(value.alarmScheduled).toBe(true);
+    expect(value.lagAlertAt).toBeNull();
+
+    const row = await readSystemStatus<PollerStatusValue>(env as Env, 'poller_status');
+    expect(row?.value.lagMs).toBe(30_000);
+    expect(row?.updatedAt).toBe(5000);
+  });
+
+  it('logs and reports once when lag crosses the threshold, and stays quiet the next minute', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const late = envWithPollerStatus(pollerStatusBody(FIREHOSE_LAG_ALERT_MS + 60_000));
+    const now = 1_000_000_000;
+
+    await recordPollerStatus(late, now);
+    await recordPollerStatus(late, now + 60_000);
+
+    const alerts = errors.mock.calls
+      .map(([entry]) => entry as { event?: string })
+      .filter((entry) => entry?.event === 'firehose_lag_high');
+    expect(alerts).toHaveLength(1);
+
+    const row = await readSystemStatus<PollerStatusValue>(env as Env, 'poller_status');
+    expect(row?.value.lagAlertAt).toBe(now);
+  });
+
+  it('throws when the poller cannot be reached, so the caller records the failure', async () => {
+    const broken = {
+      ...env,
+      JETSTREAM_POLLER: {
+        idFromName: () => 'stub-id',
+        get: () => ({ fetch: async () => new Response('nope', { status: 500 }) }),
+      },
+    } as unknown as Env;
+
+    await expect(recordPollerStatus(broken)).rejects.toThrow(/500/);
+  });
+});
+
+describe('recordProxyStats', () => {
+  it('stores cache freshness and error counts from the proxy', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          total: 200,
+          fresh: 150,
+          stale: 40,
+          inFlight: 2,
+          cacheTtlSeconds: 900,
+          errors: { total: 7, inBackoff: 3, permanent: 1 },
+        })
+      )
+    );
+
+    const value = await recordProxyStats(
+      { ...env, FEED_PROXY_URL: 'https://proxy.example', FEED_PROXY_SECRET: 'sekrit' } as Env,
+      9000
+    );
+
+    expect(value.freshPct).toBe(75);
+    expect(value.feedsInError).toBe(7);
+    expect(value.feedsPermanentlyFailed).toBe(1);
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://proxy.example/stats');
+    expect((init.headers as Record<string, string>)['X-Proxy-Secret']).toBe('sekrit');
+
+    const row = await readSystemStatus<ProxyStatsValue>(env as Env, 'proxy_stats');
+    expect(row?.value.total).toBe(200);
+  });
+
+  it('reports an unknown fresh percentage for an empty cache rather than 0%', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ total: 0, fresh: 0, stale: 0 }))
+    );
+
+    const value = await recordProxyStats({
+      ...env,
+      FEED_PROXY_URL: 'https://proxy.example',
+    } as Env);
+    expect(value.freshPct).toBeNull();
+  });
+});
+
+describe('writeMetricsSnapshot', () => {
+  it('buckets to the hour so a second run replaces the point instead of duplicating it', async () => {
+    const now = 3 * HOUR_MS + 12 * 60 * 1000;
+
+    await writeMetricsSnapshot(env as Env, now);
+    await writeMetricsSnapshot(env as Env, now + 20 * 60 * 1000);
+
+    const rows = await env.DB.prepare('SELECT captured_at FROM metrics_snapshots').all<{
+      captured_at: number;
+    }>();
+    expect(rows.results).toEqual([{ captured_at: 3 * HOUR_MS }]);
+  });
+
+  it('carries the health numbers across when they are fresh', async () => {
+    const now = 100 * HOUR_MS;
+    await writeSystemStatus(
+      env as Env,
+      'poller_status',
+      { lagMs: 42_000 } as PollerStatusValue,
+      now - 60_000
+    );
+    await writeSystemStatus(
+      env as Env,
+      'proxy_stats',
+      { freshPct: 88.5 } as ProxyStatsValue,
+      now - 60_000
+    );
+
+    await writeMetricsSnapshot(env as Env, now);
+
+    const row = await env.DB.prepare(
+      'SELECT firehose_lag_ms, proxy_fresh_pct FROM metrics_snapshots'
+    ).first<{ firehose_lag_ms: number; proxy_fresh_pct: number }>();
+    expect(row?.firehose_lag_ms).toBe(42_000);
+    expect(row?.proxy_fresh_pct).toBe(88.5);
+  });
+
+  it('records null rather than a stale value nobody refreshed', async () => {
+    const now = 200 * HOUR_MS;
+    await writeSystemStatus(
+      env as Env,
+      'poller_status',
+      { lagMs: 42_000 } as PollerStatusValue,
+      now - 60 * 60 * 1000
+    );
+
+    await writeMetricsSnapshot(env as Env, now);
+
+    const row = await env.DB.prepare('SELECT firehose_lag_ms FROM metrics_snapshots').first<{
+      firehose_lag_ms: number | null;
+    }>();
+    expect(row?.firehose_lag_ms).toBeNull();
+  });
+
+  it('prunes points past the retention window', async () => {
+    const now = 5000 * HOUR_MS;
+    const old = now - SNAPSHOT_RETENTION_MS - HOUR_MS;
+    await env.DB.prepare(
+      `INSERT INTO metrics_snapshots (captured_at, users, feeds, feed_items, subscriptions,
+        saved_articles, feeds_with_errors, active_sessions) VALUES (?, 0, 0, 0, 0, 0, 0, 0)`
+    )
+      .bind(old)
+      .run();
+
+    await writeMetricsSnapshot(env as Env, now);
+
+    const rows = await env.DB.prepare('SELECT captured_at FROM metrics_snapshots').all<{
+      captured_at: number;
+    }>();
+    expect(rows.results.map((r) => r.captured_at)).toEqual([now]);
+  });
+});
+
+describe('recordCronRun', () => {
+  it('stores the run so the admin can show liveness without a monitor', async () => {
+    await recordCronRun(env as Env, { cron: '* * * * *', healthy: true, durationMs: 120 }, 7000);
+
+    const row = await readSystemStatus<CronLastRunValue>(env as Env, 'cron_last_run');
+    expect(row?.value).toEqual({
+      at: 7000,
+      cron: '* * * * *',
+      healthy: true,
+      durationMs: 120,
+      version: 'dev',
+    });
+  });
+});
+
+describe('runRecordingStep', () => {
+  it('swallows a failure — losing a data point must not withhold the heartbeat', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      runRecordingStep('poller-status', async () => {
+        throw new Error('D1 blip');
+      })
+    ).resolves.toBeUndefined();
+
+    const logged = errors.mock.calls
+      .map(([entry]) => entry as { event?: string; step?: string })
+      .find((entry) => entry?.event === 'ops_metrics_failed');
+    expect(logged?.step).toBe('poller-status');
+  });
+});

--- a/backend/test/request-logging.spec.ts
+++ b/backend/test/request-logging.spec.ts
@@ -127,6 +127,17 @@ describe('classifyRoute', () => {
 
   it('caps the cardinality of junk paths', () => {
     // A scanner hitting random deep paths must not mint a new route value per hit.
-    expect(classifyRoute('/a/b/c/d/e/f/g')).toBe('/a/b/c/d/…');
+    expect(classifyRoute('/api/a/b/c/d/e/f/g')).toBe('/api/a/b/c/…');
+  });
+
+  it('collapses everything outside the prefixes this Worker serves', () => {
+    // Root-level probes are most of the 404 traffic on a public origin, and each
+    // one used to become its own value of the field the runbook aggregates on.
+    expect(classifyRoute('/wp-login.php')).toBe('/other');
+    expect(classifyRoute('/.env')).toBe('/other');
+    expect(classifyRoute('/xyz123')).toBe('/other');
+    // The real prefixes still classify normally.
+    expect(classifyRoute('/api/auth/me')).toBe('/api/auth/me');
+    expect(classifyRoute('/xrpc/app.skyreader.feed.save')).toBe('/xrpc/app.skyreader.feed.save');
   });
 });

--- a/backend/test/request-logging.spec.ts
+++ b/backend/test/request-logging.spec.ts
@@ -1,0 +1,132 @@
+import { SELF } from 'cloudflare:test';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { log } from '../src/utils/logger';
+import { classifyRoute, getRequestId, runWithRequestContext } from '../src/utils/request-context';
+
+// Phase 1 of the observability plan: every request carries an id, every log line
+// is a queryable object rather than a sentence, and the id reaches outbound calls.
+
+describe('request correlation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('stamps X-Request-Id on the response and exposes it to browsers', async () => {
+    const response = await SELF.fetch('http://localhost/api/unknown-route');
+
+    const requestId = response.headers.get('X-Request-Id');
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-Request-Id');
+  });
+
+  it('gives each request its own id', async () => {
+    const [first, second] = await Promise.all([
+      SELF.fetch('http://localhost/api/unknown-route'),
+      SELF.fetch('http://localhost/api/unknown-route'),
+    ]);
+
+    expect(first.headers.get('X-Request-Id')).not.toBe(second.headers.get('X-Request-Id'));
+  });
+
+  it('ignores a client-supplied request id', async () => {
+    // Accepting one would let a client merge unrelated requests into a single id
+    // and make the logs lie. There is no trusted upstream in front of this Worker.
+    const response = await SELF.fetch('http://localhost/api/unknown-route', {
+      headers: { 'X-Request-Id': 'client-chosen-id' },
+    });
+
+    expect(response.headers.get('X-Request-Id')).not.toBe('client-chosen-id');
+  });
+
+  it('logs one summary object per request, with the route class and status', async () => {
+    const logged = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await SELF.fetch('http://localhost/api/linkblog/resolve/alice.bsky.social');
+
+    const summary = logged.mock.calls
+      .map(([entry]) => entry)
+      .find(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          (entry as { event?: string }).event === 'request'
+      );
+
+    // An object, not a JSON string: Workers Logs indexes object fields and treats
+    // a string as opaque text (see src/utils/logger.ts).
+    expect(summary).toBeDefined();
+    expect(summary!.route).toBe('/api/linkblog/resolve/:id');
+    expect(summary!.method).toBe('GET');
+    expect(typeof summary!.status).toBe('number');
+    expect(typeof summary!.durationMs).toBe('number');
+    expect(summary!.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('does not log a summary line for the shallow health check', async () => {
+    // An uptime poller hits it every 30s forever; the line would be pure volume.
+    const logged = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await SELF.fetch('http://localhost/api/health');
+
+    const summaries = logged.mock.calls.filter(
+      ([entry]) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        (entry as { event?: string }).event === 'request'
+    );
+    expect(summaries).toHaveLength(0);
+  });
+});
+
+describe('logger', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('carries the ambient request context onto every line', () => {
+    const logged = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    runWithRequestContext(
+      { requestId: 'req-1', route: '/api/saved/:id', did: 'did:plc:abc' },
+      () => {
+        log.info('feed_fetched', { feedCount: 3 });
+      }
+    );
+
+    expect(logged).toHaveBeenCalledWith({
+      level: 'info',
+      event: 'feed_fetched',
+      requestId: 'req-1',
+      route: '/api/saved/:id',
+      did: 'did:plc:abc',
+      feedCount: 3,
+    });
+  });
+
+  it('works outside a request context', () => {
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    log.warn('module_init');
+
+    expect(logged).toHaveBeenCalledWith({ level: 'warn', event: 'module_init' });
+    expect(getRequestId()).toBeUndefined();
+  });
+});
+
+describe('classifyRoute', () => {
+  it('collapses identifiers so logs aggregate by endpoint', () => {
+    expect(classifyRoute('/api/linkblog/share/3lkabcdef1234')).toBe('/api/linkblog/share/:id');
+    expect(classifyRoute('/api/saved/by-guid/https%3A%2F%2Fexample.com')).toBe(
+      '/api/saved/by-guid/:id'
+    );
+    expect(classifyRoute('/api/subscriptions/3lkabcdef1234/activate')).toBe(
+      '/api/subscriptions/:id/activate'
+    );
+  });
+
+  it('leaves static routes alone', () => {
+    expect(classifyRoute('/api/auth/me')).toBe('/api/auth/me');
+    expect(classifyRoute('/api/health')).toBe('/api/health');
+  });
+
+  it('caps the cardinality of junk paths', () => {
+    // A scanner hitting random deep paths must not mint a new route value per hit.
+    expect(classifyRoute('/a/b/c/d/e/f/g')).toBe('/a/b/c/d/…');
+  });
+});

--- a/backend/test/sentry-scrub.spec.ts
+++ b/backend/test/sentry-scrub.spec.ts
@@ -123,6 +123,19 @@ describe('Sentry event scrubbing', () => {
     expect((withData.data as Record<string, unknown>).url).toBe('https://example.com/rss');
   });
 
+  // The shapes that can't be redacted in place: a scrub that only mutates would
+  // pass these through untouched while reading as if it had worked.
+  it('redacts a breadcrumb or extra that is a bare string or array', () => {
+    const tokenized = 'fetching https://example.com/rss?token=feed-secret';
+    const event = scrubEvent({
+      breadcrumbs: [{ data: tokenized as unknown as Record<string, unknown> }],
+      extra: [tokenized] as unknown as Event['extra'],
+    } as Event);
+
+    expect(event.breadcrumbs![0].data as unknown as string).not.toContain('feed-secret');
+    expect((event.extra as unknown as string[])[0]).not.toContain('feed-secret');
+  });
+
   it('redacts a tokenized URL quoted in the exception message', () => {
     const event = scrubEvent({
       exception: {

--- a/backend/test/sentry-scrub.spec.ts
+++ b/backend/test/sentry-scrub.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import type { Event } from '@sentry/cloudflare';
+import { scrubEvent } from '../src/observability/scrub';
+
+describe('Sentry event scrubbing', () => {
+  it('redacts credential headers and drops cookies', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://api.skyreader.app/api/saved',
+        headers: {
+          Authorization: 'DPoP eyJhbGciOi.secret.token',
+          'X-Health-Secret': 'super-secret',
+          Cookie: 'session_id=abc123',
+          DPoP: 'eyJ0eXAiOiJkcG9wK2p3dCJ9.proof',
+          'User-Agent': 'Skyreader/1.0',
+        },
+        cookies: { session_id: 'abc123' },
+      },
+    } as Event);
+
+    const headers = event.request!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('[redacted]');
+    expect(headers['X-Health-Secret']).toBe('[redacted]');
+    expect(headers.Cookie).toBe('[redacted]');
+    expect(headers.DPoP).toBe('[redacted]');
+    // Non-sensitive headers survive — the point is triage, not a blank event.
+    expect(headers['User-Agent']).toBe('Skyreader/1.0');
+    expect(event.request!.cookies).toBeUndefined();
+  });
+
+  it('redacts OAuth params in the query string but keeps the rest', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://api.skyreader.app/api/auth/callback',
+        query_string: 'code=abc123&state=xyz&iss=https%3A%2F%2Fbsky.social',
+      },
+    } as Event);
+
+    const query = event.request!.query_string as string;
+    expect(query).toContain('code=%5Bredacted%5D');
+    expect(query).toContain('state=%5Bredacted%5D');
+    expect(query).toContain('iss=https');
+    expect(query).not.toContain('abc123');
+  });
+
+  it('redacts OAuth params carried inline in the url', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://api.skyreader.app/api/auth/callback?code=abc123&iss=https%3A%2F%2Fbsky.social',
+      },
+    } as Event);
+
+    expect(event.request!.url).not.toContain('abc123');
+    expect(event.request!.url).toContain('/api/auth/callback?');
+    expect(event.request!.url).toContain('iss=https');
+  });
+
+  it('redacts tokens nested in a JSON body but keeps the DID', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://api.skyreader.app/api/sync/full',
+        data: {
+          did: 'did:plc:abc123',
+          tokens: { access_token: 'at-secret', refresh_token: 'rt-secret' },
+          dpopPrivateKey: '{"d":"..."}',
+        },
+      },
+    } as Event);
+
+    const data = event.request!.data as Record<string, unknown>;
+    // DIDs are public identifiers and the correlation key we actually want.
+    expect(data.did).toBe('did:plc:abc123');
+    expect(data.tokens).toBe('[redacted]');
+    expect(data.dpopPrivateKey).toBe('[redacted]');
+  });
+
+  it('redacts a raw string body too', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://api.skyreader.app/oauth/token',
+        data: JSON.stringify({ refresh_token: 'rt-secret', did: 'did:plc:abc123' }),
+      },
+    } as Event);
+
+    expect(event.request!.data as string).not.toContain('rt-secret');
+    expect(event.request!.data as string).toContain('did:plc:abc123');
+  });
+
+  it('redacts secrets in extra context', () => {
+    const event = scrubEvent({
+      extra: { feedUrl: 'https://example.com/rss', proxySecret: 'shh' },
+    } as Event);
+
+    expect(event.extra!.feedUrl).toBe('https://example.com/rss');
+    expect(event.extra!.proxySecret).toBe('[redacted]');
+  });
+
+  it('leaves an event with nothing sensitive untouched', () => {
+    const event = scrubEvent({
+      request: { url: 'https://api.skyreader.app/api/feeds', query_string: 'limit=50' },
+    } as Event);
+
+    expect(event.request!.query_string).toBe('limit=50');
+  });
+});

--- a/backend/test/sentry-scrub.spec.ts
+++ b/backend/test/sentry-scrub.spec.ts
@@ -95,6 +95,53 @@ describe('Sentry event scrubbing', () => {
     expect(event.extra!.proxySecret).toBe('[redacted]');
   });
 
+  // Breadcrumbs are the channel that bypasses every request-level rule above:
+  // whatever a call site logged before the throw ships verbatim. The Console
+  // integration is off (see observability/sentry.ts), but anything added another
+  // way still has to come out clean.
+  it('redacts credentials carried in breadcrumbs', () => {
+    const event = scrubEvent({
+      breadcrumbs: [
+        {
+          message:
+            'GET https://bsky.social/xrpc/com.atproto.server.refreshSession?refresh_token=rt-secret failed',
+        },
+        { message: 'sending header Authorization: Bearer eyJhbGciOiJFUzI1NiJ9.payload.sig' },
+        { message: 'resolving handle for did:plc:abc123' },
+        { data: { session_id: 'sid-secret', url: 'https://example.com/rss' } },
+      ],
+    } as Event);
+
+    const [tokenizedUrl, authHeader, harmless, withData] = event.breadcrumbs!;
+    expect(tokenizedUrl.message).not.toContain('rt-secret');
+    expect(tokenizedUrl.message).toContain('com.atproto.server.refreshSession');
+    expect(authHeader.message).not.toContain('eyJhbGciOiJFUzI1NiJ9');
+    expect(authHeader.message).toBe('sending header Authorization: [redacted]');
+    // DIDs survive — they're the correlation key, not a credential.
+    expect(harmless.message).toBe('resolving handle for did:plc:abc123');
+    expect((withData.data as Record<string, unknown>).session_id).toBe('[redacted]');
+    expect((withData.data as Record<string, unknown>).url).toBe('https://example.com/rss');
+  });
+
+  it('redacts a tokenized URL quoted in the exception message', () => {
+    const event = scrubEvent({
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'fetch failed: https://pds.example/xrpc/foo?access_token=at-secret&limit=50',
+          },
+        ],
+      },
+      message: 'code_verifier=cv-secret was rejected',
+    } as Event);
+
+    const value = event.exception!.values![0].value!;
+    expect(value).not.toContain('at-secret');
+    expect(value).toContain('limit=50');
+    expect(event.message).not.toContain('cv-secret');
+  });
+
   it('leaves an event with nothing sensitive untouched', () => {
     const event = scrubEvent({
       request: { url: 'https://api.skyreader.app/api/feeds', query_string: 'limit=50' },

--- a/backend/test/session-refresh.spec.ts
+++ b/backend/test/session-refresh.spec.ts
@@ -161,6 +161,27 @@ describe('auth gate: transient refresh failure (503, retryable)', () => {
     // Cookie is cleared regardless of refresh state.
     expect(res.headers.get('Set-Cookie')).toContain('session_id=');
   });
+
+  it('does NOT block client error telemetry for a transient session', async () => {
+    await insertSession('transient-telemetry', transientOpts());
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new IncomingRequest('http://localhost/api/telemetry/error', {
+        method: 'POST',
+        headers: {
+          Cookie: 'session_id=transient-telemetry',
+          'Content-Type': 'application/json',
+          Origin: env.FRONTEND_URL,
+        },
+        body: JSON.stringify({ kind: 'render', message: 'auth resolution failed' }),
+      }),
+      env,
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(204);
+  });
 });
 
 describe('token refresh: public client (local dev)', () => {

--- a/backend/test/session-refresh.spec.ts
+++ b/backend/test/session-refresh.spec.ts
@@ -68,6 +68,26 @@ async function call(path: string, sessionId?: string, method = 'GET') {
   return response;
 }
 
+/** One client error report, optionally carrying a session cookie. */
+async function postTelemetry(workerEnv: Env, sessionId?: string) {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(
+    new IncomingRequest('http://localhost/api/telemetry/error', {
+      method: 'POST',
+      headers: {
+        ...(sessionId ? { Cookie: `session_id=${sessionId}` } : {}),
+        'Content-Type': 'application/json',
+        Origin: env.FRONTEND_URL,
+      },
+      body: JSON.stringify({ kind: 'render', message: 'auth resolution failed' }),
+    }),
+    workerEnv,
+    ctx
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
 beforeEach(async () => {
   await setupUser();
 });
@@ -164,23 +184,58 @@ describe('auth gate: transient refresh failure (503, retryable)', () => {
 
   it('does NOT block client error telemetry for a transient session', async () => {
     await insertSession('transient-telemetry', transientOpts());
+    const res = await postTelemetry(env, 'transient-telemetry');
+    expect(res.status).toBe(204);
+  });
+});
+
+// The client error report is worth most when auth is broken, so it is routed
+// *before* session resolution rather than merely exempted from the auth gate.
+// Behind the gate, a D1 read failure in getSessionWithRefreshState() becomes the
+// 500 from serveRequest's catch — and the reporter never retries, so the signal
+// is simply lost in the incident it exists to describe.
+describe('client telemetry is answered before session resolution', () => {
+  // Every D1 call throws: the state a degraded database actually puts us in.
+  const brokenDb = new Proxy(
+    {},
+    {
+      get() {
+        return () => {
+          throw new Error('D1_ERROR: no such table (simulated outage)');
+        };
+      },
+    }
+  ) as D1Database;
+
+  beforeEach(() => {
+    // The handler logs the report; the 500 path logs the D1 failure.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('accepts a report from a signed-in client while D1 is down', async () => {
+    const res = await postTelemetry({ ...env, DB: brokenDb } as Env, 'any-session-id');
+    expect(res.status).toBe(204);
+  });
+
+  it('accepts a report with no session at all while D1 is down', async () => {
+    const res = await postTelemetry({ ...env, DB: brokenDb } as Env);
+    expect(res.status).toBe(204);
+  });
+
+  it('is the exception: a session-backed route still 500s in that state', async () => {
+    // Pins the contrast — the broken DB really does break session resolution, so
+    // the 204s above come from the routing order and not from a lenient stub.
     const ctx = createExecutionContext();
     const res = await worker.fetch(
-      new IncomingRequest('http://localhost/api/telemetry/error', {
-        method: 'POST',
-        headers: {
-          Cookie: 'session_id=transient-telemetry',
-          'Content-Type': 'application/json',
-          Origin: env.FRONTEND_URL,
-        },
-        body: JSON.stringify({ kind: 'render', message: 'auth resolution failed' }),
-      }),
-      env,
+      request('/api/auth/me', 'any-session-id'),
+      { ...env, DB: brokenDb } as Env,
       ctx
     );
     await waitOnExecutionContext(ctx);
-
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(500);
   });
 });
 

--- a/backend/test/telemetry.spec.ts
+++ b/backend/test/telemetry.spec.ts
@@ -1,0 +1,126 @@
+import { SELF } from 'cloudflare:test';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Phase 3: the client can finally say "I broke". Everything it says is untrusted,
+// so these pin the boundary — what is accepted, what is capped, and what never
+// leaves the request (query strings, unknown kinds, oversized payloads).
+
+const post = (body: unknown, headers: Record<string, string> = {}) =>
+  SELF.fetch('http://localhost/api/telemetry/error', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+const report = (overrides: Record<string, unknown> = {}) => ({
+  kind: 'uncaught',
+  name: 'TypeError',
+  message: 'x is not a function',
+  stack: 'TypeError: x is not a function\n  at foo (/_app/immutable/chunks/abc.js:1:1)',
+  appVersion: 'deadbeef',
+  path: '/reader/article',
+  sampleRate: 0.1,
+  ...overrides,
+});
+
+/** The one structured line this endpoint emits, if it emitted one. */
+function clientErrorLine(warn: ReturnType<typeof vi.spyOn>): Record<string, unknown> | undefined {
+  return warn.mock.calls
+    .map(([entry]) => entry)
+    .find(
+      (entry): entry is Record<string, unknown> =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        (entry as { event?: string }).event === 'client_error'
+    );
+}
+
+describe('POST /api/telemetry/error', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('accepts a well-formed report without a session', async () => {
+    // An error on the login screen has no DID and is exactly the kind we want.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const response = await post(report());
+
+    expect(response.status).toBe(204);
+    const line = clientErrorLine(warn);
+    expect(line).toMatchObject({
+      level: 'warn',
+      kind: 'uncaught',
+      errorName: 'TypeError',
+      appVersion: 'deadbeef',
+      path: '/reader/article',
+    });
+    // Correlatable with the rest of the request, like every other line.
+    expect(line!.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('rejects a kind it does not recognise', async () => {
+    // `kind` is a Sentry tag and a log facet; an open set would let a client mint
+    // unbounded values in both.
+    const response = await post(report({ kind: 'marketing_funnel' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a report with nothing to say', async () => {
+    expect((await post(report({ message: '   ' }))).status).toBe(400);
+    expect((await post('not json')).status).toBe(400);
+    expect((await post([1, 2, 3])).status).toBe(400);
+  });
+
+  it('refuses anything but POST', async () => {
+    const response = await SELF.fetch('http://localhost/api/telemetry/error');
+    expect(response.status).toBe(405);
+  });
+
+  it('rejects an oversized payload before reading it', async () => {
+    const response = await post(report(), { 'Content-Length': String(64 * 1024) });
+    expect(response.status).toBe(413);
+  });
+
+  it('keeps the path but drops the query string and the origin', async () => {
+    // A URL is where credentials leak in: share tokens, OAuth params, handles.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await post(report({ path: 'https://skyreader.app/saved?token=secret#frag' }));
+
+    expect(clientErrorLine(warn)!.path).toBe('/saved');
+  });
+
+  it('caps a runaway message and stack instead of forwarding them whole', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const response = await post(report({ message: 'a'.repeat(5000), stack: 'b'.repeat(8000) }));
+
+    expect(response.status).toBe(204);
+    const line = clientErrorLine(warn)!;
+    expect((line.errorMessage as string).length).toBeLessThanOrEqual(301);
+  });
+
+  it('defaults a nameless error rather than dropping the report', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const response = await post({ kind: 'rejection', message: 'undefined' });
+
+    expect(response.status).toBe(204);
+    expect(clientErrorLine(warn)!.errorName).toBe('Error');
+  });
+
+  it('stops a client stuck in an error loop', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const headers = { 'CF-Connecting-IP': '203.0.113.7' };
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 25; i++) {
+      statuses.push((await post(report(), headers)).status);
+    }
+
+    expect(statuses.filter((s) => s === 204).length).toBe(20);
+    expect(statuses.filter((s) => s === 429).length).toBe(5);
+    // No Retry-After: a broken page should drop the report, not schedule it.
+    const limited = await post(report(), headers);
+    expect(limited.headers.get('Retry-After')).toBeNull();
+  });
+});

--- a/backend/test/tsconfig.json
+++ b/backend/test/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["@cloudflare/vitest-pool-workers"]
   },
-  "include": ["./**/*.ts", "../worker-configuration.d.ts"],
+  "include": ["./**/*.ts", "../worker-configuration.d.ts", "../src/types/*.d.ts"],
   "exclude": []
 }

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -1,7 +1,16 @@
 name = "skyreader-api"
 main = "src/index.ts"
 compatibility_date = "2025-09-27"
-# nodejs_als: required by @sentry/cloudflare (AsyncLocalStorage-backed scopes).
+# nodejs_als: AsyncLocalStorage. Two consumers — @sentry/cloudflare's scopes, and
+# our own per-request context (src/utils/request-context.ts), which is what lets a
+# request id reach a log line or an outbound header without threading a parameter
+# through every handler.
+#
+# This is a deliberately narrower flag than the `nodejs_compat` the SDK's README
+# asks for: ALS is all it needs today (the full vitest suite runs under workerd
+# with just this), and nodejs_compat additionally injects Node globals we don't
+# want to depend on by accident. Re-check on every @sentry/cloudflare upgrade — if
+# a bump starts needing more of the Node API surface, widen this to nodejs_compat.
 # It coexists with global_fetch_strictly_public — different subsystems, no overlap.
 compatibility_flags = ["global_fetch_strictly_public", "nodejs_als"]
 

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -1,7 +1,9 @@
 name = "skyreader-api"
 main = "src/index.ts"
 compatibility_date = "2025-09-27"
-compatibility_flags = ["global_fetch_strictly_public"]
+# nodejs_als: required by @sentry/cloudflare (AsyncLocalStorage-backed scopes).
+# It coexists with global_fetch_strictly_public — different subsystems, no overlap.
+compatibility_flags = ["global_fetch_strictly_public", "nodejs_als"]
 
 [observability]
 enabled = true
@@ -53,6 +55,10 @@ FEED_PROXY_URL = "https://skyreader-feed-proxy.fly.dev"
 # Public base for users' linkblogs, baked into their site.standard.publication
 # record's `url` field (DID-based so it survives handle changes).
 LINKBLOG_PUBLIC_URL = "https://linkblogs.skyreader.app"
+# Tags every Sentry event so prod and staging errors never get confused for one
+# another. The DSN itself is a secret (`wrangler secret put SENTRY_DSN`); without
+# it error reporting is a no-op.
+SENTRY_ENVIRONMENT = "production"
 
 # Production routes
 routes = [{ pattern = "api.skyreader.app", custom_domain = true }]
@@ -69,7 +75,7 @@ vars = { FRONTEND_URL = "http://127.0.0.1:5173" }
 # Staging environment
 [env.staging]
 name = "skyreader-api-staging"
-vars = { FRONTEND_URL = "https://staging.skyreader.app", ALLOWED_ORIGINS = "https://staging.skyreader.app,https://staging-linkblogs.skyreader.app", FEED_PROXY_URL = "https://skyreader-feed-proxy.fly.dev", LINKBLOG_PUBLIC_URL = "https://staging-linkblogs.skyreader.app" }
+vars = { FRONTEND_URL = "https://staging.skyreader.app", ALLOWED_ORIGINS = "https://staging.skyreader.app,https://staging-linkblogs.skyreader.app", FEED_PROXY_URL = "https://skyreader-feed-proxy.fly.dev", LINKBLOG_PUBLIC_URL = "https://staging-linkblogs.skyreader.app", SENTRY_ENVIRONMENT = "staging" }
 routes = [{ pattern = "api-staging.skyreader.app", custom_domain = true }]
 
 [env.staging.durable_objects]

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,10 +2,10 @@
 
 What's watching Skyreader, what each signal means, and what to do when one fires.
 
-Scope note: this covers **Phases 0–2** — external checks, dead-man's switches,
-error tracking, post-deploy smoke checks, structured logs with request-id
-correlation, and the admin ops panel with its trend history. Client signal
-(Phase 3) and SLO/alert pruning (Phase 4) get their sections as they land.
+Scope note: this covers **Phases 0–4** of the observability plan — external
+checks, dead-man's switches, error tracking, post-deploy smoke checks, structured
+logs with request-id correlation, the admin ops panel and its trend history,
+client-side error reports, and the SLOs and alert policy the thresholds answer to.
 
 The operating principle: **silence means healthy**. Every alert below is
 outage-class by construction. If one fires without requiring action, fix or delete
@@ -29,9 +29,13 @@ it rather than learning to ignore it.
 | Backend cron (every minute) | `system_status` rows (D1)             | Cron liveness, poller lag, proxy cache stats.     |
 | Backend cron (hourly)       | `metrics_snapshots` rows (D1)         | One trend point per hour, pruned at 90 days.      |
 | Admin dashboard             | Ops tiles + 30-day sparklines         | The same rows, rendered. No token, works locally. |
+| Frontend PWA                | `POST /api/telemetry/error`           | Sampled client errors, forwarded to Sentry.       |
+| Frontend PWA                | Settings → Diagnostics                | On-device state. Sent nowhere; read by a human.   |
 | All deploys                 | `scripts/smoke-check.mjs`             | Post-deploy assertion against production.         |
 
-Not yet covered (by design, see the plan): client-side errors.
+Deliberately absent: per-user client telemetry (no page views, no session replay,
+no third-party SDK in the browser bundle), distributed tracing, and log shipping.
+See "Non-goals" in the plan — each was considered and declined, not overlooked.
 
 ---
 
@@ -203,6 +207,43 @@ cycle can drain. Jetstream itself being down looks like errors, not lag.
 that the number is falling. If it's flat or growing over 30 minutes, redeploy the
 backend to recycle the DO (it resumes from its stored cursor, so nothing is lost).
 
+### `source: client` errors after a deploy
+
+**Means:** the browser is throwing. One report is a user with an extension or a
+flaky network; a cluster sharing one `appVersion` tag minutes after a deploy is
+the deploy.
+
+Reports are **sampled at 10%** in the client, so treat counts as a tenth of
+reality (`sampleRate` rides along on every event for exactly this reason). The
+`kind` tag says which channel caught it:
+
+| `kind`                    | Caught by                            | What it usually means                              |
+| ------------------------- | ------------------------------------ | -------------------------------------------------- |
+| `render`                  | SvelteKit `handleError`              | A route failed to load or render.                  |
+| `uncaught`                | `window.onerror`                     | An exception outside a framework boundary.         |
+| `rejection`               | `unhandledrejection`                 | A promise nobody caught — often a failed API call. |
+| `preload_recovery_failed` | The stale-chunk guard, tripped twice | **The deploy bricked the PWA.** See below.         |
+
+**`preload_recovery_failed` is the one to page on.** It means a client asked for a
+chunk from its own build, didn't get it, reloaded once to recover, and then failed
+again — so the page is stuck and the user's only remedy is clearing storage. It is
+**never sampled away**. Its usual cause is a build whose immutable assets stopped
+being served (`scripts/retain-immutable-assets.mjs` retention expired or was
+skipped) while old tabs were still open.
+**Fix:** re-deploy the frontend, which republishes the current build's assets; if
+reports name an old `appVersion`, extend asset retention rather than chasing the
+client.
+
+**Check:** Sentry `source: client`, grouped by `kind` + message; then
+`event = client_error` in Workers Logs for the same window (the log line carries
+`path`, `appVersion` and `sampleRate`). Note that stack frames come from a
+minified client bundle — the message and the path are the useful parts, and the
+issue is grouped on them for that reason.
+
+What never reaches either place: query strings (stripped in the browser and again
+on the server), request bodies, and anything about the user beyond the DID already
+attached to their session. See `backend/src/routes/telemetry.ts`.
+
 ### Sentry error spike
 
 Triage by tag: `source` is one of `fetch`, `cron`, `jetstream-poller`, `route`,
@@ -234,6 +275,7 @@ Query patterns that pay for themselves:
 | What failed inside a cron run?   | `event = cron_phase_failed` → `phase`             |
 | Why is the ops panel stale?      | `event = ops_metrics_failed` → `step`             |
 | Did the hourly trend point land? | `event = metrics_snapshot` → `prunedRows`         |
+| Are browsers throwing?           | `event = client_error` → `kind`, `appVersion`     |
 
 The id is also returned to callers as the `X-Request-Id` response header (exposed
 via CORS), so a user-reported failure can be traced if they can quote it. The
@@ -266,14 +308,56 @@ path, so it works in local dev and staging the moment the cron has run once.
 values are written by the cron, so they stop moving exactly when it does. Cross-check
 against the `backend-cron` heartbeat before assuming the panel is broken.
 
+Staleness is graded on the **row**, not on the numbers inside it: the three poller
+tiles go red together once `poller_status` is more than 5 minutes old, and both
+proxy tiles once `proxy_stats` is more than 15 minutes old. That's the case a
+value can't see about itself — the cron alive and healthy, but its DO `/status` or
+proxy `/stats` fetch failing, leaving a green lag from an hour ago in the table.
+Three stale poller tiles with a green Cron Last Run means **the collector is
+broken, not the poller**: look for `event = ops_metrics_failed` → `step`.
+
 Below the tiles, **Trends (30 days, hourly)** sparklines the same numbers plus the
-raw counts, from `metrics_snapshots`. Gaps in a line are hours with no recorded
-value (cron down, or the source was stale) — deliberately drawn as gaps rather
-than zeroes. Retention is 90 days, pruned by the job that writes it; the panel
-shows the most recent 30.
+raw counts, from `metrics_snapshots`. The x axis is one point per hour, so an hour
+with **no snapshot row at all** is a gap in the line exactly like an hour whose
+value was unavailable — a break in a line always means "not recorded", never
+"dropped to zero", and an isolated recorded hour shows as a dot. Retention is 90
+days, pruned by the job that writes it; the panel shows the most recent 30.
 
 Cadence, if a number looks older than expected: poller status every minute, proxy
 stats every 5th minute, snapshot once an hour on the hour.
+
+---
+
+## 4c. Client signal
+
+The browser reports errors to our own backend — never to a third party — which
+decides what reaches Sentry (`frontend/src/lib/services/telemetry.ts` →
+`backend/src/routes/telemetry.ts`). The endpoint is unauthenticated on purpose: an
+error on the login screen is one worth having.
+
+What restrains it, in the order it applies:
+
+1. **Nothing in dev.** A local exception is one you're already looking at.
+2. **Once per distinct error, per page load.** A render loop reports once.
+3. **Five reports per page load.** Past that the page is telling one story.
+4. **10% sampling** — except `preload_recovery_failed`, which always sends.
+5. **20 accepted reports per minute** per DID (or per IP when anonymous),
+   enforced server-side. A 429 carries no `Retry-After`: a broken page should drop
+   the report, not schedule it.
+
+Everything the client sends is capped and validated server-side — a 300-character
+message, a 2000-character stack, a path with no query string, and a `kind` from a
+closed set. Nothing else about the page is collected.
+
+### Settings → Diagnostics
+
+Not telemetry: it's sent nowhere and read by a human. It shows the app build, the
+**service worker's** build, online state, unsynced queue depth and the last
+successful sync, with a Copy button.
+
+Ask for it in any "it's broken" report. The single most useful line is the service
+worker one — "differs from app" means an update is half-applied, which is the
+shape of most PWA weirdness, and a reload fixes it.
 
 ---
 
@@ -323,7 +407,11 @@ within the stated window. Until a drill has passed, treat the alert as unproven.
    those are free text, where a header rule can't help. The Console integration is
    disabled precisely so a `console.error` on a failure path can't ship a session
    id (`src/observability/sentry.ts`); confirm the event has no console
-   breadcrumbs at all.
+   breadcrumbs at all. **Do the same in a staging feed-proxy route**: it's the one
+   runtime whose Sentry SDK sits under Bun+Hono, where whether request data is
+   attached at all is untested. Its scrubber (`feed-proxy/src/scrub.ts`) redacts
+   `X-Proxy-Secret` and tokenised feed URLs; the drill is what proves there was
+   nothing else riding along.
 4. Deploy with a deliberately wrong version stamp → smoke step fails, workflow red.
    Do it for a Pages app too: edit the built `_app/version.json`, or deploy the
    same SHA twice while asserting a different one — the point is to see the Pages
@@ -338,3 +426,87 @@ within the stated window. Until a drill has passed, treat the alert as unproven.
    (`npx wrangler d1 execute skyreader-staging --remote --command "UPDATE system_status SET value = json_set(value, '$.lagMs', 3600000) WHERE key = 'poller_status'"`)
    — that drives the **panel**, but not the alert, which recomputes from the DO's
    cursors on the next cron minute.
+6. Throw in a staging client route (`throw new Error('drill')` in a `+page.svelte`
+   `onMount`) → a `source: client`, `kind: render` Sentry event carrying the
+   frontend's `appVersion`. Then confirm the restraints: hard-reload the page ten
+   times and count events, which should be roughly one (10% sampling), not ten.
+   Sampling that isn't working is worse than no sampling — it turns one broken
+   render loop into an unusable error tracker.
+7. Break stale-chunk recovery on staging: load a page, deploy twice so the old
+   chunks age out, then force a dynamic import from the still-open tab. First
+   failure reloads; the second reports `kind: preload_recovery_failed`. This is the
+   drill worth repeating after any change to
+   `scripts/retain-immutable-assets.mjs` — that script is what normally stops this
+   from happening at all.
+
+---
+
+## 7. SLOs
+
+Four numbers, chosen to be **thresholds worth tuning against** — not dashboards to
+admire, and not promises to anyone outside the project. Their only job is to make
+"is this alert set right?" a question with an answer.
+
+| SLO                | Target                          | Measured by                         | Window  |
+| ------------------ | ------------------------------- | ----------------------------------- | ------- |
+| API availability   | 99.5%                           | Uptime check on `/api/health`       | 30 days |
+| Firehose freshness | lag < 5 min, p95                | `metrics_snapshots.firehose_lag_ms` | 30 days |
+| Feed freshness     | ≥95% of cached feeds within TTL | `proxy_stats.freshPct` (ops panel)  | 30 days |
+| Cron liveness      | gap < 5 min                     | Heartbeat check history             | 30 days |
+
+99.5% is ~3.6 hours a month. That is a deliberately loose target for a
+single-operator project on a singleton proxy: it says "a couple of short outages a
+month is survivable, a daily one is not." Tighten it only if you're also willing
+to change the architecture it's measuring.
+
+Every alert threshold in this runbook is **looser than its SLO on purpose**: the
+firehose SLO is 5 minutes and the page fires at 15. An SLO you're paged for the
+moment you touch it is an SLO you'll stop believing. Read the trend sparklines
+monthly to see whether you're drifting; wait for the alert to be told you've
+stopped.
+
+Where a number can't be measured yet, say so rather than inventing it: **API
+availability and cron liveness live in the uptime vendor's own history**, which
+means neither is queryable from here until the checks in §2 exist.
+
+---
+
+## 8. Alert policy
+
+**Silence means healthy.** That's only trustworthy if silence is rare to break
+falsely, which is the whole point of the two rules below.
+
+**What earns a push notification.** An alert may page a phone only if it is
+outage-class — users are affected right now, or will be within minutes — _and_
+there is something a human can do about it at 3am. Everything currently
+configured passes both tests: five uptime checks, two heartbeats, and
+`preload_recovery_failed`. Everything else is a thing you find when you look:
+Sentry issues, ops tiles, trends.
+
+**What does not page.** Warning-level conditions (`firehose_lag_high` is a Sentry
+message, not a phone call), individual client errors, feeds failing to parse, a
+single 500. If one of these turns out to matter, the fix is usually a better
+signal rather than a louder one.
+
+### The pruning pass
+
+Run **2–4 weeks after the checks go live**, then quarterly. It takes ten minutes
+and it is the only thing keeping this system honest:
+
+1. List every alert that fired since the last pass.
+2. For each: did it require action? If no — delete it, loosen its threshold, or
+   downgrade it from push to email. Do this on the _first_ false page, not the
+   third; that's the point at which you start ignoring the channel.
+3. For each incident **not** caught by an alert: what would have caught it, and is
+   that worth the noise it would add? Sometimes the honest answer is no.
+4. Note the outcome in this file (below), so the next pass starts from the last
+   decision rather than from memory.
+
+An alert deleted for firing falsely is a success of this process, not a
+regression. The steady state to protect is a quiet phone that you still trust.
+
+### Pruning log
+
+| Date        | Change                                                       | Why |
+| ----------- | ------------------------------------------------------------ | --- |
+| _(pending)_ | First pass due 2–4 weeks after the §2 checks are configured. | —   |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,10 +2,10 @@
 
 What's watching Skyreader, what each signal means, and what to do when one fires.
 
-Scope note: this is the **Phase 0** runbook — external checks, dead-man's switches,
-error tracking, and post-deploy smoke checks. Structured logs (Phase 1), the admin
-ops panel (Phase 2), client signal (Phase 3), and SLO/alert pruning (Phase 4) get
-their sections as they land.
+Scope note: this covers **Phases 0–1** — external checks, dead-man's switches,
+error tracking, post-deploy smoke checks, and structured logs with request-id
+correlation. The admin ops panel (Phase 2), client signal (Phase 3), and SLO/alert
+pruning (Phase 4) get their sections as they land.
 
 The operating principle: **silence means healthy**. Every alert below is
 outage-class by construction. If one fires without requiring action, fix or delete
@@ -20,6 +20,7 @@ it rather than learning to ignore it.
 | Backend Worker               | `GET /api/health`             | Shallow: status, version, timestamp. No deps.    |
 | Backend Worker               | `GET /api/health/deep`        | D1 + poller lag + feed proxy. Secret-gated.      |
 | Backend Worker               | Sentry (`@sentry/cloudflare`) | Exceptions from `fetch`, `scheduled`, DO alarm.  |
+| Backend Worker               | Structured logs (Workers Logs) | One JSON object per event, keyed by `requestId`. |
 | Backend cron (every minute)   | Heartbeat ping (`HEARTBEAT_URL`) | Dead-man's switch; also guards the firehose.  |
 | Feed proxy                   | `GET /health`                 | Status, version, cached feed count. No auth.     |
 | Feed proxy                   | `GET /stats`                  | Cache freshness + per-feed error counts. Secret. |
@@ -27,8 +28,8 @@ it rather than learning to ignore it.
 | Feed proxy warmer            | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.     |
 | All deploys                  | `scripts/smoke-check.mjs`     | Post-deploy assertion against production.        |
 
-Not yet covered (by design, see the plan): request-level structured logs, trend
-lines, client-side errors.
+Not yet covered (by design, see the plan): trend lines, an ops panel in the admin,
+client-side errors.
 
 ---
 
@@ -186,16 +187,54 @@ Triage by tag: `source` is one of `fetch`, `cron`, `jetstream-poller`, `route`,
 `warmer`. Backend events carry the release (`GIT_COMMIT_SHA`), so "did this start
 with the last deploy?" is answerable directly in Sentry.
 
+Every backend event also carries a `requestId` tag and, when the request was
+authenticated, the user's DID. Copy the id into Workers Logs to get the whole
+request — see below.
+
+---
+
+## 4a. Reading the logs
+
+Backend logs are **objects, not sentences**: Workers Logs indexes the fields of an
+object passed to `console.*` but treats a string as opaque text. Every line from an
+instrumented path carries `level`, `event`, and — inside a request, cron run, or
+poll cycle — a `requestId`, plus `route` and `did` when known.
+
+Query patterns that pay for themselves:
+
+| Question                          | Filter                                            |
+| --------------------------------- | ------------------------------------------------- |
+| Everything about one failure      | `requestId = <id from Sentry or X-Request-Id>`    |
+| Error rate on one endpoint        | `event = request AND route = /api/v2/feeds/batch` |
+| Slow requests                     | `event = request AND durationMs > 3000`           |
+| Is the cron doing its work?       | `event = cron_run`                                |
+| Is the firehose keeping up?       | `event = jetstream_poll` → `subscriptionsLagMs`   |
+| What failed inside a cron run?    | `event = cron_phase_failed` → `phase`             |
+
+The id is also returned to callers as the `X-Request-Id` response header (exposed
+via CORS), so a user-reported failure can be traced if they can quote it. The
+backend stamps the same header on every feed-proxy call, and the proxy echoes it
+into its own error logs and Sentry tags — one id, both runtimes.
+
+Two deliberate gaps: the shallow health check emits no summary line (an uptime
+poller would drown the log in identical entries), and leaf-level `console.log`
+calls elsewhere in the codebase are still plain strings. Convert them
+opportunistically; a big-bang rewrite is churn.
+
 ---
 
 ## 5. Post-deploy smoke checks
 
 Every deploy workflow ends with `scripts/smoke-check.mjs`:
 
-- Workers/proxy: asserts `200` **and** `version === <the SHA just deployed>`. This
-  proves the new code is serving — not merely that something answers.
-- Pages apps: asserts `200` and a content sniff, since a Pages deploy carries no
-  version stamp.
+- Workers/proxy: asserts `200` **and** `version === <the SHA just deployed>` on the
+  health endpoint. This proves the new code is serving — not merely that something
+  answers.
+- Pages apps: the same version assertion against `/_app/version.json` (SvelteKit
+  writes `kit.version.name` there, and each `svelte.config.js` stamps it from
+  `$GITHUB_SHA` at build time), **plus** a content sniff. The version check catches
+  a deploy that silently didn't roll out; the sniff catches a deploy that rolled
+  out but renders nothing.
 
 It retries 6× at 10s intervals (`SMOKE_ATTEMPTS` / `SMOKE_DELAY_SECONDS` to
 override) to absorb propagation delay.
@@ -204,6 +243,7 @@ Run it by hand during an incident:
 
 ```bash
 node scripts/smoke-check.mjs https://api.skyreader.app/api/health --version <sha>
+node scripts/smoke-check.mjs https://skyreader.app/_app/version.json --version <sha>
 node scripts/smoke-check.mjs https://skyreader.app --contains '<title>Skyreader</title>'
 ```
 
@@ -222,5 +262,15 @@ within the stated window. Until a drill has passed, treat the alert as unproven.
 2. Disable the staging cron trigger and deploy → `backend-cron` heartbeat alert
    within the grace period. Re-enable, confirm auto-recovery.
 3. Throw deliberately in a staging route → Sentry event with the right
-   `environment` and release, and no `Authorization`/`Cookie` value in it.
+   `environment` and release, carrying a `requestId` tag whose value finds the
+   matching Workers Logs line (proves correlation end to end). Then read the whole
+   event, not just the headers: no `Authorization`/`Cookie`/DPoP value, no token in
+   a query string, **no credential in a breadcrumb or in the exception message** —
+   those are free text, where a header rule can't help. The Console integration is
+   disabled precisely so a `console.error` on a failure path can't ship a session
+   id (`src/observability/sentry.ts`); confirm the event has no console
+   breadcrumbs at all.
 4. Deploy with a deliberately wrong version stamp → smoke step fails, workflow red.
+   Do it for a Pages app too: edit the built `_app/version.json`, or deploy the
+   same SHA twice while asserting a different one — the point is to see the Pages
+   smoke check catch a build that isn't the one CI just made.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -308,11 +308,15 @@ path, so it works in local dev and staging the moment the cron has run once.
 | Tile                     | Source                        | Green            | Amber        | Red                          |
 | ------------------------ | ----------------------------- | ---------------- | ------------ | ---------------------------- |
 | Cron Last Run            | `system_status.cron_last_run` | <3 min ago       | <10 min ago  | ≥10 min, or the run failed   |
-| Firehose Lag             | `poller_status.lagMs`         | <5 min (the SLO) | <15 min      | ≥15 min (= the Sentry alert) |
+| Firehose Lag             | `poller_status.lagMs`         | <5 min (SLO bar) | <15 min      | ≥15 min (= the Sentry alert) |
 | Last Poll                | `poller_status.lastPollAt`    | <5 min ago       | never polled | ≥5 min ago                   |
 | Poll Errors (last cycle) | `poller_status.errors`        | 0                | ≥1           | —                            |
-| Proxy Cache Fresh        | `proxy_stats.freshPct`        | ≥95% (the SLO)   | ≥80%         | <80%, or stats >15 min old   |
+| Proxy Cache Fresh        | `proxy_stats.freshPct`        | ≥95% (SLO bar)   | ≥80%         | <80%, or stats >15 min old   |
 | Proxy Feeds in Error     | `proxy_stats.feedsInError`    | 0                | ≥1           | any permanent failures       |
+
+"SLO bar" means the tile grades the **latest reading** against the number §7's SLO
+uses; the SLO itself is that bar held across a month of hourly points, so an amber
+tile right now is not a breach and a green one is not compliance.
 
 **A tile reading "Stale" or "No data" is a real finding**, not a rendering bug: the
 values are written by the cron, so they stop moving exactly when it does. Cross-check
@@ -343,7 +347,10 @@ stats every 5th minute, snapshot once an hour on the hour.
 The browser reports errors to our own backend — never to a third party — which
 decides what reaches Sentry (`frontend/src/lib/services/telemetry.ts` →
 `backend/src/routes/telemetry.ts`). The endpoint is unauthenticated on purpose: an
-error on the login screen is one worth having.
+error on the login screen is one worth having. It is also routed **before session
+resolution**, alongside the health endpoints — a report sent while D1 or the auth
+path is degraded is the one you most want to arrive, and behind the auth gate that
+report would have become a 500 the reporter never retries.
 
 What restrains it, in the order it applies:
 
@@ -351,9 +358,9 @@ What restrains it, in the order it applies:
 2. **Once per distinct error, per page load.** A render loop reports once.
 3. **Five reports per page load.** Past that the page is telling one story.
 4. **10% sampling** — except `preload_recovery_failed`, which always sends.
-5. **20 accepted reports per minute** per DID (or per IP when anonymous),
-   enforced server-side. A 429 carries no `Retry-After`: a broken page should drop
-   the report, not schedule it.
+5. **20 accepted reports per minute per IP**, enforced server-side — by IP even
+   for a signed-in user, since the route never resolves a session. A 429 carries
+   no `Retry-After`: a broken page should drop the report, not schedule it.
 
 Everything the client sends is capped and validated server-side — a 300-character
 message, a 2000-character stack, a path with no query string, and a `kind` from a
@@ -457,17 +464,49 @@ Four numbers, chosen to be **thresholds worth tuning against** — not dashboard
 admire, and not promises to anyone outside the project. Their only job is to make
 "is this alert set right?" a question with an answer.
 
-| SLO                | Target                          | Measured by                         | Window  |
-| ------------------ | ------------------------------- | ----------------------------------- | ------- |
-| API availability   | 99.5%                           | Uptime check on `/api/health`       | 30 days |
-| Firehose freshness | lag < 5 min, p95                | `metrics_snapshots.firehose_lag_ms` | 30 days |
-| Feed freshness     | ≥95% of cached feeds within TTL | `proxy_stats.freshPct` (ops panel)  | 30 days |
-| Cron liveness      | gap < 5 min                     | Heartbeat check history             | 30 days |
+| SLO                | Target                               | Measured by                         | Window  |
+| ------------------ | ------------------------------------ | ----------------------------------- | ------- |
+| API availability   | 99.5%                                | Uptime check on `/api/health`       | 30 days |
+| Firehose freshness | lag < 5 min, p95 of hourly snapshots | `metrics_snapshots.firehose_lag_ms` | 30 days |
+| Feed freshness     | ≥95% fresh, p05 of hourly snapshots  | `metrics_snapshots.proxy_fresh_pct` | 30 days |
+| Cron liveness      | gap < 5 min                          | Heartbeat check history             | 30 days |
 
 99.5% is ~3.6 hours a month. That is a deliberately loose target for a
 single-operator project on a singleton proxy: it says "a couple of short outages a
 month is survivable, a daily one is not." Tighten it only if you're also willing
 to change the architecture it's measuring.
+
+Both freshness rows aggregate the **hourly** trend points, not the live tile: the
+tile is a point-in-time reading and "95% fresh right now" says nothing about a
+month. p95 for lag and p05 for freshness are the same statement pointed in
+opposite directions — the worst 5% of hours are allowed to miss, the other 95%
+must hold. Read them at the monthly pruning pass (§8) with the queries below (run
+from `backend/`), which take the percentile by offset because SQLite has no
+percentile function:
+
+```bash
+# Firehose lag, p95 (the 95th-worst-percent hour). Passes if < 300000.
+npx wrangler d1 execute skyreader --remote --command "
+  SELECT firehose_lag_ms FROM metrics_snapshots
+  WHERE captured_at > (unixepoch() - 30*86400) * 1000 AND firehose_lag_ms IS NOT NULL
+  ORDER BY firehose_lag_ms
+  LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 95 / 100 AS INT) FROM metrics_snapshots
+    WHERE captured_at > (unixepoch() - 30*86400) * 1000 AND firehose_lag_ms IS NOT NULL)"
+
+# Proxy cache freshness, p05 (the 5th-worst-percent hour). Passes if >= 95.
+npx wrangler d1 execute skyreader --remote --command "
+  SELECT proxy_fresh_pct FROM metrics_snapshots
+  WHERE captured_at > (unixepoch() - 30*86400) * 1000 AND proxy_fresh_pct IS NOT NULL
+  ORDER BY proxy_fresh_pct
+  LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 5 / 100 AS INT) FROM metrics_snapshots
+    WHERE captured_at > (unixepoch() - 30*86400) * 1000 AND proxy_fresh_pct IS NOT NULL)"
+```
+
+An hour with no snapshot row is absent from both queries rather than counted as a
+miss — a collector outage shows up as a **gap in the trend sparklines** (§4b), not
+as a freshness breach. If `COUNT(*)` is far below 720, the number above is
+answering for less than the window it claims; fix collection before tuning
+anything against it.
 
 Freshness alert thresholds are **looser than their SLOs on purpose**: the
 firehose SLO is 5 minutes and its warning fires at 15. Availability alerts are

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,226 @@
+# Skyreader Operations Runbook
+
+What's watching Skyreader, what each signal means, and what to do when one fires.
+
+Scope note: this is the **Phase 0** runbook — external checks, dead-man's switches,
+error tracking, and post-deploy smoke checks. Structured logs (Phase 1), the admin
+ops panel (Phase 2), client signal (Phase 3), and SLO/alert pruning (Phase 4) get
+their sections as they land.
+
+The operating principle: **silence means healthy**. Every alert below is
+outage-class by construction. If one fires without requiring action, fix or delete
+it rather than learning to ignore it.
+
+---
+
+## 1. What's instrumented
+
+| Surface                      | Signal                        | Where it lives                                   |
+| ---------------------------- | ----------------------------- | ------------------------------------------------ |
+| Backend Worker               | `GET /api/health`             | Shallow: status, version, timestamp. No deps.    |
+| Backend Worker               | `GET /api/health/deep`        | D1 + poller lag + feed proxy. Secret-gated.      |
+| Backend Worker               | Sentry (`@sentry/cloudflare`) | Exceptions from `fetch`, `scheduled`, DO alarm.  |
+| Backend cron (every minute)   | Heartbeat ping (`HEARTBEAT_URL`) | Dead-man's switch; also guards the firehose.  |
+| Feed proxy                   | `GET /health`                 | Status, version, cached feed count. No auth.     |
+| Feed proxy                   | `GET /stats`                  | Cache freshness + per-feed error counts. Secret. |
+| Feed proxy                   | Sentry (`@sentry/bun`)        | Route escapes, warmer failures.                  |
+| Feed proxy warmer            | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.     |
+| All deploys                  | `scripts/smoke-check.mjs`     | Post-deploy assertion against production.        |
+
+Not yet covered (by design, see the plan): request-level structured logs, trend
+lines, client-side errors.
+
+---
+
+## 2. External checks to configure
+
+These are **configuration, not code** — they live in the monitoring vendor's
+console. Reproduce them exactly from this list.
+
+Recommendation: use **one** vendor for both uptime checks and heartbeats. Better
+Stack does both on its free tier (verify current limits when you sign up), which
+keeps this to a single account instead of an uptime service plus Healthchecks.io.
+Any Healthchecks.io-style ping URL works for the heartbeats — the backend and
+proxy just GET whatever URL you give them.
+
+### Uptime checks
+
+| Check              | URL                                                   | Interval | Alert on                    |
+| ------------------ | ----------------------------------------------------- | -------- | --------------------------- |
+| API (shallow)      | `https://api.skyreader.app/api/health`                | 60s      | 2 consecutive failures      |
+| API (deep)         | `https://api.skyreader.app/api/health/deep`           | 5 min    | 2 consecutive non-200       |
+| App                | `https://skyreader.app`                               | 60s      | 2 consecutive failures      |
+| Linkblogs          | `https://linkblogs.skyreader.app`                     | 5 min    | 2 consecutive failures      |
+| Feed proxy         | `https://skyreader-feed-proxy.fly.dev/health`         | 60s      | 2 consecutive failures      |
+| Admin              | `https://skyreader-admin.pages.dev`                   | 5 min    | 2 consecutive failures      |
+
+The deep check needs the header `X-Health-Secret: <HEALTH_CHECK_SECRET>`. It
+returns **503 with a per-dependency breakdown** when anything is down, so it
+alerts on its own status code — no response-body assertion needed.
+
+"2 consecutive failures" everywhere: a single failed probe is usually the prober,
+not us.
+
+Alert delivery: email **and** phone push. An alert nobody sees is not an alert.
+
+### Heartbeat (dead-man's) checks
+
+| Check           | Period | Grace | Meaning when it fires                                        |
+| --------------- | ------ | ----- | ------------------------------------------------------------ |
+| `backend-cron`  | 1 min  | 5 min | The every-minute cron stopped firing or is failing every run. |
+| `proxy-warmer`  | 1 min  | 5 min | The feed-proxy warm loop wedged or the machine is down.       |
+
+Create each check, copy its ping URL, and set it as a secret (below). The backend
+pings **only after a clean run**, so "cron throws every minute" reads the same as
+"cron never fired" — both are outages.
+
+---
+
+## 3. Secrets and variables
+
+### Backend (`npx wrangler secret put <NAME>`, per environment)
+
+| Name                  | Required | Purpose                                                            |
+| --------------------- | -------- | ------------------------------------------------------------------ |
+| `SENTRY_DSN`          | no       | Error reporting. Unset ⇒ reporting is a silent no-op.              |
+| `HEARTBEAT_URL`       | no       | Cron dead-man ping URL. Unset ⇒ no ping (correct for local/dev).   |
+| `HEALTH_CHECK_SECRET` | no       | Gates `/api/health/deep`. Unset ⇒ the endpoint 503s, by design.    |
+
+`SENTRY_ENVIRONMENT` is a plain var in `wrangler.toml` (`production` / `staging`).
+`GIT_COMMIT_SHA` is passed by CI at deploy time (`--var GIT_COMMIT_SHA:<sha>`); a
+manual `wrangler deploy` will report `version: "dev"`, which is worth knowing when
+a smoke check fails right after a hand deploy.
+
+### Feed proxy (`fly secrets set <NAME>=...`)
+
+| Name                  | Required | Purpose                                        |
+| --------------------- | -------- | ---------------------------------------------- |
+| `SENTRY_DSN`          | no       | Already provisioned by `fly ext sentry create`. |
+| `WARM_HEARTBEAT_URL`  | no       | Warmer dead-man ping URL.                      |
+
+`GIT_COMMIT_SHA` is a Docker build arg passed by CI, surfaced on `/health`.
+
+### Sentry account ownership
+
+The proxy's DSN was provisioned by Fly's Sentry integration
+(`fly ext sentry create`), which creates a project in a **Fly-managed org**.
+Before pointing the backend at the same org, confirm it's one you control and can
+add projects to. If it isn't: create your own Sentry org, make two projects
+(`skyreader-backend`, `skyreader-feed-proxy`), and re-point the proxy — it's one
+secret (`fly secrets set SENTRY_DSN=...`), no code change.
+
+Both runtimes run **errors-only** (`tracesSampleRate: 0`). The backend additionally
+disables the SDK's Fetch integration: it wraps every outbound call (PDS, feed
+proxy, DID resolution) to produce spans we've turned off, and it measurably slowed
+a background extraction fetch (124ms → ~17s in `backend/test/xrpc.spec.ts`). If a
+future need for outbound breadcrumbs comes up, re-enable it deliberately and
+re-measure.
+
+Both runtimes report through a `reportError()` wrapper
+(`backend/src/observability/sentry.ts`, `feed-proxy/src/instrument.ts`) rather
+than calling the SDK at call sites, so swapping vendors — GlitchTip is
+API-compatible, or a hand-rolled envelope POST — is a one-file change per runtime.
+
+---
+
+## 4. Alert inventory and response
+
+### `API (shallow)` down
+
+**Means:** the Worker isn't serving. Everything is down for everyone.
+**Check:** Cloudflare status page, then `npx wrangler tail` for a crash loop, then
+Sentry for a spike.
+**Fix:** if a deploy caused it, re-run the previous successful deploy workflow
+(the smoke check should have caught it — see why it didn't).
+
+### `API (deep)` returning 503
+
+**Means:** the Worker is up but a dependency isn't. The body says which:
+
+```json
+{ "status": "degraded", "checks": { "database": {...}, "poller": {...}, "feedProxy": {...} } }
+```
+
+- `database.ok = false` → D1 is unavailable or slow (>3s). Check Cloudflare status.
+- `poller.ok = false` → the JetstreamPoller DO is stopped, or its last completed
+  poll is >5 min old. The every-minute cron re-pings `/start` automatically, so
+  first confirm the cron heartbeat is alive; if the cron is healthy and the poller
+  still isn't, redeploy the backend to recycle the DO.
+- `feedProxy.ok = false` → see below.
+
+### `backend-cron` heartbeat missed
+
+**Means:** the every-minute cron stopped firing or failed. **The JetstreamPoller
+only stays alive because this cron pings it**, so a dead cron takes the firehose
+with it within minutes.
+**Check:** Sentry for `source: cron` events (they carry the failing `phase` tag);
+`npx wrangler tail` for `[Cron]` lines.
+**Fix:** confirm the trigger still exists in `wrangler.toml` (`crons = ["* * * * *"]`)
+and redeploy. Cloudflare has occasionally dropped triggers on failed deploys.
+
+### `proxy-warmer` heartbeat missed
+
+**Means:** the warm loop wedged or the machine is down. Feeds go stale within the
+hour, and user requests start blocking on upstream fetches.
+**Check:** `fly status`, `fly logs -a skyreader-feed-proxy`, `/health`.
+**Fix:** `fly machine restart <id>`. **Never `fly scale count`** — the proxy is a
+deliberate singleton (SQLite on a per-machine volume, in-process firehose and
+coalescing maps); a second machine means a split-brain cache. See the invariant
+comment in `feed-proxy/fly.toml`.
+
+### `Feed proxy` uptime check down
+
+Same as above. A singleton has no failover; the alert exists to make the manual
+restart fast, not to prevent the outage.
+
+### App / Linkblogs / Admin down
+
+**Means:** Cloudflare Pages isn't serving that project.
+**Check:** the Pages dashboard for the project's latest deployment.
+**Fix:** roll back to the previous deployment in the dashboard, or re-run the
+deploy workflow.
+
+### Sentry error spike
+
+Triage by tag: `source` is one of `fetch`, `cron`, `jetstream-poller`, `route`,
+`warmer`. Backend events carry the release (`GIT_COMMIT_SHA`), so "did this start
+with the last deploy?" is answerable directly in Sentry.
+
+---
+
+## 5. Post-deploy smoke checks
+
+Every deploy workflow ends with `scripts/smoke-check.mjs`:
+
+- Workers/proxy: asserts `200` **and** `version === <the SHA just deployed>`. This
+  proves the new code is serving — not merely that something answers.
+- Pages apps: asserts `200` and a content sniff, since a Pages deploy carries no
+  version stamp.
+
+It retries 6× at 10s intervals (`SMOKE_ATTEMPTS` / `SMOKE_DELAY_SECONDS` to
+override) to absorb propagation delay.
+
+Run it by hand during an incident:
+
+```bash
+node scripts/smoke-check.mjs https://api.skyreader.app/api/health --version <sha>
+node scripts/smoke-check.mjs https://skyreader.app --contains '<title>Skyreader</title>'
+```
+
+**A red smoke step means production is wrong, not that the check is flaky.** Look
+at the deployment before re-running it.
+
+---
+
+## 6. Fire drills
+
+Run these on staging after configuring the checks; each must produce its alert
+within the stated window. Until a drill has passed, treat the alert as unproven.
+
+1. `fly machine stop` the proxy → uptime alert ≤2 min; deep health flips
+   `feedProxy.ok`. Restart, confirm recovery.
+2. Disable the staging cron trigger and deploy → `backend-cron` heartbeat alert
+   within the grace period. Re-enable, confirm auto-recovery.
+3. Throw deliberately in a staging route → Sentry event with the right
+   `environment` and release, and no `Authorization`/`Cookie` value in it.
+4. Deploy with a deliberately wrong version stamp → smoke step fails, workflow red.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -81,6 +81,16 @@ Create each check, copy its ping URL, and set it as a secret (below). The backen
 pings **only after a clean run**, so "cron throws every minute" reads the same as
 "cron never fired" — both are outages.
 
+### Sentry issue alert
+
+| Project             | Filter                                                   | Threshold             | Action               |
+| ------------------- | -------------------------------------------------------- | --------------------- | -------------------- |
+| `skyreader-backend` | `tags[source]:client tags[kind]:preload_recovery_failed` | 3 events in 5 minutes | Email and phone push |
+
+Use a three-event threshold because `kind` arrives through a deliberately public
+endpoint and is therefore forgeable. A cluster still catches a broken deploy
+quickly without letting one anonymous POST page the operator.
+
 ---
 
 ## 3. Secrets and variables
@@ -224,12 +234,12 @@ reality (`sampleRate` rides along on every event for exactly this reason). The
 | `rejection`               | `unhandledrejection`                 | A promise nobody caught — often a failed API call. |
 | `preload_recovery_failed` | The stale-chunk guard, tripped twice | **The deploy bricked the PWA.** See below.         |
 
-**`preload_recovery_failed` is the one to page on.** It means a client asked for a
-chunk from its own build, didn't get it, reloaded once to recover, and then failed
-again — so the page is stuck and the user's only remedy is clearing storage. It is
-**never sampled away**. Its usual cause is a build whose immutable assets stopped
-being served (`scripts/retain-immutable-assets.mjs` retention expired or was
-skipped) while old tabs were still open.
+**A cluster of `preload_recovery_failed` events is the one to page on.** It means
+clients asked for a chunk from their own build, didn't get it, reloaded once to
+recover, and then failed again — so the page is stuck and the user's only remedy
+is clearing storage. It is **never sampled away**. Its usual cause is a build
+whose immutable assets stopped being served (`scripts/retain-immutable-assets.mjs`
+retention expired or was skipped) while old tabs were still open.
 **Fix:** re-deploy the frontend, which republishes the current build's assets; if
 reports name an old `appVersion`, extend asset retention rather than chasing the
 client.
@@ -459,11 +469,12 @@ single-operator project on a singleton proxy: it says "a couple of short outages
 month is survivable, a daily one is not." Tighten it only if you're also willing
 to change the architecture it's measuring.
 
-Every alert threshold in this runbook is **looser than its SLO on purpose**: the
-firehose SLO is 5 minutes and the page fires at 15. An SLO you're paged for the
-moment you touch it is an SLO you'll stop believing. Read the trend sparklines
-monthly to see whether you're drifting; wait for the alert to be told you've
-stopped.
+Freshness alert thresholds are **looser than their SLOs on purpose**: the
+firehose SLO is 5 minutes and its warning fires at 15. Availability alerts are
+deliberately budget-agnostic and fire on a short current outage instead of waiting
+for the 30-day error budget to be exhausted. Cron's 5-minute grace matches its
+liveness boundary; tune both together if normal scheduling jitter approaches it.
+Read the trend sparklines monthly to see whether you're drifting.
 
 Where a number can't be measured yet, say so rather than inventing it: **API
 availability and cron liveness live in the uptime vendor's own history**, which
@@ -479,9 +490,9 @@ falsely, which is the whole point of the two rules below.
 **What earns a push notification.** An alert may page a phone only if it is
 outage-class — users are affected right now, or will be within minutes — _and_
 there is something a human can do about it at 3am. Everything currently
-configured passes both tests: five uptime checks, two heartbeats, and
-`preload_recovery_failed`. Everything else is a thing you find when you look:
-Sentry issues, ops tiles, trends.
+configured passes both tests: six uptime checks, two heartbeats, and the
+multi-event `preload_recovery_failed` Sentry alert in §2. Everything else is a
+thing you find when you look: Sentry issues, ops tiles, trends.
 
 **What does not page.** Warning-level conditions (`firehose_lag_high` is a Sentry
 message, not a phone call), individual client errors, feeds failing to parse, a

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,10 +2,10 @@
 
 What's watching Skyreader, what each signal means, and what to do when one fires.
 
-Scope note: this covers **Phases 0–1** — external checks, dead-man's switches,
-error tracking, post-deploy smoke checks, and structured logs with request-id
-correlation. The admin ops panel (Phase 2), client signal (Phase 3), and SLO/alert
-pruning (Phase 4) get their sections as they land.
+Scope note: this covers **Phases 0–2** — external checks, dead-man's switches,
+error tracking, post-deploy smoke checks, structured logs with request-id
+correlation, and the admin ops panel with its trend history. Client signal
+(Phase 3) and SLO/alert pruning (Phase 4) get their sections as they land.
 
 The operating principle: **silence means healthy**. Every alert below is
 outage-class by construction. If one fires without requiring action, fix or delete
@@ -15,21 +15,23 @@ it rather than learning to ignore it.
 
 ## 1. What's instrumented
 
-| Surface                      | Signal                        | Where it lives                                   |
-| ---------------------------- | ----------------------------- | ------------------------------------------------ |
-| Backend Worker               | `GET /api/health`             | Shallow: status, version, timestamp. No deps.    |
-| Backend Worker               | `GET /api/health/deep`        | D1 + poller lag + feed proxy. Secret-gated.      |
-| Backend Worker               | Sentry (`@sentry/cloudflare`) | Exceptions from `fetch`, `scheduled`, DO alarm.  |
-| Backend Worker               | Structured logs (Workers Logs) | One JSON object per event, keyed by `requestId`. |
-| Backend cron (every minute)   | Heartbeat ping (`HEARTBEAT_URL`) | Dead-man's switch; also guards the firehose.  |
-| Feed proxy                   | `GET /health`                 | Status, version, cached feed count. No auth.     |
-| Feed proxy                   | `GET /stats`                  | Cache freshness + per-feed error counts. Secret. |
-| Feed proxy                   | Sentry (`@sentry/bun`)        | Route escapes, warmer failures.                  |
-| Feed proxy warmer            | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.     |
-| All deploys                  | `scripts/smoke-check.mjs`     | Post-deploy assertion against production.        |
+| Surface                     | Signal                                | Where it lives                                    |
+| --------------------------- | ------------------------------------- | ------------------------------------------------- |
+| Backend Worker              | `GET /api/health`                     | Shallow: status, version, timestamp. No deps.     |
+| Backend Worker              | `GET /api/health/deep`                | D1 + poller lag + feed proxy. Secret-gated.       |
+| Backend Worker              | Sentry (`@sentry/cloudflare`)         | Exceptions from `fetch`, `scheduled`, DO alarm.   |
+| Backend Worker              | Structured logs (Workers Logs)        | One JSON object per event, keyed by `requestId`.  |
+| Backend cron (every minute) | Heartbeat ping (`HEARTBEAT_URL`)      | Dead-man's switch; also guards the firehose.      |
+| Feed proxy                  | `GET /health`                         | Status, version, cached feed count. No auth.      |
+| Feed proxy                  | `GET /stats`                          | Cache freshness + per-feed error counts. Secret.  |
+| Feed proxy                  | Sentry (`@sentry/bun`)                | Route escapes, warmer failures.                   |
+| Feed proxy warmer           | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.              |
+| Backend cron (every minute) | `system_status` rows (D1)             | Cron liveness, poller lag, proxy cache stats.     |
+| Backend cron (hourly)       | `metrics_snapshots` rows (D1)         | One trend point per hour, pruned at 90 days.      |
+| Admin dashboard             | Ops tiles + 30-day sparklines         | The same rows, rendered. No token, works locally. |
+| All deploys                 | `scripts/smoke-check.mjs`             | Post-deploy assertion against production.         |
 
-Not yet covered (by design, see the plan): trend lines, an ops panel in the admin,
-client-side errors.
+Not yet covered (by design, see the plan): client-side errors.
 
 ---
 
@@ -46,14 +48,14 @@ proxy just GET whatever URL you give them.
 
 ### Uptime checks
 
-| Check              | URL                                                   | Interval | Alert on                    |
-| ------------------ | ----------------------------------------------------- | -------- | --------------------------- |
-| API (shallow)      | `https://api.skyreader.app/api/health`                | 60s      | 2 consecutive failures      |
-| API (deep)         | `https://api.skyreader.app/api/health/deep`           | 5 min    | 2 consecutive non-200       |
-| App                | `https://skyreader.app`                               | 60s      | 2 consecutive failures      |
-| Linkblogs          | `https://linkblogs.skyreader.app`                     | 5 min    | 2 consecutive failures      |
-| Feed proxy         | `https://skyreader-feed-proxy.fly.dev/health`         | 60s      | 2 consecutive failures      |
-| Admin              | `https://skyreader-admin.pages.dev`                   | 5 min    | 2 consecutive failures      |
+| Check         | URL                                           | Interval | Alert on               |
+| ------------- | --------------------------------------------- | -------- | ---------------------- |
+| API (shallow) | `https://api.skyreader.app/api/health`        | 60s      | 2 consecutive failures |
+| API (deep)    | `https://api.skyreader.app/api/health/deep`   | 5 min    | 2 consecutive non-200  |
+| App           | `https://skyreader.app`                       | 60s      | 2 consecutive failures |
+| Linkblogs     | `https://linkblogs.skyreader.app`             | 5 min    | 2 consecutive failures |
+| Feed proxy    | `https://skyreader-feed-proxy.fly.dev/health` | 60s      | 2 consecutive failures |
+| Admin         | `https://skyreader-admin.pages.dev`           | 5 min    | 2 consecutive failures |
 
 The deep check needs the header `X-Health-Secret: <HEALTH_CHECK_SECRET>`. It
 returns **503 with a per-dependency breakdown** when anything is down, so it
@@ -66,10 +68,10 @@ Alert delivery: email **and** phone push. An alert nobody sees is not an alert.
 
 ### Heartbeat (dead-man's) checks
 
-| Check           | Period | Grace | Meaning when it fires                                        |
-| --------------- | ------ | ----- | ------------------------------------------------------------ |
-| `backend-cron`  | 1 min  | 5 min | The every-minute cron stopped firing or is failing every run. |
-| `proxy-warmer`  | 1 min  | 5 min | The feed-proxy warm loop wedged or the machine is down.       |
+| Check          | Period | Grace | Meaning when it fires                                         |
+| -------------- | ------ | ----- | ------------------------------------------------------------- |
+| `backend-cron` | 1 min  | 5 min | The every-minute cron stopped firing or is failing every run. |
+| `proxy-warmer` | 1 min  | 5 min | The feed-proxy warm loop wedged or the machine is down.       |
 
 Create each check, copy its ping URL, and set it as a secret (below). The backend
 pings **only after a clean run**, so "cron throws every minute" reads the same as
@@ -81,11 +83,11 @@ pings **only after a clean run**, so "cron throws every minute" reads the same a
 
 ### Backend (`npx wrangler secret put <NAME>`, per environment)
 
-| Name                  | Required | Purpose                                                            |
-| --------------------- | -------- | ------------------------------------------------------------------ |
-| `SENTRY_DSN`          | no       | Error reporting. Unset ⇒ reporting is a silent no-op.              |
-| `HEARTBEAT_URL`       | no       | Cron dead-man ping URL. Unset ⇒ no ping (correct for local/dev).   |
-| `HEALTH_CHECK_SECRET` | no       | Gates `/api/health/deep`. Unset ⇒ the endpoint 503s, by design.    |
+| Name                  | Required | Purpose                                                          |
+| --------------------- | -------- | ---------------------------------------------------------------- |
+| `SENTRY_DSN`          | no       | Error reporting. Unset ⇒ reporting is a silent no-op.            |
+| `HEARTBEAT_URL`       | no       | Cron dead-man ping URL. Unset ⇒ no ping (correct for local/dev). |
+| `HEALTH_CHECK_SECRET` | no       | Gates `/api/health/deep`. Unset ⇒ the endpoint 503s, by design.  |
 
 `SENTRY_ENVIRONMENT` is a plain var in `wrangler.toml` (`production` / `staging`).
 `GIT_COMMIT_SHA` is passed by CI at deploy time (`--var GIT_COMMIT_SHA:<sha>`); a
@@ -94,10 +96,10 @@ a smoke check fails right after a hand deploy.
 
 ### Feed proxy (`fly secrets set <NAME>=...`)
 
-| Name                  | Required | Purpose                                        |
-| --------------------- | -------- | ---------------------------------------------- |
-| `SENTRY_DSN`          | no       | Already provisioned by `fly ext sentry create`. |
-| `WARM_HEARTBEAT_URL`  | no       | Warmer dead-man ping URL.                      |
+| Name                 | Required | Purpose                                         |
+| -------------------- | -------- | ----------------------------------------------- |
+| `SENTRY_DSN`         | no       | Already provisioned by `fly ext sentry create`. |
+| `WARM_HEARTBEAT_URL` | no       | Warmer dead-man ping URL.                       |
 
 `GIT_COMMIT_SHA` is a Docker build arg passed by CI, surfaced on `/health`.
 
@@ -181,6 +183,26 @@ restart fast, not to prevent the outage.
 **Fix:** roll back to the previous deployment in the dashboard, or re-run the
 deploy workflow.
 
+### `firehose_lag_high` (Sentry message, not an exception)
+
+**Means:** the Jetstream cursor is more than **15 minutes** behind real time. The
+poller is running — a dead poller shows up as a missed cron heartbeat or a deep
+health 503 — but it isn't keeping up, so shares and documents from follows are
+arriving late or not at all. Users see a social feed that's quietly frozen.
+
+Sent by the every-minute cron with a fixed fingerprint, so it's **one issue, not
+one per minute**: first crossing, then a reminder every 30 minutes while it lasts.
+Recovery is silent by design — the admin's Firehose Lag tile goes green and
+`event = firehose_lag_recovered` appears in the logs.
+
+**Check:** the Ops panel (Firehose Lag, Last Poll, Poll Errors), then
+`event = jetstream_poll` in Workers Logs — `subscriptionsLagMs` climbing with
+`durationMs` at the 8s poll timeout means the stream is delivering faster than one
+cycle can drain. Jetstream itself being down looks like errors, not lag.
+**Fix:** usually none — a backlog after a Jetstream outage drains on its own; watch
+that the number is falling. If it's flat or growing over 30 minutes, redeploy the
+backend to recycle the DO (it resumes from its stored cursor, so nothing is lost).
+
 ### Sentry error spike
 
 Triage by tag: `source` is one of `fetch`, `cron`, `jetstream-poller`, `route`,
@@ -202,14 +224,16 @@ poll cycle — a `requestId`, plus `route` and `did` when known.
 
 Query patterns that pay for themselves:
 
-| Question                          | Filter                                            |
-| --------------------------------- | ------------------------------------------------- |
-| Everything about one failure      | `requestId = <id from Sentry or X-Request-Id>`    |
-| Error rate on one endpoint        | `event = request AND route = /api/v2/feeds/batch` |
-| Slow requests                     | `event = request AND durationMs > 3000`           |
-| Is the cron doing its work?       | `event = cron_run`                                |
-| Is the firehose keeping up?       | `event = jetstream_poll` → `subscriptionsLagMs`   |
-| What failed inside a cron run?    | `event = cron_phase_failed` → `phase`             |
+| Question                         | Filter                                            |
+| -------------------------------- | ------------------------------------------------- |
+| Everything about one failure     | `requestId = <id from Sentry or X-Request-Id>`    |
+| Error rate on one endpoint       | `event = request AND route = /api/v2/feeds/batch` |
+| Slow requests                    | `event = request AND durationMs > 3000`           |
+| Is the cron doing its work?      | `event = cron_run`                                |
+| Is the firehose keeping up?      | `event = jetstream_poll` → `subscriptionsLagMs`   |
+| What failed inside a cron run?   | `event = cron_phase_failed` → `phase`             |
+| Why is the ops panel stale?      | `event = ops_metrics_failed` → `step`             |
+| Did the hourly trend point land? | `event = metrics_snapshot` → `prunedRows`         |
 
 The id is also returned to callers as the `X-Request-Id` response header (exposed
 via CORS), so a user-reported failure can be traced if they can quote it. The
@@ -220,6 +244,36 @@ Two deliberate gaps: the shallow health check emits no summary line (an uptime
 poller would drown the log in identical entries), and leaf-level `console.log`
 calls elsewhere in the codebase are still plain strings. Convert them
 opportunistically; a big-bang rewrite is churn.
+
+---
+
+## 4b. The admin ops panel
+
+The first section of the admin dashboard. It reads two D1 tables the backend cron
+writes (migration `0067_system_status.sql`) — no API token, no production-only
+path, so it works in local dev and staging the moment the cron has run once.
+
+| Tile                     | Source                        | Green            | Amber        | Red                          |
+| ------------------------ | ----------------------------- | ---------------- | ------------ | ---------------------------- |
+| Cron Last Run            | `system_status.cron_last_run` | <3 min ago       | <10 min ago  | ≥10 min, or the run failed   |
+| Firehose Lag             | `poller_status.lagMs`         | <5 min (the SLO) | <15 min      | ≥15 min (= the Sentry alert) |
+| Last Poll                | `poller_status.lastPollAt`    | <5 min ago       | never polled | ≥5 min ago                   |
+| Poll Errors (last cycle) | `poller_status.errors`        | 0                | ≥1           | —                            |
+| Proxy Cache Fresh        | `proxy_stats.freshPct`        | ≥95% (the SLO)   | ≥80%         | <80%, or stats >15 min old   |
+| Proxy Feeds in Error     | `proxy_stats.feedsInError`    | 0                | ≥1           | any permanent failures       |
+
+**A tile reading "Stale" or "No data" is a real finding**, not a rendering bug: the
+values are written by the cron, so they stop moving exactly when it does. Cross-check
+against the `backend-cron` heartbeat before assuming the panel is broken.
+
+Below the tiles, **Trends (30 days, hourly)** sparklines the same numbers plus the
+raw counts, from `metrics_snapshots`. Gaps in a line are hours with no recorded
+value (cron down, or the source was stale) — deliberately drawn as gaps rather
+than zeroes. Retention is 90 days, pruned by the job that writes it; the panel
+shows the most recent 30.
+
+Cadence, if a number looks older than expected: poller status every minute, proxy
+stats every 5th minute, snapshot once an hour on the hour.
 
 ---
 
@@ -274,3 +328,13 @@ within the stated window. Until a drill has passed, treat the alert as unproven.
    Do it for a Pages app too: edit the built `_app/version.json`, or deploy the
    same SHA twice while asserting a different one — the point is to see the Pages
    smoke check catch a build that isn't the one CI just made.
+5. Point the staging poller at an unreachable Jetstream host → the admin's Firehose
+   Lag tile climbs through amber into red, and a `firehose_lag_high` Sentry event
+   arrives once lag passes 15 min. Leave it broken for an hour: exactly **three**
+   events (crossing, +30 min, +60 min), not sixty. Restore the host, confirm the
+   tile goes green and `event = firehose_lag_recovered` appears — recovery is
+   deliberately silent in Sentry, so the log line is the proof.
+   Shortcut for the impatient: write a `poller_status` row by hand
+   (`npx wrangler d1 execute skyreader-staging --remote --command "UPDATE system_status SET value = json_set(value, '$.lagMs', 3600000) WHERE key = 'poller_status'"`)
+   — that drives the **panel**, but not the alert, which recomputes from the DO's
+   cursors on the next cron minute.

--- a/feed-proxy/Dockerfile
+++ b/feed-proxy/Dockerfile
@@ -9,6 +9,12 @@ COPY src ./src
 
 RUN mkdir -p /data
 
+# Stamped by CI (`flyctl deploy --build-arg GIT_COMMIT_SHA=...`) and surfaced on
+# /health, so a post-deploy smoke check can prove this build is the one serving.
+# Declared after the source copy so it never busts the dependency layer cache.
+ARG GIT_COMMIT_SHA=dev
+ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
+
 ENV NODE_ENV=production
 
 EXPOSE 3000

--- a/feed-proxy/README.md
+++ b/feed-proxy/README.md
@@ -295,6 +295,12 @@ curl "/feed?url=...&since_guids=old-guid&limit=50"
 | `CACHE_TTL_SECONDS`  | `900`    | Fresh cache duration (15 min)             |
 | `STALE_TTL_SECONDS`  | `3600`   | Stale cache max age (1 hour)              |
 | `PORT`               | `3000`   | HTTP server port                          |
+| `SENTRY_DSN`         | (none)   | Error reporting; unset ⇒ no-op            |
+| `WARM_HEARTBEAT_URL` | (none)   | Dead-man ping after each warm tick        |
+| `GIT_COMMIT_SHA`     | `dev`    | Build stamp, reported by `/health`        |
+
+Observability setup, alert thresholds, and incident procedures live in
+[`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 ## Cache Behavior
 

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -1763,7 +1763,26 @@ export function createApp(db: Database, config: AppConfig) {
     return result;
   }
 
-  const app = new Hono();
+  const app = new Hono<{ Variables: { requestId: string } }>();
+
+  // Cross-service correlation. The backend Worker stamps X-Request-Id on every
+  // proxy call (backend/src/services/feed-proxy-client.ts); we adopt it, echo it
+  // back on the response, and tag anything we report with it — so one id follows
+  // a slow feed fetch from the Worker's request line into this process's error.
+  // A direct caller without the header still gets an id, just an unlinked one.
+  app.use('*', async (c, next) => {
+    const inbound = c.req.header('X-Request-Id');
+    const requestId =
+      inbound && /^[A-Za-z0-9_-]{8,64}$/.test(inbound) ? inbound : crypto.randomUUID();
+    c.set('requestId', requestId);
+    await next();
+    try {
+      c.header('X-Request-Id', requestId);
+    } catch {
+      // A handler that returns an upstream `Response` directly has immutable
+      // headers. Echoing the id is a convenience; never fail a good response for it.
+    }
+  });
 
   // Report any error that escapes a route handler to Sentry, then answer 500.
   // Routes handle their own expected failures (upstream 502s, 503 load-shed,
@@ -1771,9 +1790,13 @@ export function createApp(db: Database, config: AppConfig) {
   // a thrown bug, an unhandled rejection inside a handler — so it surfaces in
   // Sentry instead of vanishing into a bare 500. No-op send when Sentry is off.
   app.onError((err, c) => {
-    console.error(`[Proxy] Unhandled error on ${c.req.method} ${c.req.path}:`, err);
+    const requestId = c.get('requestId');
+    console.error(
+      `[Proxy] Unhandled error on ${c.req.method} ${c.req.path} (requestId=${requestId}):`,
+      err
+    );
     reportError(err, {
-      tags: { source: 'route' },
+      tags: { source: 'route', ...(requestId ? { requestId } : {}) },
       extra: { method: c.req.method, path: c.req.path },
     });
     return c.json({ error: 'Internal server error' }, 500);

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -20,7 +20,7 @@ import type { LaneId } from './lanes';
 import { normalizeArticleUrl } from './url-normalize';
 import { Semaphore, OverloadError } from './semaphore';
 import { safeFetch } from './ssrf-guard';
-import { Sentry } from './instrument';
+import { reportError, VERSION } from './instrument';
 
 export interface AppConfig {
   proxySecret?: string;
@@ -1772,18 +1772,21 @@ export function createApp(db: Database, config: AppConfig) {
   // Sentry instead of vanishing into a bare 500. No-op send when Sentry is off.
   app.onError((err, c) => {
     console.error(`[Proxy] Unhandled error on ${c.req.method} ${c.req.path}:`, err);
-    Sentry.captureException(err, {
+    reportError(err, {
       tags: { source: 'route' },
       extra: { method: c.req.method, path: c.req.path },
     });
     return c.json({ error: 'Internal server error' }, 500);
   });
 
-  // Health check (no auth)
+  // Health check (no auth). `version` is the deployed commit — the post-deploy
+  // smoke check asserts it matches the SHA it just shipped, which proves the new
+  // code is serving rather than just that something answers.
   app.get('/health', (c) => {
     const cacheCount = db.query<{ count: number }, []>('SELECT COUNT(*) as count FROM cache').get();
     return c.json({
       status: 'ok',
+      version: VERSION,
       timestamp: Date.now(),
       cachedFeeds: cacheCount?.count || 0,
     });

--- a/feed-proxy/src/heartbeat.ts
+++ b/feed-proxy/src/heartbeat.ts
@@ -1,0 +1,29 @@
+// Dead-man's switch ping for the self-warming loop. A wedged warmer (a tick that
+// never settles, a timer that stops firing) throws nothing, so Sentry never hears
+// about it and the cache just quietly goes stale. A monitor alerting on the
+// absence of this ping is what catches that.
+//
+// Fire-and-forget by contract: never awaited on the tick's critical path, and it
+// swallows every failure so a slow monitor can't stall warming.
+
+const HEARTBEAT_TIMEOUT_MS = 5000;
+
+/**
+ * Ping a heartbeat URL (Healthchecks.io / Better Stack). No-op when `url` is
+ * unset, which keeps local dev and tests quiet.
+ */
+export async function pingHeartbeat(url: string | undefined, source: string): Promise<void> {
+  if (!url) return;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      console.warn(`[Heartbeat] ${source} ping returned ${response.status}`);
+    }
+  } catch (error) {
+    console.warn(`[Heartbeat] ${source} ping failed:`, error);
+  }
+}

--- a/feed-proxy/src/index.ts
+++ b/feed-proxy/src/index.ts
@@ -1,10 +1,11 @@
 // Must be first: initializes Sentry before any other module loads so its global
 // error handlers and instrumentation are in place when the app boots.
-import { Sentry } from './instrument';
+import { reportError } from './instrument';
 import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'fs';
 import { createApp, initDatabase, cleanupCache } from './app';
 import { DocumentFirehose } from './jetstream';
+import { pingHeartbeat } from './heartbeat';
 
 // Config
 const PROXY_SECRET = process.env.PROXY_SECRET;
@@ -46,6 +47,9 @@ const WARM_CONCURRENCY = parseInt(process.env.WARM_CONCURRENCY || '8', 10);
 // Pre-warm Phase 5 article mention counts as feeds are warmed (extra
 // Constellation load); on by default in production, disable with WARM_MENTIONS=false.
 const WARM_MENTIONS_ENABLED = (process.env.WARM_MENTIONS ?? 'true') !== 'false';
+// Dead-man's switch for the warm loop (Healthchecks.io / Better Stack). Unset in
+// local dev, so the ping is a no-op there.
+const WARM_HEARTBEAT_URL = process.env.WARM_HEARTBEAT_URL;
 
 // /extract is the heaviest request (fetch + Defuddle DOM build). Cap concurrent
 // extractions so a burst of distinct heavy articles can't OOM the 512MB machine;
@@ -137,10 +141,14 @@ if (WARM_ENABLED) {
       .then(([feeds, docs]) => {
         if (feeds > 0) console.log(`[Proxy] Warmer refreshed ${feeds} feed(s)`);
         if (docs > 0) console.log(`[Proxy] Warmer refreshed ${docs} author document set(s)`);
+        // Dead-man's switch: only a tick that completed pings. A warmer that
+        // wedges without throwing produces no Sentry event and no error log —
+        // the missing heartbeat is the only thing that would ever notice.
+        void pingHeartbeat(WARM_HEARTBEAT_URL, 'warmer');
       })
       .catch((err) => {
         console.error('[Proxy] Warmer error:', err);
-        Sentry.captureException(err, { tags: { source: 'warmer' } });
+        reportError(err, { tags: { source: 'warmer' } });
       })
       .finally(() => {
         warmRunning = false;

--- a/feed-proxy/src/instrument.ts
+++ b/feed-proxy/src/instrument.ts
@@ -7,6 +7,7 @@
 // unset — local dev, tests — init() is a no-op and nothing is sent, so this is
 // safe to import unconditionally.
 import * as Sentry from '@sentry/bun';
+import { scrubEvent } from './scrub';
 
 const dsn = process.env.SENTRY_DSN;
 
@@ -18,6 +19,14 @@ if (dsn) {
     // high-throughput and we only want error reporting unless we deliberately
     // turn sampling on.
     tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0'),
+    // Never let the SDK attach request bodies or headers on its own judgement.
+    sendDefaultPii: false,
+    // The Worker's "nothing leaves with a credential attached" contract stopped
+    // at the runtime boundary until this. See ./scrub.ts for what it covers and
+    // fire drill #3 in docs/RUNBOOK.md for the check that proves it.
+    beforeSend(event) {
+      return scrubEvent(event);
+    },
   });
   console.log('[Proxy] Sentry initialized');
 } else {

--- a/feed-proxy/src/instrument.ts
+++ b/feed-proxy/src/instrument.ts
@@ -21,6 +21,9 @@ if (dsn) {
     tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0'),
     // Never let the SDK attach request bodies or headers on its own judgement.
     sendDefaultPii: false,
+    // Console breadcrumbs can retain a tokenised feed URL from one request and
+    // attach it to a later user's error in this long-lived process.
+    integrations: (defaults) => defaults.filter((integration) => integration.name !== 'Console'),
     // The Worker's "nothing leaves with a credential attached" contract stopped
     // at the runtime boundary until this. See ./scrub.ts for what it covers and
     // fire drill #3 in docs/RUNBOOK.md for the check that proves it.

--- a/feed-proxy/src/instrument.ts
+++ b/feed-proxy/src/instrument.ts
@@ -25,3 +25,27 @@ if (dsn) {
 }
 
 export { Sentry };
+
+// The build this process is running, stamped by the Fly build arg (see Dockerfile
+// and .github/workflows/feed-proxy-deploy.yml). Surfaced on /health so a
+// post-deploy smoke check can prove the new code is actually serving.
+export const VERSION = process.env.GIT_COMMIT_SHA || 'dev';
+
+export interface ReportContext {
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * Report an error to the error tracker. Every call site goes through this rather
+ * than `Sentry.captureException` directly, so swapping the vendor (GlitchTip, a
+ * hand-rolled envelope POST, nothing at all) stays a one-file change. Never
+ * throws — an observability failure must not become a request failure.
+ */
+export function reportError(error: unknown, context?: ReportContext): void {
+  try {
+    Sentry.captureException(error, { tags: context?.tags, extra: context?.extra });
+  } catch (reportingError) {
+    console.error('[Proxy] Failed to report error:', reportingError);
+  }
+}

--- a/feed-proxy/src/integration.test.ts
+++ b/feed-proxy/src/integration.test.ts
@@ -120,6 +120,9 @@ describe('Integration Tests', () => {
       expect(json.status).toBe('ok');
       expect(json.cachedFeeds).toBe(0);
       expect(json.timestamp).toBeTypeOf('number');
+      // Deploy stamp the post-deploy smoke check asserts against; 'dev' when the
+      // GIT_COMMIT_SHA build arg isn't set (local, tests).
+      expect(json.version).toBe(process.env.GIT_COMMIT_SHA || 'dev');
     });
 
     it('reports cached feed count', async () => {

--- a/feed-proxy/src/scrub.test.ts
+++ b/feed-proxy/src/scrub.test.ts
@@ -55,6 +55,17 @@ describe('scrubEvent', () => {
     expect(JSON.stringify(scrubEvent(event))).not.toContain('secret');
     expect(event.message).toContain('token=%5Bredacted%5D');
   });
+
+  test('scrubs a breadcrumb or extra that is a bare string or array', () => {
+    // Neither shape can be redacted in place, so a scrub that ignored the return
+    // value would pass both through while reading as if it had worked.
+    const event = {
+      breadcrumbs: [{ data: 'fetched https://example.com/feed?token=crumb-secret' }],
+      extra: ['warmed https://example.com/feed?token=extra-secret'],
+    };
+
+    expect(JSON.stringify(scrubEvent(event))).not.toContain('secret');
+  });
 });
 
 describe('scrubText', () => {

--- a/feed-proxy/src/scrub.test.ts
+++ b/feed-proxy/src/scrub.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { scrubEvent, scrubUrl } from './scrub';
+import { scrubEvent, scrubText, scrubUrl } from './scrub';
 
 // The two credentials that pass through this process: the Worker's shared secret
 // on every authenticated call, and tokenised feed URLs.
@@ -44,8 +44,23 @@ describe('scrubEvent', () => {
     expect(scrubbed.request?.data).toBeUndefined();
   });
 
-  test('passes an event with no request through untouched', () => {
-    const event = { message: 'warmer failed' };
-    expect(scrubEvent(event)).toEqual({ message: 'warmer failed' });
+  test('scrubs tokenised URLs from free-text channels without request data', () => {
+    const event = {
+      message: 'warmer failed for https://example.com/feed?token=message-secret',
+      breadcrumbs: [{ message: '[Proxy] https://example.com/feed?token=crumb-secret: HTTP 404' }],
+      exception: { values: [{ value: 'api_key=exception-secret' }] },
+      extra: { feedUrl: 'https://example.com/feed?auth=extra-secret' },
+    };
+
+    expect(JSON.stringify(scrubEvent(event))).not.toContain('secret');
+    expect(event.message).toContain('token=%5Bredacted%5D');
+  });
+});
+
+describe('scrubText', () => {
+  test('redacts authorization values embedded in prose', () => {
+    expect(scrubText('upstream returned Authorization: Bearer abcdefghijklmnop')).not.toContain(
+      'abcdefghijklmnop'
+    );
   });
 });

--- a/feed-proxy/src/scrub.test.ts
+++ b/feed-proxy/src/scrub.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { scrubEvent, scrubUrl } from './scrub';
+
+// The two credentials that pass through this process: the Worker's shared secret
+// on every authenticated call, and tokenised feed URLs.
+
+describe('scrubUrl', () => {
+  test('redacts a token in a feed URL but keeps the URL readable', () => {
+    expect(scrubUrl('https://example.com/feed.xml?token=abc123&format=rss')).toBe(
+      'https://example.com/feed.xml?token=%5Bredacted%5D&format=rss'
+    );
+  });
+
+  test('leaves an ordinary URL alone', () => {
+    expect(scrubUrl('https://example.com/feed.xml?format=rss')).toBe(
+      'https://example.com/feed.xml?format=rss'
+    );
+    expect(scrubUrl('https://example.com/feed.xml')).toBe('https://example.com/feed.xml');
+  });
+});
+
+describe('scrubEvent', () => {
+  test('redacts the shared secret the Worker sends on every call', () => {
+    const event = {
+      request: {
+        url: 'http://proxy/fetch',
+        headers: { 'X-Proxy-Secret': 'super-secret', 'User-Agent': 'skyreader' },
+      },
+    };
+
+    expect(scrubEvent(event).request.headers).toEqual({
+      'X-Proxy-Secret': '[redacted]',
+      'User-Agent': 'skyreader',
+    });
+  });
+
+  test('drops cookies and bodies entirely', () => {
+    const event = {
+      request: { cookies: { session: 'x' }, data: { apiKey: 'y' } },
+    };
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.request?.cookies).toBeUndefined();
+    expect(scrubbed.request?.data).toBeUndefined();
+  });
+
+  test('passes an event with no request through untouched', () => {
+    const event = { message: 'warmer failed' };
+    expect(scrubEvent(event)).toEqual({ message: 'warmer failed' });
+  });
+});

--- a/feed-proxy/src/scrub.ts
+++ b/feed-proxy/src/scrub.ts
@@ -127,12 +127,16 @@ export function scrubEvent<T>(event: T): T {
     for (const breadcrumb of scrubbable.breadcrumbs ?? []) {
       if (typeof breadcrumb.message === 'string')
         breadcrumb.message = scrubText(breadcrumb.message);
-      if (breadcrumb.data) scrubValue(breadcrumb.data);
+      // Assigned rather than called for its side effect: scrubValue can't redact a
+      // top-level string or array in place, so discarding the result would make the
+      // scrub a silent no-op for those shapes — the worst failure mode for a
+      // security control that swallows its own exceptions.
+      if (breadcrumb.data) breadcrumb.data = scrubValue(breadcrumb.data);
     }
     for (const exception of scrubbable.exception?.values ?? []) {
       if (typeof exception.value === 'string') exception.value = scrubText(exception.value);
     }
-    if (scrubbable.extra) scrubValue(scrubbable.extra);
+    if (scrubbable.extra) scrubbable.extra = scrubValue(scrubbable.extra);
     if (typeof scrubbable.message === 'string') scrubbable.message = scrubText(scrubbable.message);
 
     return event;

--- a/feed-proxy/src/scrub.ts
+++ b/feed-proxy/src/scrub.ts
@@ -28,6 +28,9 @@ const SENSITIVE_HEADERS = new Set([
 ]);
 
 const SENSITIVE_KEY = /(token|secret|password|authorization|cookie|api[_-]?key|signature|auth)/i;
+const URL_WITH_QUERY = /\bhttps?:\/\/[^\s"'<>]*\?[^\s"'<>]*/gi;
+const AUTH_SCHEME_VALUE = /\b(Bearer|DPoP|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+const INLINE_PAIR = /([A-Za-z0-9_.-]+)(\s*[=:]\s*)(["']?)([^\s,;&"']+)\3/g;
 
 function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY.test(key);
@@ -54,6 +57,28 @@ export function scrubUrl(url: string): string {
   return `${url.slice(0, index)}?${scrubQueryString(url.slice(index + 1))}`;
 }
 
+/** Redact tokenised URLs and inline credential-shaped values in free text. */
+export function scrubText(value: string): string {
+  return value
+    .replace(URL_WITH_QUERY, (url) => scrubUrl(url))
+    .replace(AUTH_SCHEME_VALUE, (_match, scheme: string) => `${scheme} ${REDACTED}`)
+    .replace(INLINE_PAIR, (match, key: string, separator: string, quote: string) =>
+      isSensitiveKey(key) ? `${key}${separator}${quote}${REDACTED}${quote}` : match
+    );
+}
+
+function scrubValue(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return scrubText(value);
+  if (depth > 6 || value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((entry) => scrubValue(entry, depth + 1));
+
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    record[key] = isSensitiveKey(key) ? REDACTED : scrubValue(record[key], depth + 1);
+  }
+  return record;
+}
+
 interface ScrubbableRequest {
   url?: string;
   headers?: Record<string, unknown>;
@@ -66,16 +91,13 @@ interface ScrubbableRequest {
  * Strip credentials from a Sentry event in place. Returns the same event, or the
  * untouched event if anything at all goes wrong.
  *
- * Typed over `T` rather than over the SDK's `Event`: this only ever reads two
- * well-known fields, and staying structurally loose means an SDK type change
- * can't turn a security control into a build error.
+ * Typed over `T` rather than over the SDK's `Event`: staying structurally loose
+ * means an SDK type change can't turn a security control into a build error.
  */
 export function scrubEvent<T>(event: T): T {
   try {
     const request = (event as { request?: ScrubbableRequest } | null)?.request;
-    if (!request) return event;
-
-    if (request.headers) {
+    if (request?.headers) {
       for (const key of Object.keys(request.headers)) {
         const lower = key.toLowerCase();
         if (SENSITIVE_HEADERS.has(lower) || isSensitiveKey(lower)) {
@@ -84,15 +106,34 @@ export function scrubEvent<T>(event: T): T {
       }
     }
 
-    if (typeof request.url === 'string') request.url = scrubUrl(request.url);
-    if (typeof request.query_string === 'string') {
+    if (typeof request?.url === 'string') request.url = scrubUrl(request.url);
+    if (typeof request?.query_string === 'string') {
       request.query_string = scrubQueryString(request.query_string);
     }
 
     // Neither is ever useful in a proxy stack trace, and both carry credentials
     // by definition. Dropping beats redacting when there's nothing to lose.
-    delete request.cookies;
-    delete request.data;
+    if (request) {
+      delete request.cookies;
+      delete request.data;
+    }
+
+    const scrubbable = event as {
+      breadcrumbs?: { message?: unknown; data?: unknown }[];
+      exception?: { values?: { value?: unknown }[] };
+      extra?: unknown;
+      message?: unknown;
+    };
+    for (const breadcrumb of scrubbable.breadcrumbs ?? []) {
+      if (typeof breadcrumb.message === 'string')
+        breadcrumb.message = scrubText(breadcrumb.message);
+      if (breadcrumb.data) scrubValue(breadcrumb.data);
+    }
+    for (const exception of scrubbable.exception?.values ?? []) {
+      if (typeof exception.value === 'string') exception.value = scrubText(exception.value);
+    }
+    if (scrubbable.extra) scrubValue(scrubbable.extra);
+    if (typeof scrubbable.message === 'string') scrubbable.message = scrubText(scrubbable.message);
 
     return event;
   } catch {

--- a/feed-proxy/src/scrub.ts
+++ b/feed-proxy/src/scrub.ts
@@ -1,0 +1,101 @@
+// Sentry event scrubbing for the proxy.
+//
+// The backend has a thorough scrubber (`backend/src/observability/scrub.ts`);
+// this is deliberately a smaller thing, matched to what this runtime actually
+// holds. Two credentials pass through the proxy and neither may ever reach an
+// error tracker:
+//
+//   - `X-Proxy-Secret`, on every authenticated call from the Worker.
+//   - Feed URLs, which routinely carry an API key or token in the query string
+//     (private RSS feeds, newsletter archives, Feedbin-style tokenised URLs).
+//
+// Whether @sentry/bun attaches request data at all under Bun.serve + Hono is
+// unconfirmed — which is exactly why this exists. Attaching nothing costs a
+// no-op; attaching a secret costs a leaked shared credential.
+//
+// Everything here is total and defensive: a scrubber that throws inside
+// `beforeSend` would drop the event it was meant to sanitise.
+
+const REDACTED = '[redacted]';
+
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-proxy-secret',
+  'x-api-key',
+]);
+
+const SENSITIVE_KEY = /(token|secret|password|authorization|cookie|api[_-]?key|signature|auth)/i;
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY.test(key);
+}
+
+/** Redact the values of credential-shaped params, keeping the URL readable. */
+export function scrubQueryString(queryString: string): string {
+  const leading = queryString.startsWith('?') ? '?' : '';
+  const params = new URLSearchParams(leading ? queryString.slice(1) : queryString);
+  let changed = false;
+  for (const key of [...params.keys()]) {
+    if (isSensitiveKey(key)) {
+      params.set(key, REDACTED);
+      changed = true;
+    }
+  }
+  return changed ? leading + params.toString() : queryString;
+}
+
+/** A URL with its query-string credentials redacted, if it has any. */
+export function scrubUrl(url: string): string {
+  const index = url.indexOf('?');
+  if (index === -1) return url;
+  return `${url.slice(0, index)}?${scrubQueryString(url.slice(index + 1))}`;
+}
+
+interface ScrubbableRequest {
+  url?: string;
+  headers?: Record<string, unknown>;
+  query_string?: unknown;
+  cookies?: unknown;
+  data?: unknown;
+}
+
+/**
+ * Strip credentials from a Sentry event in place. Returns the same event, or the
+ * untouched event if anything at all goes wrong.
+ *
+ * Typed over `T` rather than over the SDK's `Event`: this only ever reads two
+ * well-known fields, and staying structurally loose means an SDK type change
+ * can't turn a security control into a build error.
+ */
+export function scrubEvent<T>(event: T): T {
+  try {
+    const request = (event as { request?: ScrubbableRequest } | null)?.request;
+    if (!request) return event;
+
+    if (request.headers) {
+      for (const key of Object.keys(request.headers)) {
+        const lower = key.toLowerCase();
+        if (SENSITIVE_HEADERS.has(lower) || isSensitiveKey(lower)) {
+          request.headers[key] = REDACTED;
+        }
+      }
+    }
+
+    if (typeof request.url === 'string') request.url = scrubUrl(request.url);
+    if (typeof request.query_string === 'string') {
+      request.query_string = scrubQueryString(request.query_string);
+    }
+
+    // Neither is ever useful in a proxy stack trace, and both carry credentials
+    // by definition. Dropping beats redacting when there's nothing to lose.
+    delete request.cookies;
+    delete request.data;
+
+    return event;
+  } catch {
+    return event;
+  }
+}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -45,6 +45,19 @@ All stores use Svelte 5 runes (`.svelte.ts` files):
 | `db.ts`         | Dexie (IndexedDB) schema for offline storage       |
 | `sync-queue.ts` | Queue operations when offline, process when online |
 | `realtime.ts`   | WebSocket connection management                    |
+| `telemetry.ts`  | Sampled client error reports → our backend         |
+
+### Error reporting
+
+`hooks.client.ts` wires three channels — SvelteKit's `handleError`, `window.onerror`
+and `unhandledrejection` — into `reportClientError()`, which posts to the backend's
+`/api/telemetry/error`. No Sentry SDK ships in the bundle and no third party is
+contacted; the backend decides what reaches the error tracker.
+
+It is sampled at 10%, capped per page load, silent in dev and offline, and sends
+no query strings. The exception is `preload_recovery_failed` — the stale-chunk
+guard tripping twice, i.e. a deploy that bricked the PWA — which always sends.
+See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) §4c.
 
 ### Key Routes
 

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -1,3 +1,13 @@
+import type { HandleClientError } from '@sveltejs/kit';
+import { reportClientError } from '$lib/services/telemetry';
+
+// Two jobs, both about surviving a deploy:
+//
+// 1. Recover from stale dynamic-import failures (below).
+// 2. Tell the backend when the app breaks in a browser, so "the deploy bricked
+//    the PWA" stops being something we learn from user reports. Sampled and
+//    stripped of identifiers — see $lib/services/telemetry.
+//
 // Recover from stale dynamic-import failures after a deploy / service-worker update.
 //
 // When a new build ships, an old, still-running page can issue a dynamic import()
@@ -19,8 +29,45 @@ const RELOAD_GUARD_TTL_MS = 5 * 60 * 1000;
 window.addEventListener('vite:preloadError', (event) => {
   // Don't fight a real, persistent failure — only auto-reload once.
   const lastReloadAt = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0);
-  if (lastReloadAt && Date.now() - lastReloadAt < RELOAD_GUARD_TTL_MS) return;
+  if (lastReloadAt && Date.now() - lastReloadAt < RELOAD_GUARD_TTL_MS) {
+    // We already reloaded for this, and it happened again: the chunk is genuinely
+    // gone and the user is now stuck on a page that can't navigate. This is the
+    // "a deploy bricked the PWA" signal, and it was invisible until now — the
+    // guard's whole job is to stop reloading, which also stops anyone finding
+    // out. Never sampled away.
+    reportClientError(
+      'preload_recovery_failed',
+      new Error(
+        `Preload failed again ${Math.round((Date.now() - lastReloadAt) / 1000)}s after reload guard tripped`
+      )
+    );
+    return;
+  }
   event.preventDefault();
   sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
   window.location.reload();
 });
+
+// Anything the framework didn't route through a boundary. `error` is whatever was
+// thrown, so it may not be an Error at all — the reporter handles that.
+window.addEventListener('error', (event) => {
+  // A failed <img>/<script>/<link> also fires `error` on the window (it bubbles
+  // from the element), with no `error` and no `message`. That's a broken asset,
+  // not a broken app, and reporting it would be a stream of "undefined".
+  if (event.target && event.target !== window) return;
+  reportClientError('uncaught', event.error ?? event.message);
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  reportClientError('rejection', event.reason);
+});
+
+/**
+ * SvelteKit's client-side error hook: an error thrown while loading or rendering
+ * a route. Returning the shape SvelteKit shows the user unchanged — this hook
+ * only adds the report.
+ */
+export const handleError: HandleClientError = ({ error, message }) => {
+  reportClientError('render', error);
+  return { message };
+};

--- a/frontend/src/lib/components/settings/Diagnostics.svelte
+++ b/frontend/src/lib/components/settings/Diagnostics.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  // What's running, right here, right now.
+  //
+  // Not telemetry — nothing here is sent anywhere. It exists to turn "it's
+  // broken" into a report someone can act on: which build the page is, which
+  // build the service worker is (they differ exactly when an update is half
+  // applied, which is the shape of most PWA weirdness), how much unsynced work is
+  // sitting in IndexedDB, and when the queue last drained.
+  import { version } from '$app/environment';
+  import { onMount } from 'svelte';
+  import { syncStore } from '$lib/stores/sync.svelte';
+
+  // null = we asked and got no answer (no controller, or a worker too old to
+  // reply); undefined = we haven't asked yet. Both render as words, not blanks.
+  let workerVersion = $state<string | null | undefined>(undefined);
+  let copied = $state(false);
+
+  const shortVersion = (value: string) => (value.length > 12 ? value.slice(0, 12) : value);
+
+  // Same round-trip the layout uses to decide whether an update banner is real.
+  function controllerVersion(): Promise<string | null> {
+    if (!('serviceWorker' in navigator)) return Promise.resolve(null);
+    const controller = navigator.serviceWorker.controller;
+    if (!controller) return Promise.resolve(null);
+    return new Promise((resolve) => {
+      const channel = new MessageChannel();
+      const timeout = setTimeout(() => resolve(null), 3000);
+      channel.port1.onmessage = (event) => {
+        clearTimeout(timeout);
+        resolve(event.data?.version ?? null);
+      };
+      controller.postMessage({ type: 'GET_VERSION' }, [channel.port2]);
+    });
+  }
+
+  onMount(() => {
+    void controllerVersion().then((value) => (workerVersion = value));
+    void syncStore.updatePendingCount();
+  });
+
+  const formatTime = (at: number) => new Date(at).toLocaleTimeString();
+
+  // A service worker on a different build than the page is the single most
+  // useful thing on this panel, so say it in words rather than making someone
+  // compare two hashes.
+  const workerState = $derived.by(() => {
+    if (workerVersion === undefined) return 'Checking…';
+    if (workerVersion === null) return 'Not controlling this page';
+    if (workerVersion === version) return `${shortVersion(workerVersion)} (matches app)`;
+    return `${shortVersion(workerVersion)} — differs from app, reload to update`;
+  });
+
+  const rows = $derived([
+    { label: 'App build', value: shortVersion(version) },
+    { label: 'Service worker', value: workerState },
+    { label: 'Connection', value: syncStore.isOnline ? 'Online' : 'Offline' },
+    {
+      label: 'Unsynced changes',
+      value: syncStore.pendingCount === 0 ? 'None' : String(syncStore.pendingCount),
+    },
+    {
+      label: 'Last sync',
+      value: syncStore.lastSyncedAt
+        ? formatTime(syncStore.lastSyncedAt)
+        : 'Not since this page opened',
+    },
+  ]);
+
+  async function copy() {
+    const text = rows.map((row) => `${row.label}: ${row.value}`).join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      setTimeout(() => (copied = false), 2000);
+    } catch {
+      // Clipboard denied (or an insecure context) — the values are on screen.
+    }
+  }
+</script>
+
+<section class="card">
+  <h2>Diagnostics</h2>
+  <p>What this device is running. Useful to include when something looks wrong.</p>
+
+  <dl>
+    {#each rows as row (row.label)}
+      <div class="row">
+        <dt>{row.label}</dt>
+        <dd>{row.value}</dd>
+      </div>
+    {/each}
+  </dl>
+
+  <button class="btn btn-secondary" onclick={copy}>{copied ? 'Copied' : 'Copy'}</button>
+</section>
+
+<style>
+  dl {
+    margin: 0 0 1rem;
+  }
+
+  .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--text-sm);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  dt {
+    color: var(--color-text-secondary);
+  }
+
+  dd {
+    margin: 0;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/frontend/src/lib/services/telemetry.test.ts
+++ b/frontend/src/lib/services/telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reportClientError, resetTelemetryForTests } from './telemetry';
+
+// The reporter runs on a page that is already broken, so the properties worth
+// pinning are the restraints: it samples, it repeats itself at most once, it
+// gives up rather than retrying, and it never lets its own failure surface.
+
+const posts = () =>
+  fetchMock.mock.calls.map(([, init]) => JSON.parse((init as RequestInit).body as string));
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetTelemetryForTests();
+  fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('navigator', { onLine: true });
+  vi.stubGlobal('window', { location: { pathname: '/reader' } });
+  // Sampling is a coin flip; these tests are about everything else.
+  vi.spyOn(Math, 'random').mockReturnValue(0);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('reportClientError', () => {
+  it('sends a name, message, stack, build and path — and nothing else', () => {
+    const error = new TypeError('x is not a function');
+    error.stack = 'TypeError: x is not a function\n  at foo';
+
+    reportClientError('uncaught', error);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/telemetry/error');
+    expect((init as RequestInit).keepalive).toBe(true);
+    expect(posts()[0]).toEqual({
+      kind: 'uncaught',
+      name: 'TypeError',
+      message: 'x is not a function',
+      stack: 'TypeError: x is not a function\n  at foo',
+      appVersion: 'test-build-sha',
+      path: '/reader',
+      sampleRate: 0.1,
+    });
+  });
+
+  it('drops nine in ten reports', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    reportClientError('rejection', new Error('nope'));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('always sends the failure that means the app cannot recover', () => {
+    // A 90% chance of never hearing that a deploy bricked the PWA is not a
+    // tradeoff worth making — this is the one kind sampling doesn't apply to.
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    reportClientError('preload_recovery_failed', new Error('preload failed again'));
+    expect(posts()[0]).toMatchObject({ kind: 'preload_recovery_failed', sampleRate: 1 });
+  });
+
+  it('says the same thing at most once per page load', () => {
+    for (let i = 0; i < 10; i++) reportClientError('rejection', new Error('same'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops entirely once a page is throwing in many ways', () => {
+    for (let i = 0; i < 20; i++) reportClientError('rejection', new Error(`error ${i}`));
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('stays quiet while offline', () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    reportClientError('uncaught', new Error('boom'));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('handles a thrown non-Error without throwing itself', () => {
+    reportClientError('rejection', 'just a string');
+    reportClientError('rejection', { message: 'object with a message' });
+    reportClientError('rejection', undefined);
+    expect(posts().map((p) => p.message)).toEqual([
+      'just a string',
+      'object with a message',
+      'undefined',
+    ]);
+  });
+
+  it('truncates rather than shipping an unbounded message', () => {
+    reportClientError('uncaught', new Error('a'.repeat(5000)));
+    expect(posts()[0].message.length).toBe(301);
+  });
+
+  it('swallows a failed report instead of raising a second error', () => {
+    fetchMock.mockImplementation(() => Promise.reject(new Error('network down')));
+    expect(() => reportClientError('uncaught', new Error('boom'))).not.toThrow();
+  });
+});

--- a/frontend/src/lib/services/telemetry.ts
+++ b/frontend/src/lib/services/telemetry.ts
@@ -1,0 +1,136 @@
+import { browser, dev, version } from '$app/environment';
+
+// Client error reporting — Phase 3 of the observability plan, and deliberately
+// the smallest thing that answers one question: did a deploy break the app for
+// real users? It is not analytics. There is no third-party SDK in the bundle, no
+// session replay, no breadcrumbs, no page views. The browser posts a name, a
+// message, a truncated stack and a path to our own backend, which decides what
+// reaches the error tracker (backend/src/routes/telemetry.ts).
+//
+// Three rules keep it honest:
+//
+// 1. **Sample.** We need to know that a build is throwing, not to count every
+//    throw. One in ten is plenty of signal and a tenth of the noise — except for
+//    the failure that means the app can't recover at all, which is always sent.
+// 2. **Never make things worse.** A page reporting an error is already having a
+//    bad time: no retries, no throwing, no awaiting, and nothing sent while
+//    offline (the queue would just be another thing to go wrong).
+// 3. **Send no identifiers.** The path is stripped of its query string here and
+//    again on the server; nothing else about the page goes with it.
+
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
+/** One in ten. Enough to see a broken deploy within minutes at any real volume. */
+const SAMPLE_RATE = 0.1;
+
+/**
+ * Per page load. A render loop can throw thousands of times a minute; after this
+ * many the extra reports say nothing the first ones didn't, and the backend's
+ * rate limit would drop them anyway.
+ */
+const MAX_REPORTS_PER_LOAD = 5;
+
+const MAX_MESSAGE_CHARS = 300;
+const MAX_STACK_CHARS = 2000;
+
+export type ClientErrorKind = 'render' | 'uncaught' | 'rejection' | 'preload_recovery_failed';
+
+/**
+ * Kinds that bypass sampling: the app told us it tried to recover from a bad
+ * deploy and failed. That's the one report where a 90% chance of silence is
+ * unacceptable, and by construction it can only happen once per page.
+ */
+const ALWAYS_SEND: ReadonlySet<ClientErrorKind> = new Set(['preload_recovery_failed']);
+
+let sent = 0;
+const seen = new Set<string>();
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Whatever was thrown, reduced to a name and a message. */
+function describe(error: unknown): { name: string; message: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      name: error.name || 'Error',
+      message: truncate(error.message || String(error), MAX_MESSAGE_CHARS),
+      stack: error.stack ? truncate(error.stack, MAX_STACK_CHARS) : undefined,
+    };
+  }
+  if (error && typeof error === 'object') {
+    const message = (error as { message?: unknown }).message;
+    return {
+      name: 'Error',
+      message: truncate(
+        typeof message === 'string' ? message : JSON.stringify(error) || 'unknown',
+        MAX_MESSAGE_CHARS
+      ),
+    };
+  }
+  return { name: 'Error', message: truncate(String(error), MAX_MESSAGE_CHARS) };
+}
+
+/** Path only. Query strings are where share tokens and OAuth params live. */
+function currentPath(): string {
+  try {
+    return window.location.pathname;
+  } catch {
+    return '/';
+  }
+}
+
+/**
+ * Report a client error. Fire-and-forget by design: callers neither await nor
+ * handle failures, because a failed report must not become a second error.
+ */
+export function reportClientError(kind: ClientErrorKind, error: unknown): void {
+  // A dev-server exception is a thing you're already looking at; sending it would
+  // just mix local noise into production's error tracker.
+  if (!browser || dev) return;
+
+  try {
+    if (sent >= MAX_REPORTS_PER_LOAD) return;
+    // Offline is not a signal about the app, and holding a report until the
+    // network returns is a queue we'd have to reason about. Drop it.
+    if (navigator.onLine === false) return;
+
+    const { name, message, stack } = describe(error);
+
+    // Same error, same page load: the first one already said it.
+    const key = `${kind}|${name}|${message}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    const sampled = ALWAYS_SEND.has(kind) || Math.random() < SAMPLE_RATE;
+    if (!sampled) return;
+
+    sent++;
+    void fetch(`${API_BASE}/api/telemetry/error`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      // Survives the navigation/unload that often accompanies a fatal error.
+      keepalive: true,
+      body: JSON.stringify({
+        kind,
+        name,
+        message,
+        stack,
+        appVersion: version,
+        path: currentPath(),
+        sampleRate: ALWAYS_SEND.has(kind) ? 1 : SAMPLE_RATE,
+      }),
+    }).catch(() => {
+      // The backend is unreachable, which the uptime checks already know about.
+    });
+  } catch {
+    // Reporting must never be the thing that breaks the page.
+  }
+}
+
+/** Test seam: per-page-load state that would otherwise leak between cases. */
+export function resetTelemetryForTests(): void {
+  sent = 0;
+  seen.clear();
+}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -16,6 +16,7 @@
   import SaveBackingPicker from '$lib/components/settings/SaveBackingPicker.svelte';
   import LinkblogTargetPicker from '$lib/components/settings/LinkblogTargetPicker.svelte';
   import DeleteLinkblogModal from '$lib/components/settings/DeleteLinkblogModal.svelte';
+  import Diagnostics from '$lib/components/settings/Diagnostics.svelte';
   import StaticPageChrome from '$lib/components/feed/StaticPageChrome.svelte';
   import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
@@ -983,6 +984,8 @@
       >
     </div>
   </section>
+
+  <Diagnostics />
 
   <section class="card debug-section">
     <h2>Debug</h2>

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -13,6 +13,16 @@ const config = {
       precompress: false,
       strict: true,
     }),
+    // Stamp the build with the commit being deployed. SvelteKit writes this to
+    // `/_app/version.json`, which gives the Pages apps the same post-deploy proof
+    // the Workers get: the smoke check asserts the served version *is* the SHA CI
+    // just built, so a deploy that silently didn't roll out goes red instead of
+    // passing a content sniff against markup that never changes.
+    //
+    // It's also the version the service worker compares for deploy-vs-spurious
+    // controllerchange (src/service-worker.ts), which needs it unique per build —
+    // a commit SHA is. Local/manual builds fall back to SvelteKit's timestamp.
+    ...(process.env.GITHUB_SHA ? { version: { name: process.env.GITHUB_SHA } } : {}),
     serviceWorker: {
       // Disable SvelteKit's built-in service worker handling — @vite-pwa/sveltekit
       // (configured in vite.config.ts) now owns the service worker, its registration,

--- a/frontend/test/stubs/app-environment.ts
+++ b/frontend/test/stubs/app-environment.ts
@@ -1,0 +1,11 @@
+// Stands in for SvelteKit's `$app/environment` in unit tests, which run outside
+// the SvelteKit build and so can't resolve it. Aliased in vitest.config.ts.
+//
+// The values describe a *production browser*, because that is the only
+// configuration in which the code under test (client error reporting) does
+// anything at all.
+
+export const browser = true;
+export const dev = false;
+export const building = false;
+export const version = 'test-build-sha';

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
 
-const alias = { $lib: path.resolve(__dirname, 'src/lib') };
+const alias = {
+  $lib: path.resolve(__dirname, 'src/lib'),
+  // SvelteKit's virtual modules don't exist outside its build; the stub is what
+  // lets a module that reads `browser`/`dev`/`version` be unit tested at all.
+  '$app/environment': path.resolve(__dirname, 'test/stubs/app-environment.ts'),
+};
 
 export default defineConfig({
   test: {

--- a/linkblog-site/svelte.config.js
+++ b/linkblog-site/svelte.config.js
@@ -6,6 +6,10 @@ const config = {
   preprocess: vitePreprocess(),
 
   kit: {
+    // Deployed commit, served at `/_app/version.json` so the post-deploy smoke
+    // check can assert this build is the one actually serving (see
+    // frontend/svelte.config.js for the full rationale).
+    ...(process.env.GITHUB_SHA ? { version: { name: process.env.GITHUB_SHA } } : {}),
     adapter: adapter(),
 
     // Strict CSP for a read-only public site. SvelteKit auto-injects a nonce for

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+//
+// Post-deploy smoke check. Run right after a deploy step so a green workflow means
+// "production is serving this commit", not "the test suite passed".
+//
+// Usage:
+//   node scripts/smoke-check.mjs <url> --version <sha>    # JSON health: 200 + .version === sha
+//   node scripts/smoke-check.mjs <url> --contains <text>  # static site: 200 + body contains text
+//
+// Retries, because a fresh deploy takes a few seconds to propagate. Exits non-zero
+// (and loudly) once the attempts run out.
+//
+// Deliberately dependency-free: node is on every runner, and this stays runnable
+// by hand during an incident.
+
+const [url, mode, expected] = process.argv.slice(2);
+
+if (!url || (mode !== '--version' && mode !== '--contains') || !expected) {
+  console.error('usage: smoke-check.mjs <url> --version <sha> | --contains <text>');
+  process.exit(2);
+}
+
+const attempts = Number(process.env.SMOKE_ATTEMPTS || 6);
+const delayMs = Number(process.env.SMOKE_DELAY_SECONDS || 10) * 1000;
+const timeoutMs = Number(process.env.SMOKE_TIMEOUT_SECONDS || 20) * 1000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let lastDetail = 'no attempt completed';
+
+for (let attempt = 1; attempt <= attempts; attempt++) {
+  console.log(`Smoke check (${attempt}/${attempts}): ${url}`);
+
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { 'Cache-Control': 'no-cache' },
+    });
+    const body = await response.text();
+
+    if (!response.ok) {
+      lastDetail = `HTTP ${response.status}`;
+      console.log(`  ${lastDetail}`);
+    } else if (mode === '--contains') {
+      if (body.includes(expected)) {
+        console.log(`  OK: 200 and body contains ${JSON.stringify(expected)}`);
+        process.exit(0);
+      }
+      lastDetail = `200 but body does not contain ${JSON.stringify(expected)}`;
+      console.log(`  ${lastDetail}`);
+    } else {
+      let version;
+      try {
+        version = JSON.parse(body).version;
+      } catch {
+        version = undefined;
+      }
+      if (version === expected) {
+        console.log(`  OK: 200 and version matches ${expected}`);
+        process.exit(0);
+      }
+      lastDetail = `200 but version is ${JSON.stringify(version)}, expected ${expected}`;
+      console.log(`  ${lastDetail}`);
+    }
+  } catch (error) {
+    lastDetail = `request failed: ${error instanceof Error ? error.message : String(error)}`;
+    console.log(`  ${lastDetail}`);
+  }
+
+  if (attempt < attempts) await sleep(delayMs);
+}
+
+console.error(`FAIL: ${url} did not converge to the expected deploy (${lastDetail})`);
+process.exit(1);


### PR DESCRIPTION
Implements Skyreader observability phases 0–4: health and deep-health checks, external heartbeats, structured logs and request correlation, the admin ops panel with hourly trends, client error reporting and diagnostics, and the SLO/alert runbook.

This round closes the remaining review findings:

- `/api/telemetry/error` is now routed **before** session resolution (next to the health endpoints) instead of merely being exempt from the auth gate. Behind `resolveSessionFromRequest` a D1 read failure became a 500 and a session mid-refresh waited out the concurrent-refresh poll — dropping or delaying exactly the reports sent while auth is broken, which the reporter never retries. Rate limiting for the route is now by IP only, and it no longer pays for two rate-limit checks. Covered by a regression test with every D1 call throwing, plus a contrast test that a session-backed route still 500s in that state.
- Admin trends floor `now` to the hour it falls in, so a healthy collector no longer draws a trailing gap for 30 of every 60 minutes.
- Backend and proxy scrubbers assign `scrubValue()`'s return at the breadcrumb/extra call sites, so a top-level string or array is actually redacted rather than silently passing through; tests pin both shapes.
- RUNBOOK: the feed-freshness SLO states its aggregation (p05 of hourly `metrics_snapshots.proxy_fresh_pct`) with the monthly-review query for it and for the firehose p95 (both verified against SQLite), the ops tiles' "SLO bar" wording is distinguished from the SLO itself, and §4c documents the telemetry routing and IP-keyed limit.

Validation: backend `tsc` + Prettier clean and all 49 backend test files pass (500 tests, run in two batches — the full suite in one run hits workerd sandbox flakiness here); admin `npm run check` (0 errors, 1 pre-existing warning) and 23 tests pass. Bun is unavailable in this environment, so the proxy's Bun tests are delegated to CI; the new proxy scrub behavior was verified directly under Node, and `tsc` + Prettier are clean.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-nfh25mrqzu5ttk4k3yzd7v7k)
