### PR TITLE
Spike: saved articles on atproto Spaces (review fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,12 @@ Custom lexicons live per-package under `<package>/lexicons/app/skyreader/` (e.g.
 `frontend/lexicons/app/skyreader/feed/subscription.json`, `backend/lexicons/app/skyreader/...`):
 
 - `feed/subscription.json` - RSS subscription record
-- `feed/saved.json` - Saved article record
+- `feed/saved.json` - Saved article record — **metadata only, and not part of the live PDS
+  sync.** It exists for the flag-gated atproto Spaces spike, where it is written into a user's
+  personal _permissioned_ space (never the public repo). Nothing writes it in production; the
+  "saves live only in D1" rule above still holds. See
+  [the spike memo](docs/plans/SPACES_SAVES_SPIKE.md)
+- `space/savedAccess.json` - permission set for that space (spike; not requested by OAuth)
 - `feed/highlight.json` - Article highlight record (frontend)
 - `social/follow.json` - In-app follow relationship (frontend)
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -251,9 +251,17 @@ feed/subscription.json      - RSS feed subscription
   - tags[]
   - createdAt (required)
 
-feed/saved.json             - Saved article
-  - url (required)
-  - title, description, author, domain, image
-  - contentType, fullContent, wordCount
-  - publishedAt, savedAt (required)
+feed/saved.json             - Saved article — METADATA ONLY, and only ever written
+                              into a user's personal atproto Space (never the
+                              public repo). Flag-gated spike; see
+                              docs/plans/SPACES_SAVES_SPIKE.md
+  - savedAt (required)
+  - url, title, description, author, domain, image
+  - contentType, wordCount, publishedAt, source, itemGuid
+  - NO article body: content stays in D1
+
+space/savedAccess.json      - permission-set lexicon naming the space access an
+                              OAuth client would request as
+                              `include:app.skyreader.space.savedAccess`.
+                              NOT requested by the live OAuth flow.
 ```

--- a/backend/lexicons/app/skyreader/feed/saved.json
+++ b/backend/lexicons/app/skyreader/feed/saved.json
@@ -1,0 +1,73 @@
+{
+  "lexicon": 1,
+  "id": "app.skyreader.feed.saved",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A saved article. Metadata only — the extracted article body is deliberately NOT part of this record (it stays in Skyreader's own store). Written into a personal atproto Space, never into the public repo.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["savedAt"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "The article URL. Absent for share/document saves, which have no web URL."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "author": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Short summary/excerpt. Not the article body."
+          },
+          "contentType": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "'webpage', 'article', 'share', or 'document'."
+          },
+          "domain": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "image": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048
+          },
+          "wordCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Word count of the extracted body, which itself is not stored here."
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "savedAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "source": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "How the item was saved: 'url', 'feed', 'share', or 'document'."
+          },
+          "itemGuid": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Feed item GUID, for saves that came from a subscribed feed."
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/lexicons/app/skyreader/space/savedAccess.json
+++ b/backend/lexicons/app/skyreader/space/savedAccess.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "app.skyreader.space.savedAccess",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Skyreader saves",
+      "detail": "Read and write the saved articles in your private Skyreader space",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "space",
+          "spaceType": "app.skyreader.space.saved",
+          "authority": "*",
+          "skey": "self",
+          "collection": ["app.skyreader.feed.saved"],
+          "action": ["read", "create", "update", "delete"],
+          "manage": ["create", "update", "delete"]
+        }
+      ]
+    }
+  }
+}

--- a/backend/src/env.d.ts
+++ b/backend/src/env.d.ts
@@ -14,6 +14,10 @@ declare namespace Cloudflare {
     GIT_COMMIT_SHA?: string;
     HEARTBEAT_URL?: string;
     HEALTH_CHECK_SECRET?: string;
+    // atproto Spaces spike (docs/plans/SPACES_SAVES_SPIKE.md). `.dev.vars` only —
+    // deliberately absent from wrangler.toml, so the entire mirror/read-back path
+    // is unreachable in staging and production. Checked as `=== 'true'`.
+    SPACES_SAVES_ENABLED?: string;
     // Public base for users' linkblogs (linkblogs.skyreader.app). A [vars] entry,
     // so cf-typegen also emits it; declared here too for envs typed without it.
     LINKBLOG_PUBLIC_URL?: string;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -72,6 +72,7 @@ import {
   handleSetBacking,
 } from './routes/saved';
 import { handleExtract } from './routes/extract';
+import { handleSpacesSavedDiff } from './routes/dev-spaces';
 import { handleGetSettings, handleUpdateSettings } from './routes/settings';
 import {
   handleGetMagazines,
@@ -523,6 +524,15 @@ async function route(
     case url.pathname === '/api/extract':
       if (!session) return unauthorizedResponse(headers);
       response = await handleExtract(request, env);
+      break;
+
+    // atproto Spaces spike: read-back diff of the saved-space mirror against D1.
+    // Mounted only when the dev-only SPACES_SAVES_ENABLED var is set, so this
+    // case never matches in production (see routes/dev-spaces.ts).
+    case url.pathname === '/api/dev/spaces/saved-diff' &&
+      env.SPACES_SAVES_ENABLED === 'true' &&
+      request.method === 'GET':
+      response = await handleSpacesSavedDiff(request, env);
       break;
 
     // Saved routes

--- a/backend/src/routes/dev-spaces.ts
+++ b/backend/src/routes/dev-spaces.ts
@@ -54,9 +54,9 @@ export async function handleSpacesSavedDiff(request: Request, env: Env): Promise
 
   const rows = await readSavedRowsForSpace(env, session.did);
 
-  let records;
+  let listing;
   try {
-    records = await spacesClientForSession(session).listAllRecords({
+    listing = await spacesClientForSession(session).listAllRecords({
       space,
       repo: session.did,
       collection: SAVED_COLLECTION,
@@ -74,15 +74,19 @@ export async function handleSpacesSavedDiff(request: Request, env: Env): Promise
 
   const diff = diffSavedRecords(
     rows,
-    records.map((r) => ({ rkey: r.rkey, value: r.value ?? {} }))
+    listing.records.map((r) => ({ rkey: r.rkey, value: r.value ?? {} }))
   );
 
   return json({
     space,
     collection: SAVED_COLLECTION,
-    counts: { d1: rows.length, space: records.length },
+    counts: { d1: rows.length, space: listing.records.length },
+    truncated: listing.truncated,
     ...diff,
     inSync:
-      diff.onlyInD1.length === 0 && diff.onlyInSpace.length === 0 && diff.mismatched.length === 0,
+      !listing.truncated &&
+      diff.onlyInD1.length === 0 &&
+      diff.onlyInSpace.length === 0 &&
+      diff.mismatched.length === 0,
   });
 }

--- a/backend/src/routes/dev-spaces.ts
+++ b/backend/src/routes/dev-spaces.ts
@@ -1,0 +1,88 @@
+/**
+ * Dev-only read-back for the atproto Spaces saves spike.
+ *
+ * `GET /api/dev/spaces/saved-diff` lists the caller's `app.skyreader.feed.saved`
+ * records out of their personal space and diffs them against D1. It is the
+ * spike's truth meter: best-effort mirroring guarantees drift, and this is what
+ * makes the drift visible rather than theoretical.
+ *
+ * The route is mounted only when `SPACES_SAVES_ENABLED === 'true'`, a var that
+ * exists in `.dev.vars` and nowhere in `wrangler.toml` — so in production the
+ * path doesn't resolve at all.
+ */
+
+import type { Env } from '../types';
+import { getSessionFromRequest } from '../services/oauth';
+import { diffSavedRecords } from '../services/spaces/record';
+import { SAVED_COLLECTION } from '../services/spaces/refs';
+import {
+  ensureSavedSpace,
+  readSavedRowsForSpace,
+  spacesClientForSession,
+  spacesSavesEnabled,
+} from '../services/spaces/mirror';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export async function handleSpacesSavedDiff(request: Request, env: Env): Promise<Response> {
+  if (!spacesSavesEnabled(env)) {
+    return json({ error: 'Not found' }, 404);
+  }
+
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const space = await ensureSavedSpace(session);
+  if (!space) {
+    // The honest answer for every production PDS today, and the one a developer
+    // pointed at bsky.social should see rather than an empty diff that looks fine.
+    return json(
+      {
+        error: 'spaces_unavailable',
+        message: "This session's PDS does not host a Skyreader saved-space.",
+      },
+      503
+    );
+  }
+
+  const rows = await readSavedRowsForSpace(env, session.did);
+
+  let records;
+  try {
+    records = await spacesClientForSession(session).listAllRecords({
+      space,
+      repo: session.did,
+      collection: SAVED_COLLECTION,
+    });
+  } catch (error) {
+    return json(
+      {
+        error: 'space_read_failed',
+        message: error instanceof Error ? error.message : String(error),
+        space,
+      },
+      502
+    );
+  }
+
+  const diff = diffSavedRecords(
+    rows,
+    records.map((r) => ({ rkey: r.rkey, value: r.value ?? {} }))
+  );
+
+  return json({
+    space,
+    collection: SAVED_COLLECTION,
+    counts: { d1: rows.length, space: records.length },
+    ...diff,
+    inSync:
+      diff.onlyInD1.length === 0 && diff.onlyInSpace.length === 0 && diff.mismatched.length === 0,
+  });
+}

--- a/backend/src/routes/lexicons.ts
+++ b/backend/src/routes/lexicons.ts
@@ -1,8 +1,17 @@
 // Lexicon schemas - imported statically for Cloudflare Workers
 import feedSubscription from '../../lexicons/app/skyreader/feed/subscription.json';
+import feedSaved from '../../lexicons/app/skyreader/feed/saved.json';
+import spaceSavedAccess from '../../lexicons/app/skyreader/space/savedAccess.json';
 
 const lexicons: Record<string, object> = {
   'app/skyreader/feed/subscription.json': feedSubscription,
+  // Saves spike (atproto Spaces): the record written into a user's personal
+  // saved-space, and the permission set an OAuth client would `include:` to get
+  // access to it. Published because a second client can only validate records it
+  // can resolve the schema for — but note neither is requested by the live OAuth
+  // flow. See docs/plans/SPACES_SAVES_SPIKE.md.
+  'app/skyreader/feed/saved.json': feedSaved,
+  'app/skyreader/space/savedAccess.json': spaceSavedAccess,
 };
 
 export function handleLexicon(request: Request): Response {

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -21,6 +21,7 @@ import {
 import { hasIntegrationScopes } from './integrations';
 import { normalizeArticleUrl } from '../utils/url-normalize';
 import { chunkArray } from './reading';
+import { mirrorDeleteFromSpace, mirrorSaveToSpace } from '../services/spaces/mirror';
 
 const COLLECTION = 'app.skyreader.feed.saved';
 
@@ -235,7 +236,7 @@ export async function handleCreateSaved(
 async function handleMetadataSave(
   _request: Request,
   env: Env,
-  _ctx: ExecutionContext,
+  ctx: ExecutionContext,
   session: Session,
   body: CreateSavedBody,
   source: string
@@ -281,6 +282,10 @@ async function handleMetadataSave(
     )
     .run();
 
+  // Spike: project the save into the user's personal atproto Space. Flag-gated
+  // (SPACES_SAVES_ENABLED), best-effort, never awaited — D1 above is the save.
+  ctx.waitUntil(mirrorSaveToSpace(env, session, body.rkey));
+
   return new Response(
     JSON.stringify({
       rkey: body.rkey,
@@ -308,6 +313,12 @@ async function handleMetadataSave(
 // COALESCE shape as the backed-save upsert — so a sparse extraction never
 // blanks existing metadata. The rkey and record_uri are unchanged: this is the
 // same save, with better content.
+//
+// No space mirror here (nor in handleUpdateSaved): the space record is metadata
+// only, and what a content upgrade actually changes is the body plus a word
+// count. The drift it leaves is a stale wordCount/title, which the dev
+// saved-diff route reports as `mismatched` — see the spike memo's list of what a
+// real ship would need (a reconciliation pass, not more write hooks).
 async function handleContentUpdate(
   env: Env,
   session: Session,
@@ -393,6 +404,9 @@ async function handleUrlSave(
     )
     .run();
 
+  // Spike: same best-effort space mirror as the metadata path. See mirror.ts.
+  ctx.waitUntil(mirrorSaveToSpace(env, session, body.rkey));
+
   return new Response(
     JSON.stringify({
       uri: recordUri,
@@ -407,6 +421,12 @@ async function handleUrlSave(
  * collection and record it in the two stores. No app.skyreader.feed.saved export —
  * membership in the collection IS the save. The enrichment row stays canonical for
  * reading work (content, word count); the membership row holds the foreign handles.
+ *
+ * Deliberately OUT of the atproto Spaces spike: backing already makes the save
+ * portable (publicly, as a Semble/Margin collection member), so layering a private
+ * space mirror on top is a product question — "which store is the save?" — not a
+ * protocol one. A tester with backing on will therefore see an empty space; start
+ * from an account with backing off. See docs/plans/SPACES_SAVES_SPIKE.md.
  */
 async function handleBackedSave(
   env: Env,
@@ -1055,6 +1075,9 @@ export async function handleDeleteSaved(
       .bind(session.did, rkey)
       .run();
 
+    // Spike: retract the mirrored space record. Flag-gated, best-effort.
+    ctx.waitUntil(mirrorDeleteFromSpace(env, session, rkey));
+
     const settings = await getUserSettings(env, session.did);
     if (settings.backing.provider !== 'skyreader' && row.url_normalized) {
       // Backed: remove the membership from the foreign collection (+ tombstone).
@@ -1129,6 +1152,10 @@ export async function handleDeleteSavedByGuid(
     await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ? AND item_guid = ?')
       .bind(session.did, guid)
       .run();
+
+    // Spike: retract the mirrored space record (keyed by the row's rkey, which is
+    // the space record's rkey too). Flag-gated, best-effort.
+    ctx.waitUntil(mirrorDeleteFromSpace(env, session, row.rkey));
 
     const settings = await getUserSettings(env, session.did);
     if (settings.backing.provider !== 'skyreader' && row.url_normalized) {

--- a/backend/src/services/pds-client.ts
+++ b/backend/src/services/pds-client.ts
@@ -375,6 +375,22 @@ export class PDSClient {
   }
 
   /**
+   * Call an arbitrary XRPC method on this session's PDS with the session's auth.
+   * The typed helpers below cover `com.atproto.repo.*`; this is the escape hatch
+   * for namespaces that don't warrant their own method here (the Spaces spike
+   * calls `com.atproto.simplespace.*` / `com.atproto.space.*` through it).
+   *
+   * `endpoint` is the NSID plus, for GETs, an already-encoded query string.
+   */
+  async xrpc<T = unknown>(
+    method: 'GET' | 'POST',
+    endpoint: string,
+    body?: unknown
+  ): Promise<PDSResult<T>> {
+    return this.request<T>(method, endpoint, body);
+  }
+
+  /**
    * List records in a collection with pagination support
    */
   async listRecords<T = unknown>(

--- a/backend/src/services/pds-client.ts
+++ b/backend/src/services/pds-client.ts
@@ -96,7 +96,15 @@ export type PDSResult<T> =
   // `needsReauth` is set when the PDS host was re-resolved after a migration but
   // the existing OAuth tokens were still rejected — the user must re-authenticate
   // against the new PDS's auth server. Callers should surface this, not retry.
-  | { success: false; error: string; retryable: boolean; needsReauth?: boolean };
+  | {
+      success: false;
+      error: string;
+      /** Structured XRPC error code, when the server returned one. */
+      code?: string;
+      status?: number;
+      retryable: boolean;
+      needsReauth?: boolean;
+    };
 
 /**
  * Optional context that lets a PDSClient self-heal a stale PDS endpoint.
@@ -354,7 +362,16 @@ export class PDSClient {
             response.status === 403 ||
             errorData?.error === 'invalid_token');
 
-        return { result: { success: false, error: errorMessage, retryable }, staleEndpoint };
+        return {
+          result: {
+            success: false,
+            error: errorMessage,
+            code: errorData?.error,
+            status: response.status,
+            retryable,
+          },
+          staleEndpoint,
+        };
       }
 
       const data = (await response.json()) as T;

--- a/backend/src/services/spaces/client.ts
+++ b/backend/src/services/spaces/client.ts
@@ -1,0 +1,199 @@
+/**
+ * Workers-native client for the two atproto Spaces namespaces.
+ *
+ *   `com.atproto.simplespace.*` — the space authority: create/inspect a space and
+ *                                 manage its member list. Session-authed against
+ *                                 the authority's own PDS.
+ *   `com.atproto.space.*`       — the permissioned repo: records, sync, and the
+ *                                 delegation/credential exchange.
+ *
+ * Method names, parameter names and error codes were read off the published alpha
+ * SDK (`@atproto/api@0.0.0-spaces-alpha-20260818163953`,
+ * `dist/client/types/com/atproto/{simplespace,space}/*.d.ts`) rather than taken
+ * from proposal 0016 — see `experiments/spaces-saves/FINDINGS.md` for the diffs
+ * that matters.
+ *
+ * No `@atproto/*` dependency: the alpha SDK assumes Node, and the backend already
+ * hand-rolls its XRPC (`services/pds-client.ts`). Transport is injected as an
+ * `XrpcCall`, so the same client works with session auth (the mirror), with a
+ * space credential (cross-host reads), or with a stub (tests).
+ */
+
+import { SAVED_COLLECTION } from './refs';
+
+export type XrpcCall = <T>(
+  method: 'GET' | 'POST',
+  /** NSID plus, for GETs, an already-encoded query string. */
+  endpoint: string,
+  body?: unknown
+) => Promise<T>;
+
+export type SpacePolicy =
+  | { $type: 'com.atproto.simplespace.defs#publicPolicy' }
+  | { $type: 'com.atproto.simplespace.defs#memberListPolicy' }
+  | { $type: 'com.atproto.simplespace.defs#managingAppPolicy'; managingApp: string };
+
+export type SpaceAppAccess =
+  | { $type: 'com.atproto.simplespace.defs#open' }
+  | { $type: 'com.atproto.simplespace.defs#allowList'; allowed: string[] };
+
+export interface SpaceView {
+  uri: string;
+  policy: { $type: string };
+  appAccess: { $type: string };
+}
+
+export interface SpaceRecordRef {
+  uri: string;
+  cid: string;
+  validationStatus?: string;
+}
+
+export interface SpaceListedRecord {
+  collection: string;
+  rkey: string;
+  cid: string;
+  value?: Record<string, unknown>;
+}
+
+export class SpacesClient {
+  // Plain field assignment, not a parameter property: `experiments/spaces-saves/`
+  // imports this module directly under Node's (erasable-syntax-only) type
+  // stripping, and parameter properties aren't erasable.
+  private readonly call: XrpcCall;
+
+  constructor(call: XrpcCall) {
+    this.call = call;
+  }
+
+  // --- com.atproto.simplespace (authority) ---------------------------------
+
+  /**
+   * Create the space. `skey` is optional in the lexicon (a TID is generated when
+   * omitted); we always pass one so the space ref is derivable from the DID and
+   * no lookup table is needed.
+   */
+  createSpace(input: {
+    type: string;
+    skey?: string;
+    policy: SpacePolicy;
+    appAccess: SpaceAppAccess;
+  }): Promise<{ uri: string }> {
+    return this.call<{ uri: string }>('POST', 'com.atproto.simplespace.createSpace', input);
+  }
+
+  getSpace(space: string): Promise<SpaceView> {
+    const params = new URLSearchParams({ space });
+    return this.call<SpaceView>('GET', `com.atproto.simplespace.getSpace?${params}`);
+  }
+
+  addMember(space: string, did: string): Promise<void> {
+    return this.call<void>('POST', 'com.atproto.simplespace.addMember', { space, did });
+  }
+
+  removeMember(space: string, did: string): Promise<void> {
+    return this.call<void>('POST', 'com.atproto.simplespace.removeMember', { space, did });
+  }
+
+  listMembers(space: string, limit = 100): Promise<{ members: Array<{ did: string }> }> {
+    const params = new URLSearchParams({ space, limit: String(limit) });
+    return this.call('GET', `com.atproto.simplespace.listMembers?${params}`);
+  }
+
+  // --- com.atproto.space (permissioned repo) -------------------------------
+
+  /** Leg 1 of the credential flow; must run against the *user's* PDS. */
+  getDelegationToken(space: string): Promise<{ token: string }> {
+    const params = new URLSearchParams({ space });
+    return this.call<{ token: string }>('GET', `com.atproto.space.getDelegationToken?${params}`);
+  }
+
+  createRecord(input: {
+    space: string;
+    repo: string;
+    collection: string;
+    rkey?: string;
+    record: Record<string, unknown>;
+    validate?: boolean;
+  }): Promise<SpaceRecordRef> {
+    return this.call<SpaceRecordRef>('POST', 'com.atproto.space.createRecord', input);
+  }
+
+  putRecord(input: {
+    space: string;
+    repo: string;
+    collection: string;
+    rkey: string;
+    record: Record<string, unknown>;
+    validate?: boolean;
+  }): Promise<SpaceRecordRef> {
+    return this.call<SpaceRecordRef>('POST', 'com.atproto.space.putRecord', input);
+  }
+
+  getRecord(input: {
+    space: string;
+    repo: string;
+    collection: string;
+    rkey: string;
+  }): Promise<{ uri: string; cid: string; value: Record<string, unknown> }> {
+    const params = new URLSearchParams(input);
+    return this.call('GET', `com.atproto.space.getRecord?${params}`);
+  }
+
+  deleteRecord(input: {
+    space: string;
+    repo: string;
+    collection: string;
+    rkey: string;
+  }): Promise<void> {
+    return this.call<void>('POST', 'com.atproto.space.deleteRecord', input);
+  }
+
+  listRecords(input: {
+    space: string;
+    repo: string;
+    collection?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ records: SpaceListedRecord[]; cursor?: string }> {
+    const params = new URLSearchParams({ space: input.space, repo: input.repo });
+    if (input.collection) params.set('collection', input.collection);
+    if (input.limit !== undefined) params.set('limit', String(input.limit));
+    if (input.cursor) params.set('cursor', input.cursor);
+    return this.call('GET', `com.atproto.space.listRecords?${params}`);
+  }
+
+  /** Paginated read of one collection, with a page cap so a bad cursor can't spin. */
+  async listAllRecords(
+    input: { space: string; repo: string; collection?: string },
+    maxPages = 20
+  ): Promise<SpaceListedRecord[]> {
+    const records: SpaceListedRecord[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < maxPages; page++) {
+      const result = await this.listRecords({ ...input, limit: 100, cursor });
+      records.push(...result.records);
+      if (!result.cursor || result.records.length === 0) break;
+      cursor = result.cursor;
+    }
+    return records;
+  }
+}
+
+/**
+ * The policy the spike creates a personal saved-space with: member-list (so it
+ * starts private to its owner) and open app access.
+ *
+ * `#open` is a spike choice, not a recommendation. It means any app holding the
+ * user's authorization can read the space; `#allowList` (pinned to Skyreader's
+ * OAuth client_id) is what a shipped version would want, and it needs a stable
+ * client_id per environment. Noted in the spike memo.
+ */
+export const PERSONAL_SPACE_POLICY: SpacePolicy = {
+  $type: 'com.atproto.simplespace.defs#memberListPolicy',
+};
+export const PERSONAL_SPACE_APP_ACCESS: SpaceAppAccess = {
+  $type: 'com.atproto.simplespace.defs#open',
+};
+
+export { SAVED_COLLECTION };

--- a/backend/src/services/spaces/client.ts
+++ b/backend/src/services/spaces/client.ts
@@ -56,6 +56,12 @@ export interface SpaceListedRecord {
   value?: Record<string, unknown>;
 }
 
+export interface SpaceRecordListing {
+  records: SpaceListedRecord[];
+  /** True when the safety page cap stopped a listing that still had a cursor. */
+  truncated: boolean;
+}
+
 export class SpacesClient {
   // Plain field assignment, not a parameter property: `experiments/spaces-saves/`
   // imports this module directly under Node's (erasable-syntax-only) type
@@ -167,16 +173,16 @@ export class SpacesClient {
   async listAllRecords(
     input: { space: string; repo: string; collection?: string },
     maxPages = 20
-  ): Promise<SpaceListedRecord[]> {
+  ): Promise<SpaceRecordListing> {
     const records: SpaceListedRecord[] = [];
     let cursor: string | undefined;
     for (let page = 0; page < maxPages; page++) {
       const result = await this.listRecords({ ...input, limit: 100, cursor });
       records.push(...result.records);
-      if (!result.cursor || result.records.length === 0) break;
+      if (!result.cursor || result.records.length === 0) return { records, truncated: false };
       cursor = result.cursor;
     }
-    return records;
+    return { records, truncated: cursor !== undefined };
   }
 }
 

--- a/backend/src/services/spaces/credential.ts
+++ b/backend/src/services/spaces/credential.ts
@@ -1,0 +1,178 @@
+/**
+ * The space-credential flow: three legs before the first cross-host read.
+ *
+ *   1. `com.atproto.space.getDelegationToken` on the *user's* PDS, with ordinary
+ *      session auth  →  a short-lived, single-use delegation JWT (60s).
+ *   2. `com.atproto.space.getSpaceCredential` on the *authority's* PDS, presenting
+ *      that delegation as a Bearer token plus a DPoP proof from a fresh ES256 key
+ *      →  a credential JWT bound to that key through `cnf.jkt` (2h).
+ *   3. every subsequent space call: `Authorization: DPoP <credential>` and a proof
+ *      whose `ath` hashes the credential.
+ *
+ * TTLs are from `@atproto/space@0.0.0-spaces-alpha-20260818163953`
+ * (`dist/credential.d.ts`, `SPACE_TOKEN_TYPES`): delegation 60s/single-use,
+ * credential 7200s/reusable, client attestation 60s/single-use.
+ *
+ * Writing to your OWN repo inside a space does not need any of this — the
+ * reference app posts `com.atproto.space.createRecord` to its own PDS with plain
+ * session auth, which is what the D1 mirror does. Credentials are for reading a
+ * space from somewhere that isn't the author's own authenticated session, which
+ * is exactly the portability claim this spike is testing.
+ */
+
+import { createSpaceDpopProof, generateSpaceDpopKey, jwtExpirySeconds } from './dpop';
+import type { SpaceDpopKey } from './dpop';
+
+/** Documented alpha lifetimes; we re-read `exp` from the token rather than assume. */
+export const DELEGATION_TOKEN_TTL_SEC = 60;
+export const SPACE_CREDENTIAL_TTL_SEC = 7200;
+
+/** Refresh this long before `exp` so an in-flight request can't expire mid-call. */
+const EXPIRY_MARGIN_SEC = 60;
+
+export class SpaceCredential {
+  readonly token: string;
+  readonly key: SpaceDpopKey;
+  /** Epoch ms. */
+  readonly expiresAt: number;
+
+  // Plain field assignment rather than constructor parameter properties: these
+  // modules are imported directly by the Node experiment in
+  // `experiments/spaces-saves/`, which runs them through Node's type stripping,
+  // and that only accepts erasable TypeScript syntax.
+  constructor(token: string, key: SpaceDpopKey, expiresAt: number) {
+    this.token = token;
+    this.key = key;
+    this.expiresAt = expiresAt;
+  }
+
+  isFresh(now = Date.now()): boolean {
+    return this.expiresAt - EXPIRY_MARGIN_SEC * 1000 > now;
+  }
+
+  /** Authorize an arbitrary request against any host serving this space. */
+  async authorize(method: string, url: string): Promise<Record<string, string>> {
+    return {
+      Authorization: `DPoP ${this.token}`,
+      DPoP: await createSpaceDpopProof(this.key, {
+        htm: method,
+        htu: url,
+        credential: this.token,
+      }),
+    };
+  }
+}
+
+export class SpaceCredentialError extends Error {
+  readonly code: string;
+  readonly status?: number;
+
+  constructor(message: string, code: string, status?: number) {
+    super(message);
+    this.name = 'SpaceCredentialError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface ExchangeCredentialInput {
+  /** Base URL of the authority's PDS (no trailing slash). */
+  authorityPdsUrl: string;
+  /** The single-use delegation token from leg 1. */
+  delegationToken: string;
+  /** `at://…/space/…` reference. */
+  space: string;
+  /** The key the credential gets bound to. */
+  key: SpaceDpopKey;
+  fetchImpl?: typeof fetch;
+}
+
+/** Leg 2. Returns the raw credential JWT. */
+export async function exchangeSpaceCredential(input: ExchangeCredentialInput): Promise<string> {
+  const url = `${input.authorityPdsUrl.replace(/\/$/, '')}/xrpc/com.atproto.space.getSpaceCredential`;
+  const proof = await createSpaceDpopProof(input.key, { htm: 'POST', htu: url });
+
+  const response = await (input.fetchImpl ?? fetch)(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      // Note: Bearer, not DPoP — the delegation token is not itself key-bound;
+      // the proof on this leg is what the credential's `cnf.jkt` will name.
+      authorization: `Bearer ${input.delegationToken}`,
+      dpop: proof,
+    },
+    body: JSON.stringify({ space: input.space }),
+  });
+
+  const body = (await response.json().catch(() => undefined)) as
+    | { credential?: unknown; error?: unknown; message?: unknown }
+    | undefined;
+
+  if (!response.ok) {
+    const code = typeof body?.error === 'string' ? body.error : `HTTP${response.status}`;
+    const message = typeof body?.message === 'string' ? body.message : code;
+    throw new SpaceCredentialError(message, code, response.status);
+  }
+  if (typeof body?.credential !== 'string' || !body.credential) {
+    throw new SpaceCredentialError('credential exchange returned no credential', 'InvalidResponse');
+  }
+  return body.credential;
+}
+
+export interface MintCredentialInput {
+  space: string;
+  authorityPdsUrl: string;
+  /** Leg 1 — supplied by the caller because it needs the user's session auth. */
+  getDelegationToken: (space: string) => Promise<string>;
+  fetchImpl?: typeof fetch;
+}
+
+/** Legs 1 + 2. */
+export async function mintSpaceCredential(input: MintCredentialInput): Promise<SpaceCredential> {
+  const delegationToken = await input.getDelegationToken(input.space);
+  const key = await generateSpaceDpopKey();
+  const token = await exchangeSpaceCredential({
+    authorityPdsUrl: input.authorityPdsUrl,
+    delegationToken,
+    space: input.space,
+    key,
+    fetchImpl: input.fetchImpl,
+  });
+  const exp = jwtExpirySeconds(token);
+  const expiresAt = exp !== null ? exp * 1000 : Date.now() + SPACE_CREDENTIAL_TTL_SEC * 1000;
+  return new SpaceCredential(token, key, expiresAt);
+}
+
+/**
+ * Per-isolate credential cache.
+ *
+ * In memory only, and deliberately so: a credential is worthless without the
+ * private key it is bound to, and persisting that key to D1 would turn a
+ * two-hour token into durable stored key material for an alpha protocol. The
+ * cost is a re-mint (two round trips) on a cold isolate; the alternative is
+ * writing private keys to the database for a spike.
+ */
+const credentialCache = new Map<string, SpaceCredential>();
+
+export function cacheKeyFor(did: string, space: string): string {
+  return `${did}|${space}`;
+}
+
+export async function getOrMintSpaceCredential(
+  did: string,
+  input: MintCredentialInput
+): Promise<SpaceCredential> {
+  const key = cacheKeyFor(did, input.space);
+  const cached = credentialCache.get(key);
+  if (cached?.isFresh()) return cached;
+
+  const credential = await mintSpaceCredential(input);
+  credentialCache.set(key, credential);
+  return credential;
+}
+
+/** Test seam. */
+export function clearCredentialCache(): void {
+  credentialCache.clear();
+}

--- a/backend/src/services/spaces/dpop.ts
+++ b/backend/src/services/spaces/dpop.ts
@@ -1,0 +1,113 @@
+/**
+ * DPoP proofs for atproto Spaces credentials.
+ *
+ * This is NOT the same proof the OAuth path builds (`services/oauth.ts`
+ * `createDPoPProof`): a space proof normalizes `htu` to origin+path (RFC 9449
+ * §4.2, so one proof covers any query string), carries no `nonce`, and its `ath`
+ * hashes the *space credential* rather than an access token. Kept separate on
+ * purpose — folding the two would make the OAuth proof's behaviour depend on a
+ * spike flag.
+ *
+ * Shapes verified against `@atproto/space@0.0.0-spaces-alpha-20260818163953`
+ * (`dist/dpop.js`, `createDpopProof` / `verifyDpopProof`).
+ *
+ * WebCrypto + fetch only, so it runs unchanged on Workers and on Node.
+ */
+
+export interface SpaceDpopKey {
+  privateKey: CryptoKey;
+  /** Bare public JWK (kty/crv/x/y) — the `jwk` header of every proof. */
+  publicJwk: JsonWebKey;
+}
+
+function base64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function base64urlJson(value: unknown): string {
+  return base64url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/** Fresh ES256 key. The private half never leaves the isolate — see credential.ts. */
+export async function generateSpaceDpopKey(): Promise<SpaceDpopKey> {
+  const pair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const jwk = (await crypto.subtle.exportKey('jwk', pair.publicKey)) as JsonWebKey;
+  return {
+    privateKey: pair.privateKey,
+    publicJwk: { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y },
+  };
+}
+
+/** RFC 9449 §4.2: the proof binds the origin + path only, never the query. */
+export function normalizeHtu(url: string): string {
+  const parsed = new URL(url);
+  return parsed.origin + parsed.pathname;
+}
+
+async function sha256Base64url(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return base64url(new Uint8Array(digest));
+}
+
+export interface SpaceDpopProofOptions {
+  htm: string;
+  htu: string;
+  /**
+   * The space credential this proof is presented with. Omitted on the leg that
+   * *obtains* a credential — the alpha rejects an `ath` there ("DPoP proof 'ath'
+   * must be omitted when obtaining a credential").
+   */
+  credential?: string;
+}
+
+export async function createSpaceDpopProof(
+  key: SpaceDpopKey,
+  opts: SpaceDpopProofOptions
+): Promise<string> {
+  const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: key.publicJwk };
+  const payload: Record<string, unknown> = {
+    jti: randomHex(16),
+    htm: opts.htm,
+    htu: normalizeHtu(opts.htu),
+    iat: Math.floor(Date.now() / 1000),
+  };
+  if (opts.credential !== undefined) {
+    payload.ath = await sha256Base64url(opts.credential);
+  }
+
+  const signingInput = `${base64urlJson(header)}.${base64urlJson(payload)}`;
+  const signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    key.privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+  return `${signingInput}.${base64url(new Uint8Array(signature))}`;
+}
+
+function randomHex(length: number): string {
+  const bytes = new Uint8Array(Math.ceil(length / 2));
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, length);
+}
+
+/** `exp` (seconds) of a JWT, without verifying it — used only for cache expiry. */
+export function jwtExpirySeconds(jwt: string): number | null {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(padded + '='.repeat((4 - (padded.length % 4)) % 4));
+    const payload = JSON.parse(json) as { exp?: unknown };
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/services/spaces/mirror.ts
+++ b/backend/src/services/spaces/mirror.ts
@@ -21,7 +21,12 @@ import { createPDSClient } from '../pds-client';
 import { SpacesClient, PERSONAL_SPACE_APP_ACCESS, PERSONAL_SPACE_POLICY } from './client';
 import { savedRowToSpaceRecord, type SavedRowForSpace } from './record';
 import { SAVED_COLLECTION, SAVED_SPACE_SKEY, SAVED_SPACE_TYPE, savedSpaceRef } from './refs';
-import { isSpaceNotFound, sessionCall } from './transport';
+import {
+  isSpaceAccessDenied,
+  isSpaceNotFound,
+  isSpacesUnsupported,
+  sessionCall,
+} from './transport';
 
 /** The one switch. Absent in `wrangler.toml`, so production never enters this file. */
 export function spacesSavesEnabled(env: Env): boolean {
@@ -58,15 +63,18 @@ export function clearSpaceCapabilityCache(): void {
  * Returns null for "not available", which covers both "this PDS doesn't do
  * Spaces" and "the call failed" — the caller treats them identically.
  */
-export async function ensureSavedSpace(session: Session): Promise<string | null> {
+export async function ensureSavedSpace(
+  session: Session,
+  client: SpacesClient = spacesClientForSession(session)
+): Promise<string | null> {
   const cached = capabilityCache.get(session.did);
   if (cached && Date.now() - cached.checkedAt < CAPABILITY_TTL_MS) {
     return cached.space;
   }
 
   const space = savedSpaceRef(session.did);
-  const client = spacesClientForSession(session);
   let verdict: string | null = null;
+  let cacheVerdict = true;
 
   try {
     await client.getSpace(space);
@@ -82,16 +90,26 @@ export async function ensureSavedSpace(session: Session): Promise<string | null>
         });
         verdict = created.uri || space;
       } catch (createError) {
+        // Creation may have failed after the capability probe succeeded. Let a
+        // later save retry instead of turning that outage into a negative TTL.
+        cacheVerdict = false;
         console.warn('[spaces] createSpace failed', describe(createError));
       }
-    } else {
-      // Everything else — including "this PDS has never heard of simplespace",
-      // which is the expected answer for every production PDS today.
+    } else if (isSpacesUnsupported(error)) {
+      // Expected for ordinary PDSes. Cache this so a developer with the spike
+      // enabled pays for the capability probe only once per TTL.
+      console.warn('[spaces] PDS does not support Spaces', describe(error));
+    } else if (isSpaceAccessDenied(error)) {
       console.warn('[spaces] getSpace unavailable', describe(error));
+    } else {
+      // A network or server failure says nothing about capability. Do not turn
+      // it into a ten-minute negative verdict; the next save should retry.
+      cacheVerdict = false;
+      console.warn('[spaces] getSpace failed transiently', describe(error));
     }
   }
 
-  capabilityCache.set(session.did, { space: verdict, checkedAt: Date.now() });
+  if (cacheVerdict) capabilityCache.set(session.did, { space: verdict, checkedAt: Date.now() });
   return verdict;
 }
 
