### PR TITLE
Restore full content for truncated feed articles

### DIFF
--- a/backend/src/routes/ingest.ts
+++ b/backend/src/routes/ingest.ts
@@ -23,7 +23,13 @@ export const SANITY_CAP = 5000;
 // acts on: ArticleCard and SavedReader auto-extract the full text via /api/extract
 // when a truncated article is opened, so the body the user sees is still the
 // whole article (see frontend/src/lib/components/{ArticleCard,feed/SavedReader}.svelte).
-export const MAX_ITEM_CONTENT_BYTES = 32 * 1024;
+// Extraction, not a bigger cap, is what makes long-form feeds readable: raising
+// this to 32 KB was tried and still dropped 19 of 20 posts on the feed that
+// motivated it, while quadrupling archive growth and the weight of a timeline
+// page. The page budgets in routes/timeline.ts (MAX_LIMIT, COLD_START_MAX_ITEMS)
+// bound response size in rows and are sized against this constant — raising it
+// means re-deriving them.
+export const MAX_ITEM_CONTENT_BYTES = 8 * 1024;
 
 // How long a crawler heartbeat stays "fresh". The proxy pulls the crawl set every
 // 5 minutes whenever INGEST_URL is set, so a stamp older than this means this

--- a/backend/src/routes/ingest.ts
+++ b/backend/src/routes/ingest.ts
@@ -20,10 +20,10 @@ export const SANITY_CAP = 5000;
 // than optional: D1 has a hard 10 GB database ceiling, so storage grows with
 // ingest velocity × item size × time. Oversized bodies are dropped at ingest
 // (summary/title/url/image kept) and `contentTruncated` is set, which the reader
-// acts on: ArticleCard auto-extracts the full text via /api/extract when a
-// truncated article is opened, so the body the user sees is still the whole
-// article (see frontend/src/lib/components/ArticleCard.svelte).
-export const MAX_ITEM_CONTENT_BYTES = 8 * 1024;
+// acts on: ArticleCard and SavedReader auto-extract the full text via /api/extract
+// when a truncated article is opened, so the body the user sees is still the
+// whole article (see frontend/src/lib/components/{ArticleCard,feed/SavedReader}.svelte).
+export const MAX_ITEM_CONTENT_BYTES = 32 * 1024;
 
 // How long a crawler heartbeat stays "fresh". The proxy pulls the crawl set every
 // 5 minutes whenever INGEST_URL is set, so a stamp older than this means this

