### PR TITLE
feed-proxy: harden the Constellation client against connection resets

### DIFF
--- a/feed-proxy/Dockerfile
+++ b/feed-proxy/Dockerfile
@@ -1,8 +1,15 @@
-FROM oven/bun:1
+# Pinned, not floating `1`: several Bun 1.x releases carried fetch
+# connection-pool fixes, and with a floating tag the deployed runtime is
+# whatever happened to be current at last build — which makes a socket-level
+# bug like the Constellation ECONNRESETs impossible to reason about. Bump this
+# deliberately.
+FROM oven/bun:1.3.14
 
 WORKDIR /app
 
-COPY package.json bun.lockb* ./
+# The lockfile in this repo is the text `bun.lock` (the old binary `bun.lockb`
+# never matched, so `--frozen-lockfile` always fell through to a fresh resolve).
+COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile || bun install
 
 COPY src ./src

--- a/feed-proxy/README.md
+++ b/feed-proxy/README.md
@@ -376,7 +376,9 @@ small community-run host:
 
 1. **Circuit breaker** — 5 consecutive failing calls (timeout, network, 5xx/429)
    open it for 30 s; calls short-circuit to `null` instead of each eating the
-   10 s timeout. A clean 4xx is a healthy "no data" and does not count.
+   10 s timeout. A clean 4xx is a healthy "no data" and does not count. The check
+   runs again after a call gets its concurrency permit, so callers that were
+   queued when the breaker opened short-circuit too.
 2. **Concurrency cap** — `CONSTELLATION_CONCURRENCY` requests in flight, the rest
    queued up to `CONSTELLATION_QUEUE_MAX` and then shed to `null`. Shedding is our
    own backpressure, so it does **not** count toward the breaker.

--- a/feed-proxy/README.md
+++ b/feed-proxy/README.md
@@ -245,6 +245,21 @@ Cache statistics (requires authentication).
   "fresh": 80,
   "stale": 50,
   "inFlight": 2,
+  "extract": { "inUse": 1, "queued": 0 },
+  "constellation": {
+    "breakerOpen": false,
+    "consecutiveFailures": 0,
+    "inUse": 2,
+    "queued": 0,
+    "requests": 8421,
+    "resets": 37,
+    "retries": 37,
+    "retriesRecovered": 36,
+    "failures": 1,
+    "shed": 0,
+    "breakerOpens": 0,
+    "shortCircuited": 0
+  },
   "cacheTtlSeconds": 900,
   "staleTtlSeconds": 3600,
   "errors": {
@@ -296,6 +311,14 @@ curl "/feed?url=...&since_guids=old-guid&limit=50"
 | `STALE_TTL_SECONDS`  | `3600`   | Stale cache max age (1 hour)              |
 | `PORT`               | `3000`   | HTTP server port                          |
 
+Constellation (mentions, social context, linkblog registry):
+
+| Environment Variable        | Default | Description                                       |
+| --------------------------- | ------- | ------------------------------------------------- |
+| `CONSTELLATION_CONCURRENCY` | `6`     | Concurrent requests allowed against Constellation |
+| `CONSTELLATION_QUEUE_MAX`   | `200`   | Callers that may queue before requests are shed   |
+| `WARM_MENTIONS`             | `true`  | Set `false` to stop pre-warming mentions entirely |
+
 ## Cache Behavior
 
 | Cache State | Age       | Behavior                    |
@@ -344,6 +367,28 @@ When a feed is in backoff:
 2. Cached data (if available) is returned immediately
 3. After backoff expires, a single fetch is attempted
 4. On success, error tracking resets to zero
+
+### Constellation Client
+
+Every Constellation caller (mentions, social context, mention lanes, the linkblog
+registry) shares one client with three defenses, since they all hit one
+small community-run host:
+
+1. **Circuit breaker** — 5 consecutive failing calls (timeout, network, 5xx/429)
+   open it for 30 s; calls short-circuit to `null` instead of each eating the
+   10 s timeout. A clean 4xx is a healthy "no data" and does not count.
+2. **Concurrency cap** — `CONSTELLATION_CONCURRENCY` requests in flight, the rest
+   queued up to `CONSTELLATION_QUEUE_MAX` and then shed to `null`. Shedding is our
+   own backpressure, so it does **not** count toward the breaker.
+3. **One retry on connection resets** — a reset pooled keep-alive socket
+   (`ECONNRESET` / "socket connection was closed unexpectedly") is retried once
+   after ~250 ms. Timeouts are not retried. A reset-then-reset call counts as
+   exactly one breaker failure.
+
+Everything degrades to `null` (never throws); mentions and social adornments
+simply render empty. `GET /stats` reports `constellation`: breaker state, gate
+occupancy, and `resets` / `retriesRecovered` / `failures` / `shed` counters —
+`retriesRecovered` ≫ `failures` means resets are being absorbed.
 
 ### Error Response in Bulk Endpoint
 

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -14,6 +14,7 @@ import {
 import type { FirehoseStatus } from './jetstream';
 import { getSocialContext, type SocialContext, type SocialContextQuery } from './constellation';
 import { getLinkblogRegistry } from './linkblog-registry';
+import { getConstellationStats } from './constellation-client';
 import { readCachedMentions, enrichMentions } from './mentions';
 import { getMentionLaneItems, type MentionLaneEntry } from './mention-lane';
 import type { LaneId } from './lanes';
@@ -1833,6 +1834,10 @@ export function createApp(db: Database, config: AppConfig) {
       stale: stale?.count || 0,
       inFlight: inFlight.size,
       extract: { inUse: extractSemaphore.inUse, queued: extractSemaphore.queued },
+      // Constellation health from *our* side: breaker state, gate occupancy, and
+      // the retry/shed counters. `retriesRecovered` ≫ `failures` means the
+      // connection resets are being absorbed rather than blanking adornments.
+      constellation: getConstellationStats(),
       cacheTtlSeconds: cacheTtlMs / 1000,
       staleTtlSeconds: staleTtlMs / 1000,
       errors: {

--- a/feed-proxy/src/constellation-client.test.ts
+++ b/feed-proxy/src/constellation-client.test.ts
@@ -218,4 +218,32 @@ describe('constellationGet concurrency cap', () => {
     expect(await Promise.all(calls.slice(0, 2))).toEqual([{ ok: true }, { ok: true }]);
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  it('short-circuits callers that were queued when the breaker opened', async () => {
+    // Serial handoff, so the queue drains in a deterministic order: the first
+    // five calls fail and open the breaker while the other five are parked.
+    setConstellationLimits(1, 200);
+    const spy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => new Response('err', { status: 503 })) as unknown as typeof fetch
+    );
+
+    // All ten pass the pre-queue breaker check (it is still closed) before any
+    // of them reaches the network.
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => constellationGet('/links/all', { target: 'x' }))
+    );
+
+    expect(results.every((r) => r === null)).toBe(true);
+    expect(isConstellationBreakerOpen()).toBe(true);
+    // Without the post-acquire re-check the queued five would each have spent a
+    // full request against an already-failing host.
+    expect(spy).toHaveBeenCalledTimes(5);
+    const stats = getConstellationStats();
+    expect(stats.requests).toBe(5);
+    expect(stats.failures).toBe(5);
+    expect(stats.breakerOpens).toBe(1);
+    expect(stats.shortCircuited).toBe(5);
+    // Short-circuiting is not shedding: the queue never overflowed.
+    expect(stats.shed).toBe(0);
+  });
 });

