### PR TITLE
Persist linkblog share drafts to D1

### DIFF
--- a/backend/migrations/0073_share_drafts.sql
+++ b/backend/migrations/0073_share_drafts.sql
@@ -1,0 +1,24 @@
+-- Cross-device linkblog share drafts (D1 only, no PDS record — drafts are
+-- private unposted words; they become public only via the linkblog write path).
+-- Modeled on magazines (0059): ?since= deltas + tombstones, hourly cron GC.
+--
+-- Two clocks, mirroring what the client already keeps: `updated_at` is the
+-- server clock (unix seconds) that drives the delta cursor, and
+-- `client_updated_at` is the client's ms clock that drives last-write-wins on
+-- upsert and the drafts-list sort. `draft` is an opaque JSON blob (blocks +
+-- article metadata + repostUri/itemKey) the backend never interprets.
+CREATE TABLE IF NOT EXISTS share_drafts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_did TEXT NOT NULL,
+    article_url TEXT NOT NULL,          -- dedupe key, same as the linkblog's
+    draft TEXT NOT NULL,                -- JSON: full ShareDraft
+    client_updated_at INTEGER NOT NULL, -- client ms clock; LWW + list sort
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    deleted_at INTEGER,
+    UNIQUE(user_did, article_url),
+    FOREIGN KEY (user_did) REFERENCES users(did) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_drafts_user ON share_drafts(user_did);
+CREATE INDEX IF NOT EXISTS idx_share_drafts_user_updated ON share_drafts(user_did, updated_at);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,11 @@ import {
   handleDeletePublication,
   handleRestorePublication,
 } from './routes/linkblog';