--- a/backend/test/feed-timeline.spec.ts
+++ b/backend/test/feed-timeline.spec.ts
@@ -325,9 +325,11 @@ describe('feed timeline (D1 ingest + serve)', () => {
     });
 
     it('caps stored content and marks it truncated, leaving small items alone', async () => {
-      const big = 'x'.repeat(9000);
+      const big = 'x'.repeat(32 * 1024 + 1);
+      const withinRaisedCap = 'y'.repeat(20 * 1024);
       await ingest(FEED_A, [
         { item: item('big', { content: big, summary: 'kept' }), contentHash: 'hbig' },
+        { item: item('within-cap', { content: withinRaisedCap }), contentHash: 'hwithin' },
         { item: item('small', { content: 'tiny' }), contentHash: 'hsmall' },
       ]);
 
@@ -338,6 +340,11 @@ describe('feed timeline (D1 ingest + serve)', () => {
       expect(parsedBig.content).toBeUndefined();
       expect(parsedBig.contentTruncated).toBe(true);
       expect(parsedBig.summary).toBe('kept');
+
+      const withinCapRow = await env.DB.prepare('SELECT item_json FROM feed_items WHERE guid = ?')
+        .bind('within-cap')
+        .first<{ item_json: string }>();
+      expect(JSON.parse(withinCapRow!.item_json).content).toBe(withinRaisedCap);
 
       const smallRow = await env.DB.prepare('SELECT item_json FROM feed_items WHERE guid = ?')
         .bind('small')

--- a/backend/test/feed-timeline.spec.ts
+++ b/backend/test/feed-timeline.spec.ts
@@ -325,11 +325,11 @@ describe('feed timeline (D1 ingest + serve)', () => {
     });
 
     it('caps stored content and marks it truncated, leaving small items alone', async () => {
-      const big = 'x'.repeat(32 * 1024 + 1);
-      const withinRaisedCap = 'y'.repeat(20 * 1024);
+      const big = 'x'.repeat(8 * 1024 + 1);
+      const justUnderCap = 'y'.repeat(8 * 1024 - 100);
       await ingest(FEED_A, [
         { item: item('big', { content: big, summary: 'kept' }), contentHash: 'hbig' },
-        { item: item('within-cap', { content: withinRaisedCap }), contentHash: 'hwithin' },
+        { item: item('within-cap', { content: justUnderCap }), contentHash: 'hwithin' },
         { item: item('small', { content: 'tiny' }), contentHash: 'hsmall' },
       ]);
 
@@ -344,7 +344,7 @@ describe('feed timeline (D1 ingest + serve)', () => {
       const withinCapRow = await env.DB.prepare('SELECT item_json FROM feed_items WHERE guid = ?')
         .bind('within-cap')
         .first<{ item_json: string }>();
-      expect(JSON.parse(withinCapRow!.item_json).content).toBe(withinRaisedCap);
+      expect(JSON.parse(withinCapRow!.item_json).content).toBe(justUnderCap);
 
       const smallRow = await env.DB.prepare('SELECT item_json FROM feed_items WHERE guid = ?')
         .bind('small')

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -142,6 +142,8 @@ export interface SeedFeedItemOpts {
   url?: string;
   publishedAt?: string;
   summary?: string;
+  content?: string;
+  contentTruncated?: boolean;
 }
 
 /**
@@ -177,6 +179,8 @@ export async function seedFeedItems(
       url: item.url ?? `https://example.com/${item.guid}`,
       title: item.title,
       summary: item.summary ?? `Summary for ${item.title}`,
+      ...(item.content == null ? {} : { content: item.content }),
+      ...(item.contentTruncated == null ? {} : { contentTruncated: item.contentTruncated }),
       publishedAt,
     });
     statements.push(

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -103,7 +103,7 @@ test.describe('Timeline refresh', () => {
     expect(readGuids).not.toContain('timeline-item-2');
   });
 
-  test('reader extracts a truncated article once and reuses it on reopen', async ({
+  test('reader extracts a truncated article on open and reuses it on reopen', async ({
     authedPage,
     testUser,
   }) => {
@@ -148,12 +148,21 @@ test.describe('Timeline refresh', () => {
       has: authedPage.getByText('Truncated Reader Article', { exact: true }),
     });
     await expect(card).toBeVisible({ timeout: 15_000 });
-    await card.locator('button.article-header').click();
-    await card.getByRole('button', { name: 'Reader', exact: true }).click();
+
+    // Select and open the reader with the keyboard — no card expansion, so the
+    // reader's own on-open extract is what fires. (Expanding first would have
+    // ArticleCard fetch it and reduce the reader's call to a cache hit, which
+    // is the second half of this test, not the first.)
+    await authedPage.keyboard.press('j');
+    await expect(card.locator('.article-item.highlighted')).toBeVisible();
+    await authedPage.keyboard.press('f');
     await expect(authedPage.locator('.reader-body')).toContainText(extractedText);
     expect(extractCalls).toBe(1);
 
+    // Reopening through the card — which expands, firing ArticleCard's own
+    // truncated-article fetch — still serves the session-cached extract.
     await authedPage.getByRole('button', { name: 'Back', exact: true }).click();
+    await card.locator('button.article-header').click();
     await card.getByRole('button', { name: 'Reader', exact: true }).click();
     await expect(authedPage.locator('.reader-body')).toContainText(extractedText);
     expect(extractCalls).toBe(1);

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -102,4 +102,60 @@ test.describe('Timeline refresh', () => {
     expect(readGuids).toContain('timeline-item-1');
     expect(readGuids).not.toContain('timeline-item-2');
   });
+
+  test('reader extracts a truncated article once and reuses it on reopen', async ({
+    authedPage,
+    testUser,
+  }) => {
+    const articleUrl = 'https://example.com/truncated-reader';
+    const description = 'Short RSS description while the full article loads.';
+    const extractedText = 'Full extracted article text that was absent from the feed archive.';
+    await seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
+    await seedFeedItems(
+      FEED_URL,
+      [
+        {
+          guid: 'truncated-reader-item',
+          title: 'Truncated Reader Article',
+          url: articleUrl,
+          summary: description,
+          contentTruncated: true,
+        },
+      ],
+      { title: FEED_TITLE, siteUrl: 'https://example.com' }
+    );
+
+    let extractCalls = 0;
+    await authedPage.route('**/api/extract', async (route) => {
+      extractCalls += 1;
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          title: 'Truncated Reader Article',
+          author: null,
+          description,
+          content: `<p>${extractedText}</p>`,
+          domain: 'example.com',
+          image: null,
+          published: null,
+          wordCount: 12,
+        }),
+      });
+    });
+
+    await authedPage.goto('/feeds');
+    const card = authedPage.locator('.article-item-anchor', {
+      has: authedPage.getByText('Truncated Reader Article', { exact: true }),
+    });
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await card.locator('button.article-header').click();
+    await card.getByRole('button', { name: 'Reader', exact: true }).click();
+    await expect(authedPage.locator('.reader-body')).toContainText(extractedText);
+    expect(extractCalls).toBe(1);
+
+    await authedPage.getByRole('button', { name: 'Back', exact: true }).click();
+    await card.getByRole('button', { name: 'Reader', exact: true }).click();
+    await expect(authedPage.locator('.reader-body')).toContainText(extractedText);
+    expect(extractCalls).toBe(1);
+  });
 });

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -235,8 +235,12 @@
   // body is often just an excerpt. Fall back to the feed body in IndexedDB (the
   // in-memory article is "light", its content stripped — see toLightArticle).
   let lazyArticleContent = $state<string | null>(null);
