### PR TITLE
Show complete Semble context in article discussion

### DIFF
--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -887,8 +887,8 @@ export async function handleV2MentionLane(request: Request, env: Env): Promise<R
 
   try {
     const client = new FeedProxyClient(env);
-    const entries = await client.fetchMentionLaneItems(url, lane);
-    return new Response(JSON.stringify({ entries }), {
+    const result = await client.fetchMentionLaneItems(url, lane);
+    return new Response(JSON.stringify(result), {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -281,14 +281,6 @@ export interface SembleContextResult {
     collections: number;
     connections: { total: number; incoming: number; outgoing: number };
   } | null;
-  savers: Array<{
-    cardId: string;
-    cardUri: string | null;
-    author: { did: string; handle: string; name: string | null; avatarUrl: string | null };
-    note: string | null;
-    savedAt: string | null;
-    collections: Array<{ id: string; name: string; url: string | null }>;
-  }>;
   notes: Array<{
     id: string;
     text: string;
@@ -319,6 +311,8 @@ export interface SembleContextResult {
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';
+  /** This URL's card page on semble.so, built by the proxy. */
+  cardUrl: string | null;
 }
 
 export interface MentionLaneItemsResult {

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -274,8 +274,61 @@ export interface MentionLaneEntryResult {
   quote: string | null;
 }
 
+export interface SembleContextResult {
+  stats: {
+    saves: number;
+    notes: number;
+    collections: number;
+    connections: { total: number; incoming: number; outgoing: number };
+  } | null;
+  savers: Array<{
+    cardId: string;
+    cardUri: string | null;
+    author: { did: string; handle: string; name: string | null; avatarUrl: string | null };
+    note: string | null;
+    savedAt: string | null;
+    collections: Array<{ id: string; name: string; url: string | null }>;
+  }>;
+  notes: Array<{
+    id: string;
+    text: string;
+    author: { did: string; handle: string; name: string | null; avatarUrl: string | null };
+    createdAt: string | null;
+  }>;
+  collections: Array<{
+    id: string;
+    name: string;
+    url: string | null;
+    author: { did: string; handle: string };
+  }>;
+  connections: Array<{
+    id: string;
+    direction: 'out' | 'in';
+    type: string | null;
+    note: string | null;
+    curator: { did: string; handle: string; name: string | null; avatarUrl: string | null };
+    createdAt: string | null;
+    other: {
+      url: string;
+      title: string | null;
+      description: string | null;
+      siteName: string | null;
+      imageUrl: string | null;
+    };
+  }>;
+  truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
+  incomplete: boolean;
+  source: 'semble-api' | 'constellation-fallback';
+}
+
+export interface MentionLaneItemsResult {
+  entries: MentionLaneEntryResult[];
+  sembleContext?: SembleContextResult;
+}
+
 interface RawMentionLaneResponse {
   entries?: MentionLaneEntryResult[];
+  sembleContext?: SembleContextResult;
   error?: string;
 }
 
@@ -613,7 +666,7 @@ export class FeedProxyClient {
    * to the post / card / highlight. Resolved lazily on lane expand. Best-effort —
    * the proxy returns an empty list rather than error on a Constellation outage.
    */
-  async fetchMentionLaneItems(url: string, lane: string): Promise<MentionLaneEntryResult[]> {
+  async fetchMentionLaneItems(url: string, lane: string): Promise<MentionLaneItemsResult> {
     const raw = await this.fetch<RawMentionLaneResponse>('/mention-lane', {
       method: 'POST',
       body: JSON.stringify({ url, lane }),
@@ -623,7 +676,10 @@ export class FeedProxyClient {
       throw new FeedProxyError(raw.error || 'Invalid response from feed proxy');
     }
 
-    return raw.entries;
+    return {
+      entries: raw.entries,
+      ...(raw.sembleContext ? { sembleContext: raw.sembleContext } : {}),
+    };
   }
 
   /**

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -20,7 +20,7 @@ import { readCachedMentions, enrichMentions } from './mentions';
 import {
   getMentionLaneItems,
   MentionLaneUnavailableError,
-  type MentionLaneEntry,
+  type MentionLaneItemsResult,
 } from './mention-lane';
 import type { LaneId } from './lanes';
 import { normalizeArticleUrl } from './url-normalize';
@@ -1315,7 +1315,7 @@ export function createApp(db: Database, config: AppConfig) {
   const inFlightDiscover = new Map<string, Promise<DiscoverResult>>();
   // Collapse concurrent lane expansions for the same (url, lane): each does a
   // full Constellation + per-author PDS fan-out before the result is cached.
-  const inFlightLane = new Map<string, Promise<MentionLaneEntry[]>>();
+  const inFlightLane = new Map<string, Promise<MentionLaneItemsResult>>();
 
   // Bound the heaviest request (fetch + Defuddle DOM build). Per-URL coalescing
   // (inFlightExtract) dedups identical extractions; this caps the number of
@@ -3110,8 +3110,7 @@ export function createApp(db: Database, config: AppConfig) {
       inFlightLane.set(laneKey, pending);
     }
     try {
-      const entries = await pending;
-      return c.json({ entries });
+      return c.json(await pending);
     } catch (error) {
       // Constellation never answered. Say so rather than returning an empty
       // list, which the reader would read as "nobody wrote about this" — and

--- a/feed-proxy/src/lanes.ts
+++ b/feed-proxy/src/lanes.ts
@@ -78,11 +78,11 @@ export const LANES: Lane[] = [
   {
     id: 'semble',
     label: 'Semble',
-    verb: 'saved',
+    verb: 'referenced',
     noun: 'Semble save',
     icon: 'semble',
     // Semble writes the shared Cosmik card lexicon (.content.url / .url).
-    collections: ['network.cosmik.card'],
+    collections: ['network.cosmik.card', 'network.cosmik.connection'],
   },
 ];
 

--- a/feed-proxy/src/mention-lane.test.ts
+++ b/feed-proxy/src/mention-lane.test.ts
@@ -82,7 +82,7 @@ describe('getMentionLaneItems', () => {
       { post1: { text: 'great read' } }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
 
     expect(entries.length).toBe(1); // alice once, despite two paths
     expect(entries[0]).toEqual({
@@ -122,7 +122,7 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'linkblog');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'linkblog');
     expect(entries).toEqual([
       {
         did: 'did:plc:bob',
@@ -157,7 +157,7 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'linkblog');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'linkblog');
     expect(entries).toEqual([
       {
         did: 'did:plc:carol',
@@ -201,7 +201,7 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'linkblog');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'linkblog');
     expect(entries[0].note).toBe('the summary');
   });
 
@@ -223,7 +223,7 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'semble');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'semble');
     expect(entries).toEqual([
       {
         did: 'did:plc:eve',
@@ -261,7 +261,7 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'margin');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'margin');
     expect(entries).toEqual([
       {
         did: 'did:plc:frank',
@@ -286,7 +286,7 @@ describe('getMentionLaneItems', () => {
     );
 
     // Ask for the margin lane — no margin source exists for this URL.
-    const empty = await getMentionLaneItems(db, ARTICLE, 'margin');
+    const { entries: empty } = await getMentionLaneItems(db, ARTICLE, 'margin');
     expect(empty).toEqual([]);
 
     // A second call for the same (lane, url) is served from cache (no new fetch).
@@ -297,7 +297,7 @@ describe('getMentionLaneItems', () => {
 
   it('returns empty (no throw) for a non-http URL', async () => {
     const db = freshDb();
-    const entries = await getMentionLaneItems(db, 'at://did:plc:x/app/rk', 'bluesky');
+    const { entries } = await getMentionLaneItems(db, 'at://did:plc:x/app/rk', 'bluesky');
     expect(entries).toEqual([]);
   });
 
@@ -373,7 +373,7 @@ describe('getMentionLaneItems', () => {
       return new Response(JSON.stringify({ value: { text: 'still here' } }));
     }) as unknown as typeof fetch);
 
-    const entries = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
     expect(entries.length).toBe(1);
     expect(entries[0].note).toBe('still here');
   });
@@ -395,7 +395,9 @@ describe('getMentionLaneItems', () => {
       }
     );
 
-    const [entry] = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+    const {
+      entries: [entry],
+    } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
     expect(entry.displayName).toBe('Grace Hopper');
     expect(entry.avatar).toBe(
       'https://cdn.bsky.app/img/avatar/plain/did:plc:grace/bafyavatarcid@jpeg'
@@ -413,7 +415,9 @@ describe('getMentionLaneItems', () => {
       { post10: { text: 'no date here' } }
     );
 
-    const [entry] = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+    const {
+      entries: [entry],
+    } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
     expect(entry.displayName).toBeNull();
     expect(entry.avatar).toBeNull();
     expect(entry.createdAt).toBeNull();
@@ -429,7 +433,9 @@ describe('getMentionLaneItems', () => {
       { post11: { text: 'bad date', createdAt: 'not a date' } }
     );
 
-    const [entry] = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+    const {
+      entries: [entry],
+    } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
     expect(entry.createdAt).toBeNull();
   });
 });

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -34,6 +34,7 @@ import { safeFetch } from './ssrf-guard';
 import { resolveSiteMeta, buildCanonicalUrl, parseAtUri } from './standard-site';
 import { constellationGet, constellationGetResult } from './constellation-client';
 import { extractContentText } from './document-content';
+import { fetchSembleContext, type SembleContext } from './semble-client';
 
 // The one-per-user Skyreader linkblog publication rkey (see backend
 // linkblog-sync). Used only as a link-out fallback for our own docs.
@@ -89,6 +90,11 @@ export interface MentionLaneEntry {
   // The highlighted passage a margin.at note targets (its TextQuoteSelector),
   // distinct from the user's own comment in `note`. Null elsewhere.
   quote: string | null;
+}
+
+export interface MentionLaneItemsResult {
+  entries: MentionLaneEntry[];
+  sembleContext?: SembleContext;
 }
 
 // margin.at note motivations (W3C Web Annotation) → an honest past-tense verb.
@@ -245,10 +251,9 @@ async function resolveProfile(db: Database, did: string): Promise<AuthorProfile>
   const key = `profile:${did}`;
   const now = Date.now();
   const cached = db
-    .query<
-      CacheRow,
-      [string]
-    >('SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?')
+    .query<CacheRow, [string]>(
+      'SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?'
+    )
     .get(key);
   if (cached && now - cached.cached_at < PROFILE_CACHE_TTL_MS) {
     try {
@@ -377,7 +382,7 @@ async function resolveEntry(
 }
 
 function cacheKey(laneId: LaneId, normUrl: string): string {
-  return `lane-items:${laneId}|${normUrl}`;
+  return `lane-items2:${laneId}|${normUrl}`;
 }
 
 /**
@@ -406,23 +411,48 @@ export async function getMentionLaneItems(
   db: Database,
   rawUrl: string,
   laneId: LaneId
-): Promise<MentionLaneEntry[]> {
+): Promise<MentionLaneItemsResult> {
   const normUrl = normalizeArticleUrl(rawUrl);
-  if (!normUrl) return [];
+  if (!normUrl) return { entries: [] };
 
   const key = cacheKey(laneId, normUrl);
   const now = Date.now();
   const cached = db
-    .query<
-      CacheRow,
-      [string]
-    >('SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?')
+    .query<CacheRow, [string]>(
+      'SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?'
+    )
     .get(key);
   if (cached && now - cached.cached_at < CACHE_TTL_MS) {
     try {
-      return JSON.parse(cached.context_json) as MentionLaneEntry[];
+      const parsed = JSON.parse(cached.context_json) as MentionLaneItemsResult;
+      if (parsed && Array.isArray(parsed.entries)) return parsed;
     } catch {
       // fall through and recompute
+    }
+  }
+
+  // Semble's URL API already hydrates all public categories. Keep the legacy
+  // entries alongside the richer context so the merged human stream remains
+  // backward compatible. If every API category fails we continue into the
+  // existing Constellation/PDS saver resolver below.
+  if (laneId === 'semble') {
+    const sembleContext = await fetchSembleContext(normUrl);
+    if (sembleContext) {
+      const entries: MentionLaneEntry[] = sembleContext.savers.map((saver) => ({
+        did: saver.author.did,
+        handle: saver.author.handle || null,
+        displayName: saver.author.name,
+        avatar: saver.author.avatarUrl,
+        createdAt: saver.savedAt,
+        note: saver.note,
+        url: saver.author.handle ? `${SEMBLE_WEB_BASE}/profile/${saver.author.handle}` : null,
+        collections: saver.collections.map((c) => ({ name: c.name, url: c.url })),
+        verb: null,
+        quote: null,
+      }));
+      const result = { entries, sembleContext };
+      writeCacheJson(db, key, result, now);
+      return result;
     }
   }
 
@@ -449,8 +479,9 @@ export async function getMentionLaneItems(
     if (unreachable) throw new MentionLaneUnavailableError();
     // Cache the empty result too, so a lane with no people isn't re-queried on
     // every expand within the TTL.
-    writeCache(db, key, [], now);
-    return [];
+    const result: MentionLaneItemsResult = { entries: [] };
+    writeCacheJson(db, key, result, now);
+    return result;
   }
 
   // Gather linking records across this lane's sources, dedup by author (a person
@@ -479,12 +510,24 @@ export async function getMentionLaneItems(
   if (picked.length === 0 && unreachable) throw new MentionLaneUnavailableError();
 
   const entries = await Promise.all(picked.map((rec) => resolveEntry(db, laneId, rec)));
-  writeCache(db, key, entries, now);
-  return entries;
-}
-
-function writeCache(db: Database, key: string, entries: MentionLaneEntry[], now: number): void {
-  writeCacheJson(db, key, entries, now);
+  const result: MentionLaneItemsResult =
+    laneId === 'semble'
+      ? {
+          entries,
+          sembleContext: {
+            stats: null,
+            savers: [],
+            notes: [],
+            collections: [],
+            connections: [],
+            truncated: { savers: false, notes: false, collections: false, connections: false },
+            incomplete: true,
+            source: 'constellation-fallback',
+          },
+        }
+      : { entries };
+  writeCacheJson(db, key, result, now);
+  return result;
 }
 
 // Shared upsert for anything this module parks in `constellation_cache` (the

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -251,9 +251,10 @@ async function resolveProfile(db: Database, did: string): Promise<AuthorProfile>
   const key = `profile:${did}`;
   const now = Date.now();
   const cached = db
-    .query<CacheRow, [string]>(
-      'SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?'
-    )
+    .query<
+      CacheRow,
+      [string]
+    >('SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?')
     .get(key);
   if (cached && now - cached.cached_at < PROFILE_CACHE_TTL_MS) {
     try {
@@ -418,9 +419,10 @@ export async function getMentionLaneItems(
   const key = cacheKey(laneId, normUrl);
   const now = Date.now();
   const cached = db
-    .query<CacheRow, [string]>(
-      'SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?'
-    )
+    .query<
+      CacheRow,
+      [string]
+    >('SELECT cache_key, context_json, cached_at FROM constellation_cache WHERE cache_key = ?')
     .get(key);
   if (cached && now - cached.cached_at < CACHE_TTL_MS) {
     try {

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -34,7 +34,7 @@ import { safeFetch } from './ssrf-guard';
 import { resolveSiteMeta, buildCanonicalUrl, parseAtUri } from './standard-site';
 import { constellationGet, constellationGetResult } from './constellation-client';
 import { extractContentText } from './document-content';
-import { fetchSembleContext, type SembleContext } from './semble-client';
+import { fetchSembleContext, sembleCardUrl, type SembleContextWire } from './semble-client';
 
 // The one-per-user Skyreader linkblog publication rkey (see backend
 // linkblog-sync). Used only as a link-out fallback for our own docs.
@@ -94,7 +94,7 @@ export interface MentionLaneEntry {
 
 export interface MentionLaneItemsResult {
   entries: MentionLaneEntry[];
-  sembleContext?: SembleContext;
+  sembleContext?: SembleContextWire;
 }
 
 // margin.at note motivations (W3C Web Annotation) → an honest past-tense verb.
@@ -438,9 +438,13 @@ export async function getMentionLaneItems(
   // backward compatible. If every API category fails we continue into the
   // existing Constellation/PDS saver resolver below.
   if (laneId === 'semble') {
-    const sembleContext = await fetchSembleContext(normUrl);
-    if (sembleContext) {
-      const entries: MentionLaneEntry[] = sembleContext.savers.map((saver) => ({
+    const context = await fetchSembleContext(normUrl);
+    if (context) {
+      // The savers become the lane's people; everything else is the graph the
+      // panel draws around them. Splitting them here is what keeps the same
+      // person out of the payload twice.
+      const { savers, ...sembleContext } = context;
+      const entries: MentionLaneEntry[] = savers.map((saver) => ({
         did: saver.author.did,
         handle: saver.author.handle || null,
         displayName: saver.author.name,
@@ -448,7 +452,10 @@ export async function getMentionLaneItems(
         createdAt: saver.savedAt,
         note: saver.note,
         url: saver.author.handle ? `${SEMBLE_WEB_BASE}/profile/${saver.author.handle}` : null,
-        collections: saver.collections.map((c) => ({ name: c.name, url: c.url })),
+        // Which collection a given saver filed this into isn't something the
+        // URL API tells us, and the panel already names them all once in its
+        // "Filed in" line — so an entry carries none.
+        collections: [],
         verb: null,
         quote: null,
       }));
@@ -518,13 +525,13 @@ export async function getMentionLaneItems(
           entries,
           sembleContext: {
             stats: null,
-            savers: [],
             notes: [],
             collections: [],
             connections: [],
             truncated: { savers: false, notes: false, collections: false, connections: false },
             incomplete: true,
             source: 'constellation-fallback',
+            cardUrl: sembleCardUrl(normUrl),
           },
         }
       : { entries };

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -83,6 +83,11 @@ describe('laneForSource', () => {
     expect(laneForSource('app.bsky.feed.post', '.embed.external.uri')?.id).toBe('bluesky');
     expect(laneForSource('at.margin.note', '.target.source')?.id).toBe('margin');
     expect(laneForSource('network.cosmik.card', '.content.url')?.id).toBe('semble');
+    expect(laneForSource('network.cosmik.connection', '.source')?.id).toBe('semble');
+    expect(laneForSource('network.cosmik.connection', '.target')?.id).toBe('semble');
+    expect(laneForSource('network.cosmik.dev.connection', '.source')).toBeNull();
+    expect(laneForSource('network.cosmik.local.connection', '.target')).toBeNull();
+    expect(laneForSource('network.cosmik.test.connection', '.source')).toBeNull();
     // A bare-text URL share counts toward Bluesky.
     expect(laneForSource('app.bsky.feed.post', '.text')?.id).toBe('bluesky');
     // Genuine incidentals stay excluded even though the collection is laned.

--- a/feed-proxy/src/semble-client.test.ts
+++ b/feed-proxy/src/semble-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, afterEach, spyOn } from 'bun:test';
+import { fetchSembleContext } from './semble-client';
+
+const ARTICLE = 'https://example.com/the-article';
+
+// Answer each of the five URL-API calls with a canned body; anything not named
+// resolves empty, so a test only has to say the part it cares about.
+function mockSemble(bodies: Record<string, unknown>) {
+  return spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+    const nsid = new URL(String(input)).pathname.split('/').pop()!;
+    return new Response(JSON.stringify(bodies[nsid] ?? {}), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch);
+}
+
+const edge = (target: string, type: string, id?: string, curator = 'did:plc:eve') => ({
+  connection: { ...(id ? { id } : {}), type, curator: { id: curator, handle: 'eve.test' } },
+  source: { url: ARTICLE },
+  target: { url: target, metadata: { title: target } },
+});
+
+describe('fetchSembleContext connections', () => {
+  afterEach(() => {
+    (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
+  });
+
+  it('keeps every edge when Semble sends no connection ids', async () => {
+    mockSemble({
+      'network.cosmik.connection.getForUrl': {
+        connections: [
+          edge('https://a.example/one', 'SUPPORTS'),
+          edge('https://b.example/two', 'SUPPORTS'),
+          edge('https://c.example/three', 'REFUTES'),
+        ],
+      },
+    });
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.connections.map((c) => c.other.url)).toEqual([
+      'https://a.example/one',
+      'https://b.example/two',
+      'https://c.example/three',
+    ]);
+    // The fallback key still has to be a key: unique, so the reader can list them.
+    expect(new Set(context!.connections.map((c) => c.id)).size).toBe(3);
+  });
+
+  it('still collapses a genuine duplicate without an id', async () => {
+    mockSemble({
+      'network.cosmik.connection.getForUrl': {
+        connections: [
+          edge('https://a.example/one', 'SUPPORTS'),
+          edge('https://a.example/one', 'SUPPORTS'),
+        ],
+      },
+    });
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.connections).toHaveLength(1);
+  });
+
+  it('keeps the same claim from two curators as two edges', async () => {
+    mockSemble({
+      'network.cosmik.connection.getForUrl': {
+        connections: [
+          edge('https://a.example/one', 'SUPPORTS', undefined, 'did:plc:eve'),
+          edge('https://a.example/one', 'SUPPORTS', undefined, 'did:plc:frank'),
+        ],
+      },
+    });
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.connections.map((c) => c.curator.did)).toEqual([
+      'did:plc:eve',
+      'did:plc:frank',
+    ]);
+  });
+
+  it('prefers Semble’s own id when it sends one', async () => {
+    mockSemble({
+      'network.cosmik.connection.getForUrl': {
+        connections: [
+          edge('https://a.example/one', 'SUPPORTS', 'conn-1'),
+          edge('https://a.example/one', 'SUPPORTS', 'conn-2'),
+        ],
+      },
+    });
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.connections.map((c) => c.id)).toEqual(['conn-1', 'conn-2']);
+  });
+});

--- a/feed-proxy/src/semble-client.ts
+++ b/feed-proxy/src/semble-client.ts
@@ -11,6 +11,14 @@ export interface SembleAuthor {
   name: string | null;
   avatarUrl: string | null;
 }
+/** One person's card for this URL. Consumed only here, to build the lane's
+ *  human entries — it never crosses the wire (see `SembleContextWire`), so the
+ *  reader isn't shipped the same people twice. */
+export interface SembleSaver {
+  author: SembleAuthor;
+  note: string | null;
+  savedAt: string | null;
+}
 export interface SembleContext {
   stats: {
     saves: number;
@@ -18,14 +26,7 @@ export interface SembleContext {
     collections: number;
     connections: { total: number; incoming: number; outgoing: number };
   } | null;
-  savers: Array<{
-    cardId: string;
-    cardUri: string | null;
-    author: SembleAuthor;
-    note: string | null;
-    savedAt: string | null;
-    collections: Array<{ id: string; name: string; url: string | null }>;
-  }>;
+  savers: SembleSaver[];
   notes: Array<{ id: string; text: string; author: SembleAuthor; createdAt: string | null }>;
   collections: Array<{
     id: string;
@@ -51,6 +52,20 @@ export interface SembleContext {
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';
+  /** This URL's own card on semble.so: the page these counts were read from,
+   *  with its own Connections and Notes tabs. Built here rather than in the
+   *  reader, so only this module has to know Semble's routes. */
+  cardUrl: string | null;
+}
+
+/** What the reader actually receives. The savers are already in the lane's
+ *  `entries`; sending them again would duplicate every person in the payload. */
+export type SembleContextWire = Omit<SembleContext, 'savers'>;
+
+/** Semble's card page is keyed by the article URL, not by a card id — every
+ *  saver's card for a URL rolls up into the one page. */
+export function sembleCardUrl(url: string | null): string | null {
+  return url ? `https://semble.so/url/${encodeURIComponent(url)}` : null;
 }
 
 type Obj = Record<string, any>;
@@ -121,12 +136,9 @@ export async function fetchSembleContext(rawUrl: string): Promise<SembleContext 
   const savers = (Array.isArray(libraries.libraries) ? libraries.libraries : [])
     .slice(0, LIMIT)
     .map((x: Obj) => ({
-      cardId: text(x.card?.id, 256) ?? text(x.card?.uri, 512) ?? '',
-      cardUri: text(x.card?.uri, 512),
       author: author(x.user ?? x.card?.author),
       note: text(x.card?.note?.text ?? x.card?.note),
       savedAt: date(x.card?.createdAt),
-      collections: [],
     }));
   const saverNotes = new Set(
     savers
@@ -160,25 +172,32 @@ export async function fetchSembleContext(rawUrl: string): Promise<SembleContext 
   const connections = (Array.isArray(connectionData.connections) ? connectionData.connections : [])
     .slice(0, LIMIT)
     .flatMap((x: Obj) => {
-      const id = text(x.connection?.id, 256) ?? '';
-      if (seen.has(id)) return [];
-      seen.add(id);
       const source = httpUrl(x.source?.url),
         target = httpUrl(x.target?.url);
-      const n = normalizeArticleUrl(url);
-      const sourceIsThis = source ? normalizeArticleUrl(source) === n : false;
-      const targetIsThis = target ? normalizeArticleUrl(target) === n : false;
+      const sourceIsThis = source ? normalizeArticleUrl(source) === url : false;
+      const targetIsThis = target ? normalizeArticleUrl(target) === url : false;
       if (sourceIsThis === targetIsThis) return [];
       const other = x[sourceIsThis ? 'target' : 'source'];
       const otherUrl = httpUrl(other?.url);
       if (!otherUrl) return [];
+      const type = text(x.connection?.type, 128)?.replaceAll('_', ' ').toLowerCase() ?? null;
+      const curator = author(x.connection?.curator);
+      // Prefer Semble's own id, but never let a missing one key every edge to the
+      // same empty string — that would silently collapse the whole graph to its
+      // first edge. Who drew it, between which two pages, saying what, identifies
+      // an edge on its own: two curators making the same claim are two edges.
+      const id =
+        text(x.connection?.id, 256) ??
+        `${source ?? ''}|${target ?? ''}|${type ?? ''}|${curator.did}`;
+      if (seen.has(id)) return [];
+      seen.add(id);
       return [
         {
           id,
           direction: sourceIsThis ? ('out' as const) : ('in' as const),
-          type: text(x.connection?.type, 128)?.replaceAll('_', ' ').toLowerCase() ?? null,
+          type,
           note: text(x.connection?.note),
-          curator: author(x.connection?.curator),
+          curator,
           createdAt: date(x.connection?.createdAt),
           other: {
             url: otherUrl,
@@ -211,5 +230,6 @@ export async function fetchSembleContext(rawUrl: string): Promise<SembleContext 
     },
     incomplete: calls.some((r) => r.status === 'rejected'),
     source: 'semble-api',
+    cardUrl: sembleCardUrl(url),
   };
 }

--- a/feed-proxy/src/semble-client.ts
+++ b/feed-proxy/src/semble-client.ts
@@ -1,0 +1,215 @@
+import { normalizeArticleUrl } from './url-normalize';
+
+const API_BASE = 'https://api.semble.so/xrpc';
+const LIMIT = 20;
+const TIMEOUT_MS = 6_000;
+const MAX_TEXT = 2_000;
+
+export interface SembleAuthor {
+  did: string;
+  handle: string;
+  name: string | null;
+  avatarUrl: string | null;
+}
+export interface SembleContext {
+  stats: {
+    saves: number;
+    notes: number;
+    collections: number;
+    connections: { total: number; incoming: number; outgoing: number };
+  } | null;
+  savers: Array<{
+    cardId: string;
+    cardUri: string | null;
+    author: SembleAuthor;
+    note: string | null;
+    savedAt: string | null;
+    collections: Array<{ id: string; name: string; url: string | null }>;
+  }>;
+  notes: Array<{ id: string; text: string; author: SembleAuthor; createdAt: string | null }>;
+  collections: Array<{
+    id: string;
+    name: string;
+    url: string | null;
+    author: { did: string; handle: string };
+  }>;
+  connections: Array<{
+    id: string;
+    direction: 'out' | 'in';
+    type: string | null;
+    note: string | null;
+    curator: SembleAuthor;
+    createdAt: string | null;
+    other: {
+      url: string;
+      title: string | null;
+      description: string | null;
+      siteName: string | null;
+      imageUrl: string | null;
+    };
+  }>;
+  truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
+  incomplete: boolean;
+  source: 'semble-api' | 'constellation-fallback';
+}
+
+type Obj = Record<string, any>;
+const text = (v: unknown, max = MAX_TEXT): string | null =>
+  typeof v === 'string' && v.trim() ? v.trim().slice(0, max) : null;
+const count = (v: unknown): number =>
+  typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+const date = (v: unknown): string | null => {
+  const s = text(v, 64);
+  return s && !Number.isNaN(Date.parse(s)) ? new Date(s).toISOString() : null;
+};
+const author = (v: Obj | undefined): SembleAuthor => ({
+  did: text(v?.id, 256) ?? '',
+  handle: text(v?.handle, 256) ?? '',
+  name: text(v?.name, 256),
+  avatarUrl: httpUrl(v?.avatarUrl),
+});
+const httpUrl = (v: unknown): string | null => {
+  const s = text(v, 2048);
+  if (!s) return null;
+  try {
+    const u = new URL(s);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null;
+  } catch {
+    return null;
+  }
+};
+const hasMore = (v: Obj): boolean => v?.pagination?.hasMore === true;
+
+async function call(nsid: string, url: string, extra: Record<string, string> = {}): Promise<Obj> {
+  const qs = new URLSearchParams({ url, limit: String(LIMIT), ...extra });
+  const res = await fetch(`${API_BASE}/${nsid}?${qs}`, {
+    headers: { 'X-Semble-Client': 'skyreader', Accept: 'application/json' },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok || !(res.headers.get('content-type') ?? '').includes('json'))
+    throw new Error(`Semble ${nsid} ${res.status}`);
+  const raw = await res.text();
+  if (raw.length > 1_000_000) throw new Error(`Semble ${nsid} response too large`);
+  return JSON.parse(raw) as Obj;
+}
+
+export async function fetchSembleContext(rawUrl: string): Promise<SembleContext | null> {
+  const url = normalizeArticleUrl(rawUrl);
+  if (!url) return null;
+  const calls = await Promise.allSettled([
+    call('network.cosmik.card.getUrlMetadata', url, { includeStats: 'true' }),
+    call('network.cosmik.card.getLibrariesForUrl', url),
+    call('network.cosmik.card.getNoteCardsForUrl', url),
+    call('network.cosmik.collection.getForUrl', url),
+    call('network.cosmik.connection.getForUrl', url, { direction: 'both' }),
+  ]);
+  if (calls.every((r) => r.status === 'rejected')) return null;
+  const value = (i: number): Obj => (calls[i].status === 'fulfilled' ? calls[i].value : {});
+  const [meta, libraries, noteCards, collectionData, connectionData] = [0, 1, 2, 3, 4].map(value);
+  const stats = meta.stats
+    ? {
+        saves: count(meta.stats.libraryCount),
+        notes: count(meta.stats.noteCount),
+        collections: count(meta.stats.collectionCount),
+        connections: {
+          total: count(meta.stats.connections?.all?.total),
+          incoming: count(meta.stats.connections?.incoming?.total),
+          outgoing: count(meta.stats.connections?.outgoing?.total),
+        },
+      }
+    : null;
+  const savers = (Array.isArray(libraries.libraries) ? libraries.libraries : [])
+    .slice(0, LIMIT)
+    .map((x: Obj) => ({
+      cardId: text(x.card?.id, 256) ?? text(x.card?.uri, 512) ?? '',
+      cardUri: text(x.card?.uri, 512),
+      author: author(x.user ?? x.card?.author),
+      note: text(x.card?.note?.text ?? x.card?.note),
+      savedAt: date(x.card?.createdAt),
+      collections: [],
+    }));
+  const saverNotes = new Set(
+    savers
+      .map((s) => `${s.author.did}|${s.note?.trim().toLowerCase()}`)
+      .filter((x) => !x.endsWith('|undefined') && !x.endsWith('|null'))
+  );
+  const notes = (Array.isArray(noteCards.notes) ? noteCards.notes : [])
+    .slice(0, LIMIT)
+    .map((x: Obj) => ({
+      id: text(x.id, 256) ?? '',
+      text: text(x.note ?? x.text) ?? '',
+      author: author(x.author),
+      createdAt: date(x.createdAt),
+    }))
+    .filter(
+      (x: any) => x.text && !saverNotes.has(`${x.author.did}|${x.text.trim().toLowerCase()}`)
+    );
+  const collections = (Array.isArray(collectionData.collections) ? collectionData.collections : [])
+    .slice(0, LIMIT)
+    .map((x: Obj) => {
+      const a = author(x.author);
+      const rkey = text(x.uri, 512)?.split('/').pop();
+      return {
+        id: text(x.id, 256) ?? text(x.uri, 512) ?? '',
+        name: text(x.name, 256) ?? 'Untitled collection',
+        url: a.handle && rkey ? `https://semble.so/profile/${a.handle}/collections/${rkey}` : null,
+        author: { did: a.did, handle: a.handle },
+      };
+    });
+  const seen = new Set<string>();
+  const connections = (Array.isArray(connectionData.connections) ? connectionData.connections : [])
+    .slice(0, LIMIT)
+    .flatMap((x: Obj) => {
+      const id = text(x.connection?.id, 256) ?? '';
+      if (seen.has(id)) return [];
+      seen.add(id);
+      const source = httpUrl(x.source?.url),
+        target = httpUrl(x.target?.url);
+      const n = normalizeArticleUrl(url);
+      const sourceIsThis = source ? normalizeArticleUrl(source) === n : false;
+      const targetIsThis = target ? normalizeArticleUrl(target) === n : false;
+      if (sourceIsThis === targetIsThis) return [];
+      const other = x[sourceIsThis ? 'target' : 'source'];
+      const otherUrl = httpUrl(other?.url);
+      if (!otherUrl) return [];
+      return [
+        {
+          id,
+          direction: sourceIsThis ? ('out' as const) : ('in' as const),
+          type: text(x.connection?.type, 128)?.replaceAll('_', ' ').toLowerCase() ?? null,
+          note: text(x.connection?.note),
+          curator: author(x.connection?.curator),
+          createdAt: date(x.connection?.createdAt),
+          other: {
+            url: otherUrl,
+            title: text(other?.metadata?.title, 500),
+            description: text(other?.metadata?.description),
+            siteName: text(other?.metadata?.siteName, 256),
+            imageUrl: httpUrl(other?.metadata?.imageUrl),
+          },
+        },
+      ];
+    })
+    .sort((a: any, b: any) =>
+      a.direction === b.direction
+        ? (Date.parse(b.createdAt ?? '') || 0) - (Date.parse(a.createdAt ?? '') || 0)
+        : a.direction === 'out'
+          ? -1
+          : 1
+    );
+  return {
+    stats,
+    savers,
+    notes,
+    collections,
+    connections,
+    truncated: {
+      savers: hasMore(libraries),
+      notes: hasMore(noteCards),
+      collections: hasMore(collectionData),
+      connections: hasMore(connectionData),
+    },
+    incomplete: calls.some((r) => r.status === 'rejected'),
+    source: 'semble-api',
+  };
+}

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -893,6 +893,7 @@
   filters={atmosphere.filters}
   activeFilter={atmosphere.activeFilter}
   stream={atmosphere.stream}
+  sembleContext={atmosphere.sembleContext}
   {itemTagCount}
   {itemTags}
   {collectionPieceCount}

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -47,6 +47,8 @@
   import { socialContextStore } from '$lib/stores/socialContext.svelte';
   import { profileService } from '$lib/services/profiles';
   import { auth } from '$lib/stores/auth.svelte';
+  import { savesStore } from '$lib/stores/saves.svelte';
+  import { toggleSavedLink } from '$lib/utils/saveLink';
   import { preferences } from '$lib/stores/preferences.svelte';
   import ArticleCardView from './ArticleCardView.svelte';
   import { useAtmosphere } from '$lib/hooks/useAtmosphere.svelte';
@@ -952,6 +954,8 @@
   onComposeShare={composeShare}
   onEditShare={editShare}
   onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
+  onSaveConnection={auth.user ? toggleSavedLink : undefined}
+  isConnectionSaved={(url) => savesStore.isSaved(url)}
   onMentionClick={(did) => sidebarStore.openAddFeedModalForDid(did)}
   onCloseOverflow={() => (overflowMenuOpen = false)}
 />

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -99,6 +99,8 @@
     onComposeShare,
     onEditShare,
     onOpenAuthor,
+    onSaveConnection,
+    isConnectionSaved,
     onMentionClick,
     onCloseOverflow,
   }: ArticleCardViewProps = $props();
@@ -416,6 +418,8 @@
         onRetry={onRetryStream}
         {onCreateInLane}
         {onOpenAuthor}
+        {onSaveConnection}
+        {isConnectionSaved}
       />
       <div class="article-actions">
         <!-- Save button. Label tracks state ("Save" → "Saved") and the bookmark

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -38,6 +38,7 @@
     filters = [],
     activeFilter = 'all',
     stream = { idle: true, loading: false, entries: [] },
+    sembleContext,
     itemTagCount,
     itemTags = [],
     collectionPieceCount = 0,
@@ -407,6 +408,7 @@
         {filters}
         {activeFilter}
         {stream}
+        {sembleContext}
         lanesOpen={panelOpen}
         panelId="discussion-panel"
         showHeading={false}

--- a/frontend/src/lib/components/articleCardView.types.ts
+++ b/frontend/src/lib/components/articleCardView.types.ts
@@ -254,6 +254,11 @@ export interface ArticleCardViewProps {
    *  note and removing the share both live. */
   onEditShare?: () => void;
   onOpenAuthor?: (did: string) => void;
+  /** Toggle a Semble-connected article into the reader's Saved list. Absent when
+   *  the reader can't save; the control then doesn't render. */
+  onSaveConnection?: (url: string) => void | Promise<void>;
+  /** Reactive saved-state predicate for a connected article's URL. */
+  isConnectionSaved?: (url: string) => boolean;
   // A @mention in the note/body was clicked — open the add-feed dialog for the DID.
   onMentionClick?: (did: string) => void;
   onCloseOverflow?: () => void;

--- a/frontend/src/lib/components/articleCardView.types.ts
+++ b/frontend/src/lib/components/articleCardView.types.ts
@@ -1,5 +1,5 @@
 import type { IconName } from './Icon.svelte';
-import type { ReaderCollection, ReaderCollectionItem } from '$lib/types';
+import type { ReaderCollection, ReaderCollectionItem, SembleContext } from '$lib/types';
 
 /**
  * View-model types for the PURE presentational `ArticleCardView.svelte`.
@@ -111,6 +111,8 @@ export interface DiscussionStreamVM {
   linkOnly?: DiscussionEntryVM[];
 }
 
+export type SembleContextVM = SembleContext;
+
 export interface SocialContextVM {
   quoteCount: number;
 }
@@ -161,6 +163,7 @@ export interface ArticleCardViewProps {
   filters?: DiscussionFilterVM[];
   activeFilter?: DiscussionFilterId;
   stream?: DiscussionStreamVM;
+  sembleContext?: SembleContextVM;
 
   itemTagCount: number;
   itemTags?: string[];

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -1,0 +1,122 @@
+// Mounted component test (jsdom) — see the "component" project in vitest.config.ts.
+//
+// A typed Semble connection is a directed claim, so the row has to read in the
+// direction the edge actually points: the arrow is the sentence. An incoming
+// "A refutes this" rendered as "refutes → A → this" reverses the claim for
+// anyone reading the line rather than the aria-label.
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import AtmospherePanel from './AtmospherePanel.svelte';
+import type { LaneRowVM, SembleContextVM } from '../articleCardView.types';
+
+const mounted: Record<string, any>[] = [];
+
+const sembleLane: LaneRowVM = {
+  id: 'semble',
+  count: 1,
+  capped: false,
+  canCreate: false,
+  icon: 'semble',
+  label: 'Semble',
+  verb: 'referenced',
+  title: 'Referenced on Semble',
+  isMine: false,
+  createLabel: 'Save to Semble',
+  createIsEdit: false,
+};
+
+const emptyContext: SembleContextVM = {
+  stats: null,
+  savers: [],
+  notes: [],
+  collections: [],
+  connections: [],
+  truncated: { savers: false, notes: false, collections: false, connections: false },
+  incomplete: false,
+  source: 'semble-api',
+};
+
+function connection(direction: 'in' | 'out'): SembleContextVM['connections'][number] {
+  return {
+    id: `connection-${direction}`,
+    direction,
+    type: 'supports',
+    note: null,
+    curator: { did: 'did:plc:curator', handle: 'curator.test', name: null, avatarUrl: null },
+    createdAt: null,
+    other: {
+      url: 'https://other.example/piece',
+      title: 'The other piece',
+      description: null,
+      siteName: null,
+      imageUrl: null,
+    },
+  };
+}
+
+function render(props: {
+  sembleContext?: SembleContextVM;
+  stream?: { loading: boolean; failed?: boolean; entries: [] };
+}): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(AtmospherePanel, {
+    target,
+    props: {
+      laneRow: [sembleLane],
+      filters: [],
+      activeFilter: 'all',
+      stream: props.stream ?? { loading: false, entries: [] },
+      sembleContext: props.sembleContext,
+    },
+  });
+  flushSync();
+  mounted.push(component);
+  return target;
+}
+
+function connectionLine(direction: 'in' | 'out'): string {
+  const target = render({
+    sembleContext: { ...emptyContext, connections: [connection(direction)] },
+  });
+  const line = target.querySelector('.connection-line');
+  return (line?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+describe('AtmospherePanel Semble connections', () => {
+  afterEach(() => {
+    for (const component of mounted.splice(0)) unmount(component);
+    document.body.innerHTML = '';
+  });
+
+  it('reads this → type → other for an outgoing edge', () => {
+    expect(connectionLine('out')).toBe('this → supports → The other piece');
+  });
+
+  it('reads other → type → this for an incoming edge', () => {
+    expect(connectionLine('in')).toBe('The other piece → supports → this');
+  });
+
+  it('treats connections as content, so a connections-only article claims no emptiness', () => {
+    const target = render({
+      sembleContext: { ...emptyContext, connections: [connection('in')] },
+    });
+    expect(target.querySelector('.discussion-empty')).toBeNull();
+    expect(target.querySelector('.semble-context')).not.toBeNull();
+  });
+
+  it('still says nobody wrote when the context came back with nothing in it', () => {
+    const target = render({ sembleContext: emptyContext });
+    expect(target.querySelector('.semble-context')).toBeNull();
+    expect(target.querySelector('.discussion-empty')?.textContent).toContain('Nothing readable');
+  });
+
+  it('keeps the retry when a lane failed and only Semble context came back', () => {
+    const target = render({
+      sembleContext: { ...emptyContext, connections: [connection('out')] },
+      stream: { loading: false, failed: true, entries: [] },
+    });
+    expect(target.querySelector('.discussion-retry')).not.toBeNull();
+    expect(target.querySelector('.semble-context')).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -27,13 +27,13 @@ const sembleLane: LaneRowVM = {
 
 const emptyContext: SembleContextVM = {
   stats: null,
-  savers: [],
   notes: [],
   collections: [],
   connections: [],
   truncated: { savers: false, notes: false, collections: false, connections: false },
   incomplete: false,
   source: 'semble-api',
+  cardUrl: 'https://semble.so/url/https%3A%2F%2Fexample.com%2Fthe-article',
 };
 
 function connection(direction: 'in' | 'out'): SembleContextVM['connections'][number] {
@@ -57,6 +57,8 @@ function connection(direction: 'in' | 'out'): SembleContextVM['connections'][num
 function render(props: {
   sembleContext?: SembleContextVM;
   stream?: { loading: boolean; failed?: boolean; entries: [] };
+  onSaveConnection?: (url: string) => void | Promise<void>;
+  isConnectionSaved?: (url: string) => boolean;
 }): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
@@ -68,6 +70,8 @@ function render(props: {
       activeFilter: 'all',
       stream: props.stream ?? { loading: false, entries: [] },
       sembleContext: props.sembleContext,
+      onSaveConnection: props.onSaveConnection,
+      isConnectionSaved: props.isConnectionSaved,
     },
   });
   flushSync();
@@ -75,11 +79,11 @@ function render(props: {
   return target;
 }
 
-function connectionLine(direction: 'in' | 'out'): string {
+function relationLine(direction: 'in' | 'out'): string {
   const target = render({
     sembleContext: { ...emptyContext, connections: [connection(direction)] },
   });
-  const line = target.querySelector('.connection-line');
+  const line = target.querySelector('.relation');
   return (line?.textContent ?? '').replace(/\s+/g, ' ').trim();
 }
 
@@ -89,12 +93,82 @@ describe('AtmospherePanel Semble connections', () => {
     document.body.innerHTML = '';
   });
 
-  it('reads this → type → other for an outgoing edge', () => {
-    expect(connectionLine('out')).toBe('this → supports → The other piece');
+  it('reads this → type for an outgoing edge, with the target beneath', () => {
+    expect(relationLine('out')).toBe('this → supports');
   });
 
-  it('reads other → type → this for an incoming edge', () => {
-    expect(connectionLine('in')).toBe('The other piece → supports → this');
+  it('reads type → this for an incoming edge, so the claim never reverses', () => {
+    expect(relationLine('in')).toBe('supports → this');
+  });
+
+  it('folds many same-shaped edges into one row and holds the rest back', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      ...connection('out'),
+      id: `connection-${i}`,
+      other: { ...connection('out').other, title: `Piece ${i}` },
+    }));
+    const target = render({ sembleContext: { ...emptyContext, connections: many } });
+    // One curator, one relation, one direction: one row, one sentence.
+    expect(target.querySelectorAll('.relation').length).toBe(1);
+    expect(target.querySelector('.relation-count')?.textContent).toBe('12');
+    expect(target.querySelectorAll('.connection-target').length).toBe(3);
+    expect(target.querySelector('.semble-disclose')?.textContent?.trim()).toBe('Show 9 more');
+  });
+
+  it('keeps a differing curator, relation, or direction in its own row', () => {
+    const other = {
+      ...connection('out'),
+      id: 'connection-other-curator',
+      curator: { did: 'did:plc:second', handle: 'second.test', name: null, avatarUrl: null },
+    };
+    const target = render({
+      sembleContext: { ...emptyContext, connections: [connection('out'), connection('in'), other] },
+    });
+    expect(target.querySelectorAll('.relation').length).toBe(3);
+  });
+
+  it('says what Semble held back rather than passing a page off as the whole', () => {
+    const target = render({
+      sembleContext: {
+        ...emptyContext,
+        stats: {
+          saves: 0,
+          notes: 0,
+          collections: 0,
+          connections: { total: 27, incoming: 0, outgoing: 27 },
+        },
+        connections: [connection('out')],
+      },
+    });
+    expect(target.querySelector('.semble-foot')?.textContent).toContain('1 of 27 connections');
+  });
+
+  it('offers no keep control when the reader cannot save', () => {
+    const target = render({ sembleContext: { ...emptyContext, connections: [connection('out')] } });
+    expect(target.querySelector('.connection-save')).toBeNull();
+  });
+
+  it('gives every connected article its own keep control, reading saved state', () => {
+    const target = render({
+      sembleContext: { ...emptyContext, connections: [connection('out'), connection('in')] },
+      onSaveConnection: () => {},
+      isConnectionSaved: (url: string) => url === 'https://other.example/piece',
+    });
+    const controls = target.querySelectorAll('.connection-save');
+    expect(controls.length).toBe(2);
+    // Saved state is never carried by colour alone.
+    expect([...controls].every((c) => c.getAttribute('aria-pressed') === 'true')).toBe(true);
+    expect(controls[0].getAttribute('aria-label')).toContain('Remove');
+  });
+
+  it('hands the connected article\u2019s url to the save handler', () => {
+    const saved: string[] = [];
+    const target = render({
+      sembleContext: { ...emptyContext, connections: [connection('out')] },
+      onSaveConnection: (url: string) => void saved.push(url),
+    });
+    (target.querySelector('.connection-save') as HTMLButtonElement).click();
+    expect(saved).toEqual(['https://other.example/piece']);
   });
 
   it('treats connections as content, so a connections-only article claims no emptiness', () => {

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -98,6 +98,23 @@
   const showSemble = $derived(
     Boolean(sembleContext) && (activeFilter === 'all' || activeFilter === 'semble')
   );
+  // Whether Semble actually returned something to read. A context object that
+  // came back empty (the saver fallback, or an API answer with nothing in it) is
+  // not content: it must not stand in for the people who aren't there, or the
+  // panel would go silent instead of saying nobody wrote about this.
+  const hasSembleContent = $derived(
+    showSemble &&
+      Boolean(
+        sembleContext &&
+        (sembleContext.notes.length ||
+          sembleContext.collections.length ||
+          sembleContext.connections.length ||
+          (sembleContext.stats?.saves ?? 0) ||
+          (sembleContext.stats?.notes ?? 0) ||
+          (sembleContext.stats?.collections ?? 0) ||
+          (sembleContext.stats?.connections.total ?? 0))
+      )
+  );
   const sembleSummary = $derived.by(() => {
     if (!sembleContext?.stats) return [];
     const s = sembleContext.stats;
@@ -179,7 +196,7 @@
       </div>
     {/if}
 
-    {#if showSemble && sembleContext}
+    {#if showSemble && sembleContext && (hasSembleContent || sembleContext.incomplete)}
       <section class="semble-context" aria-label="Semble context">
         {#if sembleSummary.length}
           <p class="semble-summary">{sembleSummary.join(' · ')}</p>
@@ -227,18 +244,29 @@
                       ? `This article connects ${connection.type ?? 'to'} ${connectionLabel(connection)}`
                       : `${connectionLabel(connection)} connects ${connection.type ?? 'to'} this article`}
                   >
-                    {#if connection.direction === 'out'}<span>this</span><span aria-hidden="true"
-                        >→</span
-                      >{/if}
-                    <span class="connection-type">{connection.type ?? 'connected'}</span>
-                    {#if connection.direction === 'in'}<span aria-hidden="true">→</span>{/if}
-                    <a
-                      href={safeHref(connection.other.url)}
-                      target="_blank"
-                      rel="noopener"
-                      onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
-                    >
-                    {#if connection.direction === 'in'}<span aria-hidden="true">→ this</span>{/if}
+                    {#if connection.direction === 'out'}
+                      <span>this</span>
+                      <span aria-hidden="true">→</span>
+                      <span class="connection-type">{connection.type ?? 'connected'}</span>
+                      <span aria-hidden="true">→</span>
+                      <a
+                        href={safeHref(connection.other.url)}
+                        target="_blank"
+                        rel="noopener"
+                        onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                      >
+                    {:else}
+                      <a
+                        href={safeHref(connection.other.url)}
+                        target="_blank"
+                        rel="noopener"
+                        onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                      >
+                      <span aria-hidden="true">→</span>
+                      <span class="connection-type">{connection.type ?? 'connected'}</span>
+                      <span aria-hidden="true">→</span>
+                      <span>this</span>
+                    {/if}
                   </div>
                   {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
                   <button
@@ -450,16 +478,22 @@
       </div>
     {/if}
 
-    {#if undisclosed > 0 && shown > 0 && !showSemble}
+    {#if undisclosed > 0 && shown > 0 && !hasSembleContent}
       <p class="discussion-more">
         {undisclosed}{capped ? '+' : ''} more, further back.
       </p>
     {/if}
 
-    {#if settled && shown === 0 && !showSemble}
+    <!-- Semble context that carries something counts as readable content, so a
+         connections-only article never claims nothing came back. A lane that
+         failed still gets its retry either way — losing it behind context from a
+         different network would strand the reader on a partial answer. -->
+    {#if settled && shown === 0 && (stream.failed || !hasSembleContent)}
       {#if stream.failed}
         <p class="discussion-empty">
-          Couldn't reach the Atmosphere just now.
+          {hasSembleContent
+            ? "Some of the Atmosphere didn't answer."
+            : "Couldn't reach the Atmosphere just now."}
           <button type="button" class="discussion-retry" onclick={() => onRetry?.()}>
             Try again
           </button>

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -38,6 +38,7 @@
     DiscussionFilterId,
     DiscussionFilterVM,
     DiscussionStreamVM,
+    SembleContextVM,
   } from '../articleCardView.types';
 
   let {
@@ -45,6 +46,7 @@
     filters = [],
     activeFilter = 'all',
     stream = { idle: true, loading: false, entries: [] },
+    sembleContext,
     /** Render the discussion at all. */
     lanesOpen = true,
     /** Optional DOM id for the region (so a toggle can aria-control it). */
@@ -64,6 +66,7 @@
     filters?: DiscussionFilterVM[];
     activeFilter?: DiscussionFilterId;
     stream?: DiscussionStreamVM;
+    sembleContext?: SembleContextVM;
     lanesOpen?: boolean;
     panelId?: string;
     showHeading?: boolean;
@@ -92,6 +95,33 @@
     activeFilter === 'all' && settled && total > shown ? total - shown : 0
   );
   const hasComposeRow = $derived(Boolean(composeLead) || creatable.length > 0);
+  const showSemble = $derived(
+    Boolean(sembleContext) && (activeFilter === 'all' || activeFilter === 'semble')
+  );
+  const sembleSummary = $derived.by(() => {
+    if (!sembleContext?.stats) return [];
+    const s = sembleContext.stats;
+    return [
+      [s.saves, 'save'],
+      [s.notes, 'note'],
+      [s.collections, 'collection'],
+      [s.connections.total, 'connection'],
+    ]
+      .filter(([n]) => Number(n) > 0)
+      .map(([n, label]) => `${n} ${label}${Number(n) === 1 ? '' : 's'}`);
+  });
+
+  function connectionLabel(connection: SembleContextVM['connections'][number]): string {
+    try {
+      return (
+        connection.other.title ||
+        connection.other.siteName ||
+        new URL(connection.other.url).hostname
+      );
+    } catch {
+      return connection.other.title || 'Connected article';
+    }
+  }
 
   function displayNameFor(entry: DiscussionEntryVM): string {
     return entry.displayName?.trim() || `@${entry.handle ?? entry.did.slice(0, 18)}`;
@@ -147,6 +177,90 @@
           </button>
         {/each}
       </div>
+    {/if}
+
+    {#if showSemble && sembleContext}
+      <section class="semble-context" aria-label="Semble context">
+        {#if sembleSummary.length}
+          <p class="semble-summary">{sembleSummary.join(' · ')}</p>
+        {/if}
+        {#if sembleContext.collections.length}
+          <div class="semble-section">
+            <h3>In collections</h3>
+            <div class="semble-collections">
+              {#each sembleContext.collections as collection (collection.id)}
+                {#if collection.url}
+                  <a
+                    href={safeHref(collection.url)}
+                    target="_blank"
+                    rel="noopener"
+                    onclick={(e) => e.stopPropagation()}
+                    ><Icon name="folder" size={12} />{collection.name}</a
+                  >
+                {:else}<span><Icon name="folder" size={12} />{collection.name}</span>{/if}
+              {/each}
+            </div>
+          </div>
+        {/if}
+        {#if sembleContext.notes.length}
+          <div class="semble-section">
+            <h3>Notes</h3>
+            {#each sembleContext.notes as note (note.id)}
+              <div class="semble-note">
+                <p>{note.text}</p>
+                <button type="button" onclick={() => onOpenAuthor?.(note.author.did)}
+                  >@{note.author.handle || note.author.did.slice(0, 18)}</button
+                >
+              </div>
+            {/each}
+          </div>
+        {/if}
+        {#if sembleContext.connections.length}
+          <div class="semble-section">
+            <h3>Connections</h3>
+            <ul class="semble-connections">
+              {#each sembleContext.connections as connection (connection.id)}
+                <li>
+                  <div
+                    class="connection-line"
+                    aria-label={connection.direction === 'out'
+                      ? `This article connects ${connection.type ?? 'to'} ${connectionLabel(connection)}`
+                      : `${connectionLabel(connection)} connects ${connection.type ?? 'to'} this article`}
+                  >
+                    {#if connection.direction === 'out'}<span>this</span><span aria-hidden="true"
+                        >→</span
+                      >{/if}
+                    <span class="connection-type">{connection.type ?? 'connected'}</span>
+                    {#if connection.direction === 'in'}<span aria-hidden="true">→</span>{/if}
+                    <a
+                      href={safeHref(connection.other.url)}
+                      target="_blank"
+                      rel="noopener"
+                      onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                    >
+                    {#if connection.direction === 'in'}<span aria-hidden="true">→ this</span>{/if}
+                  </div>
+                  {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
+                  <button
+                    class="connection-curator"
+                    type="button"
+                    onclick={() => onOpenAuthor?.(connection.curator.did)}
+                    >by @{connection.curator.handle || connection.curator.did.slice(0, 18)}</button
+                  >
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+        {#if sembleContext.incomplete}<p class="semble-incomplete">
+            Some Semble context is unavailable.
+          </p>{/if}
+        {#if Object.values(sembleContext.truncated).some(Boolean)}
+          <a class="semble-more" href="https://semble.so" target="_blank" rel="noopener"
+            >Show more on Semble</a
+          >
+        {/if}
+      </section>
     {/if}
 
     {#if stream.entries.length > 0}
@@ -336,13 +450,13 @@
       </div>
     {/if}
 
-    {#if undisclosed > 0 && shown > 0}
+    {#if undisclosed > 0 && shown > 0 && !showSemble}
       <p class="discussion-more">
         {undisclosed}{capped ? '+' : ''} more, further back.
       </p>
     {/if}
 
-    {#if settled && shown === 0}
+    {#if settled && shown === 0 && !showSemble}
       {#if stream.failed}
         <p class="discussion-empty">
           Couldn't reach the Atmosphere just now.
@@ -479,6 +593,119 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+
+  .semble-context {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0;
+    border-block: 1px solid var(--color-border);
+  }
+  .semble-summary,
+  .semble-incomplete {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+  .semble-section {
+    margin-top: 0.75rem;
+  }
+  .semble-section h3 {
+    margin: 0 0 0.375rem;
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-text);
+  }
+  .semble-collections {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+  .semble-collections a,
+  .semble-collections span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1875rem 0.5rem;
+    border-radius: 999px;
+    background: var(--color-bg-secondary);
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    text-decoration: none;
+  }
+  .semble-collections a:hover,
+  .semble-more:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+  .semble-note {
+    margin-top: 0.5rem;
+  }
+  .semble-note p,
+  .connection-note {
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-text);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  .semble-note button,
+  .connection-curator {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+  }
+  .semble-note button:hover,
+  .connection-curator:hover {
+    color: var(--color-primary);
+  }
+  .semble-connections {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .connection-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.3125rem;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+  .connection-line a,
+  .semble-more {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+  .connection-type {
+    padding: 0.125rem 0.4375rem;
+    border-radius: 999px;
+    background: var(--color-bg-secondary);
+    font-size: var(--text-xs);
+  }
+  .connection-note {
+    margin-top: 0.25rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .connection-curator {
+    margin-top: 0.1875rem;
+  }
+  .semble-incomplete,
+  .semble-more {
+    display: block;
+    margin-top: 0.75rem;
+    font-size: var(--text-sm);
   }
 
   .entry {

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -31,6 +31,7 @@
   import type { Snippet } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { safeHref } from '$lib/utils/sanitize';
+  import type { IconName } from '$lib/components/Icon.svelte';
   import type {
     LaneId,
     LaneRowVM,
@@ -61,6 +62,8 @@
     onCreateInLane,
     onOpenAuthor,
     onRetry,
+    onSaveConnection,
+    isConnectionSaved,
   }: {
     laneRow?: LaneRowVM[];
     filters?: DiscussionFilterVM[];
@@ -75,7 +78,30 @@
     onCreateInLane?: (id: LaneId) => void;
     onOpenAuthor?: (did: string) => void;
     onRetry?: () => void;
+    /** Toggle a connected article into the reader's own Saved list. Absent when
+     *  the reader can't save (signed out), and the control doesn't render at
+     *  all. Async — a save fetches and extracts the article first. */
+    onSaveConnection?: (url: string) => void | Promise<void>;
+    /** Reactive saved-state predicate, so the control reads as state rather than
+     *  as an invitation the reader has already accepted. */
+    isConnectionSaved?: (url: string) => boolean;
   } = $props();
+
+  // The connections whose saves are in flight. A save costs a fetch and an
+  // extraction, so each control has to say it is working, and re-entry on the
+  // same one is blocked so a double-click can't create two saves. Different
+  // connections save concurrently — keeping three in a row is the normal case.
+  let savingUrls = $state<string[]>([]);
+
+  async function toggleSave(url: string) {
+    if (!onSaveConnection || savingUrls.includes(url)) return;
+    savingUrls = [...savingUrls, url];
+    try {
+      await onSaveConnection(url);
+    } finally {
+      savingUrls = savingUrls.filter((u) => u !== url);
+    }
+  }
 
   // The headline count: every reference across every lane, before filtering.
   const total = $derived(laneRow.reduce((sum, lane) => sum + lane.count, 0));
@@ -108,25 +134,96 @@
         sembleContext &&
         (sembleContext.notes.length ||
           sembleContext.collections.length ||
-          sembleContext.connections.length ||
-          (sembleContext.stats?.saves ?? 0) ||
-          (sembleContext.stats?.notes ?? 0) ||
-          (sembleContext.stats?.collections ?? 0) ||
-          (sembleContext.stats?.connections.total ?? 0))
+          sembleContext.connections.length)
       )
   );
-  const sembleSummary = $derived.by(() => {
-    if (!sembleContext?.stats) return [];
-    const s = sembleContext.stats;
-    return [
-      [s.saves, 'save'],
-      [s.notes, 'note'],
-      [s.collections, 'collection'],
-      [s.connections.total, 'connection'],
-    ]
-      .filter(([n]) => Number(n) > 0)
-      .map(([n, label]) => `${n} ${label}${Number(n) === 1 ? '' : 's'}`);
+
+  // ── Semble's graph, folded ──────────────────────────────────────────────
+  // A curator mapping a topic makes the same edge over and over: same person,
+  // same relation, same direction, twenty different targets. Rendered one row
+  // each that is twenty repetitions of the sentence and one line of payload.
+  // Folded on (curator, direction, type) it is one sentence and twenty titles,
+  // which is what the reader came for.
+  type SembleConnection = SembleContextVM['connections'][number];
+  interface ConnectionGroup {
+    key: string;
+    direction: 'in' | 'out';
+    type: string | null;
+    curator: SembleConnection['curator'];
+    items: SembleConnection[];
+  }
+  /** Targets listed inside a group before it asks to be opened. */
+  const GROUP_PREVIEW = 3;
+  /** Groups listed before the block asks to be opened. */
+  const BLOCK_PREVIEW = 5;
+
+  const connectionGroups = $derived.by(() => {
+    const groups = new Map<string, ConnectionGroup>();
+    for (const connection of sembleContext?.connections ?? []) {
+      const key = `${connection.direction}|${connection.type ?? ''}|${connection.curator.did}`;
+      const existing = groups.get(key);
+      if (existing) existing.items.push(connection);
+      else
+        groups.set(key, {
+          key,
+          direction: connection.direction,
+          type: connection.type,
+          curator: connection.curator,
+          items: [connection],
+        });
+    }
+    return [...groups.values()];
   });
+
+  let openGroups = $state<string[]>([]);
+  let allGroupsOpen = $state(false);
+  // A different article is a different graph: nothing stays open across it.
+  let openedFor: SembleContextVM | undefined = undefined;
+  $effect(() => {
+    if (sembleContext !== openedFor) {
+      openedFor = sembleContext;
+      openGroups = [];
+      allGroupsOpen = false;
+    }
+  });
+
+  const visibleGroups = $derived(
+    allGroupsOpen ? connectionGroups : connectionGroups.slice(0, BLOCK_PREVIEW)
+  );
+  const foldedConnections = $derived(
+    connectionGroups.slice(visibleGroups.length).reduce((n, group) => n + group.items.length, 0)
+  );
+
+  function toggleGroup(key: string) {
+    openGroups = openGroups.includes(key)
+      ? openGroups.filter((k) => k !== key)
+      : [...openGroups, key];
+  }
+
+  // Semble hands back a page of edges, not all of them. Say which, once, where
+  // the reader can act on it — rather than as a headline count that contradicts
+  // the panel's own.
+  const connectionsHeld = $derived(sembleContext?.stats?.connections.total ?? 0);
+  const connectionsGot = $derived(sembleContext?.connections.length ?? 0);
+  const connectionsBeyond = $derived(
+    connectionsHeld > connectionsGot ? connectionsHeld - connectionsGot : 0
+  );
+  const sembleTruncated = $derived(
+    Boolean(sembleContext && Object.values(sembleContext.truncated).some(Boolean))
+  );
+
+  function groupSentence(group: ConnectionGroup): string {
+    const type = group.type ?? 'connected';
+    const n = group.items.length;
+    const other = n === 1 ? 'one piece' : `${n} pieces`;
+    return group.direction === 'out'
+      ? `This article ${type} ${other}, connected by ${authorName(group.curator)}`
+      : `${other[0].toUpperCase()}${other.slice(1)} ${type} this article, connected by ${authorName(group.curator)}`;
+  }
+
+  function authorName(author: { name?: string | null; handle?: string | null; did: string }) {
+    return author.name?.trim() || `@${author.handle || author.did.slice(0, 18)}`;
+  }
 
   function connectionLabel(connection: SembleContextVM['connections'][number]): string {
     try {
@@ -144,9 +241,12 @@
     return entry.displayName?.trim() || `@${entry.handle ?? entry.did.slice(0, 18)}`;
   }
 
-  function monogramFor(entry: DiscussionEntryVM): string {
-    const source = entry.displayName?.trim() || entry.handle || entry.did.replace('did:plc:', '');
+  function monogram(source: string): string {
     return source.charAt(0).toUpperCase();
+  }
+
+  function monogramFor(entry: DiscussionEntryVM): string {
+    return monogram(entry.displayName?.trim() || entry.handle || entry.did.replace('did:plc:', ''));
   }
 
   // A broken avatar URL (a deleted blob, a CDN miss) hides the image and lets the
@@ -155,6 +255,47 @@
     (event.currentTarget as HTMLImageElement).style.display = 'none';
   }
 </script>
+
+<!-- The person: a 30px avatar wearing its network as a small glyph, and a hit
+     target that follows them in Skyreader. Shared by the stream's entries and by
+     Semble's curators, so the two can never drift apart. -->
+{#snippet person(
+  did: string,
+  handle: string | null | undefined,
+  name: string | null | undefined,
+  avatar: string | null | undefined,
+  laneIcon: IconName = 'semble',
+  laneLabel: string = 'Semble'
+)}
+  {@const label = name?.trim() || `@${handle || did.slice(0, 18)}`}
+  <button
+    type="button"
+    class="entry-avatar"
+    title="Follow {handle || did} in Skyreader"
+    aria-label="Follow {label} in Skyreader"
+    onclick={(e) => {
+      e.stopPropagation();
+      onOpenAuthor?.(did);
+    }}
+  >
+    <span class="entry-monogram" aria-hidden="true"
+      >{monogram(name?.trim() || handle || did.replace('did:plc:', ''))}</span
+    >
+    {#if avatar}
+      <img
+        class="entry-photo"
+        src={avatar}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        onerror={hideBrokenAvatar}
+      />
+    {/if}
+    <span class="entry-source" title={laneLabel}>
+      <Icon name={laneIcon} size={10} />
+    </span>
+  </button>
+{/snippet}
 
 {#if lanesOpen && (total > 0 || hasComposeRow)}
   <section class="discussion" class:no-heading={!showHeading} id={panelId} aria-label="Discussion">
@@ -196,97 +337,180 @@
       </div>
     {/if}
 
+    <!-- Semble's side is a graph, not a conversation, but it is made of the same
+         material: a person, and what they did with this article. Rendering it in
+         the stream's own grammar (avatar, head line, payload beneath) keeps it
+         from reading as a second document bolted above the discussion. -->
     {#if showSemble && sembleContext && (hasSembleContent || sembleContext.incomplete)}
-      <section class="semble-context" aria-label="Semble context">
-        {#if sembleSummary.length}
-          <p class="semble-summary">{sembleSummary.join(' · ')}</p>
-        {/if}
+      <section class="semble-context" aria-label="What Semble holds about this article">
         {#if sembleContext.collections.length}
-          <div class="semble-section">
-            <h3>In collections</h3>
-            <div class="semble-collections">
-              {#each sembleContext.collections as collection (collection.id)}
-                {#if collection.url}
-                  <a
-                    href={safeHref(collection.url)}
-                    target="_blank"
-                    rel="noopener"
-                    onclick={(e) => e.stopPropagation()}
-                    ><Icon name="folder" size={12} />{collection.name}</a
-                  >
-                {:else}<span><Icon name="folder" size={12} />{collection.name}</span>{/if}
-              {/each}
-            </div>
-          </div>
-        {/if}
-        {#if sembleContext.notes.length}
-          <div class="semble-section">
-            <h3>Notes</h3>
-            {#each sembleContext.notes as note (note.id)}
-              <div class="semble-note">
-                <p>{note.text}</p>
-                <button type="button" onclick={() => onOpenAuthor?.(note.author.did)}
-                  >@{note.author.handle || note.author.did.slice(0, 18)}</button
+          <p class="semble-filed">
+            <span class="semble-filed-label">Filed in</span>
+            {#each sembleContext.collections as collection (collection.id)}
+              {#if collection.url}
+                <a
+                  class="semble-collection"
+                  href={safeHref(collection.url)}
+                  target="_blank"
+                  rel="noopener"
+                  onclick={(e) => e.stopPropagation()}
+                  ><Icon name="folder" size={11} />{collection.name}</a
                 >
-              </div>
+              {:else}
+                <span class="semble-collection"
+                  ><Icon name="folder" size={11} />{collection.name}</span
+                >
+              {/if}
             {/each}
-          </div>
+          </p>
         {/if}
-        {#if sembleContext.connections.length}
-          <div class="semble-section">
-            <h3>Connections</h3>
-            <ul class="semble-connections">
-              {#each sembleContext.connections as connection (connection.id)}
-                <li>
-                  <div
-                    class="connection-line"
-                    aria-label={connection.direction === 'out'
-                      ? `This article connects ${connection.type ?? 'to'} ${connectionLabel(connection)}`
-                      : `${connectionLabel(connection)} connects ${connection.type ?? 'to'} this article`}
-                  >
-                    {#if connection.direction === 'out'}
-                      <span>this</span>
-                      <span aria-hidden="true">→</span>
-                      <span class="connection-type">{connection.type ?? 'connected'}</span>
-                      <span aria-hidden="true">→</span>
-                      <a
-                        href={safeHref(connection.other.url)}
-                        target="_blank"
-                        rel="noopener"
-                        onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
-                      >
-                    {:else}
-                      <a
-                        href={safeHref(connection.other.url)}
-                        target="_blank"
-                        rel="noopener"
-                        onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
-                      >
-                      <span aria-hidden="true">→</span>
-                      <span class="connection-type">{connection.type ?? 'connected'}</span>
-                      <span aria-hidden="true">→</span>
-                      <span>this</span>
+
+        {#if sembleContext.notes.length || visibleGroups.length}
+          <ul class="discussion-stream">
+            {#each sembleContext.notes as note (note.id)}
+              <li class="entry">
+                {@render person(
+                  note.author.did,
+                  note.author.handle,
+                  note.author.name,
+                  note.author.avatarUrl
+                )}
+                <div class="entry-body">
+                  <div class="entry-head">
+                    <span class="entry-name">{authorName(note.author)}</span>
+                    {#if note.author.name?.trim() && note.author.handle}
+                      <span class="entry-handle">@{note.author.handle}</span>
+                    {/if}
+                    <span class="entry-verb">noted</span>
+                  </div>
+                  <p class="entry-note">{note.text}</p>
+                </div>
+              </li>
+            {/each}
+
+            <!-- One row per (curator, relation, direction). The sentence is said
+                 once in the head line and the arrow still points the way the
+                 edge does; the titles beneath are the only part that varies. -->
+            {#each visibleGroups as group (group.key)}
+              {@const open = openGroups.includes(group.key)}
+              {@const shown = open ? group.items : group.items.slice(0, GROUP_PREVIEW)}
+              {@const folded = group.items.length - shown.length}
+              <li class="entry">
+                {@render person(
+                  group.curator.did,
+                  group.curator.handle,
+                  group.curator.name,
+                  group.curator.avatarUrl
+                )}
+                <div class="entry-body">
+                  <div class="entry-head">
+                    <span class="entry-name">{authorName(group.curator)}</span>
+                    <span class="relation" aria-label={groupSentence(group)}>
+                      {#if group.direction === 'out'}
+                        <span class="relation-self">this</span>
+                        <span class="relation-arrow" aria-hidden="true">&rarr;</span>
+                        <span class="relation-type">{group.type ?? 'connected'}</span>
+                      {:else}
+                        <span class="relation-type">{group.type ?? 'connected'}</span>
+                        <span class="relation-arrow" aria-hidden="true">&rarr;</span>
+                        <span class="relation-self">this</span>
+                      {/if}
+                    </span>
+                    {#if group.items.length > 1}
+                      <span class="relation-count">{group.items.length}</span>
                     {/if}
                   </div>
-                  {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
-                  <button
-                    class="connection-curator"
-                    type="button"
-                    onclick={() => onOpenAuthor?.(connection.curator.did)}
-                    >by @{connection.curator.handle || connection.curator.did.slice(0, 18)}</button
-                  >
-                </li>
-              {/each}
-            </ul>
-          </div>
+                  <ul class="connection-list">
+                    {#each shown as connection (connection.id)}
+                      {@const saved = isConnectionSaved?.(connection.other.url) ?? false}
+                      {@const busy = savingUrls.includes(connection.other.url)}
+                      <li>
+                        <div class="connection-row">
+                          <a
+                            class="connection-target"
+                            href={safeHref(connection.other.url)}
+                            target="_blank"
+                            rel="noopener"
+                            onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                          >
+                          <!-- The one thing a reader wants to do with someone
+                               else's connected article is keep it. The control
+                               stays put rather than appearing on hover: which of
+                               these twenty are already yours is information, not
+                               an affordance to be discovered. -->
+                          {#if onSaveConnection}
+                            <button
+                              type="button"
+                              class="connection-save"
+                              class:saved
+                              class:busy
+                              disabled={busy}
+                              aria-busy={busy}
+                              aria-pressed={saved}
+                              title={saved
+                                ? 'In your Saved list. Remove it'
+                                : 'Save to read in Skyreader'}
+                              aria-label={saved
+                                ? `Remove “${connectionLabel(connection)}” from Saved`
+                                : `Save “${connectionLabel(connection)}” to read in Skyreader`}
+                              onclick={(e) => {
+                                e.stopPropagation();
+                                toggleSave(connection.other.url);
+                              }}
+                            >
+                              <Icon name="bookmark" size={14} />
+                            </button>
+                          {/if}
+                        </div>
+                        {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
+                      </li>
+                    {/each}
+                  </ul>
+                  {#if group.items.length > GROUP_PREVIEW}
+                    <button
+                      type="button"
+                      class="semble-disclose"
+                      aria-expanded={open}
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        toggleGroup(group.key);
+                      }}
+                    >
+                      {open ? 'Show fewer' : `Show ${folded} more`}
+                    </button>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
         {/if}
-        {#if sembleContext.incomplete}<p class="semble-incomplete">
-            Some Semble context is unavailable.
-          </p>{/if}
-        {#if Object.values(sembleContext.truncated).some(Boolean)}
-          <a class="semble-more" href="https://semble.so" target="_blank" rel="noopener"
-            >Show more on Semble</a
+
+        {#if foldedConnections > 0}
+          <button
+            type="button"
+            class="semble-disclose semble-disclose-block"
+            onclick={(e) => {
+              e.stopPropagation();
+              allGroupsOpen = true;
+            }}
           >
+            {foldedConnections} more {foldedConnections === 1 ? 'connection' : 'connections'}
+          </button>
+        {/if}
+
+        {#if sembleContext.cardUrl && (connectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
+          <p class="semble-foot">
+            {#if connectionsBeyond > 0}Showing {connectionsGot} of {connectionsHeld} connections.{/if}
+            {#if sembleContext.incomplete}Some Semble context is unavailable.{/if}
+            {#if sembleContext.cardUrl}
+              <a
+                href={safeHref(sembleContext.cardUrl)}
+                target="_blank"
+                rel="noopener"
+                onclick={(e) => e.stopPropagation()}>See all on Semble</a
+              >
+            {/if}
+          </p>
         {/if}
       </section>
     {/if}
@@ -295,31 +519,14 @@
       <ul class="discussion-stream">
         {#each stream.entries as entry (entry.key)}
           <li class="entry">
-            <button
-              type="button"
-              class="entry-avatar"
-              title="Follow {entry.handle ?? entry.did} in Skyreader"
-              aria-label="Follow {displayNameFor(entry)} in Skyreader"
-              onclick={(e) => {
-                e.stopPropagation();
-                onOpenAuthor?.(entry.did);
-              }}
-            >
-              <span class="entry-monogram" aria-hidden="true">{monogramFor(entry)}</span>
-              {#if entry.avatar}
-                <img
-                  class="entry-photo"
-                  src={entry.avatar}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  onerror={hideBrokenAvatar}
-                />
-              {/if}
-              <span class="entry-source" title={entry.laneLabel}>
-                <Icon name={entry.laneIcon} size={10} />
-              </span>
-            </button>
+            {@render person(
+              entry.did,
+              entry.handle,
+              entry.displayName,
+              entry.avatar,
+              entry.laneIcon,
+              entry.laneLabel
+            )}
 
             <div class="entry-body">
               <div class="entry-head">
@@ -629,117 +836,275 @@
     gap: 1rem;
   }
 
+  /* Bracketed in hairlines, not boxed. Semble's graph is a different kind of
+     content from the conversation, and a rule above and below says so without
+     lifting it off the page. */
   .semble-context {
     margin: 0 0 1rem;
-    padding: 0.75rem 0;
+    padding: 0.875rem 0;
     border-block: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
   }
-  .semble-summary,
-  .semble-incomplete {
-    margin: 0;
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
+
+  /* When the compose row follows immediately it draws its own rule, and two
+     rules with nothing between them is an empty box. This one stands down. */
+  .semble-context:has(+ .discussion-compose) {
+    padding-bottom: 0;
+    border-bottom: 0;
   }
-  .semble-section {
-    margin-top: 0.75rem;
-  }
-  .semble-section h3 {
-    margin: 0 0 0.375rem;
-    font-size: var(--text-sm);
-    font-weight: var(--weight-semibold);
-    color: var(--color-text);
-  }
-  .semble-collections {
+
+  /* Where the article is filed. One line of pills reading as a set, with a
+     lead-in rather than a heading — a heading here would compete with the
+     panel's own, for two words of wayfinding. */
+  .semble-filed {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 0.375rem;
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
   }
-  .semble-collections a,
-  .semble-collections span {
+
+  .semble-filed-label {
+    color: var(--color-text-secondary);
+  }
+
+  .semble-collection {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
     padding: 0.1875rem 0.5rem;
     border-radius: 999px;
     background: var(--color-bg-secondary);
-    color: var(--color-text-secondary);
-    font-size: var(--text-sm);
-    text-decoration: none;
-  }
-  .semble-collections a:hover,
-  .semble-more:hover {
-    color: var(--color-primary);
-    text-decoration: underline;
-  }
-  .semble-note {
-    margin-top: 0.5rem;
-  }
-  .semble-note p,
-  .connection-note {
-    margin: 0;
-    font-size: var(--text-sm);
-    line-height: var(--leading-normal);
     color: var(--color-text);
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-  }
-  .semble-note button,
-  .connection-curator {
-    padding: 0;
-    border: 0;
-    background: none;
-    color: var(--color-text-secondary);
-    font: inherit;
-    font-size: var(--text-sm);
-    cursor: pointer;
-  }
-  .semble-note button:hover,
-  .connection-curator:hover {
-    color: var(--color-primary);
-  }
-  .semble-connections {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-  .connection-line {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.3125rem;
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-  }
-  .connection-line a,
-  .semble-more {
-    color: var(--color-primary);
     text-decoration: none;
   }
-  .connection-type {
-    padding: 0.125rem 0.4375rem;
+
+  .semble-collection :global(.icon) {
+    color: var(--color-text-secondary);
+  }
+
+  a.semble-collection:hover {
+    color: var(--color-primary);
+  }
+
+  a.semble-collection:hover :global(.icon) {
+    color: var(--color-primary);
+  }
+
+  /* The relation, said once per group. `this` is a token of the article itself,
+     so it takes the sunken pill; the arrow between them is the sentence, and it
+     points the way the edge does. */
+  .relation {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    min-width: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .relation-self {
+    flex-shrink: 0;
+    padding: 0.0625rem 0.4375rem;
     border-radius: 999px;
     background: var(--color-bg-secondary);
     font-size: var(--text-xs);
+    color: var(--color-text-secondary);
   }
-  .connection-note {
-    margin-top: 0.25rem;
+
+  .relation-count {
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .relation-type {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .relation-arrow {
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+    opacity: 0.7;
+  }
+
+  /* The payload. Titles are the only part of a group that varies, so they are
+     the only part in ink — twenty blue links would be a colour event twenty
+     times over, and the article is what the reader is here for. */
+  .connection-list {
+    list-style: none;
+    margin: 0.25rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  /* Title takes the room; the keep control holds a fixed column at the trailing
+     edge so twenty of them line up instead of ragging with the text. */
+  .connection-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  /* Quiet at rest and quiet in a column of twenty: the bookmark carries no fill
+     and no chrome until it is either hovered or holding something. */
+  .connection-save {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin: -0.125rem -0.25rem -0.125rem 0;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    background: none;
+    color: var(--color-text-secondary);
+    /* Quiet, but not below the 3:1 bar a control has to clear: 0.75 lands the
+       resting glyph at ~3.4:1 on white and ~4.1:1 on the night surface. */
+    opacity: 0.75;
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      opacity 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .connection-save:hover {
+    background: var(--color-bg-secondary);
+    color: var(--color-primary);
+    opacity: 1;
+  }
+
+  /* Kept. The bookmark fills so the state survives a glance down the column,
+     and it is never the only signal — aria-pressed and the label say it too. */
+  .connection-save.saved {
+    color: var(--color-primary);
+    opacity: 1;
+  }
+
+  .connection-save.saved :global(.icon) {
+    fill: currentColor;
+  }
+
+  /* A save fetches and extracts the article, so this is a real wait. The
+     bookmark pulses rather than swapping in a spinner the row has no room for. */
+  .connection-save.busy {
+    color: var(--color-primary);
+    opacity: 1;
+    cursor: default;
+    animation: connection-save-pulse 1.1s ease-in-out infinite;
+  }
+
+  @keyframes connection-save-pulse {
+    50% {
+      opacity: 0.35;
+    }
+  }
+
+  /* Two lines, not one: at phone width a single clipped line turns most of
+     these into an ellipsis, and the title is the whole payload of the row. */
+  .connection-target {
+    flex: 1;
+    min-width: 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    color: var(--color-text);
+    text-decoration: none;
+    overflow-wrap: anywhere;
     display: -webkit-box;
-    -webkit-line-clamp: 4;
-    line-clamp: 4;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  .connection-curator {
-    margin-top: 0.1875rem;
+
+  .connection-target:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
-  .semble-incomplete,
-  .semble-more {
-    display: block;
-    margin-top: 0.75rem;
+
+  .connection-note {
+    margin: 0.125rem 0 0;
     font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    color: var(--color-text-secondary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .semble-disclose {
+    align-self: flex-start;
+    margin-top: 0.375rem;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .semble-disclose:hover {
+    color: var(--color-primary);
+  }
+
+  .semble-disclose-block {
+    margin-top: 0;
+  }
+
+  .semble-foot {
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    color: var(--color-text-secondary);
+  }
+
+  .semble-foot a {
+    color: var(--color-text-secondary);
+    text-decoration: underline;
+    text-decoration-color: var(--color-border);
+    text-underline-offset: 2px;
+  }
+
+  .semble-foot a:hover {
+    color: var(--color-primary);
+    text-decoration-color: currentColor;
+  }
+
+  .connection-target:focus-visible,
+  .connection-save:focus-visible,
+  .semble-collection:focus-visible,
+  .semble-disclose:focus-visible,
+  .semble-foot a:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .connection-save {
+      transition: none;
+    }
+
+    .connection-save.busy {
+      animation: none;
+      opacity: 0.6;
+    }
   }
 
   .entry {

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -158,6 +158,7 @@
     filters={atmosphere.filters}
     activeFilter={atmosphere.activeFilter}
     stream={atmosphere.stream}
+    sembleContext={atmosphere.sembleContext}
     lanesOpen={true}
     {panelId}
     onSelectFilter={atmosphere.setFilter}

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -9,11 +9,13 @@
   import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
+  import { savesStore } from '$lib/stores/saves.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { useAtmosphere } from '$lib/hooks/useAtmosphere.svelte';
   import { getExternalArticleLink } from '$lib/utils/linkPost';
   import { shareTargetForDisplayItem } from '$lib/utils/shareTarget';
   import { normalizeDisplayItem } from '$lib/utils/displayItem';
+  import { toggleSavedLink } from '$lib/utils/saveLink';
   import AtmospherePanel from './AtmospherePanel.svelte';
   import Icon from '$lib/components/Icon.svelte';
 
@@ -165,6 +167,8 @@
     onRetry={atmosphere.retry}
     onCreateInLane={createInLane}
     onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
+    onSaveConnection={auth.user ? toggleSavedLink : undefined}
+    isConnectionSaved={(url) => savesStore.isSaved(url)}
     composeLead={canShareLinkblog ? shareControl : undefined}
   />
 </section>

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -26,6 +26,7 @@ import type {
   DiscussionFilterId,
   DiscussionFilterVM,
   DiscussionStreamVM,
+  SembleContextVM,
 } from '$lib/components/articleCardView.types';
 import { articleMentionsStore } from '$lib/stores/articleMentions.svelte';
 import { mentionLaneItemsStore } from '$lib/stores/mentionLaneItems.svelte';
@@ -63,7 +64,7 @@ export const LANE_META: Record<
   semble: {
     icon: 'semble',
     label: 'Semble',
-    verb: 'saved',
+    verb: 'referenced',
     noun: 'save',
     createLabel: 'Save to Semble',
   },
@@ -107,6 +108,7 @@ export interface AtmosphereApi {
   readonly activeFilter: DiscussionFilterId;
   /** The merged, filtered, newest-first discussion. */
   readonly stream: DiscussionStreamVM;
+  readonly sembleContext: SembleContextVM | undefined;
   /** Total references across lanes — the headline count on the Discussion button. */
   readonly total: number;
   /** Whether any lane hit its lookup cap (renders the count as "N+"). */
@@ -207,6 +209,15 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
   });
 
   let activeFilter = $state<DiscussionFilterId>('all');
+
+  const sembleContext = $derived(laneItems.get('semble')?.sembleContext);
+
+  let previousUrl = $state('');
+  $effect(() => {
+    const url = opts.itemUrl();
+    if (previousUrl && url !== previousUrl) activeFilter = 'all';
+    previousUrl = url;
+  });
 
   // Only lanes that actually have people can filter anything, so the chip row
   // never offers a filter that empties the stream. `All` leads and carries the
@@ -353,6 +364,9 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     },
     get stream() {
       return stream;
+    },
+    get sembleContext() {
+      return sembleContext;
     },
     get total() {
       return total;

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -16,6 +16,7 @@ import type {
   SocialContextResult,
   ArticleMentions,
   MentionLaneEntry,
+  SembleContext,
   SocialDocument,
   User,
 } from '$lib/types';
@@ -660,7 +661,10 @@ class ApiClient {
   // The people inside one lane (Phase 5 "see existing items") — who referenced
   // this URL via that lane, with their note + a link out. Lazily fetched when a
   // lane is expanded. Best-effort adornment; degrades to an empty list.
-  async fetchMentionLaneItems(url: string, lane: string): Promise<{ entries: MentionLaneEntry[] }> {
+  async fetchMentionLaneItems(
+    url: string,
+    lane: string
+  ): Promise<{ entries: MentionLaneEntry[]; sembleContext?: SembleContext }> {
     return this.fetch('/api/v2/mention-lane', {
       method: 'POST',
       body: JSON.stringify({ url, lane }),

--- a/frontend/src/lib/stores/mentionLaneItems.svelte.ts
+++ b/frontend/src/lib/stores/mentionLaneItems.svelte.ts
@@ -9,7 +9,7 @@
 // only: a failure degrades to an empty list.
 
 import { api } from '$lib/services/api';
-import type { MentionLaneEntry } from '$lib/types';
+import type { MentionLaneEntry, SembleContext } from '$lib/types';
 
 export type LaneItemsState = {
   loading: boolean;
@@ -22,6 +22,7 @@ export type LaneItemsState = {
    */
   failed: boolean;
   entries: MentionLaneEntry[];
+  sembleContext?: SembleContext;
 };
 
 const LOADING: LaneItemsState = { loading: true, loaded: false, failed: false, entries: [] };
@@ -54,7 +55,13 @@ function createMentionLaneItemsStore() {
     const p = api
       .fetchMentionLaneItems(url, lane)
       .then((res) => {
-        set(key, { loading: false, loaded: true, failed: false, entries: res.entries ?? [] });
+        set(key, {
+          loading: false,
+          loaded: true,
+          failed: false,
+          entries: res.entries ?? [],
+          sembleContext: res.sembleContext,
+        });
       })
       .catch((e) => {
         console.error('Failed to fetch mention lane items:', e);

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -2,6 +2,7 @@ import { db } from '$lib/services/db';
 import { safePut, safeBulkPut } from '$lib/services/safeDb.svelte';
 import { api, UrlSaveLimitError } from '$lib/services/api';
 import { generateTid } from '$lib/utils/tid';
+import { urlKey } from '$lib/utils/urlKey';
 import { syncQueue, type SavedPayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
 import { extractArticle } from '$lib/services/extract';
@@ -42,16 +43,27 @@ function createSavesStore() {
   // O(1) lookup maps
   let savedByGuid = $state<Map<string, SavedItem>>(new Map());
   let savedByUrl = $state<Map<string, SavedItem>>(new Map());
+  // The same saves under their canonical form, so a link that arrives from
+  // another network (a Semble connection, a share) still finds the save the
+  // reader already has when only a trailing slash or a utm param differs.
+  // Exact matches always win; this is only consulted when one misses.
+  let savedByUrlKey = $state<Map<string, SavedItem>>(new Map());
 
   function rebuildMaps() {
     const byGuid = new Map<string, SavedItem>();
     const byUrl = new Map<string, SavedItem>();
+    const byUrlKey = new Map<string, SavedItem>();
     for (const bm of articles) {
       if (bm.itemGuid) byGuid.set(bm.itemGuid, bm);
-      if (bm.url) byUrl.set(bm.url, bm);
+      if (bm.url) {
+        byUrl.set(bm.url, bm);
+        const key = urlKey(bm.url);
+        if (key) byUrlKey.set(key, bm);
+      }
     }
     savedByGuid = byGuid;
     savedByUrl = byUrl;
+    savedByUrlKey = byUrlKey;
   }
 
   // Self-heal old saves that have a body but no stored word count (pre-fix
@@ -583,7 +595,9 @@ function createSavesStore() {
   }
 
   function isSaved(guidOrUrl: string): boolean {
-    return savedByGuid.has(guidOrUrl) || savedByUrl.has(guidOrUrl);
+    if (savedByGuid.has(guidOrUrl) || savedByUrl.has(guidOrUrl)) return true;
+    const key = urlKey(guidOrUrl);
+    return key !== null && savedByUrlKey.has(key);
   }
 
   function getByUri(uri: string): SavedItem | undefined {
@@ -591,7 +605,10 @@ function createSavesStore() {
   }
 
   function getByUrl(url: string): SavedItem | undefined {
-    return savedByUrl.get(url);
+    const exact = savedByUrl.get(url);
+    if (exact) return exact;
+    const key = urlKey(url);
+    return key ? savedByUrlKey.get(key) : undefined;
   }
 
   function getByGuid(guid: string): SavedItem | undefined {

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -814,14 +814,6 @@ export interface SembleContext {
     collections: number;
     connections: { total: number; incoming: number; outgoing: number };
   } | null;
-  savers: Array<{
-    cardId: string;
-    cardUri: string | null;
-    author: SembleAuthor;
-    note: string | null;
-    savedAt: string | null;
-    collections: Array<{ id: string; name: string; url: string | null }>;
-  }>;
   notes: Array<{ id: string; text: string; author: SembleAuthor; createdAt: string | null }>;
   collections: Array<{
     id: string;
@@ -847,6 +839,9 @@ export interface SembleContext {
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';
+  /** This URL's card page on semble.so — the page these counts were read from.
+   *  Built by the feed proxy; null when the URL couldn't be normalized. */
+  cardUrl: string | null;
 }
 
 // An in-app notification (currently only @mention-on-a-share). `actor*` fields

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -801,6 +801,54 @@ export interface SembleCollectionRef {
   url: string | null;
 }
 
+export interface SembleAuthor {
+  did: string;
+  handle: string;
+  name: string | null;
+  avatarUrl: string | null;
+}
+export interface SembleContext {
+  stats: {
+    saves: number;
+    notes: number;
+    collections: number;
+    connections: { total: number; incoming: number; outgoing: number };
+  } | null;
+  savers: Array<{
+    cardId: string;
+    cardUri: string | null;
+    author: SembleAuthor;
+    note: string | null;
+    savedAt: string | null;
+    collections: Array<{ id: string; name: string; url: string | null }>;
+  }>;
+  notes: Array<{ id: string; text: string; author: SembleAuthor; createdAt: string | null }>;
+  collections: Array<{
+    id: string;
+    name: string;
+    url: string | null;
+    author: { did: string; handle: string };
+  }>;
+  connections: Array<{
+    id: string;
+    direction: 'out' | 'in';
+    type: string | null;
+    note: string | null;
+    curator: SembleAuthor;
+    createdAt: string | null;
+    other: {
+      url: string;
+      title: string | null;
+      description: string | null;
+      siteName: string | null;
+      imageUrl: string | null;
+    };
+  }>;
+  truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
+  incomplete: boolean;
+  source: 'semble-api' | 'constellation-fallback';
+}
+
 // An in-app notification (currently only @mention-on-a-share). `actor*` fields
 // are the sharer who mentioned you; `sourceUri` is the mentioning
 // site.standard.document; `title` is the shared article's title. Sourced

--- a/frontend/src/lib/utils/saveLink.ts
+++ b/frontend/src/lib/utils/saveLink.ts
@@ -1,0 +1,21 @@
+// Save an arbitrary web URL into the reader's own Saved list, from anywhere a
+// link to someone else's article shows up (a Semble connection, a link menu).
+//
+// Saving fetches and extracts the article first, so it is genuinely slow enough
+// to need a pending state — callers hold one while this runs. Success is visible
+// in the control itself (the bookmark fills), so only the failure has to say
+// anything; a toast for the happy path would be noise on a reading surface.
+import { savesStore } from '$lib/stores/saves.svelte';
+import { toastStore } from '$lib/stores/toast.svelte';
+
+/** Toggle `url` in and out of Saved. Resolves once the list reflects the change. */
+export async function toggleSavedLink(url: string): Promise<void> {
+  const existing = savesStore.getByUrl(url);
+  try {
+    if (existing) await savesStore.remove(existing.rkey);
+    else await savesStore.saveFromUrl(url);
+  } catch {
+    const id = toastStore.add(existing ? 'Could not remove that save' : 'Could not save that');
+    toastStore.update(id, 'error');
+  }
+}

--- a/frontend/src/lib/utils/urlKey.test.ts
+++ b/frontend/src/lib/utils/urlKey.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { urlKey } from './urlKey';
+
+describe('urlKey', () => {
+  it('collapses the forms the same article travels in', () => {
+    const canonical = urlKey('https://example.com/post');
+    expect(urlKey('https://example.com/post/')).toBe(canonical);
+    expect(urlKey('https://example.com/post#section')).toBe(canonical);
+    expect(urlKey('https://EXAMPLE.com/post')).toBe(canonical);
+    expect(urlKey('https://example.com:443/post')).toBe(canonical);
+    expect(urlKey('https://example.com/post?utm_source=semble')).toBe(canonical);
+  });
+
+  it('keeps the query params a page actually needs, in a stable order', () => {
+    expect(urlKey('https://example.com/p?b=2&a=1')).toBe(urlKey('https://example.com/p?a=1&b=2'));
+    expect(urlKey('https://example.com/p?id=7')).toContain('id=7');
+  });
+
+  it('keeps hosts apart that are only cosmetically alike', () => {
+    expect(urlKey('https://www.example.com/p')).not.toBe(urlKey('https://example.com/p'));
+    expect(urlKey('http://example.com/p')).not.toBe(urlKey('https://example.com/p'));
+    expect(urlKey('https://example.com/a')).not.toBe(urlKey('https://example.com/b'));
+  });
+
+  it('leaves the bare root alone', () => {
+    expect(urlKey('https://example.com/')).toBe('https://example.com/');
+  });
+
+  it('returns null for anything that is not a web page, so callers can tell', () => {
+    expect(urlKey('at://did:plc:abc/app.bsky.feed.post/123')).toBeNull();
+    expect(urlKey('some-feed-item-guid')).toBeNull();
+    expect(urlKey('')).toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/urlKey.ts
+++ b/frontend/src/lib/utils/urlKey.ts
@@ -1,0 +1,85 @@
+// A stable key for "is this the same page?" comparisons between a URL the app
+// stored and a URL some other network handed us.
+//
+// Saved items are keyed by the exact URL string they were saved with, which is
+// fine while both sides came from the same place. It stops being fine the moment
+// a link arrives from elsewhere — a Semble connection, a share, the extension —
+// because the same article routinely travels as `…/post`, `…/post/`, and
+// `…/post?utm_source=…`. Compared literally, an article the reader already keeps
+// reads as unsaved.
+//
+// Deliberately mirrors `feed-proxy/src/url-normalize.ts` (the canonical form used
+// for Constellation lookups), including its two non-normalizations: the scheme
+// and `www` are preserved, because they distinguish real hosts more often than
+// they mask duplicates. Keep the two in step.
+
+// Pure tracking / session noise. Anything unlisted is preserved — some sites key
+// real content off `?p=` or `?id=`.
+const TRACKING_PARAMS = new Set([
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  'utm_name',
+  'utm_reader',
+  'ref',
+  'ref_src',
+  'ref_url',
+  'source',
+  'fbclid',
+  'gclid',
+  'dclid',
+  'msclkid',
+  'mc_cid',
+  'mc_eid',
+  'igshid',
+  'igsh',
+  'si',
+  'spm',
+  'cmpid',
+  '_hsenc',
+  '_hsmi',
+  'vero_id',
+  'oly_anon_id',
+  'oly_enc_id',
+]);
+
+/**
+ * Canonicalize a URL for same-page matching. Returns `null` for anything that
+ * isn't an http(s) URL — a guid, an at:// uri, a bare id — so callers that
+ * accept either can tell the two apart and fall back to an exact match.
+ *
+ * - lowercases the host (keeps `www`)
+ * - drops the fragment and the default port
+ * - strips tracking params, sorts the rest
+ * - trims one trailing slash on a non-root path
+ */
+export function urlKey(input: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  url.hostname = url.hostname.toLowerCase();
+  url.hash = '';
+  url.port = '';
+
+  const kept: Array<[string, string]> = [];
+  for (const [key, value] of url.searchParams) {
+    if (TRACKING_PARAMS.has(key.toLowerCase())) continue;
+    kept.push([key, value]);
+  }
+  kept.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  url.search = '';
+  for (const [key, value] of kept) url.searchParams.append(key, value);
+
+  if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+    url.pathname = url.pathname.slice(0, -1);
+  }
+  return url.toString();
+}

--- a/frontend/src/routes/dev/discussion/+page.svelte
+++ b/frontend/src/routes/dev/discussion/+page.svelte
@@ -5,7 +5,7 @@
   // backend (see ../+layout.ts).
   import AtmospherePanel from '$lib/components/feed/AtmospherePanel.svelte';
   import { hoursAgo, laneVM, splitStream, streamEntry } from '../cards/fixtures';
-  import type { DiscussionFilterId } from '$lib/components/articleCardView.types';
+  import type { DiscussionFilterId, SembleContextVM } from '$lib/components/articleCardView.types';
   import Showcase from '../_harness/Showcase.svelte';
   import Case from '../_harness/Case.svelte';
 
@@ -114,6 +114,98 @@
     }),
   ];
 
+  // What Semble knows about the URL beyond the people already in the stream:
+  // aggregate counts, collection placements, standalone notes, and the typed
+  // edges in both directions. Savers arrive as ordinary stream entries (Erin,
+  // above), so they are deliberately absent here — the block never repeats them.
+  const sembleAuthor = (handle: string, name: string) => ({
+    did: `did:plc:${handle.split('.')[0]}`,
+    handle,
+    name,
+    avatarUrl: null,
+  });
+  const emptyContext: SembleContextVM = {
+    stats: null,
+    savers: [],
+    notes: [],
+    collections: [],
+    connections: [],
+    truncated: { savers: false, notes: false, collections: false, connections: false },
+    incomplete: false,
+    source: 'semble-api',
+  };
+  const outgoing = {
+    id: 'conn-out',
+    direction: 'out' as const,
+    type: 'supports',
+    note: 'The measurement here is the evidence the argument in the article leans on.',
+    curator: sembleAuthor('erin.bsky.social', 'Erin Vasquez'),
+    createdAt: hoursAgo(9),
+    other: {
+      url: 'https://example.org/measuring-the-open-web',
+      title: 'Measuring the open web',
+      description: null,
+      siteName: 'example.org',
+      imageUrl: null,
+    },
+  };
+  const incoming = {
+    id: 'conn-in',
+    direction: 'in' as const,
+    type: 'refutes',
+    note: null,
+    curator: sembleAuthor('dana.margin.at', 'Dana Okafor'),
+    createdAt: hoursAgo(30),
+    other: {
+      url: 'https://another.example/the-counterargument',
+      title: 'The counterargument, at length',
+      description: null,
+      siteName: 'another.example',
+      imageUrl: null,
+    },
+  };
+  // Direction is carried by the row's order as well as its label: an outgoing
+  // edge reads this → type → other, an incoming one other → type → this.
+  const untypedIncoming = {
+    ...incoming,
+    id: 'conn-in-untyped',
+    type: null,
+    createdAt: hoursAgo(40),
+    other: { ...incoming.other, title: null, siteName: null },
+  };
+  const sembleContext: SembleContextVM = {
+    ...emptyContext,
+    stats: {
+      saves: 4,
+      notes: 2,
+      collections: 2,
+      connections: { total: 3, incoming: 2, outgoing: 1 },
+    },
+    notes: [
+      {
+        id: 'note-1',
+        text: 'Pairs badly with the piece it cites in the third section — that study says the opposite.',
+        author: sembleAuthor('gia.bsky.social', 'Gia Ferrante'),
+        createdAt: hoursAgo(12),
+      },
+    ],
+    collections: [
+      {
+        id: 'col-1',
+        name: 'AI & the open web',
+        url: 'https://semble.so/profile/erin.bsky.social/collections/3kread',
+        author: { did: 'did:plc:erin', handle: 'erin.bsky.social' },
+      },
+      {
+        id: 'col-2',
+        name: 'Protocol design',
+        url: null,
+        author: { did: 'did:plc:erin', handle: 'erin.bsky.social' },
+      },
+    ],
+    connections: [outgoing, incoming, untypedIncoming],
+  };
+
   let activeFilter = $state<DiscussionFilterId>('all');
   const filtered = $derived(
     activeFilter === 'all' ? entries : entries.filter((e) => e.lane === activeFilter)
@@ -139,7 +231,78 @@
       {filters}
       {activeFilter}
       {stream}
+      {sembleContext}
       onSelectFilter={(id) => (activeFilter = id)}
+    />
+  </Case>
+
+  <Case
+    name="Semble · everything it knows"
+    note="What Semble holds about this URL that isn't a person in the stream: the counts, where it's filed, notes nobody attached to a save, and the typed edges. Outbound reads this → type → other; inbound reads other → type → this, so the arrow never lies about which way the claim points. Shown under All and Semble only — switch the chips above to watch it leave."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={lanes}
+      filters={[]}
+      {sembleContext}
+      stream={{ loading: false, ...splitStream(entries.filter((e) => e.lane === 'semble')) }}
+    />
+  </Case>
+
+  <Case
+    name="Semble · connections only"
+    note="Nobody said anything and nobody saved it — the URL exists in Semble purely as the endpoint of other people's edges. That still counts as readable content, so the panel must not claim nothing came back."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={[laneVM('semble', { count: 2 })]}
+      filters={[]}
+      sembleContext={{
+        ...emptyContext,
+        stats: {
+          saves: 0,
+          notes: 0,
+          collections: 0,
+          connections: { total: 2, incoming: 1, outgoing: 1 },
+        },
+        connections: [outgoing, incoming],
+      }}
+      stream={{ loading: false, entries: [] }}
+    />
+  </Case>
+
+  <Case
+    name="Semble · partial and truncated"
+    note="One category timed out and another had more than one page. Both are disclosed in a line rather than silently rounded off — what returned still renders."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={lanes}
+      filters={[]}
+      sembleContext={{
+        ...sembleContext,
+        notes: [],
+        truncated: { savers: false, notes: false, collections: false, connections: true },
+        incomplete: true,
+      }}
+      stream={{ loading: false, ...splitStream(entries.filter((e) => e.lane === 'semble')) }}
+    />
+  </Case>
+
+  <Case
+    name="Semble · saver fallback"
+    note="The API was unreachable and the Constellation/PDS resolver answered instead: the people it found still read normally, and no aggregate is invented to fill the space."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={[laneVM('semble', { count: 1 })]}
+      filters={[]}
+      sembleContext={{ ...emptyContext, incomplete: true, source: 'constellation-fallback' }}
+      stream={{ loading: false, ...splitStream(entries.filter((e) => e.lane === 'semble')) }}
     />
   </Case>
 

--- a/frontend/src/routes/dev/discussion/+page.svelte
+++ b/frontend/src/routes/dev/discussion/+page.svelte
@@ -126,13 +126,13 @@
   });
   const emptyContext: SembleContextVM = {
     stats: null,
-    savers: [],
     notes: [],
     collections: [],
     connections: [],
     truncated: { savers: false, notes: false, collections: false, connections: false },
     incomplete: false,
     source: 'semble-api',
+    cardUrl: 'https://semble.so/url/https%3A%2F%2Fexample.com%2Fthe-article',
   };
   const outgoing = {
     id: 'conn-out',
@@ -206,6 +206,77 @@
     connections: [outgoing, incoming, untypedIncoming],
   };
 
+  // The shape that forced this fold: one curator mapping a topic. Twenty edges
+  // come back, all outgoing, all "supplement", all theirs — only the title
+  // varies — and Semble holds seven more it did not return.
+  const mappedTitles = [
+    'The Rise of Faceless YouTube Channels in 2025, and How AI Is Powering the Revolution',
+    'Mark Zuckerberg \u2018Loves\u2019 AI-Generated \u2018Challah Horse\u2019 On Facebook',
+    'Facebook\u2019s AI-Generated \u2018Shrimp Jesus,\u2019 Explained',
+    'AI Slop Is a Brute Force Attack on the Algorithms That Control Reality',
+    "As many as 48 million Twitter accounts aren't people, says study",
+    'The spreading of misinformation online',
+    "Vote Leave's targeted Brexit ads released by Facebook",
+    "The saga of 'Pizzagate': The fake story that shows how conspiracy theories spread",
+    'How Facebook got addicted to spreading misinformation',
+    'Engagement is the enemy of a shared reality',
+    'The attention economy has no brakes',
+    'Recommender systems and the collapse of the public square',
+    'What the Twitter Files actually showed',
+    'Synthetic personas at scale',
+    'A short history of the feed',
+    'The bot problem nobody wants to measure',
+    'Polarization is a product decision',
+    'Why platforms cannot moderate their way out',
+    'The half-life of an online lie',
+    'Reading in the age of the algorithm',
+  ];
+  const mapper = sembleAuthor('justinm.one', 'Justin Mavromatis');
+  const mappedContext: SembleContextVM = {
+    ...emptyContext,
+    stats: {
+      saves: 1,
+      notes: 0,
+      collections: 1,
+      connections: { total: 27, incoming: 0, outgoing: 27 },
+    },
+    collections: [
+      {
+        id: 'col-pol',
+        name: 'Social Media \u2014 Algorithmic Distortions and Polarization',
+        url: 'https://semble.so/profile/justinm.one/collections/3kpol',
+        author: { did: 'did:plc:justinm', handle: 'justinm.one' },
+      },
+    ],
+    connections: mappedTitles.map((title, i) => ({
+      id: `mapped-${i}`,
+      direction: 'out' as const,
+      type: 'supplement',
+      note: null,
+      curator: mapper,
+      createdAt: hoursAgo(i + 3),
+      other: {
+        url: `https://example.org/mapped-${i}`,
+        title,
+        description: null,
+        siteName: 'example.org',
+        imageUrl: null,
+      },
+    })),
+    truncated: { savers: false, notes: false, collections: false, connections: true },
+  };
+
+  // Saving a connected article is a real fetch in the app; here it is a stubbed
+  // delay so the pending state, the toggle, and the kept state are all reachable.
+  let savedLinks = $state<string[]>([]);
+  async function toggleSavedLink(url: string) {
+    await new Promise((r) => setTimeout(r, 700));
+    savedLinks = savedLinks.includes(url)
+      ? savedLinks.filter((u) => u !== url)
+      : [...savedLinks, url];
+  }
+  const isLinkSaved = (url: string) => savedLinks.includes(url);
+
   let activeFilter = $state<DiscussionFilterId>('all');
   const filtered = $derived(
     activeFilter === 'all' ? entries : entries.filter((e) => e.lane === activeFilter)
@@ -232,7 +303,25 @@
       {activeFilter}
       {stream}
       {sembleContext}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
       onSelectFilter={(id) => (activeFilter = id)}
+    />
+  </Case>
+
+  <Case
+    name="Semble · a mapped topic"
+    note="The shape that forced the fold: one curator, twenty outgoing edges of the same type, only the title varying. Unfolded that was sixty lines of the same sentence. Folded on (curator, relation, direction) the sentence is said once and the titles are the only thing left. Semble held twenty-seven and returned twenty; the foot says so where the reader can act on it."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={[laneVM('semble', { count: 1 })]}
+      filters={[]}
+      sembleContext={mappedContext}
+      stream={{ loading: false, entries: [] }}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
     />
   </Case>
 
@@ -246,6 +335,8 @@
       laneRow={lanes}
       filters={[]}
       {sembleContext}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
       stream={{ loading: false, ...splitStream(entries.filter((e) => e.lane === 'semble')) }}
     />
   </Case>
@@ -269,6 +360,8 @@
         },
         connections: [outgoing, incoming],
       }}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
       stream={{ loading: false, entries: [] }}
     />
   </Case>

--- a/frontend/src/routes/privacy/+page.svelte
+++ b/frontend/src/routes/privacy/+page.svelte
@@ -125,8 +125,13 @@
         choose to sync. Public social data may be read from the Bluesky firehose and related public directories.
       </li>
       <li>
-        <strong>Semble, Margin, Leaflet, and Standard.site</strong> receive data only if you connect one
-        of those integrations.
+        <strong>Semble</strong> receives an article's URL when its Discussion section nears the screen,
+        so Skyreader can show public saves, notes, collections, and connections for that article. No Skyreader
+        account data or Semble login is sent with this lookup.
+      </li>
+      <li>
+        <strong>Margin, Leaflet, and Standard.site</strong> receive data only if you connect one of those
+        integrations.
       </li>
     </ul>
     <p>


### PR DESCRIPTION
## Summary

- add a bounded Semble API adapter for URL metadata, savers, notes, collections, and typed connections
- preserve Constellation/PDS saver fallback and existing retry semantics
- render compact Semble context in the shared merged Discussion surface and disclose the lookup in the privacy policy

### Review follow-up

- format `feed-proxy/src/mention-lane.ts` back to the repository's Prettier style (the failing `Type Check` job)
- read connections in the direction they point: outgoing rows render `this → type → other`, incoming rows `other → type → this`, matching the aria-label instead of reversing it
- an empty Semble context no longer counts as content — a bare context stops suppressing "No one has written about this yet", and a failed lane keeps its retry when only Semble context came back
- `/dev/discussion` gains Semble cases: full context, connections-only, partial + truncated, and the saver fallback
- new mounted component test `AtmospherePanel.component.test.ts` covers both directions and the settlement rules

## Checks

- `feed-proxy`: `bun run check` and `bun test` — 352 pass, 0 fail
- `frontend`: `npm run check` (0 errors) and `npm test` — 386 pass
- backend untouched by the follow-up; its CI jobs passed on the previous commit

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-ob5vlpy66gvb3obd4zinbgox)