+import {
+  handleGetShareDrafts,
+  handleUpsertShareDraft,
+  handleDeleteShareDraft,
+} from './routes/share-drafts';
 import { handleAtmosphereSubscription } from './routes/atmosphere';
 import {
   handleCreateSubscription,
@@ -383,6 +388,24 @@ async function route(
     case url.pathname === '/api/linkblog/discover':
       if (!session) return unauthorizedResponse(headers);
       response = await handleDiscover(request, env);
+      break;
+
+    // Unposted share drafts — private to the account, D1 only, delta-synced so
+    // a draft started on one device can be finished on another.
+    case url.pathname === '/api/linkblog/drafts':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetShareDrafts(request, env);
+      } else if (request.method === 'PUT') {
+        response = await handleUpsertShareDraft(request, env);
+      } else if (request.method === 'DELETE') {
+        response = await handleDeleteShareDraft(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       break;
 
     // Linkblog endpoints — sharing as portable site.standard.document records
@@ -937,6 +960,23 @@ async function runScheduled(
           ...serializeError(error),
         });
         reportError(error, { tags: { source: 'cron', phase: 'magazine-tombstone-purge' } });
+      }
+
+      // Purge old share-draft tombstones (same 90-day retention, same reason:
+      // a client that was offline across the deletion still has to replay it).
+      try {
+        const shareDraftCutoff = Math.floor(now / 1000) - 90 * 24 * 60 * 60;
+        await env.DB.prepare(
+          'DELETE FROM share_drafts WHERE deleted_at IS NOT NULL AND deleted_at < ?'
+        )
+          .bind(shareDraftCutoff)
+          .run();
+      } catch (error) {
+        log.error('cron_phase_failed', {
+          phase: 'share-draft-tombstone-purge',
+          ...serializeError(error),
+        });
+        reportError(error, { tags: { source: 'cron', phase: 'share-draft-tombstone-purge' } });
       }
 
       d1CleanupDuration = Date.now() - cleanupStart;

--- a/backend/src/routes/share-drafts.ts
+++ b/backend/src/routes/share-drafts.ts
@@ -1,0 +1,248 @@
+import type { Env } from '../types';
+import { getSessionFromRequest } from '../services/oauth';
+
+// Cross-device linkblog share drafts. A draft is the unposted state of a share,
+// keyed by the external article URL — the same key the linkblog dedups on. The
+// body is an opaque JSON blob (blocks + article metadata + repostUri/itemKey)
+// the backend never interprets, exactly like magazines' params/items. D1 only:
+// drafts are private to the account and never become a PDS record; they go
+// public only when the user posts, through the linkblog write path.
+//
+// Sync is delta-based like magazines: `?since=` returns rows changed since the
+// client's cursor, tombstones included so deletions replay to other devices.
+//
+// Two clocks. `updated_at` is the server clock (unix seconds) and drives the
+// delta cursor. `client_updated_at` is the client's ms clock and drives
+// last-write-wins: unlike magazines (which upsert unconditionally) a draft is
+// keystroke-level content, so an offline-queued write from a stale device must
+// not clobber a newer edit made elsewhere.
+
+interface ShareDraftRow {
+  id: number;
+  article_url: string;
+  draft: string;
+  client_updated_at: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at: number | null;
+}
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+// A draft is prose plus a little article metadata; 64 KB is far more than any
+// real one and keeps a runaway client from bloating rows.
+const MAX_DRAFT_BYTES = 64 * 1024;
+const MAX_ARTICLE_URL_LENGTH = 2048;
+
+function encodeCursor(updatedAt: number, id: number): string {
+  return btoa(`${updatedAt}:${id}`);
+}
+
+function decodeCursor(cursor: string): { updatedAt: number; id: number } | null {
+  try {
+    const [updatedAtStr, idStr] = atob(cursor).split(':');
+    const updatedAt = Number(updatedAtStr);
+    const id = Number(idStr);
+    if (isNaN(updatedAt) || isNaN(id)) return null;
+    return { updatedAt, id };
+  } catch {
+    return null;
+  }
+}
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function rowToDraft(row: ShareDraftRow) {
+  // A tombstone carries no body — the client only needs to know which draft
+  // died and when, and shipping the last words of a deleted draft back out
+  // would defeat the point of deleting it.
+  const deleted = row.deleted_at !== null;
+  return {
+    articleUrl: row.article_url,
+    draft: deleted ? null : JSON.parse(row.draft),
+    clientUpdatedAt: row.client_updated_at,
+    createdAt: row.created_at,
+    serverUpdatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+  };
+}
+
+// GET /api/linkblog/drafts - list drafts (full snapshot, or `?since=` delta)
+export async function handleGetShareDrafts(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return unauthorized();
+
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get('cursor');
+  const limitParam = url.searchParams.get('limit');
+  const limit = Math.min(Math.max(1, Number(limitParam) || DEFAULT_LIMIT), MAX_LIMIT);
+  const sinceParam = url.searchParams.get('since');
+  const since = sinceParam !== null ? parseInt(sinceParam, 10) : NaN;
+
+  try {
+    let query = `SELECT id, article_url, draft, client_updated_at, created_at, updated_at, deleted_at
+      FROM share_drafts
+      WHERE user_did = ?`;
+    const params: (string | number)[] = [session.did];
+
+    if (Number.isFinite(since)) {
+      query += ' AND updated_at > ?';
+      params.push(since);
+    } else {
+      query += ' AND deleted_at IS NULL';
+    }
+
+    if (cursor) {
+      const parsed = decodeCursor(cursor);
+      if (!parsed) return json({ error: 'Invalid cursor' }, 400);
+      query += ' AND (updated_at < ? OR (updated_at = ? AND id < ?))';
+      params.push(parsed.updatedAt, parsed.updatedAt, parsed.id);
+    }
+
+    query += ' ORDER BY updated_at DESC, id DESC LIMIT ?';
+    params.push(limit + 1);
+
+    const result = await env.DB.prepare(query)
+      .bind(...params)
+      .all<ShareDraftRow>();
+
+    const hasMore = result.results.length > limit;
+    const rows = hasMore ? result.results.slice(0, limit) : result.results;
+    const drafts = rows.map(rowToDraft);
+    const nextCursor = hasMore
+      ? encodeCursor(rows[rows.length - 1].updated_at, rows[rows.length - 1].id)
+      : undefined;
+
+    return json({ drafts, cursor: nextCursor });
+  } catch (error) {
+    console.error('Failed to get share drafts:', error);
+    return json({ error: 'Failed to get share drafts' }, 500);
+  }
+}
+
+interface UpsertShareDraftRequest {
+  articleUrl: string;
+  draft: unknown;
+  updatedAt: number;
+}
+
+// PUT /api/linkblog/drafts - create or replace a draft (last write wins)
+export async function handleUpsertShareDraft(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return unauthorized();
+
+  let body: UpsertShareDraftRequest;
+  try {
+    body = (await request.json()) as UpsertShareDraftRequest;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const { articleUrl, draft, updatedAt } = body;
+  if (!articleUrl || typeof articleUrl !== 'string' || articleUrl.length > MAX_ARTICLE_URL_LENGTH) {
+    return json({ error: 'articleUrl is required' }, 400);
+  }
+  if (typeof draft !== 'object' || draft === null || Array.isArray(draft)) {
+    return json({ error: 'draft must be an object' }, 400);
+  }
+  const clientUpdatedAt = Number(updatedAt);
+  if (!Number.isFinite(clientUpdatedAt)) {
+    return json({ error: 'updatedAt must be a number' }, 400);
+  }
+
+  const serialized = JSON.stringify(draft);
+  if (new TextEncoder().encode(serialized).length > MAX_DRAFT_BYTES) {
+    return json({ error: 'Draft too large' }, 413);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  try {
+    // The guard is what makes an offline queue safe: a write carrying an older
+    // client clock than the row already here is dropped rather than applied.
+    // That still answers success — the newer content is already stored, and the
+    // client's next delta hands it back.
+    await env.DB.prepare(
+      `INSERT INTO share_drafts (user_did, article_url, draft, client_updated_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(user_did, article_url) DO UPDATE SET
+         draft = excluded.draft,
+         client_updated_at = excluded.client_updated_at,
+         updated_at = excluded.updated_at,
+         deleted_at = NULL
+       WHERE excluded.client_updated_at >= share_drafts.client_updated_at`
+    )
+      .bind(session.did, articleUrl, serialized, clientUpdatedAt, now, now)
+      .run();
+
+    return json({ success: true, articleUrl });
+  } catch (error) {
+    console.error('Failed to upsert share draft:', error);
+    return json({ error: 'Failed to upsert share draft' }, 500);
+  }
+}
+
+interface DeleteShareDraftRequest {
+  articleUrl: string;
+  updatedAt?: number;
+}
+
+// DELETE /api/linkblog/drafts - soft-delete (tombstone) a draft. Posting or
+// discarding a draft on one device clears it on the others through this.
+export async function handleDeleteShareDraft(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return unauthorized();
+
+  let body: DeleteShareDraftRequest;
+  try {
+    body = (await request.json()) as DeleteShareDraftRequest;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!body.articleUrl || typeof body.articleUrl !== 'string') {
+    return json({ error: 'articleUrl is required' }, 400);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const clientUpdatedAt = Number.isFinite(Number(body.updatedAt))
+    ? Number(body.updatedAt)
+    : now * 1000;
+
+  try {
+    // Stamping client_updated_at with the deletion's client ms puts the delete
+    // on the same LWW clock as edits, and the guard makes the rule symmetric
+    // with upsert: a delete queued offline before an edit made elsewhere does
+    // not destroy that newer edit. Losing a delete race just means the draft
+    // comes back and the user discards it again; losing an edit race would mean
+    // losing their words.
+    //
+    // The body is cleared, not just hidden: a discarded draft's text should not
+    // sit in the tombstone for the 90 days before the cron sweeps it.
+    await env.DB.prepare(
+      `UPDATE share_drafts
+       SET deleted_at = ?, updated_at = ?, client_updated_at = ?, draft = '{}'
+       WHERE user_did = ? AND article_url = ? AND ? >= client_updated_at`
+    )
+      .bind(now, now, clientUpdatedAt, session.did, body.articleUrl, clientUpdatedAt)
+      .run();
+    // Deleting a draft that was never pushed (or is already gone) is a no-op,
+    // not an error — the client's intent is satisfied either way.
+    return json({ success: true });
+  } catch (error) {
+    console.error('Failed to delete share draft:', error);
+    return json({ error: 'Failed to delete share draft' }, 500);
+  }
+}

--- a/backend/src/routes/share-drafts.ts
+++ b/backend/src/routes/share-drafts.ts
@@ -8,8 +8,11 @@ import { getSessionFromRequest } from '../services/oauth';
 // drafts are private to the account and never become a PDS record; they go
 // public only when the user posts, through the linkblog write path.
 //
-// Sync is delta-based like magazines: `?since=` returns rows changed since the
-// client's cursor, tombstones included so deletions replay to other devices.
+// Sync is delta-based like magazines: `?since=` returns rows changed at or
+// after the client's cursor, tombstones included so deletions replay to other
+// devices. The inclusive boundary is deliberate: updated_at has second
+// precision, so a mutation can land in the same second after a client has
+// checkpointed it. Clients merge the replayed boundary rows idempotently.
 //
 // Two clocks. `updated_at` is the server clock (unix seconds) and drives the
 // delta cursor. `client_updated_at` is the client's ms clock and drives
@@ -98,7 +101,10 @@ export async function handleGetShareDrafts(request: Request, env: Env): Promise<
     const params: (string | number)[] = [session.did];
 
     if (Number.isFinite(since)) {
-      query += ' AND updated_at > ?';
+      // Overlap the checkpoint second. A strict `>` can permanently miss a row
+      // written later in the same second as the last sync. Pagination remains
+      // collision-safe through the (updated_at, id) page cursor below.
+      query += ' AND updated_at >= ?';
       params.push(since);
     } else {
       query += ' AND deleted_at IS NULL';

--- a/backend/test/share-drafts.spec.ts
+++ b/backend/test/share-drafts.spec.ts
@@ -210,6 +210,31 @@ describe('/api/linkblog/drafts', () => {
     expect(delta.body.drafts[0].draft).toBeNull();
   });
 
+  it('replays the checkpoint second so a later same-second mutation is not missed', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('first'),
+      updatedAt: 1000,
+    });
+    await backdate('https://example.com/a', 700);
+
+    const checkpoint = await getDrafts('/api/linkblog/drafts');
+    expect(checkpoint.body.drafts[0].serverUpdatedAt).toBe(700);
+
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/b',
+      draft: draftBody('same second, later', 'https://example.com/b'),
+      updatedAt: 2000,
+    });
+    await backdate('https://example.com/b', 700);
+
+    const delta = await getDrafts('/api/linkblog/drafts?since=700');
+    expect(delta.body.drafts.map((draft) => draft.articleUrl).sort()).toEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ]);
+  });
+
   it('deleting a draft that was never pushed succeeds', async () => {
     const del = await mutate('DELETE', { articleUrl: 'https://example.com/never', updatedAt: 1 });
     expect(del.status).toBe(200);

--- a/backend/test/share-drafts.spec.ts
+++ b/backend/test/share-drafts.spec.ts
@@ -1,0 +1,315 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '../src/index';
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+const TEST_DID = 'did:plc:drafts123';
+const TEST_SESSION_ID = 'test-session-drafts';
+const OTHER_DID = 'did:plc:drafts456';
+const OTHER_SESSION_ID = 'test-session-drafts-other';
+
+async function insertUser(did: string, handle: string, sessionId: string) {
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url, tier, created_at) VALUES (?, ?, ?, 'free', unixepoch())`
+  )
+    .bind(did, handle, 'https://test.pds.example')
+    .run();
+
+  await env.DB.prepare(
+    `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      sessionId,
+      did,
+      handle,
+      'https://test.pds.example',
+      'test-access-token',
+      'test-refresh-token',
+      JSON.stringify({ kty: 'EC' }),
+      Date.now() + 3600000
+    )
+    .run();
+}
+
+type DraftRecord = {
+  articleUrl: string;
+  draft: { blocks?: { kind: string; text: string }[] } | null;
+  clientUpdatedAt: number;
+  createdAt: number;
+  serverUpdatedAt: number;
+  deletedAt: number | null;
+};
+
+type DraftsResponse = { drafts: DraftRecord[]; cursor?: string; error?: string };
+
+async function getDrafts(
+  path: string,
+  sessionId = TEST_SESSION_ID
+): Promise<{ status: number; body: DraftsResponse }> {
+  const ctx = createExecutionContext();
+  const request = new IncomingRequest(`http://localhost${path}`, {
+    headers: { Cookie: `session_id=${sessionId}`, Origin: env.FRONTEND_URL },
+  });
+  const response = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return { status: response.status, body: (await response.json()) as DraftsResponse };
+}
+
+async function mutate(
+  method: 'PUT' | 'DELETE',
+  body: unknown,
+  sessionId = TEST_SESSION_ID
+): Promise<{ status: number; body: { success?: boolean; error?: string } }> {
+  const ctx = createExecutionContext();
+  const request = new IncomingRequest('http://localhost/api/linkblog/drafts', {
+    method,
+    headers: {
+      Cookie: `session_id=${sessionId}`,
+      Origin: env.FRONTEND_URL,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const response = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return {
+    status: response.status,
+    body: (await response.json()) as { success?: boolean; error?: string },
+  };
+}
+
+function draftBody(text: string, url = 'https://example.com/a') {
+  return {
+    articleUrl: url,
+    articleTitle: 'A post',
+    blocks: [{ kind: 'text', text }],
+    createdAt: 1,
+    updatedAt: 2,
+  };
+}
+
+// The server clock only has second resolution, so rows written in the same test
+// tick share an updated_at. Backdate explicitly when a delta boundary matters.
+async function backdate(articleUrl: string, updatedAt: number) {
+  await env.DB.prepare(
+    'UPDATE share_drafts SET updated_at = ? WHERE user_did = ? AND article_url = ?'
+  )
+    .bind(updatedAt, TEST_DID, articleUrl)
+    .run();
+}
+
+describe('/api/linkblog/drafts', () => {
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM share_drafts').run();
+    await env.DB.prepare('DELETE FROM sessions').run();
+    await env.DB.prepare('DELETE FROM users').run();
+    await insertUser(TEST_DID, 'drafts.bsky.social', TEST_SESSION_ID);
+    await insertUser(OTHER_DID, 'other.bsky.social', OTHER_SESSION_ID);
+  });
+
+  it('returns 401 without a session', async () => {
+    const ctx = createExecutionContext();
+    const request = new IncomingRequest('http://localhost/api/linkblog/drafts', {
+      headers: { Origin: env.FRONTEND_URL },
+    });
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(401);
+  });
+
+  it('round-trips an upserted draft', async () => {
+    const put = await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('hello'),
+      updatedAt: 1000,
+    });
+    expect(put.status).toBe(200);
+
+    const { status, body } = await getDrafts('/api/linkblog/drafts');
+    expect(status).toBe(200);
+    expect(body.drafts).toHaveLength(1);
+    expect(body.drafts[0].articleUrl).toBe('https://example.com/a');
+    expect(body.drafts[0].draft?.blocks?.[0].text).toBe('hello');
+    expect(body.drafts[0].clientUpdatedAt).toBe(1000);
+    expect(body.drafts[0].deletedAt).toBeNull();
+  });
+
+  it('never leaks another user’s drafts', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('mine'),
+      updatedAt: 1000,
+    });
+
+    const { body } = await getDrafts('/api/linkblog/drafts', OTHER_SESSION_ID);
+    expect(body.drafts).toHaveLength(0);
+  });
+
+  it('a newer client clock replaces the stored draft', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('first'),
+      updatedAt: 1000,
+    });
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('second'),
+      updatedAt: 2000,
+    });
+
+    const { body } = await getDrafts('/api/linkblog/drafts');
+    expect(body.drafts).toHaveLength(1);
+    expect(body.drafts[0].draft?.blocks?.[0].text).toBe('second');
+    expect(body.drafts[0].clientUpdatedAt).toBe(2000);
+  });
+
+  it('an older client clock is dropped, not applied (LWW guard)', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('newer'),
+      updatedAt: 5000,
+    });
+    // The shape an offline queue produces: a write composed before the newer
+    // edit but delivered after it.
+    const stale = await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('stale'),
+      updatedAt: 1000,
+    });
+    expect(stale.status).toBe(200);
+    expect(stale.body.success).toBe(true);
+
+    const { body } = await getDrafts('/api/linkblog/drafts');
+    expect(body.drafts[0].draft?.blocks?.[0].text).toBe('newer');
+    expect(body.drafts[0].clientUpdatedAt).toBe(5000);
+  });
+
+  it('delete tombstones: hidden from the snapshot, replayed in the delta', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('bye'),
+      updatedAt: 1000,
+    });
+    await backdate('https://example.com/a', 500);
+
+    const del = await mutate('DELETE', {
+      articleUrl: 'https://example.com/a',
+      updatedAt: 2000,
+    });
+    expect(del.status).toBe(200);
+
+    const snapshot = await getDrafts('/api/linkblog/drafts');
+    expect(snapshot.body.drafts).toHaveLength(0);
+
+    const delta = await getDrafts('/api/linkblog/drafts?since=500');
+    expect(delta.body.drafts).toHaveLength(1);
+    expect(delta.body.drafts[0].deletedAt).not.toBeNull();
+    // A tombstone carries no words.
+    expect(delta.body.drafts[0].draft).toBeNull();
+  });
+
+  it('deleting a draft that was never pushed succeeds', async () => {
+    const del = await mutate('DELETE', { articleUrl: 'https://example.com/never', updatedAt: 1 });
+    expect(del.status).toBe(200);
+    expect(del.body.success).toBe(true);
+  });
+
+  it('a newer write after a delete resurrects the draft', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('v1'),
+      updatedAt: 1000,
+    });
+    await mutate('DELETE', { articleUrl: 'https://example.com/a', updatedAt: 2000 });
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('v2'),
+      updatedAt: 3000,
+    });
+
+    const { body } = await getDrafts('/api/linkblog/drafts');
+    expect(body.drafts).toHaveLength(1);
+    expect(body.drafts[0].draft?.blocks?.[0].text).toBe('v2');
+    expect(body.drafts[0].deletedAt).toBeNull();
+  });
+
+  it('a write queued before a delete does not resurrect it', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('v1'),
+      updatedAt: 1000,
+    });
+    // Post clears the draft at t=2000; the composer's trailing throttle then
+    // fires with the pre-post content it captured at t=1500.
+    await mutate('DELETE', { articleUrl: 'https://example.com/a', updatedAt: 2000 });
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('late'),
+      updatedAt: 1500,
+    });
+
+    const { body } = await getDrafts('/api/linkblog/drafts');
+    expect(body.drafts).toHaveLength(0);
+  });
+
+  it('a stale delete does not destroy a newer edit', async () => {
+    await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('newer edit'),
+      updatedAt: 5000,
+    });
+    await mutate('DELETE', { articleUrl: 'https://example.com/a', updatedAt: 1000 });
+
+    const { body } = await getDrafts('/api/linkblog/drafts');
+    expect(body.drafts).toHaveLength(1);
+    expect(body.drafts[0].draft?.blocks?.[0].text).toBe('newer edit');
+  });
+
+  it('paginates with a cursor', async () => {
+    for (let i = 0; i < 5; i++) {
+      await mutate('PUT', {
+        articleUrl: `https://example.com/${i}`,
+        draft: draftBody(`draft ${i}`, `https://example.com/${i}`),
+        updatedAt: 1000 + i,
+      });
+      await backdate(`https://example.com/${i}`, 1000 + i);
+    }
+
+    const first = await getDrafts('/api/linkblog/drafts?limit=2');
+    expect(first.body.drafts).toHaveLength(2);
+    expect(first.body.cursor).toBeTruthy();
+
+    const seen = [...first.body.drafts.map((d) => d.articleUrl)];
+    let cursor = first.body.cursor;
+    while (cursor) {
+      const page = await getDrafts(
+        `/api/linkblog/drafts?limit=2&cursor=${encodeURIComponent(cursor)}`
+      );
+      seen.push(...page.body.drafts.map((d) => d.articleUrl));
+      cursor = page.body.cursor;
+    }
+
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  it('rejects a malformed or oversized write', async () => {
+    expect((await mutate('PUT', { draft: draftBody('x'), updatedAt: 1 })).status).toBe(400);
+    expect(
+      (await mutate('PUT', { articleUrl: 'https://example.com/a', draft: 'nope', updatedAt: 1 }))
+        .status
+    ).toBe(400);
+    expect(
+      (await mutate('PUT', { articleUrl: 'https://example.com/a', draft: draftBody('x') })).status
+    ).toBe(400);
+
+    const huge = await mutate('PUT', {
+      articleUrl: 'https://example.com/a',
+      draft: draftBody('x'.repeat(70 * 1024)),
+      updatedAt: 1,
+    });
+    expect(huge.status).toBe(413);
+  });
+});

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -215,10 +215,40 @@ export async function seedItemLabel(user: TestUser, opts: SeedItemLabelOpts): Pr
   return rkey;
 }
 