--- a/feed-proxy/src/constellation-client.test.ts
+++ b/feed-proxy/src/constellation-client.test.ts
@@ -1,15 +1,36 @@
 import { describe, expect, it, afterEach, beforeEach, spyOn } from 'bun:test';
 import {
   constellationGet,
+  getConstellationStats,
   isConstellationBreakerOpen,
   resetConstellationBreaker,
+  setConstellationLimits,
 } from './constellation-client';
 
-beforeEach(() => resetConstellationBreaker());
+beforeEach(() => {
+  resetConstellationBreaker();
+  setConstellationLimits();
+});
 afterEach(() => {
   (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
   resetConstellationBreaker();
+  setConstellationLimits();
 });
+
+/** The shape Bun surfaces when a pooled keep-alive socket is reset mid-request. */
+function connectionReset(): Error {
+  const error = new Error(
+    'The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()'
+  );
+  (error as Error & { code: string }).code = 'ECONNRESET';
+  return error;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+}
 
 describe('constellationGet', () => {
   it('returns parsed JSON on success and keeps the breaker closed', async () => {
@@ -72,5 +93,129 @@ describe('constellationGet', () => {
 
     for (let i = 0; i < 12; i++) await constellationGet('/links/all', { target: 'x' });
     expect(isConstellationBreakerOpen()).toBe(false);
+  });
+});
+
+describe('constellationGet connection-reset retry', () => {
+  it('retries once after a reset and returns the data', async () => {
+    let call = 0;
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      call++;
+      if (call === 1) throw connectionReset();
+      return new Response(JSON.stringify({ total: 3 }));
+    }) as unknown as typeof fetch);
+
+    const data = await constellationGet<{ total: number }>('/links/distinct-dids', { target: 'x' });
+    expect(data?.total).toBe(3);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(isConstellationBreakerOpen()).toBe(false);
+    const stats = getConstellationStats();
+    expect(stats.retriesRecovered).toBe(1);
+    expect(stats.failures).toBe(0);
+  });
+
+  it('recognises the reset by message alone when no code is attached', async () => {
+    let call = 0;
+    spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      call++;
+      if (call === 1) throw new Error('The socket connection was closed unexpectedly.');
+      return new Response(JSON.stringify({ ok: true }));
+    }) as unknown as typeof fetch);
+
+    expect(await constellationGet<{ ok: boolean }>('/links/all', { target: 'x' })).toEqual({
+      ok: true,
+    });
+    expect(call).toBe(2);
+  });
+
+  it('counts a reset-then-reset as exactly one breaker failure', async () => {
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw connectionReset();
+    }) as unknown as typeof fetch);
+
+    // Four logical calls = 8 sockets died, but only 4 breaker failures.
+    for (let i = 0; i < 4; i++) {
+      expect(await constellationGet('/links/all', { target: 'x' })).toBeNull();
+    }
+    expect(spy).toHaveBeenCalledTimes(8);
+    expect(isConstellationBreakerOpen()).toBe(false);
+    expect(getConstellationStats().failures).toBe(4);
+
+    // The fifth logical call is what opens it.
+    expect(await constellationGet('/links/all', { target: 'x' })).toBeNull();
+    expect(isConstellationBreakerOpen()).toBe(true);
+  });
+
+  it('does not retry a timeout — the caller already waited out the full budget', async () => {
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      const error = new Error('The operation timed out.');
+      error.name = 'TimeoutError';
+      throw error;
+    }) as unknown as typeof fetch);
+
+    expect(await constellationGet('/links/all', { target: 'x' })).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(getConstellationStats().failures).toBe(1);
+  });
+
+  it('does not retry an HTTP-level failure', async () => {
+    const spy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => new Response('err', { status: 503 })) as unknown as typeof fetch
+    );
+    expect(await constellationGet('/links/all', { target: 'x' })).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('constellationGet concurrency cap', () => {
+  it('never runs more than the cap in flight, and all callers still resolve', async () => {
+    setConstellationLimits(3, 200);
+    let active = 0;
+    let peak = 0;
+    const gate = deferred();
+    spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await gate.promise;
+      active--;
+      return new Response(JSON.stringify({ ok: true }));
+    }) as unknown as typeof fetch);
+
+    const calls = Array.from({ length: 12 }, () =>
+      constellationGet<{ ok: boolean }>('/links/all', { target: 'x' })
+    );
+    // Let everything that can start, start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getConstellationStats().inUse).toBe(3);
+    expect(getConstellationStats().queued).toBe(9);
+
+    gate.resolve();
+    const results = await Promise.all(calls);
+    expect(peak).toBe(3);
+    expect(results.every((r) => r?.ok === true)).toBe(true);
+    expect(getConstellationStats().inUse).toBe(0);
+  });
+
+  it('sheds on queue overflow, returning null without counting a breaker failure', async () => {
+    setConstellationLimits(1, 1);
+    const gate = deferred();
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      await gate.promise;
+      return new Response(JSON.stringify({ ok: true }));
+    }) as unknown as typeof fetch);
+
+    // 1 in flight + 1 queued is the whole capacity; the rest are shed.
+    const calls = Array.from({ length: 6 }, () => constellationGet('/links/all', { target: 'x' }));
+    const results = await Promise.all([...calls.slice(2)]);
+    expect(results.every((r) => r === null)).toBe(true);
+    expect(getConstellationStats().shed).toBe(4);
+    // Shedding is our own backpressure, not a Constellation health signal.
+    expect(getConstellationStats().failures).toBe(0);
+    expect(isConstellationBreakerOpen()).toBe(false);
+
+    gate.resolve();
+    expect(await Promise.all(calls.slice(0, 2))).toEqual([{ ok: true }, { ok: true }]);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/feed-proxy/src/constellation-client.ts
+++ b/feed-proxy/src/constellation-client.ts
@@ -17,7 +17,9 @@
  *    timeouts / 5xx / network errors it opens, and calls short-circuit to `null`
  *    immediately for a cooldown instead of each eating a 10 s timeout. A clean
  *    4xx is a definitive "no data" answer (the service is healthy), so it does