+  // Whether that body is the user's own saved snapshot rather than the feed's —
+  // the display ladder below treats the two differently.
+  let lazyArticleIsSavedCopy = $state(false);
   $effect(() => {
     lazyArticleContent = null;
+    lazyArticleIsSavedCopy = false;
     if (readerItem.type !== 'article') return;
     const {
       id,
@@ -253,7 +257,10 @@
         if (saved?.rkey) {
           const savedBody = await savesStore.getContent(saved.rkey);
           if (savedBody) {
-            if (!cancelled) lazyArticleContent = savedBody;
+            if (!cancelled) {
+              lazyArticleContent = savedBody;
+              lazyArticleIsSavedCopy = true;
+            }
             return;
           }
         }
@@ -311,14 +318,20 @@
     // Prefer the lazily-loaded body for saved items; normalized.displayContent
     // falls back to the description until it arrives.
     if (readerItem.type === 'saved' && lazySavedContent) return lazySavedContent;
-    // Same for a saved feed article rendered via the 'article' path — its body
-    // was stripped from memory and is read back from IndexedDB above.
-    if (readerItem.type === 'article' && lazyArticleContent) return lazyArticleContent;
-    // Oversized feed bodies are omitted from D1. When that ladder is empty, the
-    // on-open extract upgrades the interim RSS description in place.
+    // A save's own snapshot still outranks everything — it's the body the user
+    // kept (and what their highlights are anchored in).
+    if (readerItem.type === 'article' && lazyArticleIsSavedCopy && lazyArticleContent)
+      return lazyArticleContent;
+    // Otherwise an extract of the original wins over the feed's body, matching
+    // ArticleCard: the entry only exists because something asked for it (Shift+F,
+    // the ⋯ menu, the truncated-article nudge), and an RSS body is often just an
+    // excerpt. It's also how an oversized body — dropped at ingest — gets here.
     const extractedArticle =
       readerItem.type === 'article' ? linkPostContentStore.get(readerItem.item.url) : undefined;
     if (extractedArticle?.content) return extractedArticle.content;
+    // Else the feed body for an article rendered via the 'article' path — it was
+    // stripped from memory and is read back from IndexedDB above.
+    if (readerItem.type === 'article' && lazyArticleContent) return lazyArticleContent;
     // For a stripped document, re-render with the lazily-loaded textContent fed
     // back in — structured `content` still wins inside getDisplayContent, so this
     // only changes the unrecognized-format fallback (description → full text).

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -37,7 +37,7 @@
   import { magazineThemeVars } from '$lib/utils/magazineTheme';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
-  import { tick, onMount, onDestroy } from 'svelte';
+  import { tick, onMount, onDestroy, untrack } from 'svelte';
 
   let {
     readerItem,
@@ -238,7 +238,14 @@
   $effect(() => {
     lazyArticleContent = null;
     if (readerItem.type !== 'article') return;
-    const { id, guid, subscriptionId, content: inMemoryContent } = readerItem.item;
+    const {
+      id,
+      guid,
+      subscriptionId,
+      content: inMemoryContent,
+      contentTruncated,
+      url,
+    } = readerItem.item;
     let cancelled = false;
     (async () => {
       try {
@@ -262,9 +269,19 @@
             .filter((a) => a.subscriptionId === subscriptionId)
             .first();
         }
-        if (!cancelled) lazyArticleContent = row?.content ?? '';
+        const cachedContent = row?.content ?? '';
+        if (!cancelled) lazyArticleContent = cachedContent;
+        if (!cancelled && !cachedContent && contentTruncated && url) {
+          // Keep the store's reactive entry map out of this effect's dependency
+          // graph. Failed extracts delete their entry so a later open can retry;
+          // tracking that deletion here would create an immediate retry loop.
+          untrack(() => linkPostContentStore.fetch(url));
+        }
       } catch {
         if (!cancelled) lazyArticleContent = '';
+        if (!cancelled && contentTruncated && url) {
+          untrack(() => linkPostContentStore.fetch(url));
+        }
       }
     })();
     return () => {
@@ -297,6 +314,11 @@
     // Same for a saved feed article rendered via the 'article' path — its body
     // was stripped from memory and is read back from IndexedDB above.
     if (readerItem.type === 'article' && lazyArticleContent) return lazyArticleContent;
+    // Oversized feed bodies are omitted from D1. When that ladder is empty, the
+    // on-open extract upgrades the interim RSS description in place.
+    const extractedArticle =
+      readerItem.type === 'article' ? linkPostContentStore.get(readerItem.item.url) : undefined;
+    if (extractedArticle?.content) return extractedArticle.content;
     // For a stripped document, re-render with the lazily-loaded textContent fed
     // back in — structured `content` still wins inside getDisplayContent, so this
     // only changes the unrecognized-format fallback (description → full text).


### PR DESCRIPTION
## Summary
- auto-extract truncated feed articles when SavedReader has no stored body
- reader content ladder: an explicitly fetched extract outranks the feed body (matching ArticleCard), while a save's own snapshot still wins over both
- keep the D1 item-content cap at **8 KB** (the 32 KB raise was reverted after review — see below)
- E2E: open the reader with `j`/`f` so SavedReader's own on-open extract is exercised; reopen through the card still asserts a single `/api/extract` call

## Why the cap stayed at 8 KB
Measured against `thezvi.substack.com/feed`, 32 KB changed the outcome for 1 of 20 items, so it bought
almost nothing while quadrupling archive growth and timeline page weight — and `timeline.ts`'s row
budgets (`MAX_LIMIT`, `COLD_START_MAX_ITEMS`) are documented as bounds on response weight derived from
this constant and were never re-derived. Extraction on open, not a bigger cap, is what makes a
long-form feed readable. The constant's comment now records that, plus the coupling to the timeline
budgets. Note there is no backfill either way: items already stored as `contentTruncated` keep no
body, so the extract path is what recovers the existing archive.

## Checks
- backend: `npm run check` (tsc + prettier) — clean
- backend: full vitest suite, run file-by-file (the sandbox's 512-pid cgroup can't host all isolates at once) — 52/52 spec files pass, including `feed-timeline.spec.ts` (51 tests)
- frontend: `npm run check` — 0 errors, 18 pre-existing warnings; prettier clean
- root: `prettier --check e2e` — clean
- E2E: still not executable here — Chromium can't launch (`$HOME` and `/tmp` are `noexec`, and installing the missing system libs needs root). The backend/frontend dev servers did start; only the browser launch fails.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-kxiswxdpjdj6fk5p73fii3wq)