+export interface SeedShareDraftOpts {
+  articleUrl: string;
+  articleTitle?: string;
+  text: string;
+  /** Client ms clock. Drives last-write-wins and the drafts-list sort. */
+  updatedAt?: number;
+}
+
+/**
+ * Write a share draft straight into D1, standing in for "the user typed this on
+ * another device." The `draft` column is the opaque ShareDraft blob the client
+ * stores; the backend never interprets it.
+ */
+export async function seedShareDraft(user: TestUser, opts: SeedShareDraftOpts): Promise<void> {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const updatedAt = opts.updatedAt ?? Date.now();
+  const draft = JSON.stringify({
+    articleUrl: opts.articleUrl,
+    articleTitle: opts.articleTitle,
+    blocks: [{ kind: 'text', text: opts.text }],
+    createdAt: updatedAt,
+    updatedAt,
+  });
+
+  await execD1([
+    `INSERT OR REPLACE INTO share_drafts (user_did, article_url, draft, client_updated_at, created_at, updated_at) VALUES (${sqlString(user.did)}, ${sqlString(opts.articleUrl)}, ${sqlString(draft)}, ${updatedAt}, ${nowSeconds}, ${nowSeconds})`,
+  ]);
+}
+
 export async function cleanupTestData(user: TestUser) {
   await execD1([
     `DELETE FROM item_labels_cache WHERE user_did = '${user.did}'`,
     `DELETE FROM saved_articles WHERE user_did = '${user.did}'`,
+    `DELETE FROM share_drafts WHERE user_did = '${user.did}'`,
     `DELETE FROM subscriptions_cache WHERE user_did = '${user.did}'`,
     `DELETE FROM user_settings WHERE user_did = '${user.did}'`,
     `DELETE FROM sessions WHERE did = '${user.did}'`,

--- a/e2e/share-drafts.spec.ts
+++ b/e2e/share-drafts.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from './fixtures';
+import { seedShareDraft } from './seed';
+
+// Share drafts are durable and cross-device: D1 is the store of record and
+// IndexedDB is a cache. These specs exercise the two directions of that claim
+// against the real backend — a draft written elsewhere shows up here, and a
+// draft discarded here stays discarded after the cache is gone.
+
+const ARTICLE_URL = 'https://example.com/drafts/cross-device';
+const ARTICLE_TITLE = 'A Piece Worth Linking';
+const DRAFT_TEXT = 'Started this on the phone and never finished the thought.';
+
+/** Wipe the Dexie cache so the next load has nothing but the server to go on. */
+async function evictCache(page: import('@playwright/test').Page) {
+  // The delete is queued behind this document's open connection; the reload
+  // closes it, the delete runs, and the fresh document then opens an empty DB.
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('skyreader');
+  });
+  await page.reload();
+}
+
+test.describe('Share drafts', () => {
+  test('a draft written on another device appears here, and survives an evicted cache', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedShareDraft(testUser, {
+      articleUrl: ARTICLE_URL,
+      articleTitle: ARTICLE_TITLE,
+      text: DRAFT_TEXT,
+    });
+
+    await authedPage.goto('/linkblog');
+
+    // The entry renders in the draft shape — chip, headline, the words typed
+    // elsewhere. Generous timeout: the drafts sync rides the background refresh.
+    const entry = authedPage.locator('article.entry.draft');
+    await expect(entry).toHaveCount(1, { timeout: 15_000 });
+    await expect(entry.getByText(ARTICLE_TITLE)).toBeVisible();
+    await expect(entry.getByText(DRAFT_TEXT)).toBeVisible();
+
+    // Nothing about this came from IndexedDB the first time, but prove it can't
+    // have: wipe the cache and load again.
+    await evictCache(authedPage);
+    await expect(authedPage.locator('article.entry.draft')).toHaveCount(1, { timeout: 15_000 });
+    await expect(authedPage.getByText(DRAFT_TEXT)).toBeVisible();
+  });
+
+  test('discarding a draft tombstones it on the server', async ({ authedPage, testUser }) => {
+    await seedShareDraft(testUser, {
+      articleUrl: ARTICLE_URL,
+      articleTitle: ARTICLE_TITLE,
+      text: DRAFT_TEXT,
+    });
+
+    await authedPage.goto('/linkblog');
+    const entry = authedPage.locator('article.entry.draft');
+    await expect(entry).toHaveCount(1, { timeout: 15_000 });
+
+    // Discard is two-step (arm, then confirm) — the same one-way-action pattern
+    // the rest of the linkblog uses.
+    const deleteRequest = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/linkblog/drafts') && res.request().method() === 'DELETE'
+    );
+    await entry.locator('.menu-trigger').click();
+    await authedPage.getByRole('menuitem', { name: 'Discard draft' }).click();
+    await authedPage.getByRole('menuitem', { name: 'Discard draft?' }).click();
+    await deleteRequest;
+
+    await expect(authedPage.locator('article.entry.draft')).toHaveCount(0);
+
+    // The delete has to have reached D1, not just the local cache: come back
+    // with an empty cache and the draft must still be gone.
+    await evictCache(authedPage);
+    await expect(authedPage.locator('article.entry.draft')).toHaveCount(0);
+    await expect(authedPage.getByText(DRAFT_TEXT)).toHaveCount(0);
+  });
+});