- *    NOT count toward the breaker.
+ *    NOT count toward the breaker. It is checked twice — once on entry and again
+ *    after the concurrency permit is granted — so a caller that queued while the
+ *    breaker was closed still short-circuits if it opened in the meantime.
  * 2. **Concurrency cap**, because nothing else bounds our fan-out: the warm loop
  *    refreshes 8 feeds at once, each firing up to 25 mention enrichments, each of
  *    which issues up to 12 parallel per-source queries. Unbounded, that's
@@ -266,6 +268,15 @@ export async function constellationGet<T>(
   }
 
   try {
+    // The breaker may have opened while we sat in the queue: with the default
+    // queue that's up to 200 callers who passed the check above and would each
+    // otherwise spend a 10 s timeout on an already-failing host — exactly the
+    // storm the breaker exists to stop. Re-check now that it's our turn.
+    if (isConstellationBreakerOpen()) {
+      counters.shortCircuited++;
+      return null;
+    }
+
     counters.requests++;
     let result = await attempt<T>(url);
 

--- a/feed-proxy/src/constellation-client.ts
+++ b/feed-proxy/src/constellation-client.ts
@@ -1,21 +1,44 @@
 /**
  * Shared client for constellation.microcosm.blue, with a circuit breaker.
  *
- * Mentions counts (mentions.ts), link-post social context (constellation.ts), and
- * lane expansion (mention-lane.ts) all query the same Constellation host, and all
- * three are *adornments* that degrade to empty on failure. The risk isn't a
- * single failed call — it's that Constellation slowing down makes every call wait
- * out the full 10 s timeout, and with the warm loop pre-fetching mentions for up
+ * Mentions counts (mentions.ts), link-post social context (constellation.ts),
+ * lane expansion (mention-lane.ts) and the linkblog registry
+ * (linkblog-registry.ts) all query the same Constellation host, and all of them
+ * are *adornments* that degrade to empty on failure. The risk isn't a single
+ * failed call — it's that Constellation slowing down makes every call wait out
+ * the full 10 s timeout, and with the warm loop pre-fetching mentions for up
  * to 25 items × 200 feeds per tick that fan-out ties up the single machine in
  * dead waits.
  *
- * The breaker is module-level (one host, shared across all three callers) so a
- * Constellation outage backs every caller off together: after a run of
- * timeouts / 5xx / network errors it opens, and calls short-circuit to `null`
- * immediately for a cooldown instead of each eating a 10 s timeout. A clean 4xx
- * is a definitive "no data" answer (the service is healthy), so it does NOT count
- * toward the breaker.
+ * Three mechanisms, in the order a request meets them:
+ *
+ * 1. **Circuit breaker** (module-level, one host, shared across all callers) so
+ *    a Constellation outage backs every caller off together: after a run of
+ *    timeouts / 5xx / network errors it opens, and calls short-circuit to `null`
+ *    immediately for a cooldown instead of each eating a 10 s timeout. A clean
+ *    4xx is a definitive "no data" answer (the service is healthy), so it does
+ *    NOT count toward the breaker.
+ * 2. **Concurrency cap**, because nothing else bounds our fan-out: the warm loop
+ *    refreshes 8 feeds at once, each firing up to 25 mention enrichments, each of
+ *    which issues up to 12 parallel per-source queries. Unbounded, that's
+ *    hundreds of simultaneous sockets against a small community-run service,
+ *    which sheds load by resetting connections — i.e. we cause the very errors we
+ *    then have to absorb. Queue overflow returns `null` *without* counting a
+ *    breaker failure: that's our own backpressure, not a Constellation health
+ *    signal.
+ * 3. **One retry on connection resets.** Constellation (or a proxy in front of
+ *    it) idle-closes pooled keep-alive sockets; when Bun's fetch reuses one it
+ *    fails with ECONNRESET / "socket connection was closed unexpectedly" before
+ *    the request is served. These GETs are idempotent, so a single retry turns
+ *    that into a success. Timeouts are NOT retried — the caller already waited
+ *    10 s, and the breaker is the right tool for a slow service.
+ *
+ * Breaker, semaphore and counters are per-process module state. That's exactly
+ * right on today's single Fly machine; a multi-machine deploy would get one
+ * breaker *per machine*, not global coordination.
  */
+
+import { OverloadError, Semaphore } from './semaphore';
 
 const CONSTELLATION_BASE = 'https://constellation.microcosm.blue';
 const HEADERS = { 'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)' };
@@ -26,29 +49,98 @@ const FETCH_TIMEOUT_MS = 10 * 1000;
 const BREAKER_THRESHOLD = 5;
 const BREAKER_COOLDOWN_MS = 30 * 1000;
 
+// Concurrent requests allowed against the host, and how many callers may park
+// waiting. The queue is generous because every caller is fire-and-forget or
+// already tolerant of a 10 s wait; it exists to bound memory, not latency.
+const DEFAULT_CONCURRENCY = parseInt(process.env.CONSTELLATION_CONCURRENCY || '6', 10);
+const DEFAULT_QUEUE_MAX = parseInt(process.env.CONSTELLATION_QUEUE_MAX || '200', 10);
+
+// Backoff before the single retry, jittered so a burst of resets (the common
+// case — a pool of pooled sockets goes stale together) doesn't re-collide.
+const RETRY_DELAY_MS = 250;
+const RETRY_JITTER_MS = 100;
+
+// An outage otherwise logs one line per failed call; the warm loop makes that
+// thousands. Log the first failure of a streak, then every Nth with a count.
+const LOG_EVERY_N_FAILURES = 25;
+
 let consecutiveFailures = 0;
 let openUntil = 0;
+let failureStreak = 0;
+let semaphore = new Semaphore(DEFAULT_CONCURRENCY, DEFAULT_QUEUE_MAX);
+
+const counters = {
+  /** Logical calls that reached the network (breaker closed, permit acquired). */
+  requests: 0,
+  /** Connection resets seen (both attempts of a retried call count once each). */
+  resets: 0,
+  /** Retries attempted after a reset. */
+  retries: 0,
+  /** Retries that then succeeded — the errors this hardening absorbs. */
+  retriesRecovered: 0,
+  /** Logical calls that counted a breaker failure. */
+  failures: 0,
+  /** Calls dropped by our own backpressure (queue full). */
+  shed: 0,
+  /** Times the breaker transitioned to open. */
+  breakerOpens: 0,
+  /** Calls short-circuited because the breaker was open. */
+  shortCircuited: 0,
+};
 
 /** True while the breaker is open (calls short-circuit to null). */
 export function isConstellationBreakerOpen(now: number = Date.now()): boolean {
   return now < openUntil;
 }
 
-/** Test/ops hook: clear breaker state. */
+/** Test/ops hook: clear breaker state and counters. */
 export function resetConstellationBreaker(): void {
   consecutiveFailures = 0;
   openUntil = 0;
+  failureStreak = 0;
+  for (const key of Object.keys(counters) as Array<keyof typeof counters>) counters[key] = 0;
+}
+
+/**
+ * Test hook: resize the concurrency gate. Production sets it once from env at
+ * module load — this exists so tests can exercise the cap and the shed path
+ * without firing hundreds of calls. Only safe with nothing in flight.
+ */
+export function setConstellationLimits(
+  concurrency: number = DEFAULT_CONCURRENCY,
+  maxQueue: number = DEFAULT_QUEUE_MAX
+): void {
+  semaphore = new Semaphore(concurrency, maxQueue);
+}
+
+/** Snapshot for /stats: what the breaker, the gate and the retry path are doing. */
+export function getConstellationStats(): {
+  breakerOpen: boolean;
+  consecutiveFailures: number;
+  inUse: number;
+  queued: number;
+} & typeof counters {
+  return {
+    breakerOpen: isConstellationBreakerOpen(),
+    consecutiveFailures,
+    inUse: semaphore.inUse,
+    queued: semaphore.queued,
+    ...counters,
+  };
 }
 
 function recordSuccess(): void {
   consecutiveFailures = 0;
   openUntil = 0;
+  failureStreak = 0;
 }
 
 function recordFailure(now: number): void {
+  counters.failures++;
   consecutiveFailures++;
   if (consecutiveFailures >= BREAKER_THRESHOLD) {
     openUntil = now + BREAKER_COOLDOWN_MS;
+    counters.breakerOpens++;
     // Reset the counter so the cooldown is the gate; the first failure after it
     // expires re-opens the breaker rather than tripping instantly.
     consecutiveFailures = 0;
@@ -59,20 +151,62 @@ function recordFailure(now: number): void {
   }
 }
 
-/**
- * GET a Constellation endpoint and parse JSON, or return null. Never throws —
- * every failure (breaker open, timeout, network, non-OK, parse) degrades to null
- * so callers stay best-effort.
- */
-export async function constellationGet<T>(
-  path: string,
-  params: Record<string, string>
-): Promise<T | null> {
-  if (isConstellationBreakerOpen()) return null;
+/** First failure of a streak logs in full; the rest are summarised periodically. */
+function logFailure(path: string, error: unknown): void {
+  failureStreak++;
+  if (failureStreak === 1) {
+    console.error(`[constellation] ${path} error:`, error);
+  } else if (failureStreak % LOG_EVERY_N_FAILURES === 0) {
+    console.error(`[constellation] ${failureStreak} consecutive failures (latest ${path}):`, error);
+  }
+}
 
+/**
+ * Is this a mid-flight connection reset — the stale-keep-alive shape that a
+ * retry fixes? Deliberately defensive about Bun's error shapes: it surfaces
+ * these as `code: 'ECONNRESET'` on some paths and as a bare message on others,
+ * and the wording has moved between releases. A shape we don't recognise simply
+ * doesn't retry (today's behavior), never crashes.
+ *
+ * Timeouts (`TimeoutError` from AbortSignal.timeout) and caller aborts are
+ * excluded on purpose: waiting another 10 s helps nobody.
+ */
+function isRetryableConnectionError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { name, code, message } = error as { name?: string; code?: unknown; message?: unknown };
+  if (name === 'TimeoutError' || name === 'AbortError') return false;
+  if (typeof code === 'string' && ['ECONNRESET', 'EPIPE', 'ConnectionClosed'].includes(code)) {
+    return true;
+  }
+  if (typeof message !== 'string') return false;
+  const text = message.toLowerCase();
+  return (
+    text.includes('socket connection was closed') ||
+    text.includes('connection closed') ||
+    text.includes('connection reset') ||
+    text.includes('econnreset') ||
+    text.includes('epipe')
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One network attempt. Returns the parsed body, or a verdict for the caller:
+ * `retry` for a connection reset (worth one more go), `fail` for anything that
+ * should count toward the breaker, `null-ok` for a definitive 4xx.
+ */
+type Attempt<T> =
+  | { kind: 'ok'; data: T }
+  | { kind: 'null-ok' }
+  | { kind: 'fail'; error?: unknown }
+  | { kind: 'retry'; error: unknown };
+
+async function attempt<T>(url: string): Promise<Attempt<T>> {
   try {
-    const qs = new URLSearchParams(params);
-    const res = await fetch(`${CONSTELLATION_BASE}${path}?${qs}`, {
+    const res = await fetch(url, {
       headers: HEADERS,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
@@ -80,17 +214,89 @@ export async function constellationGet<T>(
       // 5xx / 429 → the service itself is unhealthy; count toward the breaker.
       // Any other non-OK (e.g. 400/404) is a definitive answer from a healthy
       // service — return null without tripping the breaker.
-      if (res.status >= 500 || res.status === 429) recordFailure(Date.now());
-      else recordSuccess();
+      if (res.status >= 500 || res.status === 429) {
+        return { kind: 'fail', error: `HTTP ${res.status}` };
+      }
+      return { kind: 'null-ok' };
+    }
+    return { kind: 'ok', data: (await res.json()) as T };
+  } catch (error) {
+    if (isRetryableConnectionError(error)) {
+      counters.resets++;
+      return { kind: 'retry', error };
+    }
+    return { kind: 'fail', error };
+  }
+}
+
+/**
+ * GET a Constellation endpoint and parse JSON, or return null. Never throws —
+ * every failure (breaker open, overload, timeout, network, non-OK, parse)
+ * degrades to null so callers stay best-effort.
+ *
+ * A reset-then-success sequence counts as one success; a reset-then-reset
+ * sequence counts as exactly *one* breaker failure, so the threshold still
+ * means "5 logical calls failed", not "5 sockets died".
+ */
+export async function constellationGet<T>(
+  path: string,
+  params: Record<string, string>
+): Promise<T | null> {
+  if (isConstellationBreakerOpen()) {
+    counters.shortCircuited++;
+    return null;
+  }
+
+  const qs = new URLSearchParams(params);
+  const url = `${CONSTELLATION_BASE}${path}?${qs}`;
+
+  try {
+    await semaphore.acquire();
+  } catch (error) {
+    if (error instanceof OverloadError) {
+      // Our own backpressure, not a Constellation health signal — no breaker
+      // failure, and the count in /stats is the signal worth looking at.
+      counters.shed++;
+      if (counters.shed === 1 || counters.shed % LOG_EVERY_N_FAILURES === 0) {
+        console.warn(`[constellation] shed ${counters.shed} request(s): queue full (${path})`);
+      }
       return null;
     }
-    const data = (await res.json()) as T;
-    recordSuccess();
-    return data;
-  } catch (error) {
-    // Timeout / network error → service slow or unreachable.
-    recordFailure(Date.now());
-    console.error(`[constellation] ${path} error:`, error);
-    return null;
+    throw error;
+  }
+
+  try {
+    counters.requests++;
+    let result = await attempt<T>(url);
+
+    if (result.kind === 'retry') {
+      counters.retries++;
+      await sleep(RETRY_DELAY_MS + Math.random() * RETRY_JITTER_MS);
+      const first = result.error;
+      result = await attempt<T>(url);
+      if (result.kind === 'ok') {
+        counters.retriesRecovered++;
+        console.warn(`[constellation] ${path} connection reset, retry succeeded`);
+      } else if (result.kind === 'retry') {
+        // Two resets in a row: one logical failure, keeping the first error for
+        // context (it's the one that names the socket that died first).
+        result = { kind: 'fail', error: result.error ?? first };
+      }
+    }
+
+    switch (result.kind) {
+      case 'ok':
+        recordSuccess();
+        return result.data;
+      case 'null-ok':
+        recordSuccess();
+        return null;
+      default:
+        recordFailure(Date.now());
+        logFailure(path, result.error);
+        return null;
+    }
+  } finally {
+    semaphore.release();
   }
 }

--- a/feed-proxy/src/linkblog-registry.test.ts
+++ b/feed-proxy/src/linkblog-registry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, afterEach, beforeEach, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initDatabase } from './app';
+import { getLinkblogRegistry } from './linkblog-registry';
+import { resetConstellationBreaker, setConstellationLimits } from './constellation-client';
+
+const MARKER_URL = 'https://skyreader.app/linkblog';
+
+function freshDb(): Database {
+  const db = new Database(':memory:');
+  initDatabase(db);
+  return db;
+}
+
+function seedCache(db: Database, dids: string[], cachedAt: number): void {
+  db.run('INSERT INTO linkblog_registry_cache (marker, dids_json, cached_at) VALUES (?, ?, ?)', [
+    MARKER_URL,
+    JSON.stringify(dids),
+    cachedAt,
+  ]);
+}
+
+beforeEach(() => {
+  resetConstellationBreaker();
+  setConstellationLimits();
+});
+afterEach(() => {
+  (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
+  resetConstellationBreaker();
+  setConstellationLimits();
+});
+
+describe('getLinkblogRegistry', () => {
+  it('unions paginated results across both marked collections', async () => {
+    // Page 1 of each collection carries a cursor; page 2 ends it. The two
+    // collections overlap on did:c, which must appear once.
+    const pages: Record<string, { linking_dids: string[]; cursor?: string }> = {
+      'site.standard.publication|': { linking_dids: ['did:a', 'did:b'], cursor: 'p2' },
+      'site.standard.publication|p2': { linking_dids: ['did:c'] },
+      'site.standard.document|': { linking_dids: ['did:c', 'did:d'] },
+    };
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe('/links/distinct-dids');
+      expect(url.searchParams.get('target')).toBe(MARKER_URL);
+      const key = `${url.searchParams.get('collection')}|${url.searchParams.get('cursor') ?? ''}`;
+      return new Response(JSON.stringify(pages[key] ?? { linking_dids: [] }));
+    }) as unknown as typeof fetch);
+
+    const db = freshDb();
+    expect((await getLinkblogRegistry(db)).sort()).toEqual(['did:a', 'did:b', 'did:c', 'did:d']);
+
+    // Cached — a second call answers from SQLite without touching the network.
+    const callsBefore = (globalThis.fetch as ReturnType<typeof spyOn>).mock.calls.length;
+    expect((await getLinkblogRegistry(db)).sort()).toEqual(['did:a', 'did:b', 'did:c', 'did:d']);
+    expect((globalThis.fetch as ReturnType<typeof spyOn>).mock.calls.length).toBe(callsBefore);
+  });
+
+  it('serves the stale cache without a fetch while the shared breaker is open', async () => {
+    const spy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => new Response('err', { status: 503 })) as unknown as typeof fetch
+    );
+    const db = freshDb();
+    seedCache(db, ['did:stale'], Date.now() - 60 * 60 * 1000); // an hour old
+
+    // First refresh attempt: 5xx on both collections, so the registry falls back
+    // to the stale cache (and its failures count toward the shared breaker).
+    expect(await getLinkblogRegistry(db)).toEqual(['did:stale']);
+    expect(spy.mock.calls.length).toBeGreaterThan(0);
+
+    // Enough failures from anywhere in the process open the breaker; from then on
+    // the registry stops issuing requests at all and keeps serving stale.
+    for (let i = 0; i < 3; i++) await getLinkblogRegistry(db);
+    const callsBefore = spy.mock.calls.length;
+    expect(await getLinkblogRegistry(db)).toEqual(['did:stale']);
+    expect(spy.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('returns an empty list when Constellation fails and nothing is cached', async () => {
+    spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch);
+    expect(await getLinkblogRegistry(freshDb())).toEqual([]);
+  });
+});

--- a/feed-proxy/src/linkblog-registry.ts
+++ b/feed-proxy/src/linkblog-registry.ts
@@ -25,8 +25,7 @@
  * whole for /discover.
  */
 import { Database } from 'bun:sqlite';
-
-const CONSTELLATION_BASE = 'https://constellation.microcosm.blue';
+import { constellationGet } from './constellation-client';
 
 // The constant marker — MUST match backend LINKBLOG_MARKER_URL exactly, or the
 // registry won't find the publications it stamps.
@@ -45,11 +44,6 @@ const REGISTRY_TTL_MS = 15 * 60 * 1000;
 const EMPTY_TTL_MS = 60 * 1000;
 const PAGE_LIMIT = 200;
 const MAX_PAGES = 25; // hard cap (~5k authors) so a runaway cursor can't loop.
-const FETCH_TIMEOUT_MS = 10 * 1000;
-
-const CONSTELLATION_HEADERS = {
-  'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
-};
 
 interface ConstellationDistinctDidsResponse {
   linking_dids?: string[];
@@ -68,30 +62,30 @@ interface RegistryCacheRow {
 // on a *total* failure (first page errored) so the caller can fall back to a
 // stale cache; a mid-pagination failure returns whatever resolved so far (better
 // a partial registry than none).
+//
+// Goes through the shared Constellation client, so registry refreshes share the
+// host's circuit breaker, concurrency gate and connection-reset retry with every
+// other caller instead of hammering the service on their own. A `null` from the
+// client (breaker open, shed, error) lands on the same failure paths as the old
+// raw fetch did — during an outage the registry now falls back to its stale cache
+// immediately instead of eating timeouts.
 async function fetchCollectionFromConstellation(collection: string): Promise<string[] | null> {
   const seen = new Set<string>();
   let cursor: string | undefined;
 
   for (let page = 0; page < MAX_PAGES; page++) {
-    const params = new URLSearchParams({
+    const params: Record<string, string> = {
       target: MARKER_URL,
       collection,
       path: MARKER_PATH,
       limit: String(PAGE_LIMIT),
-    });
-    if (cursor) params.set('cursor', cursor);
+    };
+    if (cursor) params.cursor = cursor;
 
-    let data: ConstellationDistinctDidsResponse | null = null;
-    try {
-      const res = await fetch(`${CONSTELLATION_BASE}/links/distinct-dids?${params}`, {
-        headers: CONSTELLATION_HEADERS,
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
-      if (res.ok) data = (await res.json()) as ConstellationDistinctDidsResponse;
-      else console.error(`[linkblog-registry] Constellation returned HTTP ${res.status}`);
-    } catch (error) {
-      console.error('[linkblog-registry] fetch error:', error);
-    }
+    const data = await constellationGet<ConstellationDistinctDidsResponse>(
+      '/links/distinct-dids',
+      params
+    );
     if (!data) return seen.size > 0 ? [...seen] : null;
 
     for (const did of data.linking_dids ?? []) {


### PR DESCRIPTION
Fixes the reported `[constellation] /links/distinct-dids ... ECONNRESET` errors from the feed proxy.

The error is Bun's `fetch` reusing a pooled keep-alive socket that Constellation (or a proxy in front of it) idle-closed. It never broke reads — `constellationGet` degrades to `null` — but each reset counted toward the shared circuit breaker, flooded Fly logs, and got cached-as-empty by the mention decay gate, silently under-counting mentions.

## Changes (all in `feed-proxy/`)

- **Retry once on connection resets** (~250 ms + jitter), classified defensively across Bun error shapes (`code` and message). Timeouts are *not* retried. A reset-then-reset sequence counts as exactly **one** breaker failure.
- **Host-level concurrency cap** — `CONSTELLATION_CONCURRENCY` (default 6) / `CONSTELLATION_QUEUE_MAX` (default 200), reusing the existing `Semaphore`. Nothing bounded the fan-out before: 8 warm workers × 25 mention enrichments × up to 12 parallel per-source queries. Queue overflow returns `null` **without** a breaker failure — that's our own backpressure.
- **`linkblog-registry.ts` migrated onto the shared client**, removing a duplicate raw `fetch` that bypassed the breaker entirely. Behavior change: while the breaker is open it serves its stale cache immediately instead of issuing independent requests.
- **Observability** — failure logging throttled (first of a streak, then every 25th with a count); `GET /stats` now carries a `constellation` block (breaker state, gate occupancy, `resets`/`retries`/`retriesRecovered`/`failures`/`shed`).
- **Ops** (separate commit) — pin `oven/bun:1` → `oven/bun:1.3.14` and fix the `bun.lockb*` COPY glob (the repo has a text `bun.lock`, so `--frozen-lockfile` never matched).

The `T | null` / never-throws contract is unchanged, so `mentions.ts`, `constellation.ts` and `mention-lane.ts` are untouched.

## Verification

- `bun test` — 286 pass, 0 fail (7 new client tests + 3 new registry tests).
- `bun run check` — tsc + prettier clean.
- Probed the real error shape: a Bun `fetch` against a socket reset mid-request throws `{ code: 'ECONNRESET', message: 'The socket connection was closed unexpectedly...' }` — exactly what the classifier matches and what production logged.
- Smoke-tested `GET /stats` renders the new `constellation` block.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-6hqptkgtgglwfz3qilbxbzjj)


## Review follow-up

- **Breaker re-check after queuing.** A call that passed the breaker check and then parked on the concurrency gate was guaranteed to reach the network once it got a permit, even if the calls ahead of it had opened the breaker meanwhile — up to a full queue (200) of extra requests, each able to burn the 10 s timeout, into an already-failing host. `constellationGet` now re-checks the breaker after `semaphore.acquire()` and short-circuits to `null` (counted as `shortCircuited`, permit released as before). New test drains a serial queue where the first five calls open the breaker and asserts the other five resolve `null` with no fetch.
- `bun test`: 287 pass, 0 fail. `bun run check`: clean.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-ljum6iw6f7lenc256vs6wgi2)