@@ -118,7 +136,7 @@ export async function mirrorSaveToSpace(env: Env, session: Session, rkey: string
     if (!space) return;
 
     const record = savedRowToSpaceRecord(row);
-    await spacesClientForSession(session).createRecord({
+    await spacesClientForSession(session).putRecord({
       space,
       repo: session.did,
       collection: SAVED_COLLECTION,

--- a/backend/src/services/spaces/mirror.ts
+++ b/backend/src/services/spaces/mirror.ts
@@ -1,0 +1,172 @@
+/**
+ * Flag-gated, best-effort mirror of D1 saves into the user's personal atproto
+ * Space. Spike code — see `docs/plans/SPACES_SAVES_SPIKE.md`.
+ *
+ * Rules this file exists to hold:
+ *
+ *  - **D1 stays canonical.** The mirror is a projection. Nothing here is ever
+ *    awaited by an HTTP handler; every entry point swallows its own failures.
+ *  - **Dead in production.** `SPACES_SAVES_ENABLED` is a `.dev.vars`-only var,
+ *    absent from `wrangler.toml`. Every entry point checks it first, before any
+ *    import-level work or D1 read, so with the flag unset the cost is one string
+ *    comparison.
+ *  - **Silent on ordinary PDSes.** No real PDS implements Spaces today. The
+ *    capability probe caches its verdict (including the negative one) per isolate
+ *    so a flag-on developer against bsky.social pays one failed call, not one per
+ *    save.
+ */
+
+import type { Env, Session } from '../../types';
+import { createPDSClient } from '../pds-client';
+import { SpacesClient, PERSONAL_SPACE_APP_ACCESS, PERSONAL_SPACE_POLICY } from './client';
+import { savedRowToSpaceRecord, type SavedRowForSpace } from './record';
+import { SAVED_COLLECTION, SAVED_SPACE_SKEY, SAVED_SPACE_TYPE, savedSpaceRef } from './refs';
+import { isSpaceNotFound, sessionCall } from './transport';
+
+/** The one switch. Absent in `wrangler.toml`, so production never enters this file. */
+export function spacesSavesEnabled(env: Env): boolean {
+  return env.SPACES_SAVES_ENABLED === 'true';
+}
+
+/** A space client bound to the user's own PDS via their session. */
+export function spacesClientForSession(session: Session): SpacesClient {
+  return new SpacesClient(sessionCall(createPDSClient(session)));
+}
+
+interface CapabilityVerdict {
+  /** The space ref, or null when this PDS can't host one. */
+  space: string | null;
+  checkedAt: number;
+}
+
+const CAPABILITY_TTL_MS = 10 * 60 * 1000;
+const capabilityCache = new Map<string, CapabilityVerdict>();
+
+/** Test seam. */
+export function clearSpaceCapabilityCache(): void {
+  capabilityCache.clear();
+}
+
+/**
+ * Resolve (and, once, create) the user's saved-space.
+ *
+ * Personal space: the authority is the user's own DID, so there is no third
+ * party to ask and no membership to grant — the owner is a member by
+ * construction. `getSpace` is the probe; `createSpace` runs only when it says
+ * the space isn't there.
+ *
+ * Returns null for "not available", which covers both "this PDS doesn't do
+ * Spaces" and "the call failed" — the caller treats them identically.
+ */
+export async function ensureSavedSpace(session: Session): Promise<string | null> {
+  const cached = capabilityCache.get(session.did);
+  if (cached && Date.now() - cached.checkedAt < CAPABILITY_TTL_MS) {
+    return cached.space;
+  }
+
+  const space = savedSpaceRef(session.did);
+  const client = spacesClientForSession(session);
+  let verdict: string | null = null;
+
+  try {
+    await client.getSpace(space);
+    verdict = space;
+  } catch (error) {
+    if (isSpaceNotFound(error)) {
+      try {
+        const created = await client.createSpace({
+          type: SAVED_SPACE_TYPE,
+          skey: SAVED_SPACE_SKEY,
+          policy: PERSONAL_SPACE_POLICY,
+          appAccess: PERSONAL_SPACE_APP_ACCESS,
+        });
+        verdict = created.uri || space;
+      } catch (createError) {
+        console.warn('[spaces] createSpace failed', describe(createError));
+      }
+    } else {
+      // Everything else — including "this PDS has never heard of simplespace",
+      // which is the expected answer for every production PDS today.
+      console.warn('[spaces] getSpace unavailable', describe(error));
+    }
+  }
+
+  capabilityCache.set(session.did, { space: verdict, checkedAt: Date.now() });
+  return verdict;
+}
+
+const SAVED_ROW_COLUMNS =
+  'rkey, url, title, author, description, content_type, domain, image, word_count, published_at, saved_at, source, item_guid';
+
+/**
+ * Mirror one save into the space. Call inside `ctx.waitUntil` — it never throws
+ * and never returns anything the request path should branch on.
+ */
+export async function mirrorSaveToSpace(env: Env, session: Session, rkey: string): Promise<void> {
+  if (!spacesSavesEnabled(env)) return;
+
+  try {
+    const row = await env.DB.prepare(
+      `SELECT ${SAVED_ROW_COLUMNS} FROM saved_articles WHERE user_did = ? AND rkey = ?`
+    )
+      .bind(session.did, rkey)
+      .first<SavedRowForSpace>();
+
+    if (!row) return;
+
+    const space = await ensureSavedSpace(session);
+    if (!space) return;
+
+    const record = savedRowToSpaceRecord(row);
+    await spacesClientForSession(session).createRecord({
+      space,
+      repo: session.did,
+      collection: SAVED_COLLECTION,
+      // Same rkey as D1, so the mapping between the two stores is implicit and
+      // no migration or join table is needed.
+      rkey: row.rkey,
+      record: record as unknown as Record<string, unknown>,
+    });
+  } catch (error) {
+    console.warn('[spaces] mirrorSaveToSpace failed', { rkey, error: describe(error) });
+  }
+}
+
+/** Remove one save from the space. Same contract as `mirrorSaveToSpace`. */
+export async function mirrorDeleteFromSpace(
+  env: Env,
+  session: Session,
+  rkey: string
+): Promise<void> {
+  if (!spacesSavesEnabled(env)) return;
+
+  try {
+    const space = await ensureSavedSpace(session);
+    if (!space) return;
+
+    await spacesClientForSession(session).deleteRecord({
+      space,
+      repo: session.did,
+      collection: SAVED_COLLECTION,
+      rkey,
+    });
+  } catch (error) {
+    console.warn('[spaces] mirrorDeleteFromSpace failed', { rkey, error: describe(error) });
+  }
+}
+
+/** Read every save row for a user, in the shape the record mapping wants. */
+export async function readSavedRowsForSpace(env: Env, did: string): Promise<SavedRowForSpace[]> {
+  const result = await env.DB.prepare(
+    `SELECT ${SAVED_ROW_COLUMNS} FROM saved_articles WHERE user_did = ? ORDER BY saved_at DESC`
+  )
+    .bind(did)
+    .all<SavedRowForSpace>();
+  return result.results ?? [];
+}
+
+function describe(error: unknown): string {
+  if (error instanceof Error)
+    return `${(error as { code?: string }).code ?? error.name}: ${error.message}`;
+  return String(error);
+}

--- a/backend/src/services/spaces/record.ts
+++ b/backend/src/services/spaces/record.ts
@@ -1,0 +1,150 @@
+/**
+ * Mapping between a `saved_articles` row and an `app.skyreader.feed.saved`
+ * record in the user's saved space, plus the diff used by the dev read-back
+ * route. Pure functions, no I/O — unit-tested in `test/spaces-record.spec.ts`.
+ */
+
+import { SAVED_COLLECTION } from './refs';
+
+/** The subset of `saved_articles` the space record is built from. */
+export interface SavedRowForSpace {
+  rkey: string;
+  url: string | null;
+  title: string | null;
+  author: string | null;
+  description: string | null;
+  content_type: string | null;
+  domain: string | null;
+  image: string | null;
+  word_count: number | null;
+  published_at: number | null;
+  saved_at: number;
+  source: string | null;
+  item_guid: string | null;
+}
+
+export interface SavedSpaceRecord {
+  $type: typeof SAVED_COLLECTION;
+  url?: string;
+  title?: string;
+  author?: string;
+  description?: string;
+  contentType?: string;
+  domain?: string;
+  image?: string;
+  wordCount?: number;
+  publishedAt?: string;
+  savedAt: string;
+  source?: string;
+  itemGuid?: string;
+}
+
+/** D1 stores epoch ms; records want ISO datetimes. Junk timestamps are dropped. */
+function toIso(epochMs: number | null | undefined): string | undefined {
+  if (epochMs === null || epochMs === undefined) return undefined;
+  if (!Number.isFinite(epochMs)) return undefined;
+  const date = new Date(epochMs);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+/** Empty strings are as absent as nulls, and an absent field is left off entirely. */
+function text(value: string | null | undefined, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+/**
+ * Build the space record for a saved row.
+ *
+ * Metadata only, by design: `content` is never read here. The extracted article
+ * body stays in D1 — the same content split the (now removed) public-repo export
+ * observed, and the thing that keeps a record inside sane size limits.
+ */
+export function savedRowToSpaceRecord(row: SavedRowForSpace): SavedSpaceRecord {
+  const record: SavedSpaceRecord = {
+    $type: SAVED_COLLECTION,
+    // A row always has saved_at; fall back to "now" rather than emitting an
+    // invalid record if a legacy row somehow carries a bad timestamp.
+    savedAt: toIso(row.saved_at) ?? new Date().toISOString(),
+  };
+
+  const url = text(row.url, 2048);
+  if (url) record.url = url;
+  const title = text(row.title, 1024);
+  if (title) record.title = title;
+  const author = text(row.author, 512);
+  if (author) record.author = author;
+  const description = text(row.description, 2048);
+  if (description) record.description = description;
+  const contentType = text(row.content_type, 64);
+  if (contentType) record.contentType = contentType;
+  const domain = text(row.domain, 512);
+  if (domain) record.domain = domain;
+  const image = text(row.image, 2048);
+  if (image) record.image = image;
+  const source = text(row.source, 64);
+  if (source) record.source = source;
+  const itemGuid = text(row.item_guid, 2048);
+  if (itemGuid) record.itemGuid = itemGuid;
+
+  if (
+    typeof row.word_count === 'number' &&
+    Number.isFinite(row.word_count) &&
+    row.word_count >= 0
+  ) {
+    record.wordCount = Math.round(row.word_count);
+  }
+
+  const publishedAt = toIso(row.published_at);
+  if (publishedAt) record.publishedAt = publishedAt;
+
+  return record;
+}
+
+export interface SavedDiff {
+  /** rkeys present in D1 with no record in the space. */
+  onlyInD1: string[];
+  /** rkeys present in the space with no D1 row (a stale mirror). */
+  onlyInSpace: string[];
+  /** rkeys present in both whose field values disagree. */
+  mismatched: Array<{ rkey: string; field: string; d1: unknown; space: unknown }>;
+}
+
+/**
+ * The spike's truth meter: does the mirror actually reflect D1?
+ *
+ * Only the fields the mapping produces are compared, and only for rkeys present
+ * on both sides — a field the space record carries but the mapping never emits
+ * would be someone else's write, which is out of scope for a drift check.
+ */
+export function diffSavedRecords(
+  rows: SavedRowForSpace[],
+  spaceRecords: Array<{ rkey: string; value: Record<string, unknown> }>
+): SavedDiff {
+  const spaceByRkey = new Map(spaceRecords.map((r) => [r.rkey, r.value]));
+  const diff: SavedDiff = { onlyInD1: [], onlyInSpace: [], mismatched: [] };
+
+  for (const row of rows) {
+    const remote = spaceByRkey.get(row.rkey);
+    if (!remote) {
+      diff.onlyInD1.push(row.rkey);
+      continue;
+    }
+    const expected = savedRowToSpaceRecord(row) as unknown as Record<string, unknown>;
+    for (const field of Object.keys(expected)) {
+      if (expected[field] !== remote[field]) {
+        diff.mismatched.push({ rkey: row.rkey, field, d1: expected[field], space: remote[field] });
+      }
+    }
+  }
+
+  const d1Rkeys = new Set(rows.map((r) => r.rkey));
+  for (const record of spaceRecords) {
+    if (!d1Rkeys.has(record.rkey)) diff.onlyInSpace.push(record.rkey);
+  }
+
+  return diff;
+}

--- a/backend/src/services/spaces/refs.ts
+++ b/backend/src/services/spaces/refs.ts
@@ -1,0 +1,73 @@
+/**
+ * atproto Spaces — identifiers and constants for the saved-articles spike.
+ *
+ * Deliberately dependency-free (no Env, no D1, no Workers globals) so the same
+ * module is importable from the standalone Node experiment in
+ * `experiments/spaces-saves/`, which exercises this exact code against a real
+ * spaces-capable PDS. See that directory's FINDINGS.md.
+ */
+
+/**
+ * The space *type* NSID. A space type is just an NSID naming the modality of the
+ * space; the alpha does not require a lexicon document for it (the reference app,
+ * bluesky-social/bulletin, ships none for `my.bulletin.board`).
+ */
+export const SAVED_SPACE_TYPE = 'app.skyreader.space.saved';
+
+/** One saved-space per user, so the space key is constant. */
+export const SAVED_SPACE_SKEY = 'self';
+
+/**
+ * The record collection inside the space. Same NSID the retired public-repo
+ * export used — inside a permissioned repo it finally means what it says, so the
+ * synthetic `record_uri` D1 already stores lines up with a record that exists.
+ */
+export const SAVED_COLLECTION = 'app.skyreader.feed.saved';
+
+/**
+ * OAuth permission set that would be requested (as `include:<nsid>`) to get space
+ * access for a real user. NOT requested by this spike — see `config/scopes.ts` and
+ * the risks section of the spike memo.
+ */
+export const SAVED_SPACE_PERMISSION_SET = 'app.skyreader.space.savedAccess';
+
+export interface SpaceRef {
+  /** DID of the space authority. For a personal space this is the user's own DID. */
+  authority: string;
+  /** Space type NSID. */
+  type: string;
+  /** Space key. */
+  skey: string;
+  /** The canonical `at://…/space/…` reference. */
+  uri: string;
+}
+
+/** `at://{authority}/space/{type}/{skey}` — the alpha's space-ref string format. */
+export function formatSpaceRef(authority: string, type: string, skey: string): string {
+  return `at://${authority}/space/${type}/${skey}`;
+}
+
+/** The saved-articles space owned by (and hosted for) `did`. */
+export function savedSpaceRef(did: string): string {
+  return formatSpaceRef(did, SAVED_SPACE_TYPE, SAVED_SPACE_SKEY);
+}
+
+/** Parse a space-ref, returning null when it isn't one. */
+export function parseSpaceRef(uri: string): SpaceRef | null {
+  const match = /^at:\/\/(did:[^/]+)\/space\/([^/]+)\/([^/]+)$/.exec(uri);
+  if (!match) return null;
+  return { authority: match[1], type: match[2], skey: match[3], uri };
+}
+
+/**
+ * Address of a single record inside a space:
+ * `at://{authority}/space/{type}/{skey}/{authorDid}/{collection}/{rkey}`.
+ */
+export function spaceRecordUri(
+  space: string,
+  authorDid: string,
+  collection: string,
+  rkey: string
+): string {
+  return `${space}/${authorDid}/${collection}/${rkey}`;
+}

--- a/backend/src/services/spaces/transport.ts
+++ b/backend/src/services/spaces/transport.ts
@@ -1,0 +1,150 @@
+/**
+ * `XrpcCall` transports for `SpacesClient`.
+ *
+ * Two auth modes, both real and both used:
+ *
+ *   sessionCall     — ordinary OAuth session auth against the user's own PDS.
+ *                     Enough to create a personal space and to write records into
+ *                     your own repo inside it (the reference app does exactly
+ *                     this), so the D1 mirror needs nothing more.
+ *   credentialCall  — a DPoP-bound space credential, presented to any host serving
+ *                     the space. What a *second* client needs to read the space —
+ *                     i.e. the portability claim.
+ *
+ * Kept free of Workers/Env imports so `experiments/spaces-saves/` can run the
+ * identical code on Node against a live spaces PDS.
+ */
+
+import type { SpaceCredential } from './credential';
+import type { XrpcCall } from './client';
+
+export class SpaceXrpcError extends Error {
+  readonly code: string;
+  readonly status?: number;
+
+  constructor(message: string, code: string, status?: number) {
+    super(message);
+    this.name = 'SpaceXrpcError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/** Minimal shape of `PDSClient` — structural, so this module stays dependency-free. */
+export interface SessionXrpcClient {
+  xrpc<T>(
+    method: 'GET' | 'POST',
+    endpoint: string,
+    body?: unknown
+  ): Promise<{ success: true; data: T } | { success: false; error: string; retryable: boolean }>;
+}
+
+/** Session auth (OAuth access token + the session's own DPoP key). */
+export function sessionCall(client: SessionXrpcClient): XrpcCall {
+  return async <T>(method: 'GET' | 'POST', endpoint: string, body?: unknown): Promise<T> => {
+    const result = await client.xrpc<T>(method, endpoint, body);
+    if (!result.success) {
+      throw new SpaceXrpcError(result.error, endpoint.split('?')[0], undefined);
+    }
+    return result.data;
+  };
+}
+
+/**
+ * Space-credential auth against one host. The credential is re-authorized per
+ * request because the DPoP proof binds method + URL (and carries a fresh `jti`),
+ * so it cannot be built once and reused.
+ */
+export function credentialCall(
+  host: string,
+  credential: SpaceCredential,
+  fetchImpl: typeof fetch = fetch
+): XrpcCall {
+  return httpCall(host, (method, url) => credential.authorize(method, url), fetchImpl);
+}
+
+/**
+ * Legacy `com.atproto.server.createSession` auth (Bearer access JWT).
+ *
+ * Not used by the backend — production sessions are OAuth/DPoP. It exists for
+ * the standalone Node experiment, which drives a throwaway account on an alpha
+ * PDS and has no reason to stand up an OAuth client to do it.
+ */
+export function bearerCall(
+  host: string,
+  accessJwt: string,
+  fetchImpl: typeof fetch = fetch
+): XrpcCall {
+  return httpCall(host, async () => ({ Authorization: `Bearer ${accessJwt}` }), fetchImpl);
+}
+
+function httpCall(
+  host: string,
+  authorize: (method: string, url: string) => Promise<Record<string, string>>,
+  fetchImpl: typeof fetch
+): XrpcCall {
+  const base = host.replace(/\/$/, '');
+  return async <T>(method: 'GET' | 'POST', endpoint: string, body?: unknown): Promise<T> => {
+    const url = `${base}/xrpc/${endpoint}`;
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      ...(await authorize(method, url)),
+    };
+    if (body !== undefined) headers['content-type'] = 'application/json';
+
+    const response = await fetchImpl(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = text ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = undefined;
+    }
+
+    if (!response.ok) {
+      const err = (parsed ?? {}) as { error?: unknown; message?: unknown };
+      const code = typeof err.error === 'string' ? err.error : `HTTP${response.status}`;
+      const message = typeof err.message === 'string' ? err.message : code;
+      throw new SpaceXrpcError(message, code, response.status);
+    }
+    return parsed as T;
+  };
+}
+
+/** True when the error means "this space does not exist (here)". */
+export function isSpaceNotFound(error: unknown): boolean {
+  const code = errorCode(error);
+  return code === 'SpaceNotFound' || code === 'SpaceDeleted';
+}
+
+/** True when the error means "you are not allowed into this space". */
+export function isSpaceAccessDenied(error: unknown): boolean {
+  const code = errorCode(error);
+  return (
+    code === 'UserNotAuthorized' ||
+    code === 'AppNotAuthorized' ||
+    code === 'NotAuthorized' ||
+    code === 'RepoNotFound'
+  );
+}
+
+/**
+ * True when the host doesn't implement Spaces at all — every real PDS today.
+ * The probe has to be cheap and silent for those, so this is checked first.
+ */
+export function isSpacesUnsupported(error: unknown): boolean {
+  const code = errorCode(error);
+  if (code === 'MethodNotImplemented' || code === 'InvalidRequest') return true;
+  const status = (error as { status?: unknown })?.status;
+  return status === 404 || status === 501;
+}
+
+function errorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown })?.code;
+  return typeof code === 'string' ? code : undefined;
+}

--- a/backend/src/services/spaces/transport.ts
+++ b/backend/src/services/spaces/transport.ts
@@ -36,7 +36,10 @@ export interface SessionXrpcClient {
     method: 'GET' | 'POST',
     endpoint: string,
     body?: unknown
-  ): Promise<{ success: true; data: T } | { success: false; error: string; retryable: boolean }>;
+  ): Promise<
+    | { success: true; data: T }
+    | { success: false; error: string; code?: string; status?: number; retryable: boolean }
+  >;
 }
 
 /** Session auth (OAuth access token + the session's own DPoP key). */
@@ -44,7 +47,11 @@ export function sessionCall(client: SessionXrpcClient): XrpcCall {
   return async <T>(method: 'GET' | 'POST', endpoint: string, body?: unknown): Promise<T> => {
     const result = await client.xrpc<T>(method, endpoint, body);
     if (!result.success) {
-      throw new SpaceXrpcError(result.error, endpoint.split('?')[0], undefined);
+      throw new SpaceXrpcError(
+        result.error,
+        result.code ?? `HTTP${result.status ?? 0}`,
+        result.status
+      );
     }
     return result.data;
   };

--- a/backend/test/spaces-mirror.spec.ts
+++ b/backend/test/spaces-mirror.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import worker from '../src/index';
 import { GRANULAR_SCOPES } from '../src/config/scopes';
 import * as mirror from '../src/services/spaces/mirror';
+import { SpacesClient, type XrpcCall } from '../src/services/spaces/client';
+import { SpaceXrpcError } from '../src/services/spaces/transport';
 
 // Verification criteria 5 and 6 of the atproto Spaces spike:
 //   - with SPACES_SAVES_ENABLED unset, no spaces code runs at all;
@@ -159,6 +161,36 @@ describe('spaces mirror — best effort with the flag on', () => {
     expect(res.body.error).toBe('spaces_unavailable');
   });
 
+  it('creates and caches the personal space when the probe returns SpaceNotFound', async () => {
+    const endpoints: string[] = [];
+    const call: XrpcCall = async <T>(_method, endpoint) => {
+      endpoints.push(endpoint);
+      if (endpoint.startsWith('com.atproto.simplespace.getSpace')) {
+        throw new SpaceXrpcError('No such space', 'SpaceNotFound', 400);
+      }
+      if (endpoint === 'com.atproto.simplespace.createSpace') {
+        return { uri: `at://${DID}/space/app.skyreader.space.saved/self` } as T;
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    };
+    const session = {
+      did: DID,
+      handle: 'sm.bsky.social',
+      pdsUrl: 'https://pds.test',
+      accessToken: 'tok',
+      refreshToken: 'rtok',
+      dpopPrivateKey: JSON.stringify({ kty: 'EC' }),
+      expiresAt: Date.now() + 3_600_000,
+    };
+
+    const expected = `at://${DID}/space/app.skyreader.space.saved/self`;
+    expect(await mirror.ensureSavedSpace(session, new SpacesClient(call))).toBe(expected);
+    expect(endpoints).toHaveLength(2);
+
+    expect(await mirror.ensureSavedSpace(session, new SpacesClient(call))).toBe(expected);
+    expect(endpoints).toHaveLength(2);
+  });
+
   it('caches the capability verdict so an ordinary PDS is probed once, not per save', async () => {
     const session = {
       did: DID,
@@ -170,10 +202,13 @@ describe('spaces mirror — best effort with the flag on', () => {
       expiresAt: Date.now() + 3_600_000,
     };
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-    expect(await mirror.ensureSavedSpace(session)).toBeNull();
-    const afterFirst = fetchSpy.mock.calls.length;
-    expect(await mirror.ensureSavedSpace(session)).toBeNull();
-    expect(fetchSpy.mock.calls.length).toBe(afterFirst);
+    let calls = 0;
+    const unsupported: XrpcCall = async () => {
+      calls++;
+      throw new SpaceXrpcError('Unknown method', 'MethodNotImplemented', 501);
+    };
+    expect(await mirror.ensureSavedSpace(session, new SpacesClient(unsupported))).toBeNull();
+    expect(await mirror.ensureSavedSpace(session, new SpacesClient(unsupported))).toBeNull();
+    expect(calls).toBe(1);
   });
 });

--- a/backend/test/spaces-mirror.spec.ts
+++ b/backend/test/spaces-mirror.spec.ts
@@ -1,0 +1,179 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src/index';
+import { GRANULAR_SCOPES } from '../src/config/scopes';
+import * as mirror from '../src/services/spaces/mirror';
+
+// Verification criteria 5 and 6 of the atproto Spaces spike:
+//   - with SPACES_SAVES_ENABLED unset, no spaces code runs at all;
+//   - with it set but the space unreachable, a save still succeeds and D1 still
+//     holds the row (the mirror is best-effort, D1 is canonical).
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+const DID = 'did:plc:spacesmirror';
+const SESSION = 'sess-spaces-mirror';
+
+async function reset() {
+  await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM sessions WHERE did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM user_settings WHERE user_did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(DID).run();
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url, tier, created_at) VALUES (?, 'sm.bsky.social', 'https://pds.test', 'free', unixepoch())`
+  )
+    .bind(DID)
+    .run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at, granted_scopes)
+     VALUES (?, ?, 'sm.bsky.social', 'https://pds.test', 'tok', 'rtok', ?, ?, ?)`
+  )
+    .bind(SESSION, DID, JSON.stringify({ kty: 'EC' }), Date.now() + 3_600_000, GRANULAR_SCOPES)
+    .run();
+  mirror.clearSpaceCapabilityCache();
+}
+
+function saveRequest(body: unknown) {
+  return new IncomingRequest('http://localhost/api/saved', {
+    method: 'POST',
+    headers: {
+      Cookie: `session_id=${SESSION}`,
+      Origin: env.FRONTEND_URL,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function call(req: Request, overrides: Record<string, string> = {}) {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, { ...env, ...overrides } as typeof env, ctx);
+  await waitOnExecutionContext(ctx);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+function spacesWarnings(warn: { mock: { calls: unknown[][] } }): unknown[][] {
+  return warn.mock.calls.filter((args) => String(args[0]).startsWith('[spaces]'));
+}
+
+const FEED_SAVE = {
+  url: 'https://example.com/spaces-article',
+  rkey: '3lspacesaaaaa',
+  source: 'feed',
+  itemGuid: 'guid-spaces-1',
+  title: 'Spaces article',
+  wordCount: 400,
+};
+
+describe('spaces mirror — flag gate', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does not touch the space path at all when the flag is unset', async () => {
+    // env from wrangler.toml has no SPACES_SAVES_ENABLED, which is the
+    // production shape: the var exists only in .dev.vars.
+    expect((env as { SPACES_SAVES_ENABLED?: string }).SPACES_SAVES_ENABLED).toBeUndefined();
+    expect(mirror.spacesSavesEnabled(env)).toBe(false);
+
+    // The mirror's only observable trace is its own warning, so the absence of
+    // one is the assertion. (Spying on the module's exports wouldn't prove
+    // anything: saved.ts holds a direct binding to mirrorSaveToSpace.)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { status } = await call(saveRequest(FEED_SAVE));
+
+    expect(status).toBe(200);
+    expect(spacesWarnings(warn)).toEqual([]);
+
+    const row = await env.DB.prepare('SELECT rkey FROM saved_articles WHERE user_did = ?')
+      .bind(DID)
+      .first<{ rkey: string }>();
+    expect(row?.rkey).toBe(FEED_SAVE.rkey);
+  });
+
+  it('does reach the space path once the flag is on (the control for the test above)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await call(saveRequest(FEED_SAVE), { SPACES_SAVES_ENABLED: 'true' });
+    expect(spacesWarnings(warn).length).toBeGreaterThan(0);
+  });
+
+  it('leaves the dev read-back route unmounted when the flag is unset', async () => {
+    const res = await call(
+      new IncomingRequest('http://localhost/api/dev/spaces/saved-diff', {
+        headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('spaces mirror — best effort with the flag on', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('still saves, and keeps the D1 row, when the space is unreachable', async () => {
+    // The seeded session carries a placeholder DPoP key, so every PDS call fails
+    // closed — the same shape as a PDS that has never heard of Spaces.
+    const { status, body } = await call(saveRequest(FEED_SAVE), {
+      SPACES_SAVES_ENABLED: 'true',
+    });
+
+    expect(status).toBe(200);
+    expect(body.rkey).toBe(FEED_SAVE.rkey);
+
+    const row = await env.DB.prepare(
+      'SELECT rkey, title FROM saved_articles WHERE user_did = ? AND rkey = ?'
+    )
+      .bind(DID, FEED_SAVE.rkey)
+      .first<{ rkey: string; title: string }>();
+    expect(row?.title).toBe('Spaces article');
+  });
+
+  it('still deletes, and removes the D1 row, when the space is unreachable', async () => {
+    await call(saveRequest(FEED_SAVE), { SPACES_SAVES_ENABLED: 'true' });
+
+    const res = await call(
+      new IncomingRequest(`http://localhost/api/saved/${FEED_SAVE.rkey}`, {
+        method: 'DELETE',
+        headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+      }),
+      { SPACES_SAVES_ENABLED: 'true' }
+    );
+
+    expect(res.status).toBe(200);
+    const row = await env.DB.prepare('SELECT rkey FROM saved_articles WHERE user_did = ?')
+      .bind(DID)
+      .first();
+    expect(row).toBeNull();
+  });
+
+  it('reports spaces_unavailable from the diff route rather than a clean empty diff', async () => {
+    const res = await call(
+      new IncomingRequest('http://localhost/api/dev/spaces/saved-diff', {
+        headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+      }),
+      { SPACES_SAVES_ENABLED: 'true' }
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('spaces_unavailable');
+  });
+
+  it('caches the capability verdict so an ordinary PDS is probed once, not per save', async () => {
+    const session = {
+      did: DID,
+      handle: 'sm.bsky.social',
+      pdsUrl: 'https://pds.test',
+      accessToken: 'tok',
+      refreshToken: 'rtok',
+      dpopPrivateKey: JSON.stringify({ kty: 'EC' }),
+      expiresAt: Date.now() + 3_600_000,
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    expect(await mirror.ensureSavedSpace(session)).toBeNull();
+    const afterFirst = fetchSpy.mock.calls.length;
+    expect(await mirror.ensureSavedSpace(session)).toBeNull();
+    expect(fetchSpy.mock.calls.length).toBe(afterFirst);
+  });
+});

--- a/backend/test/spaces-protocol.spec.ts
+++ b/backend/test/spaces-protocol.spec.ts
@@ -308,8 +308,18 @@ describe('SpacesClient request shapes', () => {
       ) as T;
     };
 
-    const records = await new SpacesClient(call).listAllRecords({ space: SPACE, repo: DID });
-    expect(records.map((r) => r.rkey)).toEqual(['a', 'b']);
+    const listing = await new SpacesClient(call).listAllRecords({ space: SPACE, repo: DID });
+    expect(listing.records.map((r) => r.rkey)).toEqual(['a', 'b']);
+    expect(listing.truncated).toBe(false);
+  });
+
+  it('marks a listing truncated when the page cap stops a pending cursor', async () => {
+    const call: XrpcCall = async <T>() =>
+      ({ records: [{ collection: 'c', rkey: 'a', cid: '1' }], cursor: 'next' }) as T;
+
+    const listing = await new SpacesClient(call).listAllRecords({ space: SPACE, repo: DID }, 1);
+    expect(listing.records).toHaveLength(1);
+    expect(listing.truncated).toBe(true);
   });
 });
 
@@ -321,6 +331,21 @@ describe('transports', () => {
     await expect(call('POST', 'com.atproto.space.createRecord', {})).rejects.toBeInstanceOf(
       SpaceXrpcError
     );
+  });
+
+  it('preserves the structured error code and status from a failed session call', async () => {
+    const call = sessionCall({
+      xrpc: async () => ({
+        success: false as const,
+        error: 'No such space',
+        code: 'SpaceNotFound',
+        status: 400,
+        retryable: false,
+      }),
+    });
+    const error = await call('GET', 'com.atproto.simplespace.getSpace?space=x').catch((e) => e);
+    expect(error).toMatchObject({ code: 'SpaceNotFound', status: 400 });
+    expect(isSpaceNotFound(error)).toBe(true);
   });
 
   it('presents the credential as DPoP on every credential-authed call', async () => {

--- a/backend/test/spaces-protocol.spec.ts
+++ b/backend/test/spaces-protocol.spec.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSpaceDpopProof,
+  generateSpaceDpopKey,
+  jwtExpirySeconds,
+  normalizeHtu,
+} from '../src/services/spaces/dpop';
+import {
+  exchangeSpaceCredential,
+  mintSpaceCredential,
+  getOrMintSpaceCredential,
+  clearCredentialCache,
+  SpaceCredential,
+  SpaceCredentialError,
+} from '../src/services/spaces/credential';
+import {
+  PERSONAL_SPACE_APP_ACCESS,
+  PERSONAL_SPACE_POLICY,
+  SpacesClient,
+  type XrpcCall,
+} from '../src/services/spaces/client';
+import {
+  credentialCall,
+  isSpaceAccessDenied,
+  isSpaceNotFound,
+  sessionCall,
+  SpaceXrpcError,
+} from '../src/services/spaces/transport';
+import { SAVED_SPACE_SKEY, SAVED_SPACE_TYPE, savedSpaceRef } from '../src/services/spaces/refs';
+
+// Wire-level coverage of the Spaces client: the DPoP proofs, the credential
+// exchange, and the exact request shapes we send. Method and parameter names are
+// pinned against @atproto/api@0.0.0-spaces-alpha-20260818163953 — if the alpha
+// renames something, these assertions are what notices.
+
+const DID = 'did:plc:spaceproto';
+const SPACE = savedSpaceRef(DID);
+
+function decodeJwtPart(part: string): Record<string, unknown> {
+  const padded = part.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(padded + '='.repeat((4 - (padded.length % 4)) % 4)));
+}
+
+describe('space DPoP proofs', () => {
+  it('signs an ES256 proof carrying the bare public JWK', async () => {
+    const key = await generateSpaceDpopKey();
+    const proof = await createSpaceDpopProof(key, {
+      htm: 'POST',
+      htu: 'https://pds.test/xrpc/com.atproto.space.createRecord',
+    });
+
+    const [header, payload, signature] = proof.split('.');
+    expect(signature).toBeTruthy();
+
+    const decodedHeader = decodeJwtPart(header) as { typ: string; alg: string; jwk: JsonWebKey };
+    expect(decodedHeader.typ).toBe('dpop+jwt');
+    expect(decodedHeader.alg).toBe('ES256');
+    expect(Object.keys(decodedHeader.jwk).sort()).toEqual(['crv', 'kty', 'x', 'y']);
+    // The private half must never ride along in the proof header.
+    expect((decodedHeader.jwk as Record<string, unknown>).d).toBeUndefined();
+
+    const decodedPayload = decodeJwtPart(payload);
+    expect(decodedPayload.htm).toBe('POST');
+    expect(decodedPayload.jti).toEqual(expect.any(String));
+    expect(decodedPayload.iat).toEqual(expect.any(Number));
+  });
+
+  it('strips query and fragment from htu (RFC 9449 §4.2)', async () => {
+    expect(normalizeHtu('https://pds.test/xrpc/com.atproto.space.listRecords?space=a&repo=b')).toBe(
+      'https://pds.test/xrpc/com.atproto.space.listRecords'
+    );
+
+    const key = await generateSpaceDpopKey();
+    const proof = await createSpaceDpopProof(key, {
+      htm: 'GET',
+      htu: 'https://pds.test/xrpc/com.atproto.space.listRecords?space=a#frag',
+    });
+    expect(decodeJwtPart(proof.split('.')[1]).htu).toBe(
+      'https://pds.test/xrpc/com.atproto.space.listRecords'
+    );
+  });
+
+  it('omits ath when obtaining a credential and includes it when presenting one', async () => {
+    const key = await generateSpaceDpopKey();
+
+    const obtaining = await createSpaceDpopProof(key, { htm: 'POST', htu: 'https://pds.test/x' });
+    expect(decodeJwtPart(obtaining.split('.')[1]).ath).toBeUndefined();
+
+    const presenting = await createSpaceDpopProof(key, {
+      htm: 'POST',
+      htu: 'https://pds.test/x',
+      credential: 'cred-abc',
+    });
+    expect(decodeJwtPart(presenting.split('.')[1]).ath).toEqual(expect.any(String));
+  });
+
+  it('reads exp out of a credential without verifying it', () => {
+    const jwt = `x.${btoa(JSON.stringify({ exp: 1800000000 }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '')}.y`;
+    expect(jwtExpirySeconds(jwt)).toBe(1800000000);
+    expect(jwtExpirySeconds('not-a-jwt')).toBeNull();
+  });
+});
+
+describe('space credential exchange', () => {
+  it('presents the delegation token as Bearer with an ath-less DPoP proof', async () => {
+    const key = await generateSpaceDpopKey();
+    const seen: { url?: string; init?: RequestInit } = {};
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      seen.url = String(url);
+      seen.init = init;
+      return new Response(JSON.stringify({ credential: 'cred-1' }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const credential = await exchangeSpaceCredential({
+      authorityPdsUrl: 'https://pds.test/',
+      delegationToken: 'deleg-1',
+      space: SPACE,
+      key,
+      fetchImpl,
+    });
+
+    expect(credential).toBe('cred-1');
+    expect(seen.url).toBe('https://pds.test/xrpc/com.atproto.space.getSpaceCredential');
+    const headers = seen.init!.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer deleg-1');
+    expect(decodeJwtPart(headers.dpop.split('.')[1]).ath).toBeUndefined();
+    expect(JSON.parse(seen.init!.body as string)).toEqual({ space: SPACE });
+  });
+
+  it('surfaces the alpha error code when the exchange is refused', async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ error: 'UserNotAuthorized', message: 'nope' }), {
+        status: 401,
+      })) as unknown as typeof fetch;
+
+    const error = await exchangeSpaceCredential({
+      authorityPdsUrl: 'https://pds.test',
+      delegationToken: 'deleg-1',
+      space: SPACE,
+      key: await generateSpaceDpopKey(),
+      fetchImpl,
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(SpaceCredentialError);
+    expect(error.code).toBe('UserNotAuthorized');
+    expect(isSpaceAccessDenied(error)).toBe(true);
+  });
+
+  it('mints through both legs and caches until close to expiry', async () => {
+    clearCredentialCache();
+    const exp = Math.floor(Date.now() / 1000) + 7200;
+    const token = `x.${btoa(JSON.stringify({ exp }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '')}.y`;
+
+    const getDelegationToken = vi.fn(async () => 'deleg-1');
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ credential: token }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const input = {
+      space: SPACE,
+      authorityPdsUrl: 'https://pds.test',
+      getDelegationToken,
+      fetchImpl,
+    };
+
+    const first = await getOrMintSpaceCredential(DID, input);
+    const second = await getOrMintSpaceCredential(DID, input);
+
+    expect(second).toBe(first);
+    expect(getDelegationToken).toHaveBeenCalledTimes(1);
+    expect(first.isFresh()).toBe(true);
+    // 2h TTL, read off the token rather than assumed.
+    expect(Math.round((first.expiresAt - Date.now()) / 1000)).toBeGreaterThan(7000);
+  });
+
+  it('re-mints once the cached credential is inside the expiry margin', async () => {
+    clearCredentialCache();
+    const nearlyExpired = Math.floor(Date.now() / 1000) + 5;
+    const token = (exp: number) =>
+      `x.${btoa(JSON.stringify({ exp }))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')}.y`;
+
+    let issued = 0;
+    const fetchImpl = (async () => {
+      issued++;
+      return new Response(
+        JSON.stringify({
+          credential: token(issued === 1 ? nearlyExpired : Math.floor(Date.now() / 1000) + 7200),
+        }),
+        { status: 200 }
+      );
+    }) as unknown as typeof fetch;
+
+    const input = {
+      space: SPACE,
+      authorityPdsUrl: 'https://pds.test',
+      getDelegationToken: async () => 'deleg-1',
+      fetchImpl,
+    };
+
+    const stale = await getOrMintSpaceCredential(DID, input);
+    expect(stale.isFresh()).toBe(false);
+    await getOrMintSpaceCredential(DID, input);
+    expect(issued).toBe(2);
+  });
+
+  it('mints a usable credential that authorizes a request with a bound proof', async () => {
+    const token = 'cred-xyz';
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ credential: token }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    const credential = await mintSpaceCredential({
+      space: SPACE,
+      authorityPdsUrl: 'https://pds.test',
+      getDelegationToken: async () => 'deleg-1',
+      fetchImpl,
+    });
+
+    const headers = await credential.authorize('GET', 'https://pds.test/xrpc/x?y=1');
+    expect(headers.Authorization).toBe(`DPoP ${token}`);
+    expect(decodeJwtPart(headers.DPoP.split('.')[1]).ath).toEqual(expect.any(String));
+  });
+});
+
+describe('SpacesClient request shapes', () => {
+  function recording() {
+    const calls: Array<{ method: string; endpoint: string; body?: unknown }> = [];
+    const call: XrpcCall = async <T>(method: 'GET' | 'POST', endpoint: string, body?: unknown) => {
+      calls.push({ method, endpoint, body });
+      return {} as T;
+    };
+    return { calls, client: new SpacesClient(call) };
+  }
+
+  it('creates a personal space that is member-list private with open app access', async () => {
+    const { calls, client } = recording();
+    await client.createSpace({
+      type: SAVED_SPACE_TYPE,
+      skey: SAVED_SPACE_SKEY,
+      policy: PERSONAL_SPACE_POLICY,
+      appAccess: PERSONAL_SPACE_APP_ACCESS,
+    });
+
+    expect(calls[0]).toEqual({
+      method: 'POST',
+      endpoint: 'com.atproto.simplespace.createSpace',
+      body: {
+        type: 'app.skyreader.space.saved',
+        skey: 'self',
+        policy: { $type: 'com.atproto.simplespace.defs#memberListPolicy' },
+        appAccess: { $type: 'com.atproto.simplespace.defs#open' },
+      },
+    });
+  });
+
+  it('writes and deletes records with the space, repo, collection and rkey', async () => {
+    const { calls, client } = recording();
+    await client.createRecord({
+      space: SPACE,
+      repo: DID,
+      collection: 'app.skyreader.feed.saved',
+      rkey: '3laaaaaaaaaaa',
+      record: { $type: 'app.skyreader.feed.saved', savedAt: '2026-01-01T00:00:00.000Z' },
+    });
+    await client.deleteRecord({
+      space: SPACE,
+      repo: DID,
+      collection: 'app.skyreader.feed.saved',
+      rkey: '3laaaaaaaaaaa',
+    });
+
+    expect(calls[0].endpoint).toBe('com.atproto.space.createRecord');
+    expect(calls[0].body).toMatchObject({ space: SPACE, repo: DID, rkey: '3laaaaaaaaaaa' });
+    expect(calls[1].endpoint).toBe('com.atproto.space.deleteRecord');
+  });
+
+  it('encodes reads as query strings on the GET endpoints', async () => {
+    const { calls, client } = recording();
+    await client.getSpace(SPACE);
+    await client.getDelegationToken(SPACE);
+    await client.listRecords({ space: SPACE, repo: DID, collection: 'app.skyreader.feed.saved' });
+
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].endpoint).toContain('com.atproto.simplespace.getSpace?space=');
+    expect(calls[1].endpoint).toContain('com.atproto.space.getDelegationToken?space=');
+    expect(calls[2].endpoint).toContain('com.atproto.space.listRecords?space=');
+    expect(calls[2].endpoint).toContain('collection=app.skyreader.feed.saved');
+  });
+
+  it('follows the cursor when listing a whole collection', async () => {
+    let page = 0;
+    const call: XrpcCall = async <T>() => {
+      page++;
+      return (
+        page === 1
+          ? { records: [{ collection: 'c', rkey: 'a', cid: '1' }], cursor: 'next' }
+          : { records: [{ collection: 'c', rkey: 'b', cid: '2' }] }
+      ) as T;
+    };
+
+    const records = await new SpacesClient(call).listAllRecords({ space: SPACE, repo: DID });
+    expect(records.map((r) => r.rkey)).toEqual(['a', 'b']);
+  });
+});
+
+describe('transports', () => {
+  it('turns a failed session call into a throw the mirror can swallow', async () => {
+    const call = sessionCall({
+      xrpc: async () => ({ success: false as const, error: 'boom', retryable: false }),
+    });
+    await expect(call('POST', 'com.atproto.space.createRecord', {})).rejects.toBeInstanceOf(
+      SpaceXrpcError
+    );
+  });
+
+  it('presents the credential as DPoP on every credential-authed call', async () => {
+    const credential = new SpaceCredential(
+      'cred-1',
+      await generateSpaceDpopKey(),
+      Date.now() + 60_000
+    );
+    let seenHeaders: Record<string, string> = {};
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      seenHeaders = init!.headers as Record<string, string>;
+      expect(String(url)).toBe('https://host.test/xrpc/com.atproto.space.listRecords?space=x');
+      return new Response(JSON.stringify({ records: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const call = credentialCall('https://host.test/', credential, fetchImpl);
+    await call('GET', 'com.atproto.space.listRecords?space=x');
+
+    expect(seenHeaders.Authorization).toBe('DPoP cred-1');
+    expect(seenHeaders.DPoP).toEqual(expect.any(String));
+  });
+
+  it('classifies the alpha error codes the spike branches on', async () => {
+    const denied = (async () =>
+      new Response(JSON.stringify({ error: 'UserNotAuthorized' }), {
+        status: 403,
+      })) as unknown as typeof fetch;
+    const missing = (async () =>
+      new Response(JSON.stringify({ error: 'SpaceNotFound' }), {
+        status: 400,
+      })) as unknown as typeof fetch;
+
+    const credential = new SpaceCredential(
+      'cred-1',
+      await generateSpaceDpopKey(),
+      Date.now() + 60_000
+    );
+
+    const deniedError = await credentialCall(
+      'https://host.test',
+      credential,
+      denied
+    )('GET', 'com.atproto.space.listRecords?space=x').catch((e) => e);
+    expect(isSpaceAccessDenied(deniedError)).toBe(true);
+    expect(isSpaceNotFound(deniedError)).toBe(false);
+
+    const missingError = await credentialCall(
+      'https://host.test',
+      credential,
+      missing
+    )('GET', 'com.atproto.simplespace.getSpace?space=x').catch((e) => e);
+    expect(isSpaceNotFound(missingError)).toBe(true);
+  });
+});

--- a/backend/test/spaces-record.spec.ts
+++ b/backend/test/spaces-record.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  diffSavedRecords,
+  savedRowToSpaceRecord,
+  type SavedRowForSpace,
+} from '../src/services/spaces/record';
+import {
+  formatSpaceRef,
+  parseSpaceRef,
+  savedSpaceRef,
+  spaceRecordUri,
+  SAVED_COLLECTION,
+} from '../src/services/spaces/refs';
+
+// Phase 1 of the atproto Spaces saves spike: the pure D1-row -> space-record
+// mapping and the drift diff behind the dev read-back route.
+
+const DID = 'did:plc:spacerecord';
+
+function row(overrides: Partial<SavedRowForSpace> = {}): SavedRowForSpace {
+  return {
+    rkey: '3laaaaaaaaaaa',
+    url: 'https://example.com/article',
+    title: 'An article',
+    author: 'A. Writer',
+    description: 'A short summary.',
+    content_type: 'webpage',
+    domain: 'example.com',
+    image: 'https://example.com/hero.png',
+    word_count: 1234,
+    published_at: Date.UTC(2026, 0, 2, 3, 4, 5),
+    saved_at: Date.UTC(2026, 1, 3, 4, 5, 6),
+    source: 'url',
+    item_guid: null,
+    ...overrides,
+  };
+}
+
+describe('savedRowToSpaceRecord', () => {
+  it('maps a full row, converting epoch ms to ISO datetimes', () => {
+    const record = savedRowToSpaceRecord(row());
+
+    expect(record).toEqual({
+      $type: SAVED_COLLECTION,
+      url: 'https://example.com/article',
+      title: 'An article',
+      author: 'A. Writer',
+      description: 'A short summary.',
+      contentType: 'webpage',
+      domain: 'example.com',
+      image: 'https://example.com/hero.png',
+      wordCount: 1234,
+      publishedAt: '2026-01-02T03:04:05.000Z',
+      savedAt: '2026-02-03T04:05:06.000Z',
+      source: 'url',
+    });
+  });
+
+  it('omits null and empty fields entirely rather than emitting nulls', () => {
+    const record = savedRowToSpaceRecord(
+      row({
+        title: null,
+        author: '',
+        description: '   ',
+        image: null,
+        word_count: null,
+        published_at: null,
+        item_guid: null,
+      })
+    );
+
+    expect(Object.keys(record).sort()).toEqual(
+      ['$type', 'contentType', 'domain', 'savedAt', 'source', 'url'].sort()
+    );
+    expect('title' in record).toBe(false);
+    expect('publishedAt' in record).toBe(false);
+  });
+
+  it('never carries the article body — content is not even an input', () => {
+    // The row type has no `content`, so a body cannot reach the record by
+    // accident. Belt and braces: an extra property on the row is ignored.
+    const withBody = { ...row(), content: '<p>The whole article</p>' } as SavedRowForSpace;
+    const record = savedRowToSpaceRecord(withBody) as Record<string, unknown>;
+
+    expect(record.content).toBeUndefined();
+    expect(JSON.stringify(record)).not.toContain('The whole article');
+  });
+
+  it('drops junk timestamps instead of emitting an invalid datetime', () => {
+    const record = savedRowToSpaceRecord(row({ published_at: Number.NaN }));
+    expect('publishedAt' in record).toBe(false);
+  });
+
+  it('falls back to now when saved_at is unusable, since savedAt is required', () => {
+    const record = savedRowToSpaceRecord(row({ saved_at: Number.POSITIVE_INFINITY }));
+    expect(() => new Date(record.savedAt).toISOString()).not.toThrow();
+    expect(Number.isNaN(new Date(record.savedAt).getTime())).toBe(false);
+  });
+
+  it('keeps a share save with no URL valid', () => {
+    const record = savedRowToSpaceRecord(row({ url: '', source: 'share', content_type: 'share' }));
+    expect('url' in record).toBe(false);
+    expect(record.source).toBe('share');
+    expect(record.savedAt).toBeTruthy();
+  });
+
+  it('rounds a fractional word count and drops a negative one', () => {
+    expect(savedRowToSpaceRecord(row({ word_count: 10.6 })).wordCount).toBe(11);
+    expect('wordCount' in savedRowToSpaceRecord(row({ word_count: -1 }))).toBe(false);
+  });
+});
+
+describe('space refs', () => {
+  it('formats and parses the alpha space-ref shape', () => {
+    const ref = savedSpaceRef(DID);
+    expect(ref).toBe(`at://${DID}/space/app.skyreader.space.saved/self`);
+
+    const parsed = parseSpaceRef(ref);
+    expect(parsed).toEqual({
+      authority: DID,
+      type: 'app.skyreader.space.saved',
+      skey: 'self',
+      uri: ref,
+    });
+  });
+
+  it('rejects a plain record at-uri', () => {
+    expect(parseSpaceRef(`at://${DID}/app.skyreader.feed.saved/3laaaaaaaaaaa`)).toBeNull();
+    expect(parseSpaceRef('not-a-uri')).toBeNull();
+  });
+
+  it('addresses a record inside a space', () => {
+    expect(spaceRecordUri(formatSpaceRef(DID, 'x.y.z', 'self'), DID, SAVED_COLLECTION, 'r1')).toBe(
+      `at://${DID}/space/x.y.z/self/${DID}/${SAVED_COLLECTION}/r1`
+    );
+  });
+});
+
+describe('diffSavedRecords', () => {
+  it('reports nothing when the mirror matches D1', () => {
+    const rows = [row({ rkey: 'a' }), row({ rkey: 'b', url: 'https://example.com/b' })];
+    const records = rows.map((r) => ({
+      rkey: r.rkey,
+      value: savedRowToSpaceRecord(r) as unknown as Record<string, unknown>,
+    }));
+
+    expect(diffSavedRecords(rows, records)).toEqual({
+      onlyInD1: [],
+      onlyInSpace: [],
+      mismatched: [],
+    });
+  });
+
+  it('reports a save the mirror never got', () => {
+    const rows = [row({ rkey: 'a' }), row({ rkey: 'b' })];
+    const records = [
+      { rkey: 'a', value: savedRowToSpaceRecord(rows[0]) as unknown as Record<string, unknown> },
+    ];
+
+    const diff = diffSavedRecords(rows, records);
+    expect(diff.onlyInD1).toEqual(['b']);
+    expect(diff.onlyInSpace).toEqual([]);
+  });
+
+  it('reports a record left behind by a delete that never propagated', () => {
+    const diff = diffSavedRecords([], [{ rkey: 'ghost', value: { $type: SAVED_COLLECTION } }]);
+    expect(diff.onlyInSpace).toEqual(['ghost']);
+  });
+
+  it('reports the field that drifted — e.g. a content upgrade the mirror skipped', () => {
+    const r = row({ rkey: 'a', word_count: 900 });
+    const stale = savedRowToSpaceRecord(row({ rkey: 'a', word_count: 100 }));
+
+    const diff = diffSavedRecords(
+      [r],
+      [{ rkey: 'a', value: stale as unknown as Record<string, unknown> }]
+    );
+
+    expect(diff.mismatched).toEqual([{ rkey: 'a', field: 'wordCount', d1: 900, space: 100 }]);
+  });
+});

--- a/docs/plans/SPACES_SAVES_SPIKE.md
+++ b/docs/plans/SPACES_SAVES_SPIKE.md
@@ -1,0 +1,137 @@
+# Spike: saved articles on atproto Spaces
+
+**Status:** spike, flag-gated off. Not a decision to ship.
+**Flag:** `SPACES_SAVES_ENABLED` (`.dev.vars` only — absent from `wrangler.toml`).
+**Protocol findings:** [`experiments/spaces-saves/FINDINGS.md`](../../experiments/spaces-saves/FINDINGS.md)
+
+## Why
+
+Skyreader's saves sit in two corners of a quadrant, and the interesting one is
+empty:
+
+|                           | Private                         | Public                           |
+| ------------------------- | ------------------------------- | -------------------------------- |
+| **Skyreader-only**        | D1 `saved_articles` (canonical) | —                                |
+| **Portable (Atmosphere)** | **nothing — this is the gap**   | Semble / Margin external backing |
+
+Saves live only in D1. The old `app.skyreader.feed.saved` PDS export was removed
+because a public repo made every save publicly visible, which is why the copy
+rules say never to claim saves live on the PDS. The one portability path today is
+external backing, and it makes the whole Saved list a _public_ foreign
+collection.
+
+[atproto Spaces](https://atproto.com/blog/atproto-spaces-alpha) is non-public data
+on the protocol: records in per-space permissioned repos on the author's PDS,
+gated by a space authority and a membership policy. That is exactly the missing
+quadrant. This spike stores saved-article records in a personal space to find out
+whether it's real.
+
+## Shape
+
+One personal space per user, owned by the user:
+
+- **Authority** = the user's own DID; the space is hosted on their PDS.
+- **Space ref** `at://{did}/space/app.skyreader.space.saved/self` — derivable
+  from the DID, so no lookup table.
+- **Policy** `#memberListPolicy` (private to its owner, who is a member by
+  construction) with `appAccess: #open` for the spike.
+- **Records** in `app.skyreader.feed.saved` — the retired collection name, which
+  inside a permissioned repo finally means what it says. **Metadata only**: the
+  article body stays in D1, same content split the removed export observed.
+- **rkey identical to the D1 rkey**, so the mapping between the stores is
+  implicit and no migration is needed.
+- **D1 stays canonical.** The space is a best-effort mirror written under
+  `ctx.waitUntil`. A space failure never fails a save.
+
+## What was built
+
+| Piece                                                                                     | Where                                                                          |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Protocol lifecycle experiment (11 checks, incl. outsider-denial and the portability read) | `experiments/spaces-saves/`                                                    |
+| Record lexicon (metadata-only) + the OAuth permission set                                 | `backend/lexicons/app/skyreader/feed/saved.json`, `.../space/savedAccess.json` |
+| Space refs, record mapping, DPoP, credential flow, XRPC client, transports                | `backend/src/services/spaces/`                                                 |
+| Flag gate, capability probe, mirror hooks                                                 | `backend/src/services/spaces/mirror.ts`                                        |
+| Dual-write on save/delete                                                                 | `backend/src/routes/saved.ts`                                                  |
+| Dev read-back diff                                                                        | `GET /api/dev/spaces/saved-diff` (`backend/src/routes/dev-spaces.ts`)          |
+| Tests                                                                                     | `backend/test/spaces-{record,protocol,mirror}.spec.ts`                         |
+
+The backend takes no `@atproto/*` dependency: the alpha SDK assumes Node, and the
+Worker already hand-rolls its XRPC. The Node experiment imports the _same_
+modules, so Phase 0 exercises the code Phases 1–3 ship rather than a parallel
+implementation.
+
+## What the alpha turned out to be
+
+Three findings changed the plan (details and citations in FINDINGS.md):
+
+1. **Writing to your own repo in a space needs no space credential** — plain
+   session auth against your own PDS. So the mirror is an ordinary authenticated
+   XRPC POST. The credential flow (delegation → credential → DPoP, 2 round trips,
+   2h reusable credential) is needed only for reading a space from somewhere that
+   isn't the author's session — which is precisely the portability proof.
+2. **There is no `space:` OAuth scope.** Access is requested as
+   `include:<nsid>` naming a **permission-set lexicon**. Ours is committed as
+   `app.skyreader.space.savedAccess`, and is deliberately _not_ requested by the
+   live OAuth flow.
+3. **`createSpace` takes no member list** — policy and app access only, membership
+   afterwards. A personal space needs no `addMember` call.
+
+## Demo checklist
+
+Start from an account with **backing off** (a backed save skips the mirror by
+design, so the space would look broken).
+
+1. Run a spaces PDS: `docker run -p 2583:2583 ghcr.io/bluesky-social/atproto:pds-spaces-alpha`.
+2. `cd experiments/spaces-saves && SPACES_PDS_URL=http://localhost:2583 npm run lifecycle`
+   — 11/11 is the gate. If the outsider is _not_ denied, stop the spike.
+3. Add `SPACES_SAVES_ENABLED=true` to `backend/.dev.vars`, point a session at the
+   spaces PDS, and `./scripts/dev-local.sh`.
+4. Save an article in the reader; delete another.
+5. `GET /api/dev/spaces/saved-diff` → `inSync: true`.
+6. Read the same record back with the Phase 0 script's credential path — a second
+   client, its own credentials, the same data. That is the portability claim,
+   demonstrated outside Skyreader.
+
+## Recommendation
+
+**(c) too early to ship — revisit at beta, and revisit as option (a).**
+
+The protocol fits the gap better than expected, and the integration cost is lower
+than the plan assumed: writes are ordinary session-authed XRPC, records map to D1
+rows one-to-one, and the whole path is one env var wide. Nothing about the design
+argues against it.
+
+Everything blocking is operational:
+
+- **No user can use it.** No production PDS implements Spaces. Until PDS coverage
+  is real, a user-facing "private Atmospheric backup" toggle would be a switch
+  that fails for every account.
+- **Alpha terms forbid it.** Weekly breaking changes, no backups, destructive
+  migrations, the sandbox is deleted at the end of the alpha, production use
+  explicitly prohibited.
+- **Best-effort mirroring drifts.** Acceptable for a spike because D1 is canonical
+  and `saved-diff` makes drift visible; a ship needs a reconciliation job (cf.
+  `RETENTION_SYNC_PLAN.md`) and a backfill of existing saves.
+
+When it does land, it should land as **(a) a third backing option — "private
+Atmospheric backup" — alongside Semble and Margin**, not as (b) the canonical
+store. Backing is already the concept "your saves also live somewhere portable";
+Spaces adds the private variant of it, and the settings surface, the enable/
+disable flow, and the user's mental model all exist. Making the space canonical
+would mean betting the Saved list on an alpha protocol for no reader-visible gain.
+
+Before any user-facing ship:
+
+- request `include:app.skyreader.space.savedAccess` in `config/scopes.ts` and the
+  client metadata — kept out of `GRANULAR_SCOPES` so it doesn't force existing
+  users through re-auth, and checked against the scope-string reconstruction on
+  the refresh path;
+- switch `appAccess` from `#open` to `#allowList` pinned to Skyreader's
+  `client_id` per environment;
+- a reconciliation job plus a backfill of existing saves;
+- decide the interaction with external backing (both on at once?);
+- and update the CLAUDE.md copy rule. Today "saves never live on the PDS" is
+  exactly true. A shipped space mirror makes saves live in a _permissioned_ repo
+  on the PDS — still not public, still not the public repo the old export used.
+  The copy would need to say that precisely, or it will read as the thing we
+  removed.

--- a/experiments/spaces-saves/FINDINGS.md
+++ b/experiments/spaces-saves/FINDINGS.md
@@ -145,6 +145,10 @@ Not measurable without a live PDS. A live run should record:
 - whether `getDelegationToken` is issued to any session (as our fake assumes) or
   gated on membership — that determines whether "outsider denied" fails at leg 1
   or leg 2.
+- whether a permission set accepts `authority: "*"`. The reference app uses a
+  fixed authority, but Skyreader's personal-space authority is each user's DID;
+  rejection would make the proposed `include:app.skyreader.space.savedAccess`
+  scope require a different permission shape.
 
 ## Alpha operational reality
 

--- a/experiments/spaces-saves/FINDINGS.md
+++ b/experiments/spaces-saves/FINDINGS.md
@@ -1,0 +1,170 @@
+# Findings: atproto Spaces, as of the alpha
+
+Phase 0 of the saved-articles spike. What the alpha's API surface actually is,
+where it diverges from proposal 0016, and what it costs to use.
+
+**Status of these findings.** Everything below marked _observed_ was read off the
+published alpha artifacts — the SDK's generated lexicon types and the reference
+app's client code — at the pinned versions in the next section. Everything marked
+_unverified_ needs a run of `npm run lifecycle` against a real spaces PDS, which
+has not happened yet: this environment has no Docker and no BPS invite, and
+`@atproto/pds@alpha` will not resolve here. The harness is written and green
+against an in-process fake (`npm run lifecycle:fake`, 11/11), so the live run is
+a protocol question, not a "does the script work" question.
+
+## Pinned versions
+
+| Artifact         | Version / ref                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| `@atproto/api`   | `0.0.0-spaces-alpha-20260818163953` (npm tag `alpha`)                                             |
+| `@atproto/space` | `0.0.0-spaces-alpha-20260818163953`                                                               |
+| `@atproto/pds`   | `0.0.0-spaces-alpha-20260818163953`                                                               |
+| Reference app    | `bluesky-social/bulletin`, `main`, read 2026-08-23                                                |
+| Proposal         | `bluesky-social/proposals` `0016-permissioned-data`                                               |
+| PDS image        | `ghcr.io/bluesky-social/atproto:pds-spaces-alpha` (digest not pinned — fill in on first live run) |
+
+The alpha updates on Thursdays with breaking changes, so treat every shape below
+as accurate for that snapshot and nothing later.
+
+## The API surface, as implemented _(observed)_
+
+Two namespaces, not one:
+
+**`com.atproto.simplespace.*`** — the space authority. Session-authed, called on
+the authority's own PDS.
+
+| Method                        | Input                              | Output / notes                                                                                                               |
+| ----------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `createSpace`                 | `{type, skey?, policy, appAccess}` | `{uri}`. `skey` auto-generates a TID when omitted. Errors: `SpaceAlreadyExists`, `UnsupportedPolicy`, `UnsupportedAppAccess` |
+| `getSpace`                    | `?space=`                          | `{uri, policy, appAccess}`. Error: `SpaceNotFound`                                                                           |
+| `updateSpace` / `deleteSpace` | `{space, …}`                       | —                                                                                                                            |
+| `addMember` / `removeMember`  | `{space, did}`                     | Errors: `SpaceNotFound`, `NotSpaceOwner`                                                                                     |
+| `listMembers`                 | `?space=`                          | —                                                                                                                            |
+| `checkUserAccess`             | `?space=&user=&clientId=`          | `{authorized}` — the callback a `managingApp` policy makes _to the app_                                                      |
+
+Policies are `$type`-tagged unions in `com.atproto.simplespace.defs`:
+`#publicPolicy`, `#memberListPolicy` (default), `#managingAppPolicy{managingApp}`.
+App access: `#open` or `#allowList{allowed: string[]}` — evaluated against the
+attested OAuth `client_id`.
+
+**`com.atproto.space.*`** — the permissioned repo.
+
+| Method                                                                                         | Input                                                                                   |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `createRecord`                                                                                 | `{space, repo, collection, rkey?, validate?, record}` → `{uri, cid, validationStatus?}` |
+| `putRecord` / `deleteRecord` / `applyWrites`                                                   | `{space, repo, collection, rkey, …}`                                                    |
+| `getRecord`                                                                                    | `?space=&repo=&collection=&rkey=`                                                       |
+| `listRecords`                                                                                  | `?space=&repo=&collection?&limit?&cursor?&reverse?&excludeValues?`                      |
+| `getDelegationToken`                                                                           | `?space=` → `{token}`                                                                   |
+| `getSpaceCredential`                                                                           | `{space, clientAttestation?}` → `{credential}`                                          |
+| `listRepoOps`, `getLatestCommit`, `getRepo`, `listRepos`, `listSpaces`, `getBlob`, `listBlobs` | sync/read surface                                                                       |
+| `registerNotify`, `unregisterNotify`, `notifyWrite`, `notifySpaceDeleted`                      | push-style sync                                                                         |
+
+Error codes worth branching on: `SpaceNotFound`, `SpaceDeleted`,
+`UserNotAuthorized`, `AppNotAuthorized`, `NotAuthorized`,
+`InvalidDelegationToken`, `InvalidClientAttestation`, `RecordAlreadyExists`,
+`RecordNotFound`, plus the repo-state family (`RepoNotFound`, `RepoTakendown`,
+`RepoSuspended`, `RepoDeactivated`).
+
+Space refs are `at://{authorityDid}/space/{type}/{skey}` (string format
+`space-ref`); a record inside one is
+`at://{authorityDid}/space/{type}/{skey}/{authorDid}/{collection}/{rkey}`.
+
+## Where the implementation differs from what the plan assumed
+
+1. **Writing to your own repo needs no credential at all.** _(observed)_ The plan
+   (following proposal 0016) assumed every space call rides a space credential.
+   The reference app calls `com.atproto.space.createRecord` with the ordinary
+   OAuth session client against the user's own PDS. Credentials are for reading a
+   space from somewhere that isn't the author's authenticated session — i.e.
+   cross-host sync and other members' repos.
+
+   **This is the single biggest finding for us.** A personal-space mirror of D1
+   saves is a plain authenticated XRPC POST — the existing `PDSClient` shape, no
+   new auth machinery on the write path. The credential flow is only needed for
+   the thing that makes the spike interesting: proving a _different_ client can
+   read the data.
+
+2. **There is no `space:` OAuth scope.** _(observed)_ The plan expected
+   `space:<spaceType>?authority=…`. What the reference app actually requests is
+   `include:my.bulletin.permissions` — an NSID naming a **permission-set
+   lexicon** whose entries are `{type: permission, resource: "space", spaceType,
+authority, skey, collection[], action[], manage[]}`. Our equivalent is
+   committed as `app.skyreader.space.savedAccess`.
+
+3. **The space type needs no lexicon document.** _(observed)_ It is just an NSID.
+   The reference app ships none for `my.bulletin.board`.
+
+4. **`createSpace` takes no member list.** _(observed)_ Policy and app-access
+   only; membership is managed afterwards via `addMember`. For a personal space
+   (authority = the user) the owner is a member by construction, so the spike
+   never calls `addMember` — **`ensureSavedSpace` assumes this**, and it is the
+   first thing a live run should confirm.
+
+5. **The credential exchange presents the delegation as `Bearer`, not `DPoP`.**
+   _(observed)_ Leg 2 sends `Authorization: Bearer <delegation>` plus a DPoP proof
+   from a fresh key; the returned credential is bound to that key via `cnf.jkt`,
+   and legs 3+ send `Authorization: DPoP <credential>`.
+
+## Token lifetimes and round-trip cost _(observed from `@atproto/space`)_
+
+`SPACE_TOKEN_TYPES` in `dist/credential.d.ts`:
+
+| Token              | `typ`                            | TTL   | Single use | DPoP-bound               |
+| ------------------ | -------------------------------- | ----- | ---------- | ------------------------ |
+| delegation         | `atproto-space-delegation+jwt`   | 60s   | yes        | no                       |
+| **credential**     | `atproto-space-credential+jwt`   | 7200s | no         | yes (`cnf.jkt` required) |
+| client attestation | `atproto-client-attestation+jwt` | 60s   | yes        | no                       |
+
+So a cold credential costs **two round trips**, and then two hours of reuse. Clock
+skew allowance is 5s; a DPoP proof is valid for 60s.
+
+That 2h/reusable shape is what makes an in-memory, per-isolate cache the right
+call for Workers (`services/spaces/credential.ts`): a cold isolate re-mints, and
+we never write the bound private key to D1. Persisting the key would turn a
+two-hour token into durable stored key material for an alpha protocol.
+
+DPoP proof details (`dist/dpop.js`): ES256 only; `htu` is normalized to
+origin+path, so one proof covers any query string; `ath` is
+`base64url(sha256(credential))` and **must be omitted** on the leg that obtains a
+credential.
+
+## Latency, size limits, sync — _unverified_
+
+Not measurable without a live PDS. A live run should record:
+
+- wall-clock for each leg of the credential flow (the script prints it);
+- whether `validate` defaults to validating known lexicons, and what
+  `validationStatus` comes back as for `app.skyreader.feed.saved` once the
+  lexicon is resolvable;
+- the record size ceiling (our records are metadata-only and ~300–600 bytes, so
+  this is about headroom, not risk);
+- whether `listRepoOps` / `getLatestCommit` give a usable incremental cursor for a
+  future reconciliation job, and whether `registerNotify` is reachable from
+  Workers at all;
+- whether `getDelegationToken` is issued to any session (as our fake assumes) or
+  gated on membership — that determines whether "outsider denied" fails at leg 1
+  or leg 2.
+
+## Alpha operational reality
+
+No backups, destructive migrations, weekly breaking changes, the sandbox PDS gets
+deleted at the end of the alpha, and production use is explicitly prohibited. No
+production PDS — bsky.social or otherwise — implements Spaces today. That is why
+`SPACES_SAVES_ENABLED` exists only in `.dev.vars` and why the capability probe
+caches its negative verdict.
+
+## Out of scope, deliberately
+
+- **Backed saves** (Semble/Margin). Backing already makes a save portable and
+  public; layering a private space mirror on top is a product question, not a
+  protocol one. A tester with backing on sees an empty space — start from an
+  account with backing off.
+- **Content updates** (`handleContentUpdate` / `handleUpdateSaved`). The space
+  record is metadata-only, so what a content upgrade changes is mostly the body.
+  The residual drift (a stale `wordCount` or `title`) shows up in the dev
+  `saved-diff` route as `mismatched`, which is the honest way to carry it: the
+  fix is a reconciliation pass, not more write hooks.
+- **The OAuth flow.** The spike does not touch `config/scopes.ts`. Adding an
+  alpha `include:` scope would push every existing user through re-auth and risks
+  the scope-string reconstruction on the refresh path.

--- a/experiments/spaces-saves/README.md
+++ b/experiments/spaces-saves/README.md
@@ -1,0 +1,61 @@
+# experiments/spaces-saves
+
+Phase 0 of the atproto Spaces saved-articles spike: the protocol lifecycle in
+isolation, before any of it is trusted by the app. Findings live in
+[FINDINGS.md](FINDINGS.md); the product decision lives in
+[`docs/plans/SPACES_SAVES_SPIKE.md`](../../docs/plans/SPACES_SAVES_SPIKE.md).
+
+## Run it
+
+```bash
+cd experiments/spaces-saves
+
+# Against a real spaces-capable PDS (this is the run that produces findings)
+SPACES_PDS_URL=http://localhost:2583 npm run lifecycle
+
+# Harness self-test against an in-process fake — no PDS, no network
+npm run lifecycle:fake
+```
+
+To get a real PDS, either:
+
+- run `docker run -p 2583:2583 ghcr.io/bluesky-social/atproto:pds-spaces-alpha`
+  (pin the digest and record it in FINDINGS.md), or
+- get an invite from your BPS account for the hosted alpha PDS and pass
+  `SPACES_PDS_URL=<alpha pds> SPACES_INVITE_CODE=<code>`.
+
+The script creates two throwaway accounts (an owner and an outsider), so point it
+only at a sandbox.
+
+## What it checks
+
+11 checks, in three groups. The two that decide the spike:
+
+- **privacy** — the outsider is denied both a direct read and a space credential.
+  If either succeeds, the "private and portable" claim is false and the spike
+  should stop.
+- **portability** — a client holding nothing but a minted credential (no session,
+  no cookie) reads the saved record back out of the space.
+
+The rest cover create → get → list → delete and the credential round-trip cost.
+
+## No SDK
+
+The script imports the backend's own modules under
+`backend/src/services/spaces/` rather than `@atproto/*@alpha`. The backend runs
+on Workers and can't take the alpha SDK (it assumes Node), so the wire code has
+to be hand-rolled regardless — and a Phase 0 that exercises different code from
+Phases 1–3 would prove nothing about them. `ts-resolve.mjs` is the small hook
+that lets Node import those extensionless TypeScript imports directly.
+
+Node ≥ 22.18 (type stripping on by default). Node prints a
+`MODULE_TYPELESS_PACKAGE_JSON` warning for the backend sources — harmless.
+
+## `--fake` is a harness test, not a protocol result
+
+`fake-pds.mjs` is our own reading of the alpha's behaviour. It verifies real
+ES256 DPoP proofs (including the `cnf.jkt` binding and the "no `ath` when
+obtaining a credential" rule) and enforces the member list, so a green run means
+the client code, the credential flow, and the script's assertions all work. It
+says nothing about what the real implementation does. Never quote a `--fake` run
+as a finding.

--- a/experiments/spaces-saves/fake-pds.mjs
+++ b/experiments/spaces-saves/fake-pds.mjs
@@ -1,0 +1,313 @@
+/**
+ * An in-process stand-in for a spaces-capable PDS, used by `lifecycle.mjs --fake`.
+ *
+ * READ THIS BEFORE TRUSTING A GREEN RUN: this is our own reading of the alpha,
+ * so a passing `--fake` run says nothing about how the real implementation
+ * behaves. What it *does* prove is that the harness works — the client's request
+ * shapes, the three-leg credential flow, the DPoP proofs (verified here with
+ * WebCrypto, against the key the credential's `cnf.jkt` names), the record
+ * mapping, and the fact that the script's privacy assertions actually fire. It
+ * turns the live run against a real PDS into a protocol question rather than a
+ * "does my script work" question.
+ *
+ * Implements only what the lifecycle touches:
+ *   com.atproto.server.{createAccount,createSession}
+ *   com.atproto.simplespace.{createSpace,getSpace}
+ *   com.atproto.space.{getDelegationToken,getSpaceCredential,
+ *                      createRecord,getRecord,listRecords,deleteRecord}
+ */
+
+const enc = new TextEncoder();
+
+function b64url(bytes) {
+  return Buffer.from(bytes).toString('base64url');
+}
+function b64urlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+function decodeJwt(jwt) {
+  const [header, payload] = jwt.split('.');
+  return {
+    header: JSON.parse(Buffer.from(header, 'base64url').toString()),
+    payload: JSON.parse(Buffer.from(payload, 'base64url').toString()),
+  };
+}
+
+async function sha256b64url(input) {
+  return b64url(new Uint8Array(await crypto.subtle.digest('SHA-256', enc.encode(input))));
+}
+
+/** RFC 7638 thumbprint of an EC public JWK. */
+async function jkt(jwk) {
+  const canonical = JSON.stringify({ crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y });
+  return b64url(new Uint8Array(await crypto.subtle.digest('SHA-256', enc.encode(canonical))));
+}
+
+/** Verify a DPoP proof the way the alpha's `verifyDpopProof` does. */
+async function verifyDpopProof(proof, { htm, htu, credential, expectedJkt }) {
+  const [header, payload, signature] = proof.split('.');
+  const { header: h, payload: p } = decodeJwt(proof);
+  if (h.typ !== 'dpop+jwt' || h.alg !== 'ES256') throw error('BadDpopProof', 'bad proof header');
+
+  const key = await crypto.subtle.importKey(
+    'jwk',
+    { ...h.jwk, ext: true },
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify']
+  );
+  const valid = await crypto.subtle.verify(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    key,
+    Buffer.from(signature, 'base64url'),
+    enc.encode(`${header}.${payload}`)
+  );
+  if (!valid) throw error('BadDpopProofSignature', 'proof signature does not verify');
+  if (p.htm !== htm) throw error('BadDpopProof', 'htm mismatch');
+
+  const normalized = new URL(htu);
+  if (p.htu !== normalized.origin + normalized.pathname) {
+    throw error('BadDpopProof', `htu mismatch: ${p.htu}`);
+  }
+  if (Math.abs(Math.floor(Date.now() / 1000) - p.iat) > 60) {
+    throw error('DpopProofExpired', 'iat outside the 60s window');
+  }
+  if (credential === undefined) {
+    if (p.ath !== undefined) throw error('BadDpopProof', 'ath must be omitted when obtaining');
+  } else if (p.ath !== (await sha256b64url(credential))) {
+    throw error('BadDpopProof', 'ath does not match the credential');
+  }
+
+  const thumbprint = await jkt(h.jwk);
+  if (expectedJkt !== undefined && thumbprint !== expectedJkt) {
+    throw error('DpopKeyMismatch', 'proof is not signed by the bound key');
+  }
+  return thumbprint;
+}
+
+function error(code, message) {
+  const e = new Error(message);
+  e.xrpcError = code;
+  return e;
+}
+
+export function createFakePds(origin = 'https://fake-spaces-pds.test') {
+  const accounts = new Map(); // handle -> {did, password, accessJwt}
+  const sessions = new Map(); // accessJwt -> did
+  const spaces = new Map(); // spaceUri -> {authority, policy, appAccess, members:Set}
+  const repos = new Map(); // `${space}|${did}|${collection}` -> Map<rkey, value>
+  const delegations = new Map(); // token -> {did, space, used}
+  const credentials = new Map(); // credential -> {did, space, jkt, exp}
+
+  let counter = 0;
+  const next = () => `${++counter}`;
+
+  function requireSession(headers) {
+    const auth = headers.get('authorization') ?? '';
+    const did = auth.startsWith('Bearer ') ? sessions.get(auth.slice(7)) : undefined;
+    if (!did) throw error('AuthRequired', 'no session');
+    return did;
+  }
+
+  function requireSpace(uri) {
+    const space = spaces.get(uri);
+    if (!space) throw error('SpaceNotFound', `no such space: ${uri}`);
+    return space;
+  }
+
+  function assertMember(space, did) {
+    if (!space.members.has(did)) throw error('UserNotAuthorized', 'not a member of this space');
+  }
+
+  /** Space access via either a session (own repo) or a space credential. */
+  async function authorize(request, url, spaceUri) {
+    const auth = request.headers.get('authorization') ?? '';
+    const space = requireSpace(spaceUri);
+
+    if (auth.startsWith('DPoP ')) {
+      const token = auth.slice(5);
+      const record = credentials.get(token);
+      if (!record) throw error('InvalidCredential', 'unknown credential');
+      if (record.space !== spaceUri)
+        throw error('NotAuthorized', 'credential is for another space');
+      if (record.exp * 1000 < Date.now()) throw error('InvalidCredential', 'credential expired');
+      await verifyDpopProof(request.headers.get('dpop') ?? '', {
+        htm: request.method,
+        htu: url.toString(),
+        credential: token,
+        expectedJkt: record.jkt,
+      });
+      assertMember(space, record.did);
+      return record.did;
+    }
+
+    const did = requireSession(request.headers);
+    assertMember(space, did);
+    return did;
+  }
+
+  const handlers = {
+    'com.atproto.server.createAccount': async (_req, _url, body) => {
+      if (accounts.has(body.handle)) throw error('HandleNotAvailable', 'taken');
+      const did = `did:plc:fake${next()}`;
+      accounts.set(body.handle, { did, password: body.password });
+      return { did, handle: body.handle };
+    },
+
+    'com.atproto.server.createSession': async (_req, _url, body) => {
+      const account = accounts.get(body.identifier);
+      if (!account || account.password !== body.password) {
+        throw error('AuthenticationRequired', 'bad credentials');
+      }
+      const accessJwt = `access-${next()}`;
+      sessions.set(accessJwt, account.did);
+      return { did: account.did, handle: body.identifier, accessJwt, refreshJwt: 'refresh' };
+    },
+
+    'com.atproto.simplespace.createSpace': async (req, _url, body) => {
+      const did = requireSession(req.headers);
+      const uri = `at://${did}/space/${body.type}/${body.skey ?? next()}`;
+      if (spaces.has(uri)) throw error('SpaceAlreadyExists', 'already exists');
+      spaces.set(uri, {
+        authority: did,
+        policy: body.policy,
+        appAccess: body.appAccess,
+        // The owner of a personal space is a member by construction.
+        members: new Set([did]),
+      });
+      return { uri };
+    },
+
+    'com.atproto.simplespace.getSpace': async (req, url) => {
+      requireSession(req.headers);
+      const uri = url.searchParams.get('space');
+      const space = requireSpace(uri);
+      return { uri, policy: space.policy, appAccess: space.appAccess };
+    },
+
+    'com.atproto.space.getDelegationToken': async (req, url) => {
+      const did = requireSession(req.headers);
+      const uri = url.searchParams.get('space');
+      requireSpace(uri);
+      // Note: issued to anyone with a session. The *credential* exchange is
+      // where membership is enforced.
+      const token = `deleg-${next()}`;
+      delegations.set(token, { did, space: uri, exp: Math.floor(Date.now() / 1000) + 60 });
+      return { token };
+    },
+
+    'com.atproto.space.getSpaceCredential': async (req, url, body) => {
+      const auth = req.headers.get('authorization') ?? '';
+      if (!auth.startsWith('Bearer ')) throw error('InvalidDelegationToken', 'expected Bearer');
+      const delegation = delegations.get(auth.slice(7));
+      if (!delegation) throw error('InvalidDelegationToken', 'unknown delegation token');
+      delegations.delete(auth.slice(7)); // single use
+      if (delegation.exp * 1000 < Date.now()) {
+        throw error('InvalidDelegationToken', 'delegation expired');
+      }
+      if (delegation.space !== body.space) {
+        throw error('InvalidDelegationToken', 'delegation is for another space');
+      }
+
+      const space = requireSpace(body.space);
+      assertMember(space, delegation.did);
+
+      const thumbprint = await verifyDpopProof(req.headers.get('dpop') ?? '', {
+        htm: 'POST',
+        htu: url.toString(),
+      });
+      const exp = Math.floor(Date.now() / 1000) + 7200;
+      const credential = `${b64urlJson({ typ: 'atproto-space-credential+jwt', alg: 'ES256' })}.${b64urlJson(
+        { iss: space.authority, sub: delegation.did, exp, cnf: { jkt: thumbprint } }
+      )}.sig`;
+      credentials.set(credential, { did: delegation.did, space: body.space, jkt: thumbprint, exp });
+      return { credential };
+    },
+
+    'com.atproto.space.createRecord': async (req, url, body) => {
+      const did = await authorize(req, url, body.space);
+      if (did !== body.repo) throw error('NotAuthorized', 'can only write your own repo');
+      const key = `${body.space}|${body.repo}|${body.collection}`;
+      const collection = repos.get(key) ?? new Map();
+      const rkey = body.rkey ?? next();
+      if (collection.has(rkey)) throw error('RecordAlreadyExists', 'rkey taken');
+      collection.set(rkey, body.record);
+      repos.set(key, collection);
+      return {
+        uri: `${body.space}/${body.repo}/${body.collection}/${rkey}`,
+        cid: `cid-${next()}`,
+        validationStatus: 'unknown',
+      };
+    },
+
+    'com.atproto.space.getRecord': async (req, url) => {
+      const space = url.searchParams.get('space');
+      await authorize(req, url, space);
+      const collection = repos.get(
+        `${space}|${url.searchParams.get('repo')}|${url.searchParams.get('collection')}`
+      );
+      const value = collection?.get(url.searchParams.get('rkey'));
+      if (!value) throw error('RecordNotFound', 'no such record');
+      return {
+        uri: `${space}/${url.searchParams.get('repo')}/${url.searchParams.get('collection')}/${url.searchParams.get('rkey')}`,
+        cid: 'cid-x',
+        value,
+      };
+    },
+
+    'com.atproto.space.listRecords': async (req, url) => {
+      const space = url.searchParams.get('space');
+      await authorize(req, url, space);
+      const collectionName = url.searchParams.get('collection');
+      const collection = repos.get(`${space}|${url.searchParams.get('repo')}|${collectionName}`);
+      return {
+        records: [...(collection ?? new Map())].map(([rkey, value]) => ({
+          collection: collectionName,
+          rkey,
+          cid: 'cid-x',
+          value,
+        })),
+      };
+    },
+
+    'com.atproto.space.deleteRecord': async (req, url, body) => {
+      const did = await authorize(req, url, body.space);
+      if (did !== body.repo) throw error('NotAuthorized', 'can only write your own repo');
+      repos.get(`${body.space}|${body.repo}|${body.collection}`)?.delete(body.rkey);
+      return {};
+    },
+  };
+
+  /** A drop-in `fetch` serving the above. */
+  async function fakeFetch(input, init = {}) {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    if (url.origin !== origin) throw new Error(`fake PDS got a request for ${url.origin}`);
+
+    const nsid = url.pathname.replace('/xrpc/', '');
+    const handler = handlers[nsid];
+    if (!handler) {
+      return Response.json({ error: 'MethodNotImplemented', message: nsid }, { status: 501 });
+    }
+
+    let body;
+    if (request.method === 'POST') {
+      const text = await request.text();
+      body = text ? JSON.parse(text) : undefined;
+    }
+
+    try {
+      return Response.json(await handler(request, url, body));
+    } catch (e) {
+      if (!e.xrpcError) throw e;
+      const status = ['SpaceNotFound', 'RecordAlreadyExists', 'RecordNotFound'].includes(
+        e.xrpcError
+      )
+        ? 400
+        : 403;
+      return Response.json({ error: e.xrpcError, message: e.message }, { status });
+    }
+  }
+
+  return { origin, fetch: fakeFetch };
+}

--- a/experiments/spaces-saves/lifecycle.mjs
+++ b/experiments/spaces-saves/lifecycle.mjs
@@ -1,0 +1,320 @@
+/**
+ * Phase 0 of the atproto Spaces saves spike: the full protocol lifecycle against
+ * a real spaces-capable PDS, with every request/response summarised as it goes.
+ *
+ * It deliberately imports the backend's own spaces modules rather than the alpha
+ * `@atproto/*` SDK. Two reasons: the backend runs on Workers and can't take the
+ * SDK, so the wire code has to be hand-rolled anyway; and a Phase 0 that
+ * exercises different code from Phases 1-3 proves nothing about them. Node runs
+ * the .ts sources directly via type stripping (Node >= 22.18 / 24).
+ *
+ * Usage:
+ *
+ *   SPACES_PDS_URL=http://localhost:2583 \
+ *   SPACES_INVITE_CODE=...        # if the PDS requires one
+ *   node experiments/spaces-saves/lifecycle.mjs
+ *
+ * It creates two throwaway accounts (an owner and an outsider), so point it only
+ * at a sandbox: the alpha hosted PDS (BPS invite) or a local
+ * `ghcr.io/bluesky-social/atproto:pds-spaces-alpha`.
+ *
+ * Exit code 0 means every check passed, including the two that matter most:
+ * the outsider is denied, and a second, independent client reads the record back
+ * with its own credential.
+ */
+
+import {
+  SpacesClient,
+  PERSONAL_SPACE_POLICY,
+  PERSONAL_SPACE_APP_ACCESS,
+} from '../../backend/src/services/spaces/client.ts';
+import {
+  bearerCall,
+  credentialCall,
+  isSpaceAccessDenied,
+  isSpaceNotFound,
+} from '../../backend/src/services/spaces/transport.ts';
+import { mintSpaceCredential } from '../../backend/src/services/spaces/credential.ts';
+import { savedRowToSpaceRecord } from '../../backend/src/services/spaces/record.ts';
+import {
+  SAVED_COLLECTION,
+  SAVED_SPACE_SKEY,
+  SAVED_SPACE_TYPE,
+  savedSpaceRef,
+} from '../../backend/src/services/spaces/refs.ts';
+
+// `--fake` swaps in an in-process stand-in (fake-pds.mjs) so the harness itself
+// can be exercised without a spaces PDS. A green --fake run proves the script and
+// the client code work; it proves nothing about the real implementation. Read the
+// header of fake-pds.mjs before quoting a --fake result as a finding.
+const FAKE = process.argv.includes('--fake') || process.env.SPACES_FAKE === '1';
+if (FAKE) {
+  const { createFakePds } = await import('./fake-pds.mjs');
+  const fake = createFakePds();
+  process.env.SPACES_PDS_URL = fake.origin;
+  globalThis.fetch = fake.fetch;
+}
+
+const PDS_URL = (process.env.SPACES_PDS_URL ?? 'http://localhost:2583').replace(/\/$/, '');
+const INVITE_CODE = process.env.SPACES_INVITE_CODE;
+const SUFFIX = Math.random().toString(36).slice(2, 8);
+
+const results = [];
+let failed = 0;
+
+function step(name) {
+  const startedAt = Date.now();
+  return {
+    ok(detail) {
+      const ms = Date.now() - startedAt;
+      results.push({ name, status: 'ok', ms, detail });
+      console.log(`  ✓ ${name} (${ms}ms)${detail ? ` — ${detail}` : ''}`);
+    },
+    fail(error) {
+      const ms = Date.now() - startedAt;
+      failed++;
+      const detail = error?.code
+        ? `${error.code}: ${error.message}`
+        : String(error?.message ?? error);
+      results.push({ name, status: 'FAILED', ms, detail });
+      console.error(`  ✗ ${name} (${ms}ms) — ${detail}`);
+    },
+  };
+}
+
+async function xrpc(method, endpoint, body, headers = {}) {
+  const url = `${PDS_URL}/xrpc/${endpoint}`;
+  const response = await fetch(url, {
+    method,
+    headers: {
+      accept: 'application/json',
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const parsed = text ? JSON.parse(text) : undefined;
+  if (!response.ok) {
+    const error = new Error(parsed?.message ?? `HTTP ${response.status}`);
+    error.code = parsed?.error ?? `HTTP${response.status}`;
+    throw error;
+  }
+  return parsed;
+}
+
+async function createAccount(label) {
+  const handle = `${label}-${SUFFIX}.test`;
+  const password = `pw-${SUFFIX}`;
+  try {
+    await xrpc('POST', 'com.atproto.server.createAccount', {
+      handle,
+      email: `${label}-${SUFFIX}@example.invalid`,
+      password,
+      ...(INVITE_CODE ? { inviteCode: INVITE_CODE } : {}),
+    });
+  } catch (error) {
+    if (error.code !== 'HandleNotAvailable') throw error;
+  }
+  const session = await xrpc('POST', 'com.atproto.server.createSession', {
+    identifier: handle,
+    password,
+  });
+  console.log(`  · ${label}: ${session.did} (${handle})`);
+  return { did: session.did, accessJwt: session.accessJwt, handle };
+}
+
+/** A saved_articles row shaped like the one the backend mirrors. */
+function sampleRow(rkey) {
+  return {
+    rkey,
+    url: 'https://example.com/spaces-spike',
+    title: 'Saved through a space',
+    author: 'Skyreader spike',
+    description: 'Metadata only — the body stays in D1.',
+    content_type: 'webpage',
+    domain: 'example.com',
+    image: null,
+    word_count: 987,
+    published_at: Date.UTC(2026, 7, 20),
+    saved_at: Date.now(),
+    source: 'url',
+    item_guid: null,
+  };
+}
+
+async function main() {
+  console.log(`atproto Spaces lifecycle against ${PDS_URL}\n`);
+
+  console.log('accounts');
+  const owner = await createAccount('owner');
+  const outsider = await createAccount('outsider');
+
+  const ownerClient = new SpacesClient(bearerCall(PDS_URL, owner.accessJwt));
+  const outsiderClient = new SpacesClient(bearerCall(PDS_URL, outsider.accessJwt));
+  const space = savedSpaceRef(owner.did);
+  const rkey = `3lspike${SUFFIX}`;
+
+  console.log('\nspace lifecycle');
+
+  let s = step('createSpace (member-list policy, open app access)');
+  try {
+    const created = await ownerClient.createSpace({
+      type: SAVED_SPACE_TYPE,
+      skey: SAVED_SPACE_SKEY,
+      policy: PERSONAL_SPACE_POLICY,
+      appAccess: PERSONAL_SPACE_APP_ACCESS,
+    });
+    s.ok(created.uri);
+    if (created.uri !== space) {
+      console.warn(`    ! space uri differs from the derived ref: ${created.uri} vs ${space}`);
+    }
+  } catch (error) {
+    if (error.code === 'SpaceAlreadyExists') s.ok('already existed');
+    else s.fail(error);
+  }
+
+  s = step('getSpace');
+  try {
+    const view = await ownerClient.getSpace(space);
+    s.ok(`${view.policy?.$type} / ${view.appAccess?.$type}`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  const record = savedRowToSpaceRecord(sampleRow(rkey));
+
+  s = step('createRecord (session auth, own repo)');
+  try {
+    const created = await ownerClient.createRecord({
+      space,
+      repo: owner.did,
+      collection: SAVED_COLLECTION,
+      rkey,
+      record,
+    });
+    s.ok(`${created.uri} (validation: ${created.validationStatus ?? 'n/a'})`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  s = step('getRecord round-trips every field');
+  try {
+    const fetched = await ownerClient.getRecord({
+      space,
+      repo: owner.did,
+      collection: SAVED_COLLECTION,
+      rkey,
+    });
+    const drift = Object.keys(record).filter((k) => fetched.value?.[k] !== record[k]);
+    if (drift.length) throw Object.assign(new Error(`fields changed: ${drift.join(', ')}`), {});
+    s.ok(`${Object.keys(record).length} fields intact`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  s = step('listRecords sees the record');
+  try {
+    const listed = await ownerClient.listAllRecords({
+      space,
+      repo: owner.did,
+      collection: SAVED_COLLECTION,
+    });
+    if (!listed.some((r) => r.rkey === rkey)) throw new Error('record missing from listing');
+    s.ok(`${listed.length} record(s)`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  console.log('\nprivacy');
+
+  s = step('outsider is DENIED a read of the space');
+  try {
+    await outsiderClient.listRecords({ space, repo: owner.did, collection: SAVED_COLLECTION });
+    s.fail(new Error('outsider read SUCCEEDED — the privacy claim fails'));
+  } catch (error) {
+    if (isSpaceAccessDenied(error) || error.status === 401 || error.status === 403) {
+      s.ok(error.code);
+    } else {
+      s.fail(error);
+    }
+  }
+
+  s = step('outsider cannot mint a credential for the space');
+  try {
+    await mintSpaceCredential({
+      space,
+      authorityPdsUrl: PDS_URL,
+      getDelegationToken: async (target) => (await outsiderClient.getDelegationToken(target)).token,
+    });
+    s.fail(new Error('outsider minted a credential — the privacy claim fails'));
+  } catch (error) {
+    if (isSpaceAccessDenied(error)) s.ok(error.code);
+    else s.fail(error);
+  }
+
+  console.log('\nportability (the point of the spike)');
+
+  s = step('owner mints a space credential (delegation -> credential -> DPoP)');
+  let credential;
+  try {
+    const startedAt = Date.now();
+    credential = await mintSpaceCredential({
+      space,
+      authorityPdsUrl: PDS_URL,
+      getDelegationToken: async (target) => (await ownerClient.getDelegationToken(target)).token,
+    });
+    const ttlSec = Math.round((credential.expiresAt - Date.now()) / 1000);
+    s.ok(`two round trips in ${Date.now() - startedAt}ms, credential TTL ~${ttlSec}s`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  s = step('an independent client reads the save with only that credential');
+  try {
+    if (!credential) throw new Error('no credential');
+    // Nothing of the owner's session is in play here — just the credential and
+    // the key it is bound to. This is the portability claim, executed.
+    const independent = new SpacesClient(credentialCall(PDS_URL, credential));
+    const fetched = await independent.getRecord({
+      space,
+      repo: owner.did,
+      collection: SAVED_COLLECTION,
+      rkey,
+    });
+    if (fetched.value?.url !== record.url) throw new Error('record did not match');
+    s.ok(`read "${fetched.value?.title}" out of the space`);
+  } catch (error) {
+    s.fail(error);
+  }
+
+  console.log('\nteardown');
+
+  s = step('deleteRecord');
+  try {
+    await ownerClient.deleteRecord({ space, repo: owner.did, collection: SAVED_COLLECTION, rkey });
+    s.ok();
+  } catch (error) {
+    s.fail(error);
+  }
+
+  s = step('the deleted record is gone');
+  try {
+    await ownerClient.getRecord({ space, repo: owner.did, collection: SAVED_COLLECTION, rkey });
+    s.fail(new Error('record still readable after delete'));
+  } catch (error) {
+    if (error.code === 'RecordNotFound' || isSpaceNotFound(error)) s.ok(error.code);
+    else s.fail(error);
+  }
+
+  console.log(`\n${results.length - failed}/${results.length} checks passed`);
+  console.log('\nPaste this into FINDINGS.md:\n');
+  console.log(JSON.stringify({ pds: PDS_URL, results }, null, 2));
+
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error('\nlifecycle aborted:', error);
+  process.exit(2);
+});

--- a/experiments/spaces-saves/lifecycle.mjs
+++ b/experiments/spaces-saves/lifecycle.mjs
@@ -215,13 +215,15 @@ async function main() {
 
   s = step('listRecords sees the record');
   try {
-    const listed = await ownerClient.listAllRecords({
+    const listing = await ownerClient.listAllRecords({
       space,
       repo: owner.did,
       collection: SAVED_COLLECTION,
     });
-    if (!listed.some((r) => r.rkey === rkey)) throw new Error('record missing from listing');
-    s.ok(`${listed.length} record(s)`);
+    if (!listing.records.some((r) => r.rkey === rkey))
+      throw new Error('record missing from listing');
+    if (listing.truncated) throw new Error('record listing was truncated');
+    s.ok(`${listing.records.length} record(s)`);
   } catch (error) {
     s.fail(error);
   }

--- a/experiments/spaces-saves/package.json
+++ b/experiments/spaces-saves/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "spaces-saves-experiment",
+  "private": true,
+  "type": "module",
+  "description": "Phase 0 protocol experiment for the atproto Spaces saved-articles spike",
+  "engines": {
+    "node": ">=22.18"
+  },
+  "scripts": {
+    "lifecycle": "node --import ./ts-resolve.mjs ./lifecycle.mjs",
+    "lifecycle:fake": "node --import ./ts-resolve.mjs ./lifecycle.mjs --fake"
+  }
+}

--- a/experiments/spaces-saves/ts-resolve.mjs
+++ b/experiments/spaces-saves/ts-resolve.mjs
@@ -1,0 +1,30 @@
+/**
+ * Lets Node import the backend's TypeScript sources as-is.
+ *
+ * Node strips types happily, but its ESM resolver demands file extensions, and
+ * the backend (bundled by Wrangler/esbuild) writes extensionless relative
+ * imports — `import { ... } from './refs'`. This hook retries a failed relative
+ * resolution with `.ts`, then `/index.ts`.
+ *
+ * Loaded with `node --import ./ts-resolve.mjs`; see package.json's scripts.
+ */
+
+import { registerHooks } from 'node:module';
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (error) {
+      if (!specifier.startsWith('.') || /\.[cm]?[jt]sx?$/.test(specifier)) throw error;
+      for (const candidate of [`${specifier}.ts`, `${specifier}/index.ts`]) {
+        try {
+          return nextResolve(candidate, context);
+        } catch {
+          // try the next shape
+        }
+      }
+      throw error;
+    }
+  },
+});

--- a/frontend/lexicons/app/skyreader/feed/saved.json
+++ b/frontend/lexicons/app/skyreader/feed/saved.json
@@ -1,0 +1,73 @@
+{
+  "lexicon": 1,
+  "id": "app.skyreader.feed.saved",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A saved article. Metadata only — the extracted article body is deliberately NOT part of this record (it stays in Skyreader's own store). Written into a personal atproto Space, never into the public repo.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["savedAt"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "The article URL. Absent for share/document saves, which have no web URL."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "author": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Short summary/excerpt. Not the article body."
+          },
+          "contentType": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "'webpage', 'article', 'share', or 'document'."
+          },
+          "domain": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "image": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048
+          },
+          "wordCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Word count of the extracted body, which itself is not stored here."
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "savedAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "source": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "How the item was saved: 'url', 'feed', 'share', or 'document'."
+          },
+          "itemGuid": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Feed item GUID, for saves that came from a subscribed feed."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Spike: store saved articles in a personal atproto Space behind a dev-only flag. D1 remains canonical and mirroring remains best-effort.

This update resolves the review findings on the original spike:

- preserves structured XRPC error codes and status through session transport, allowing a missing space to be created;
- covers the `SpaceNotFound` → `createSpace` mirror path and unsupported-PDS caching;
- retries transient capability failures rather than caching them for ten minutes;
- makes mirrored writes replay-safe with `putRecord`;
- reports capped record listings as `truncated` and never calls an incomplete diff in sync;
- records wildcard permission-authority support as an explicit live-PDS unknown.

Checks: backend type/format check; 603 tests across 55 files in low-concurrency batches; fake Spaces lifecycle 11/11.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-fycamenwwf7wlhwao52ngf5v)