--- a/frontend/src/lib/components/feed/LinkblogEntry.svelte
+++ b/frontend/src/lib/components/feed/LinkblogEntry.svelte
@@ -30,7 +30,7 @@
 -->
 <script lang="ts">
   // One entry on your own linkblog: a published `site.standard.document` link
-  // post, or a local ShareDraft that has not been posted yet. Both render in the
+  // post, or a ShareDraft that has not been posted yet. Both render in the
   // same shape — the headline, your commentary, your quotes, the source row —
   // and both hand editing to the shared ShareComposer drawer, which is mounted
   // once in AppShell. That drawer outlives this page, so you can open the article
@@ -60,7 +60,7 @@
   interface Props {
     /** A published link post. Mutually exclusive with `draft`. */
     doc?: SocialDocument;
-    /** An unposted local draft. Mutually exclusive with `doc`. */
+    /** An unposted draft. Mutually exclusive with `doc`. */
     draft?: ShareDraft;
     /** Open the linked article in the in-app reader (published entries only). */
     onOpenReader?: () => void;

--- a/frontend/src/lib/components/feed/LinkblogListView.svelte
+++ b/frontend/src/lib/components/feed/LinkblogListView.svelte
@@ -3,8 +3,9 @@
   //
   // One chronological stream: unposted local drafts sit alongside the published
   // entries they will become, in the same entry shape, so there is no second
-  // design for "not finished yet". Drafts are device-local and carry no server
-  // pagination, so they are merged in client-side by their own edit time.
+  // design for "not finished yet". Drafts sync across the user's devices but
+  // carry no server pagination of their own — the store holds the whole set —
+  // so they are merged into this list client-side by their own edit time.
   import LinkblogEntry from './LinkblogEntry.svelte';
   import SavedReader from './SavedReader.svelte';
   import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';

--- a/frontend/src/lib/components/feed/ShareComposer.svelte
+++ b/frontend/src/lib/components/feed/ShareComposer.svelte
@@ -8,7 +8,7 @@
   // The draft is an ordered list of blocks: commentary text and atomic quoted
   // passages. Quotes render as real blockquotes (the gold quotation rule), not
   // `> ` Markdown — serialization to the wire format happens on post. Create
-  // mode auto-saves to a local draft; nothing is public until Post.
+  // mode auto-saves the draft privately to the account; nothing is public until Post.
   //
   // Mounted once in AppShell and driven by shareComposerStore, so the drawer —
   // and the draft — survive closing the reader or navigating.
@@ -184,7 +184,7 @@
   }
 
   // ── Discard / Remove (two-step) ─────────────────────────────────────────────
-  // Create mode discards the local draft; edit mode takes the posted share down.
+  // Create mode discards the draft (everywhere); edit mode takes the posted share down.
   // Same two-step arm-then-confirm, since both are one-way.
   let confirmingDiscard = $state(false);
   let discardTimer: ReturnType<typeof setTimeout> | undefined;

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -11,6 +11,8 @@ import type {
   MagazinePosition,
   MarginCollection,
   ParsedFeed,
+  RemoteShareDraft,
+  ShareDraft,
   SaveBacking,
   SembleCollection,
   SocialContextResult,
@@ -969,6 +971,48 @@ class ApiClient {
     return this.fetch('/api/magazines', {
       method: 'DELETE',
       body: JSON.stringify({ rkey }),
+    });
+  }
+
+  // Share drafts (unposted linkblog shares, private to the account)
+  async getShareDrafts(
+    options: { since?: number; cursor?: string; limit?: number } = {}
+  ): Promise<{ drafts: RemoteShareDraft[]; cursor?: string }> {
+    const params = new URLSearchParams();
+    if (options.since !== undefined) params.set('since', String(options.since));
+    if (options.cursor) params.set('cursor', options.cursor);
+    if (options.limit) params.set('limit', String(options.limit));
+    const query = params.toString();
+    return this.fetch(`/api/linkblog/drafts${query ? `?${query}` : ''}`);
+  }
+
+  // Paginate the full draft set (or delta when `since` is given).
+  async getAllShareDrafts(options: { since?: number } = {}): Promise<RemoteShareDraft[]> {
+    const all: RemoteShareDraft[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await this.getShareDrafts({ ...options, cursor, limit: 500 });
+      all.push(...response.drafts);
+      cursor = response.cursor;
+    } while (cursor);
+    return all;
+  }
+
+  async upsertShareDraft(draft: ShareDraft): Promise<{ success: boolean; articleUrl: string }> {
+    return this.fetch('/api/linkblog/drafts', {
+      method: 'PUT',
+      body: JSON.stringify({
+        articleUrl: draft.articleUrl,
+        draft,
+        updatedAt: draft.updatedAt,
+      }),
+    });
+  }
+
+  async deleteShareDraft(articleUrl: string, updatedAt: number): Promise<{ success: boolean }> {
+    return this.fetch('/api/linkblog/drafts', {
+      method: 'DELETE',
+      body: JSON.stringify({ articleUrl, updatedAt }),
     });
   }
 

--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -24,7 +24,8 @@ export interface SyncQueueEntry {
     | 'label'
     | 'saved'
     | 'integration'
-    | 'magazine';
+    | 'magazine'
+    | 'shareDraft';
   key: string; // Deduplication key (e.g., articleGuid, rkey)
   payload: string; // JSON-serialized data
   timestamp: number;

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -1,7 +1,12 @@
 import { db, type SyncQueueEntry } from './db';
 import { api } from './api';
 import { toUnifiedReadItem } from './readSync';
-import type { MagazineItemSnapshot, MagazineParams, MagazinePosition } from '$lib/types';
+import type {
+  MagazineItemSnapshot,
+  MagazineParams,
+  MagazinePosition,
+  ShareDraft,
+} from '$lib/types';
 
 const MAX_RETRIES = 5;
 
@@ -12,7 +17,8 @@ export type SyncCollection =
   | 'label'
   | 'saved'
   | 'integration'
-  | 'magazine';
+  | 'magazine'
+  | 'shareDraft';
 
 // Payload types for each collection
 export interface ReadingPayload {
@@ -93,6 +99,14 @@ export interface MagazinePayload {
   title?: string | null;
 }
 
+// Offline share-draft write. Carries the whole draft (like magazines) so the
+// generic create+update / update+update conflict collapse stays trivial; the
+// key is the article URL. The draft's own `updatedAt` (client ms) is what the
+// server's last-write-wins guard compares, so a queued write that has been
+// overtaken by an edit elsewhere is dropped server-side rather than clobbering
+// it — which is exactly what makes replaying a stale queue safe.
+export type ShareDraftPayload = ShareDraft;
+
 type SyncPayload =
   | ReadingPayload
   | SocialReadingPayload
@@ -100,7 +114,8 @@ type SyncPayload =
   | SavedPayload
   | IntegrationPayload
   | MarginNotePayload
-  | MagazinePayload;
+  | MagazinePayload
+  | ShareDraftPayload;
 
 class SyncQueue {
   private processing = false;
@@ -444,6 +459,24 @@ class SyncQueue {
       }
       case 'magazine':
         await this.executeMagazineOperation(entry.operation, payload as MagazinePayload);
+        break;
+      case 'shareDraft':
+        await this.executeShareDraftOperation(entry.operation, payload as ShareDraftPayload);
+        break;
+    }
+  }
+
+  private async executeShareDraftOperation(
+    operation: SyncOperation,
+    payload: ShareDraftPayload
+  ): Promise<void> {
+    switch (operation) {
+      case 'create':
+      case 'update':
+        await api.upsertShareDraft(payload);
+        break;
+      case 'delete':
+        await api.deleteShareDraft(payload.articleUrl, payload.updatedAt);
         break;
     }
   }

--- a/frontend/src/lib/stores/app.svelte.ts
+++ b/frontend/src/lib/stores/app.svelte.ts
@@ -134,6 +134,7 @@ function createAppManager() {
         syncSubscriptions(),
         itemLabelsStore.load(),
         magazineStore.load(),
+        shareDraftsStore.sync(),
         socialStore.loadFeed(true),
         filteredViewsStore.syncWithBackend(),
         // Pull the user's own linkblog so share-state reconciles across devices.

--- a/frontend/src/lib/stores/shareComposer.svelte.ts
+++ b/frontend/src/lib/stores/shareComposer.svelte.ts
@@ -3,9 +3,9 @@
 // card, reader chrome, saved list, drafts list — and mounted once in AppShell,
 // so a draft survives closing the reader or navigating while it's open.
 //
-// Create mode edits a local ShareDraft (auto-saved to IndexedDB, public only on
-// Post). Edit mode edits the note of an already-posted share; those edits go to
-// the live record on Update and are not drafted.
+// Create mode edits a ShareDraft (auto-saved privately, public only on Post).
+// Edit mode edits the note of an already-posted share; those edits go to the
+// live record on Update and are not drafted.
 
 import { linkblogStore } from '$lib/stores/linkblog.svelte';
 import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
@@ -79,23 +79,26 @@ function createShareComposerStore() {
 
   // Persist the create-mode draft, debounced off keystrokes. An emptied-out
   // draft deletes its row instead, so clearing the composer clears the marker.
-  function persistDraft() {
+  async function persistDraft() {
     const draft = currentDraft();
     if (!draft) return;
-    if (draftHasContent(draft.blocks)) void shareDraftsStore.save(draft);
-    else void shareDraftsStore.remove(draft.articleUrl);
+    if (draftHasContent(draft.blocks)) await shareDraftsStore.save(draft);
+    else await shareDraftsStore.remove(draft.articleUrl);
   }
 
   function touch() {
     if (!session || session.mode !== 'create') return;
     clearTimeout(saveTimer);
-    saveTimer = setTimeout(persistDraft, 600);
+    saveTimer = setTimeout(() => void persistDraft(), 600);
   }
 
+  // Save now and push now: closing, switching articles, or posting is the point
+  // where the draft should already be on the user's other devices, not up to
+  // five seconds from it.
   function flush() {
     clearTimeout(saveTimer);
     saveTimer = undefined;
-    persistDraft();
+    void persistDraft().then(() => shareDraftsStore.flushServer());
   }
 
   function open(options: ComposerOpenOptions) {

--- a/frontend/src/lib/stores/shareDrafts.svelte.test.ts
+++ b/frontend/src/lib/stores/shareDrafts.svelte.test.ts
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RemoteShareDraft, ShareDraft } from '$lib/types';
+
+// The store is where cross-device drafts actually get decided: which side of a
+// concurrent edit wins, whether a tombstone from another device is obeyed, and
+// whether a write that can't go out now is queued rather than dropped. All of
+// that is client-side policy the backend tests can't see, so it's tested here
+// against fakes for Dexie, the API, and the sync queue.
+
+const { dbRows, metadata, api, enqueue, online, authed } = vi.hoisted(() => ({
+  dbRows: new Map<string, ShareDraft>(),
+  metadata: new Map<string, unknown>(),
+  api: {
+    getAllShareDrafts: vi.fn(),
+    upsertShareDraft: vi.fn(),
+    deleteShareDraft: vi.fn(),
+  },
+  enqueue: vi.fn(),
+  online: { value: true },
+  authed: { value: true },
+}));
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+vi.mock('$lib/services/db', () => ({
+  db: {
+    shareDrafts: {
+      toArray: async () => [...dbRows.values()],
+      put: async (row: ShareDraft) => void dbRows.set(row.articleUrl, row),
+      delete: async (key: string) => void dbRows.delete(key),
+    },
+  },
+  getMetadata: async (key: string) => metadata.get(key) ?? null,
+  setMetadata: async (key: string, value: unknown) => void metadata.set(key, value),
+}));
+
+vi.mock('$lib/services/api', () => ({ api }));
+vi.mock('$lib/services/sync-queue', () => ({ syncQueue: { enqueue } }));
+vi.mock('./sync.svelte', () => ({
+  syncStore: {
+    get isOnline() {
+      return online.value;
+    },
+  },
+}));
+vi.mock('./auth.svelte', () => ({
+  auth: {
+    get isAuthenticated() {
+      return authed.value;
+    },
+  },
+}));
+
+function draft(url: string, text: string, updatedAt: number): ShareDraft {
+  return {
+    articleUrl: url,
+    articleTitle: 'A post',
+    blocks: [{ kind: 'text', text }],
+    createdAt: 1,
+    updatedAt,
+  };
+}
+
+function remote(d: ShareDraft, serverUpdatedAt = 100): RemoteShareDraft {
+  return {
+    articleUrl: d.articleUrl,
+    draft: d,
+    clientUpdatedAt: d.updatedAt,
+    createdAt: 1,
+    serverUpdatedAt,
+    deletedAt: null,
+  };
+}
+
+function tombstone(url: string, clientUpdatedAt: number, serverUpdatedAt = 100): RemoteShareDraft {
+  return {
+    articleUrl: url,
+    draft: null,
+    clientUpdatedAt,
+    createdAt: 1,
+    serverUpdatedAt,
+    deletedAt: serverUpdatedAt,
+  };
+}
+
+type Store = typeof import('./shareDrafts.svelte').shareDraftsStore;
+
+async function freshStore(): Promise<Store> {
+  vi.resetModules();
+  const mod = await import('./shareDrafts.svelte');
+  return mod.shareDraftsStore;
+}
+
+describe('shareDraftsStore', () => {
+  beforeEach(() => {
+    dbRows.clear();
+    metadata.clear();
+    vi.clearAllMocks();
+    online.value = true;
+    authed.value = true;
+    api.getAllShareDrafts.mockResolvedValue([]);
+    api.upsertShareDraft.mockResolvedValue({ success: true, articleUrl: 'x' });
+    api.deleteShareDraft.mockResolvedValue({ success: true });
+  });
+
+  it('brings in a draft written on another device', async () => {
+    api.getAllShareDrafts.mockResolvedValue([
+      remote(draft('https://a.example/', 'elsewhere', 500)),
+    ]);
+    const store = await freshStore();
+
+    await store.sync();
+
+    expect(store.list.map((d) => d.blocks[0].text)).toEqual(['elsewhere']);
+    // Cached, so the next cold start has it before the network answers.
+    expect(dbRows.get('https://a.example/')?.blocks[0].text).toBe('elsewhere');
+  });
+
+  it('keeps the newer local edit and pushes it on the first full sync', async () => {
+    dbRows.set('https://a.example/', draft('https://a.example/', 'mine, newer', 900));
+    api.getAllShareDrafts.mockResolvedValue([remote(draft('https://a.example/', 'theirs', 500))]);
+    const store = await freshStore();
+
+    await store.sync();
+
+    expect(store.list.map((d) => d.blocks[0].text)).toEqual(['mine, newer']);
+    expect(api.upsertShareDraft).toHaveBeenCalledTimes(1);
+    expect(api.upsertShareDraft.mock.calls[0][0].blocks[0].text).toBe('mine, newer');
+  });
+
+  it('uploads drafts that predate the upgrade and exist nowhere on the server', async () => {
+    dbRows.set('https://a.example/', draft('https://a.example/', 'marooned', 400));
+    const store = await freshStore();
+
+    await store.sync();
+
+    expect(api.upsertShareDraft).toHaveBeenCalledTimes(1);
+    expect(api.upsertShareDraft.mock.calls[0][0].articleUrl).toBe('https://a.example/');
+  });
+
+  it('obeys a tombstone from another device', async () => {
+    dbRows.set('https://a.example/', draft('https://a.example/', 'posted elsewhere', 400));
+    api.getAllShareDrafts.mockResolvedValue([tombstone('https://a.example/', 800)]);
+    const store = await freshStore();
+
+    await store.sync();
+
+    expect(store.list).toHaveLength(0);
+    expect(dbRows.has('https://a.example/')).toBe(false);
+  });
+
+  it('ignores a tombstone the local edit has already outrun', async () => {
+    dbRows.set('https://a.example/', draft('https://a.example/', 'still writing', 900));
+    api.getAllShareDrafts.mockResolvedValue([tombstone('https://a.example/', 400)]);
+    const store = await freshStore();
+
+    await store.sync();
+
+    expect(store.list.map((d) => d.blocks[0].text)).toEqual(['still writing']);
+    // And it goes back up, so the other device stops showing it as deleted.
+    expect(api.upsertShareDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for a delta on the second sync and persists the cursor', async () => {
+    api.getAllShareDrafts.mockResolvedValue([
+      remote(draft('https://a.example/', 'one', 500), 1700),
+    ]);
+    const store = await freshStore();
+
+    await store.sync();
+    expect(api.getAllShareDrafts.mock.calls[0][0]).toEqual({});
+    expect(metadata.get('shareDraftsCursor')).toBe(1700);
+
+    api.getAllShareDrafts.mockResolvedValue([]);
+    await store.sync();
+    expect(api.getAllShareDrafts.mock.calls[1][0]).toEqual({ since: 1700 });
+  });
+
+  it('throttles the server write and flushes it on demand', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = await freshStore();
+      await store.load();
+
+      await store.save(draft('https://a.example/', 'typing', 100));
+      await store.save(draft('https://a.example/', 'typing more', 200));
+      // Cached immediately; only the network write waits.
+      expect(dbRows.get('https://a.example/')?.blocks[0].text).toBe('typing more');
+      expect(api.upsertShareDraft).not.toHaveBeenCalled();
+
+      await store.flushServer();
+      expect(api.upsertShareDraft).toHaveBeenCalledTimes(1);
+      expect(api.upsertShareDraft.mock.calls[0][0].blocks[0].text).toBe('typing more');
+
+      // The timer that was pending must not fire a second, redundant write.
+      await vi.runAllTimersAsync();
+      expect(api.upsertShareDraft).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('queues the write when offline instead of losing it', async () => {
+    vi.useFakeTimers();
+    try {
+      online.value = false;
+      const store = await freshStore();
+      await store.load();
+
+      await store.save(draft('https://a.example/', 'written on a train', 100));
+      await store.flushServer();
+
+      expect(api.upsertShareDraft).not.toHaveBeenCalled();
+      expect(enqueue).toHaveBeenCalledWith(
+        'update',
+        'shareDraft',
+        'https://a.example/',
+        expect.objectContaining({ articleUrl: 'https://a.example/' })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('discards the pending write when the draft is removed', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = await freshStore();
+      await store.load();
+
+      await store.save(draft('https://a.example/', 'about to post this', 100));
+      await store.remove('https://a.example/');
+
+      expect(api.deleteShareDraft).toHaveBeenCalledTimes(1);
+      expect(api.deleteShareDraft.mock.calls[0][0]).toBe('https://a.example/');
+      await vi.runAllTimersAsync();
+      expect(api.upsertShareDraft).not.toHaveBeenCalled();
+      expect(store.list).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stays off the network entirely when signed out', async () => {
+    authed.value = false;
+    const store = await freshStore();
+
+    await store.sync();
+    await store.save(draft('https://a.example/', 'dev harness', 100));
+    await store.flushServer();
+    await store.remove('https://a.example/');
+
+    expect(api.getAllShareDrafts).not.toHaveBeenCalled();
+    expect(api.upsertShareDraft).not.toHaveBeenCalled();
+    expect(api.deleteShareDraft).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/shareDrafts.svelte.ts
+++ b/frontend/src/lib/stores/shareDrafts.svelte.ts
@@ -23,7 +23,9 @@ import { auth } from './auth.svelte';
 import { draftHasContent } from '$lib/utils/shareNote';
 import type { RemoteShareDraft, ShareDraft } from '$lib/types';
 
-// Persisted delta cursor: the max server `updated_at` (unix seconds) seen.
+// Persisted delta cursor: the max server `updated_at` (unix seconds) seen. The
+// backend overlaps this second on the next delta, and the LWW merge below makes
+// those boundary replays idempotent while catching same-second late writes.
 // `db.metadata.clear()` on logout wipes it, so the next account starts cold.
 const CURSOR_KEY = 'shareDraftsCursor';
 

--- a/frontend/src/lib/stores/shareDrafts.svelte.ts
+++ b/frontend/src/lib/stores/shareDrafts.svelte.ts
@@ -1,14 +1,40 @@
-// Local share drafts (device-only). A draft is the unposted state of a linkblog
-// share, keyed by the external article URL — the same key the linkblog dedups
-// on. Drafts live in IndexedDB only: nothing leaves the device until the user
-// posts, which is the whole point of drafting a public share.
+// Share drafts. A draft is the unposted state of a linkblog share, keyed by the
+// external article URL — the same key the linkblog dedups on.
+//
+// Drafts are durable and cross-device: D1 is the store of record and IndexedDB
+// is an offline cache, so a draft started on the phone can be finished on the
+// laptop and survives an IndexedDB eviction (a real hazard on iOS PWAs — see
+// `checkDbHealth`). They are private to the account, exactly like saves and read
+// state: never a PDS record, never public. Only posting makes a draft public,
+// through the linkblog write path.
+//
+// Sync follows the magazines pattern: a persisted `?since=` cursor, tombstoned
+// deletes replayed from other devices, and offline writes through the sync
+// queue. Where it differs is the merge — a draft is keystroke-level content, so
+// both sides resolve last-write-wins on the client ms clock (`ShareDraft.updatedAt`)
+// rather than trusting arrival order, and the server enforces the same rule.
 
-import { db } from '$lib/services/db';
+import { browser } from '$app/environment';
+import { db, getMetadata, setMetadata } from '$lib/services/db';
+import { api } from '$lib/services/api';
+import { syncQueue } from '$lib/services/sync-queue';
+import { syncStore } from './sync.svelte';
+import { auth } from './auth.svelte';
 import { draftHasContent } from '$lib/utils/shareNote';
-import type { ShareDraft } from '$lib/types';
+import type { RemoteShareDraft, ShareDraft } from '$lib/types';
+
+// Persisted delta cursor: the max server `updated_at` (unix seconds) seen.
+// `db.metadata.clear()` on logout wipes it, so the next account starts cold.
+const CURSOR_KEY = 'shareDraftsCursor';
+
+// The composer already debounces its Dexie write at 600 ms. The server push is
+// throttled on top of that — trailing, so the first keystroke of a burst starts
+// the clock and the last edit in the window is what lands. Bounds D1 at roughly
+// one write per 5 s of active typing per draft instead of one per typing pause.
+const PUSH_THROTTLE_MS = 5000;
 
 function toPlain(draft: ShareDraft): ShareDraft {
-  // $state proxies can't cross into IndexedDB — copy to plain objects.
+  // $state proxies can't cross into IndexedDB (or JSON) — copy to plain objects.
   return { ...draft, blocks: draft.blocks.map((b) => ({ ...b })) };
 }
 
@@ -18,8 +44,19 @@ function createShareDraftsStore() {
   // `hasLoaded` flag is what makes `await load()` mean "the drafts are here":
   // a flag set before the await lets a second caller through while the read is
   // still running, and the composer would then open blank over a saved draft
-  // and overwrite it on the first keystroke.
+  // and overwrite it on the first keystroke. It stays Dexie-only for the same
+  // reason — the composer awaits it, and it must not wait on the network.
   let loadPromise: Promise<void> | null = null;
+
+  let cursor = 0;
+  let cursorLoaded = false;
+  let cursorHasValue = false;
+  let syncInFlight: Promise<void> | null = null;
+
+  // Trailing server pushes, one timer per article URL. `pending` holds the draft
+  // the timer will send, replaced (not queued) by later edits in the window.
+  const pushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pending = new Map<string, ShareDraft>();
 
   const list = $derived(
     [...drafts.values()]
@@ -44,6 +81,180 @@ function createShareDraftsStore() {
     return (loadPromise ??= hydrate());
   }
 
+  // Server traffic is skipped entirely when logged out, so the /dev/linkblog
+  // harness and any signed-out surface keep working purely against Dexie.
+  function canSync(): boolean {
+    return auth.isAuthenticated && syncStore.isOnline;
+  }
+
+  function setLocal(draft: ShareDraft) {
+    drafts.set(draft.articleUrl, draft);
+    drafts = new Map(drafts);
+  }
+
+  function deleteLocal(articleUrl: string) {
+    if (drafts.delete(articleUrl)) drafts = new Map(drafts);
+  }
+
+  /** Whether a remote row is usable as a draft (well-formed and not emptied out). */
+  function remoteDraftIsLive(row: RemoteShareDraft): boolean {
+    return (
+      row.deletedAt === null &&
+      !!row.draft &&
+      Array.isArray(row.draft.blocks) &&
+      draftHasContent(row.draft.blocks)
+    );
+  }
+
+  async function mergeRemote(rows: RemoteShareDraft[]) {
+    for (const row of rows) {
+      const local = drafts.get(row.articleUrl);
+      // The server's row is authoritative for its own key, and only the client
+      // clock decides the winner — the server's second-resolution `updated_at`
+      // is a cursor, not a merge input.
+      const remoteClock = row.draft?.updatedAt ?? row.clientUpdatedAt;
+
+      if (!remoteDraftIsLive(row)) {
+        // A tombstone, or a row emptied out elsewhere — either way there is no
+        // draft to show. Drop ours unless it is strictly newer, in which case
+        // the local edit won and the one-time/queued push resurrects it.
+        if (local && local.updatedAt > remoteClock) continue;
+        deleteLocal(row.articleUrl);
+        try {
+          await db.shareDrafts.delete(row.articleUrl);
+        } catch (e) {
+          console.error('Failed to drop cached share draft:', e);
+        }
+        continue;
+      }
+
+      if (local && local.updatedAt >= remoteClock) continue;
+
+      const merged = toPlain({ ...(row.draft as ShareDraft), articleUrl: row.articleUrl });
+      setLocal(merged);
+      try {
+        await db.shareDrafts.put(merged);
+      } catch (e) {
+        console.error('Failed to cache share draft:', e);
+      }
+    }
+  }
+
+  // First sync on an upgraded client: drafts already in IndexedDB have never
+  // been pushed anywhere. Without this they would stay marooned on whichever
+  // device typed them — or, on a second device, be quietly outvoted by an empty
+  // server state. Only runs on the no-cursor (full snapshot) path.
+  async function uploadPreExisting(rows: RemoteShareDraft[]) {
+    const remoteClocks = new Map(
+      rows.map((row) => [row.articleUrl, row.draft?.updatedAt ?? row.clientUpdatedAt])
+    );
+    for (const draft of [...drafts.values()]) {
+      if (!draftHasContent(draft.blocks)) continue;
+      const remoteClock = remoteClocks.get(draft.articleUrl);
+      if (remoteClock !== undefined && remoteClock >= draft.updatedAt) continue;
+      await push(toPlain(draft));
+    }
+  }
+
+  async function syncFromServer() {
+    if (!cursorLoaded) {
+      const persisted = await getMetadata<number>(CURSOR_KEY);
+      if (typeof persisted === 'number') {
+        cursor = persisted;
+        cursorHasValue = true;
+      }
+      cursorLoaded = true;
+    }
+
+    const isFull = !cursorHasValue;
+    const rows = await api.getAllShareDrafts(isFull ? {} : { since: cursor });
+
+    let maxUpdatedAt = cursor;
+    for (const row of rows) {
+      if (row.serverUpdatedAt > maxUpdatedAt) maxUpdatedAt = row.serverUpdatedAt;
+    }
+
+    await mergeRemote(rows);
+    if (isFull) await uploadPreExisting(rows);
+
+    // Advance only after the merge: a cursor committed ahead of a failed merge
+    // would skip those rows forever.
+    if (maxUpdatedAt > cursor || !cursorHasValue) {
+      cursor = maxUpdatedAt;
+      cursorHasValue = true;
+      await setMetadata(CURSOR_KEY, cursor);
+    }
+  }
+
+  /**
+   * Pull the account's drafts (full snapshot the first time, `?since=` delta
+   * after) and merge them in. Safe to call on every refresh; concurrent callers
+   * share one request.
+   */
+  function sync(): Promise<void> {
+    if (!canSync()) return Promise.resolve();
+    // Claimed synchronously: two refreshes firing in the same tick would both
+    // get past an `await` before either had set the flag, and the second run's
+    // merge would race the first one's cursor commit.
+    if (syncInFlight) return syncInFlight;
+    syncInFlight = (async () => {
+      try {
+        // The cache first, so the merge has something to resolve against.
+        await load();
+        await syncFromServer();
+      } catch (e) {
+        console.error('Failed to sync share drafts:', e);
+      } finally {
+        syncInFlight = null;
+      }
+    })();
+    return syncInFlight;
+  }
+
+  async function push(draft: ShareDraft) {
+    if (!auth.isAuthenticated) return;
+    if (!syncStore.isOnline) {
+      await syncQueue.enqueue('update', 'shareDraft', draft.articleUrl, draft);
+      return;
+    }
+    try {
+      await api.upsertShareDraft(draft);
+    } catch (e) {
+      console.error('Failed to sync share draft, queueing for retry:', e);
+      await syncQueue.enqueue('update', 'shareDraft', draft.articleUrl, draft);
+    }
+  }
+
+  function cancelPush(articleUrl: string) {
+    const timer = pushTimers.get(articleUrl);
+    if (timer) clearTimeout(timer);
+    pushTimers.delete(articleUrl);
+    pending.delete(articleUrl);
+  }
+
+  async function flushOne(articleUrl: string) {
+    const draft = pending.get(articleUrl);
+    cancelPush(articleUrl);
+    if (draft) await push(draft);
+  }
+
+  function schedulePush(draft: ShareDraft) {
+    pending.set(draft.articleUrl, draft);
+    if (pushTimers.has(draft.articleUrl)) return;
+    pushTimers.set(
+      draft.articleUrl,
+      setTimeout(() => void flushOne(draft.articleUrl), PUSH_THROTTLE_MS)
+    );
+  }
+
+  /**
+   * Send any throttled writes now. Drained on composer close/switch/post and on
+   * `pagehide`, so words typed a second before the PWA is backgrounded still land.
+   */
+  async function flushServer(): Promise<void> {
+    await Promise.all([...pending.keys()].map((url) => flushOne(url)));
+  }
+
   function get(articleUrl: string): ShareDraft | undefined {
     return drafts.get(articleUrl);
   }
@@ -56,27 +267,48 @@ function createShareDraftsStore() {
 
   async function save(draft: ShareDraft) {
     const plain = toPlain(draft);
-    drafts.set(plain.articleUrl, plain);
-    drafts = new Map(drafts);
+    setLocal(plain);
     try {
       await db.shareDrafts.put(plain);
     } catch (e) {
       console.error('Failed to persist share draft:', e);
     }
+    schedulePush(plain);
   }
 
   async function remove(articleUrl: string) {
-    drafts.delete(articleUrl);
-    drafts = new Map(drafts);
+    deleteLocal(articleUrl);
     try {
       await db.shareDrafts.delete(articleUrl);
     } catch (e) {
       console.error('Failed to delete share draft:', e);
     }
+
+    // Drop the throttled upsert this delete supersedes. It would be rejected by
+    // the server's clock guard anyway, but there is no reason to send it.
+    cancelPush(articleUrl);
+    if (!auth.isAuthenticated) return;
+
+    // Stamped with the client clock so the delete is on the same last-write-wins
+    // footing as an edit made on another device.
+    const updatedAt = Date.now();
+    const tombstone: ShareDraft = { articleUrl, blocks: [], createdAt: 0, updatedAt };
+    if (!syncStore.isOnline) {
+      await syncQueue.enqueue('delete', 'shareDraft', articleUrl, tombstone);
+      return;
+    }
+    try {
+      await api.deleteShareDraft(articleUrl, updatedAt);
+    } catch (e) {
+      console.error('Failed to delete share draft on the server, queueing for retry:', e);
+      await syncQueue.enqueue('delete', 'shareDraft', articleUrl, tombstone);
+    }
   }
 
   return {
     load,
+    sync,
+    flushServer,
     get,
     hasDraft,
     save,
@@ -88,3 +320,15 @@ function createShareDraftsStore() {
 }
 
 export const shareDraftsStore = createShareDraftsStore();
+
+// A backgrounded PWA can be frozen or killed without another chance to write, so
+// drain the throttle on the way out. `visibilitychange` is the one that actually
+// fires on mobile; `pagehide` covers the desktop tab-close. The local copy is
+// already in IndexedDB either way — this is about the words reaching the account.
+if (browser) {
+  const drain = () => void shareDraftsStore.flushServer();
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') drain();
+  });
+  window.addEventListener('pagehide', drain);
+}

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -713,10 +713,15 @@ export interface ShareDraftBlock {
   text: string;
 }
 
-// A local (device-only) draft of a linkblog share, keyed by the external
-// article URL — the same key the linkblog dedups on. Carries enough article
-// metadata to post the share later without the original Article object (so a
-// draft can be resumed from the drafts list long after the feed item is gone).
+// An unposted draft of a linkblog share, keyed by the external article URL —
+// the same key the linkblog dedups on. Carries enough article metadata to post
+// the share later without the original Article object (so a draft can be
+// resumed from the drafts list long after the feed item is gone).
+//
+// Stored privately on the Skyreader servers and cached in IndexedDB, so a draft
+// started on one device can be finished on another. It stays private until the
+// user posts it — nothing about a draft is public, and none of it goes to the
+// PDS. `updatedAt` (ms) is the clock the cross-device merge resolves on.
 export interface ShareDraft {
   articleUrl: string; // primary key
   articleTitle?: string;
@@ -731,6 +736,19 @@ export interface ShareDraft {
   blocks: ShareDraftBlock[];
   createdAt: number;
   updatedAt: number;
+}
+
+// One draft row as the server hands it back. `serverUpdatedAt` is the server's
+// second-resolution clock and is only a delta cursor — never a merge input; the
+// merge resolves on the client ms clock inside `draft.updatedAt`. A tombstone
+// (`deletedAt` set) carries no body: it says a draft died, not what it said.
+export interface RemoteShareDraft {
+  articleUrl: string;
+  draft: ShareDraft | null;
+  clientUpdatedAt: number;
+  createdAt: number;
+  serverUpdatedAt: number;
+  deletedAt: number | null;
 }
 
 // One other person who linked the same external article (Constellation), with

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -13,20 +13,23 @@ export default defineConfig({
   test: {
     projects: [
       {
-        // Plain unit tests (node environment).
+        // Plain unit tests (node environment). Rune modules are excluded: they
+        // need the Svelte compiler, so their tests run in the project below.
         test: {
           name: 'unit',
           include: ['src/**/*.test.ts'],
-          exclude: ['src/**/*.component.test.ts'],
+          exclude: ['src/**/*.component.test.ts', 'src/**/*.svelte.test.ts'],
         },
         resolve: { alias },
       },
       {
-        // Component tests: compile .svelte files and mount them in jsdom.
+        // Everything that needs the Svelte compiler, in jsdom: components mounted
+        // from .svelte files, and the rune-based stores/hooks in .svelte.ts modules
+        // (an uncompiled $state() is just an undefined identifier).
         plugins: [svelte({ hot: false })],
         test: {
           name: 'component',
-          include: ['src/**/*.component.test.ts'],
+          include: ['src/**/*.component.test.ts', 'src/**/*.svelte.test.ts'],
           environment: 'jsdom',
         },
         resolve: { alias, conditions: ['browser'] },


### PR DESCRIPTION
Persists linkblog share drafts to D1 as the cross-device store of record, with IndexedDB as the offline cache. Draft writes and tombstones use client-clock last-write-wins merging, offline queueing, throttled writes, and paginated delta sync.

This revision fixes the review finding in the delta checkpoint: the backend now overlaps the checkpoint second (`updated_at >= since`) so a mutation arriving later in the same Unix second cannot be skipped forever. Existing client LWW merging safely deduplicates boundary replays, while the `(updated_at, id)` page cursor keeps pagination collision-safe. A backend regression test reproduces the same-second race.

Privacy remains unchanged from the original implementation: unposted drafts are private on Skyreader servers, never written to a PDS, and become public only when posted.

Checks:

- Backend share-drafts spec: 13/13 passed
- Backend `npm run check`: passed
- Frontend `npm run check`: passed with 18 existing warnings
- Browser E2E not rerun in this environment

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-oxrky7bp2oepfmyewiz3bn54)