### PR TITLE
Highlight review mode + opt-in Margin highlight ingest

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -88,6 +88,7 @@ import {
   handleListSembleCollections,
   handleCreateMarginBookmark,
   handleListMarginCollections,
+  handleListMarginHighlights,
   handleCreateMarginNote,
   handleUpdateMarginNote,
   handleDeleteMarginNote,
@@ -658,6 +659,17 @@ async function route(
     case url.pathname === '/api/integrations/margin/collections':
       if (!session) return unauthorizedResponse(headers);
       response = await handleListMarginCollections(request, env);
+      break;
+    case url.pathname === '/api/integrations/margin/highlights':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method !== 'GET') {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } else {
+        response = await handleListMarginHighlights(request, env);
+      }
       break;
     case url.pathname === '/api/integrations/margin/notes':
       if (!session) return unauthorizedResponse(headers);

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -11,6 +11,8 @@ import {
 } from '../services/integration-membership';
 import { SEMBLE_SCOPES, MARGIN_SCOPES } from './auth';
 import { SEMBLE_CONNECTION_SCOPES } from '../config/scopes';
+import { listAllRecordsPublic } from '../services/backing/read';
+import { resolvePdsUrl } from '../utils/did-resolver';
 
 /**
  * The scope sets a request can be gated on. `semble-connections` is a *separate*
@@ -895,6 +897,205 @@ export async function handleListMarginCollections(request: Request, env: Env): P
   }));
 
   return new Response(JSON.stringify({ collections }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// --- Margin highlight import (the READ direction) -------------------------
+//
+// Skyreader has always pushed highlights out as at.margin.note records; this is
+// the only path that reads the user's own notes back, so the review deck can
+// cover everything they've highlighted across the Atmosphere. The read itself is
+// public XRPC against their own repo (same auth-free primitive the backed-saves
+// snapshot uses), but it is still gated on the margin scopes: without them a
+// note edit on an imported highlight would queue a PDS write the session can't
+// perform, which is a worse state than not importing at all.
+//
+// at.margin.note is a third-party lexicon that has already changed shape once,
+// so every field is parsed defensively — one malformed record is skipped, never
+// thrown, so a single bad note can't lose the whole poll.
+
+// How many URLs one lookup carries. Each is bound TWICE (url_normalized and the
+// legacy url column), and D1 caps a statement at 100 bound parameters — so 40
+// URLs is 81 params, comfortably under the cap.
+export const MATCH_CHUNK = 40;
+
+export interface MarginHighlightNote {
+  uri: string;
+  rkey: string;
+  url: string;
+  urlNormalized: string;
+  title?: string;
+  selector: { type: 'TextQuoteSelector'; exact: string; prefix?: string; suffix?: string };
+  note?: string;
+  createdAt?: string;
+  /** The user's save this note's URL landed on, when there is one. */
+  match: { itemGuid: string | null; uri: string | null } | null;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+/**
+ * Parse one at.margin.note into a highlight, or null when it isn't one we can
+ * use: a bookmarking note (that's a save, not a highlight), a missing or
+ * non-TextQuote selector, an empty quote, or a source that isn't an http(s) URL.
+ */
+export function parseMarginHighlightNote(
+  uri: string,
+  value: unknown
+): Omit<MarginHighlightNote, 'match'> | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (record.motivation !== 'highlighting') return null;
+
+  const target = record.target;
+  if (!target || typeof target !== 'object') return null;
+  const targetRecord = target as Record<string, unknown>;
+
+  const source = optionalString(targetRecord.source);
+  if (!source) return null;
+  const urlNormalized = normalizeArticleUrl(source);
+  if (!urlNormalized) return null;
+
+  const selector = targetRecord.selector;
+  if (!selector || typeof selector !== 'object') return null;
+  const selectorRecord = selector as Record<string, unknown>;
+  if (selectorRecord.type !== 'TextQuoteSelector') return null;
+  const exact = optionalString(selectorRecord.exact);
+  if (!exact) return null;
+
+  const rkey = uri.split('/').pop();
+  if (!rkey) return null;
+
+  // The note body is a W3C comment body ({ value, format }); older records may
+  // carry a bare string.
+  let note: string | undefined;
+  const body = record.body;
+  if (typeof body === 'string') note = optionalString(body);
+  else if (body && typeof body === 'object') {
+    note = optionalString((body as Record<string, unknown>).value);
+  }
+
+  return {
+    uri,
+    rkey,
+    url: source,
+    urlNormalized,
+    title: optionalString(targetRecord.title),
+    selector: {
+      type: 'TextQuoteSelector',
+      exact,
+      prefix: optionalString(selectorRecord.prefix),
+      suffix: optionalString(selectorRecord.suffix),
+    },
+    note,
+    createdAt: optionalString(record.createdAt),
+  };
+}
+
+/**
+ * Join parsed notes onto the user's saves by normalized URL. Legacy saves
+ * predate `url_normalized`, so their raw `url` is normalized in-process and
+ * matched too. Returns a lookup keyed by normalized URL.
+ */
+async function matchNotesToSaves(
+  env: Env,
+  did: string,
+  urls: string[]
+): Promise<Map<string, { itemGuid: string | null; uri: string | null }>> {
+  const matches = new Map<string, { itemGuid: string | null; uri: string | null }>();
+  if (urls.length === 0) return matches;
+
+  for (let i = 0; i < urls.length; i += MATCH_CHUNK) {
+    const chunk = urls.slice(i, i + MATCH_CHUNK);
+    const placeholders = chunk.map(() => '?').join(', ');
+    const result = await env.DB.prepare(
+      `SELECT url, url_normalized, item_guid, record_uri FROM saved_articles
+       WHERE user_did = ? AND (url_normalized IN (${placeholders}) OR url IN (${placeholders}))`
+    )
+      .bind(did, ...chunk, ...chunk)
+      .all<{
+        url: string | null;
+        url_normalized: string | null;
+        item_guid: string | null;
+        record_uri: string | null;
+      }>();
+
+    // Key by whichever candidate is actually one of the URLs we asked for — a
+    // row matched on the legacy `url` column must not be filed under a
+    // `url_normalized` the caller never looks up.
+    const requested = new Set(chunk);
+    for (const row of result.results || []) {
+      const candidates = [
+        row.url_normalized,
+        row.url ? normalizeArticleUrl(row.url) : null,
+        row.url,
+      ];
+      const key = candidates.find((value): value is string => !!value && requested.has(value));
+      if (!key || matches.has(key)) continue;
+      matches.set(key, { itemGuid: row.item_guid, uri: row.record_uri });
+    }
+  }
+  return matches;
+}
+
+/**
+ * GET /api/integrations/margin/highlights — the user's own at.margin.note
+ * highlights, matched against their saves. The client turns these into normal
+ * Skyreader highlights (see services/marginHighlightImport.ts).
+ */
+export async function handleListMarginHighlights(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const checkResult = checkIntegrationScopes(session, 'margin');
+  if (checkResult) return checkResult;
+
+  const pds = (await resolvePdsUrl(session.did)) || session.pdsUrl;
+  if (!pds) {
+    return new Response(JSON.stringify({ error: 'Could not resolve your PDS' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let records: { uri: string; value: unknown }[];
+  let truncated = false;
+  try {
+    const listed = await listAllRecordsPublic(pds, session.did, 'at.margin.note');
+    records = listed.records;
+    truncated = listed.truncated;
+  } catch (error) {
+    console.error('Failed to list at.margin.note records:', error);
+    return new Response(JSON.stringify({ error: 'Could not read your Margin highlights' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const parsed: Omit<MarginHighlightNote, 'match'>[] = [];
+  for (const record of records) {
+    const note = parseMarginHighlightNote(record.uri, record.value);
+    if (note) parsed.push(note);
+  }
+
+  const matches = await matchNotesToSaves(env, session.did, [
+    ...new Set(parsed.map((note) => note.urlNormalized)),
+  ]);
+
+  const notes: MarginHighlightNote[] = parsed.map((note) => ({
+    ...note,
+    match: matches.get(note.urlNormalized) ?? null,
+  }));
+
+  return new Response(JSON.stringify({ notes, truncated }), {
     headers: { 'Content-Type': 'application/json' },
   });
 }

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -915,9 +915,8 @@ export async function handleListMarginCollections(request: Request, env: Env): P
 // so every field is parsed defensively — one malformed record is skipped, never
 // thrown, so a single bad note can't lose the whole poll.
 
-// How many URLs one lookup carries. Each is bound TWICE (url_normalized and the
-// legacy url column), and D1 caps a statement at 100 bound parameters — so 40
-// URLs is 81 params, comfortably under the cap.
+// How many normalized URLs one indexed lookup carries. Keep comfortably below
+// D1's 100 bound-parameter cap.
 export const MATCH_CHUNK = 40;
 
 export interface MarginHighlightNote {
@@ -1008,14 +1007,15 @@ async function matchNotesToSaves(
   const matches = new Map<string, { itemGuid: string | null; uri: string | null }>();
   if (urls.length === 0) return matches;
 
+  // Current rows have an indexed normalized key, so keep that lookup bounded.
   for (let i = 0; i < urls.length; i += MATCH_CHUNK) {
     const chunk = urls.slice(i, i + MATCH_CHUNK);
     const placeholders = chunk.map(() => '?').join(', ');
     const result = await env.DB.prepare(
       `SELECT url, url_normalized, item_guid, record_uri FROM saved_articles
-       WHERE user_did = ? AND (url_normalized IN (${placeholders}) OR url IN (${placeholders}))`
+       WHERE user_did = ? AND url_normalized IN (${placeholders})`
     )
-      .bind(did, ...chunk, ...chunk)
+      .bind(did, ...chunk)
       .all<{
         url: string | null;
         url_normalized: string | null;
@@ -1023,20 +1023,29 @@ async function matchNotesToSaves(
         record_uri: string | null;
       }>();
 
-    // Key by whichever candidate is actually one of the URLs we asked for — a
-    // row matched on the legacy `url` column must not be filed under a
-    // `url_normalized` the caller never looks up.
-    const requested = new Set(chunk);
     for (const row of result.results || []) {
-      const candidates = [
-        row.url_normalized,
-        row.url ? normalizeArticleUrl(row.url) : null,
-        row.url,
-      ];
-      const key = candidates.find((value): value is string => !!value && requested.has(value));
+      const key = row.url_normalized;
       if (!key || matches.has(key)) continue;
       matches.set(key, { itemGuid: row.item_guid, uri: row.record_uri });
     }
+  }
+
+  // Rows from before migration 0057 have no normalized key. Their raw URL may
+  // contain tracking parameters or a fragment, so it cannot be filtered by the
+  // already-normalized note URLs in SQL. Fetch this shrinking legacy subset once
+  // and normalize it before matching.
+  const requested = new Set(urls);
+  const legacy = await env.DB.prepare(
+    `SELECT url, item_guid, record_uri FROM saved_articles
+     WHERE user_did = ? AND url_normalized IS NULL`
+  )
+    .bind(did)
+    .all<{ url: string | null; item_guid: string | null; record_uri: string | null }>();
+
+  for (const row of legacy.results || []) {
+    const key = row.url ? normalizeArticleUrl(row.url) : null;
+    if (!key || !requested.has(key) || matches.has(key)) continue;
+    matches.set(key, { itemGuid: row.item_guid, uri: row.record_uri });
   }
   return matches;
 }

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -707,6 +707,61 @@ export function buildMarginNoteRecord(body: MarginNoteBody, createdAt: string) {
 }
 
 /**
+ * Did the read establish what the record is, or only that we couldn't tell?
+ *
+ * `mergeMarginNoteUpdate` falls back to rebuilding when there is nothing to
+ * merge onto, and `putRecord` replaces — so answering "absent" for a read that
+ * merely failed is destructive: a 502 or a rate-limit on a record *Margin*
+ * wrote would stamp Skyreader's shape over the reader's own note. Only a
+ * definitive answer may reach the fallback, and `retryable` is what separates
+ * "it isn't there" from "ask again".
+ */
+export function readProvesAbsence(result: { success: boolean; retryable?: boolean }): boolean {
+  return result.success || !result.retryable;
+}
+
+/**
+ * Apply a note edit to the record that is already on the PDS.
+ *
+ * A note edit only ever changes the comment body, but `putRecord` replaces the
+ * whole record — so rebuilding it from the handful of fields Skyreader happens
+ * to know strips everything else. That was harmless while every updatable note
+ * was one Skyreader had written. Margin ingest ends that: the reader can now
+ * annotate a highlight *Margin* made, and a rebuild would stamp Skyreader's
+ * `generator` onto their record, swap `target.source` for our normalized URL,
+ * and drop any field of this third-party lexicon we don't model.
+ *
+ * So the edit is a merge, and the rebuild is only the fallback for a record
+ * that isn't there to merge onto (in which case `putRecord` is creating it, and
+ * Skyreader's own shape is the right one).
+ */
+export function mergeMarginNoteUpdate(
+  existing: unknown,
+  body: MarginNoteBody,
+  createdAt: string
+): Record<string, unknown> {
+  if (!existing || typeof existing !== 'object') return buildMarginNoteRecord(body, createdAt);
+  const record = existing as Record<string, unknown>;
+  if (record.$type !== 'at.margin.note') return buildMarginNoteRecord(body, createdAt);
+
+  const note = body.note?.trim();
+  const next = { ...record };
+  if (!note) {
+    // Clearing the note drops the body; everything else the record carries stays.
+    delete next.body;
+    return next;
+  }
+
+  // Keep whatever format the record already declared — Margin owns that choice
+  // for its own notes, and only a body we're introducing gets our default. A
+  // legacy bare-string body has no format to keep, and reads as undefined here.
+  const previous = next.body as Record<string, unknown> | undefined;
+  const format = typeof previous?.format === 'string' ? previous.format : 'text/plain';
+  next.body = { value: note, format };
+  return next;
+}
+
+/**
  * POST /api/integrations/margin/notes — create an at.margin.note (highlight) on PDS
  */
 export async function handleCreateMarginNote(request: Request, env: Env): Promise<Response> {
@@ -800,12 +855,22 @@ export async function handleUpdateMarginNote(request: Request, env: Env): Promis
 
   const pdsClient = createPDSClient(session);
 
-  // Preserve the record's original creation time — a note edit reuses the rkey
-  // and must not rewrite when the highlight was first made. Fall back to now if
-  // the existing record is missing or carries no createdAt.
-  const existing = await pdsClient.getRecord<{ createdAt?: string }>('at.margin.note', rkey);
-  const createdAt = (existing.success && existing.data.value.createdAt) || new Date().toISOString();
-  const record = buildMarginNoteRecord(body, createdAt);
+  // Read the record before writing it: `putRecord` replaces, so the edit is a
+  // merge onto what's already there (see mergeMarginNoteUpdate). That also
+  // preserves the original creation time — a note edit reuses the rkey and must
+  // not rewrite when the highlight was first made. Only when there's nothing to
+  // merge onto does the record get rebuilt, with `now` as its createdAt.
+  const existing = await pdsClient.getRecord<Record<string, unknown>>('at.margin.note', rkey);
+
+  if (!readProvesAbsence(existing)) {
+    return new Response(JSON.stringify({ error: 'Could not read the note to update' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const existingValue = existing.success ? existing.data.value : null;
+  const record = mergeMarginNoteUpdate(existingValue, body, new Date().toISOString());
 
   const result = await pdsClient.putRecord('at.margin.note', rkey, record);
 
@@ -1055,14 +1120,23 @@ async function matchNotesToSaves(
     }
   }
 
+  // Only what the indexed pass couldn't answer. A Semble/Margin-backed account
+  // has a normalized key on every save and matched everything above, so running
+  // this anyway would be one statement per 40 hosts, every poll, over rows that
+  // by definition hold none of them.
+  const unmatched = urls.filter((url) => !matches.has(url));
+  if (unmatched.length === 0) return matches;
+
   // Un-keyed rows: the raw URL may carry tracking parameters or a fragment, so it
   // can't be compared to an already-normalized note URL in SQL. Filter by host in
   // SQL — the one part both forms share — and normalize the survivors in-process.
   // ORDER BY id so two rows normalizing to the same URL (the same article saved
   // twice with different tracking params) always resolve to the same save, the
   // oldest, exactly as `backfillUrlNormalized` picks it.
-  const requested = new Set(urls);
-  const prefixes = [...new Set(urls.map(hostLikePrefix).filter((p): p is string => p !== null))];
+  const requested = new Set(unmatched);
+  const prefixes = [
+    ...new Set(unmatched.map(hostLikePrefix).filter((p): p is string => p !== null)),
+  ];
 
   for (let i = 0; i < prefixes.length; i += MATCH_CHUNK) {
     const chunk = prefixes.slice(i, i + MATCH_CHUNK);

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -915,8 +915,8 @@ export async function handleListMarginCollections(request: Request, env: Env): P
 // so every field is parsed defensively — one malformed record is skipped, never
 // thrown, so a single bad note can't lose the whole poll.
 
-// How many normalized URLs one indexed lookup carries. Keep comfortably below
-// D1's 100 bound-parameter cap.
+// How many URLs (or host prefixes) one save-matching statement carries. Keep
+// comfortably below D1's 100 bound-parameter cap.
 export const MATCH_CHUNK = 40;
 
 export interface MarginHighlightNote {
@@ -995,9 +995,34 @@ export function parseMarginHighlightNote(
 }
 
 /**
- * Join parsed notes onto the user's saves by normalized URL. Legacy saves
- * predate `url_normalized`, so their raw `url` is normalized in-process and
- * matched too. Returns a lookup keyed by normalized URL.
+ * A LIKE prefix that every raw save URL keying to `normalized` must start with:
+ * scheme + host, the two parts normalization preserves (it lowercases the host —
+ * LIKE is ASCII-case-insensitive, so that still matches — and only ever edits the
+ * port, query, fragment and trailing slash after it). Narrowing the un-keyed read
+ * by host is what keeps it from being "every save this user has ever made".
+ */
+function hostLikePrefix(normalized: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return null;
+  }
+  // `\` escapes LIKE's own wildcards so a host containing `_` or `%` (legal in a
+  // stored URL, rare in practice) stays a literal.
+  const literal = `${url.protocol}//${url.hostname}`.replace(/[\\%_]/g, '\\$&');
+  return `${literal}%`;
+}
+
+/**
+ * Join parsed notes onto the user's saves by normalized URL. Returns a lookup
+ * keyed by normalized URL.
+ *
+ * Two passes, because `url_normalized` is only written on the backed-save path
+ * (`saved.ts` — the native inserts omit it, and `backfillUrlNormalized` runs only
+ * when a user turns Semble/Margin backing on). So for a default-backing account
+ * every save has a NULL key and the second pass is the one that matches; for a
+ * backed account the first, indexed pass is. Neither is the "legacy tail".
  */
 async function matchNotesToSaves(
   env: Env,
@@ -1030,22 +1055,31 @@ async function matchNotesToSaves(
     }
   }
 
-  // Rows from before migration 0057 have no normalized key. Their raw URL may
-  // contain tracking parameters or a fragment, so it cannot be filtered by the
-  // already-normalized note URLs in SQL. Fetch this shrinking legacy subset once
-  // and normalize it before matching.
+  // Un-keyed rows: the raw URL may carry tracking parameters or a fragment, so it
+  // can't be compared to an already-normalized note URL in SQL. Filter by host in
+  // SQL — the one part both forms share — and normalize the survivors in-process.
+  // ORDER BY id so two rows normalizing to the same URL (the same article saved
+  // twice with different tracking params) always resolve to the same save, the
+  // oldest, exactly as `backfillUrlNormalized` picks it.
   const requested = new Set(urls);
-  const legacy = await env.DB.prepare(
-    `SELECT url, item_guid, record_uri FROM saved_articles
-     WHERE user_did = ? AND url_normalized IS NULL`
-  )
-    .bind(did)
-    .all<{ url: string | null; item_guid: string | null; record_uri: string | null }>();
+  const prefixes = [...new Set(urls.map(hostLikePrefix).filter((p): p is string => p !== null))];
 
-  for (const row of legacy.results || []) {
-    const key = row.url ? normalizeArticleUrl(row.url) : null;
-    if (!key || !requested.has(key) || matches.has(key)) continue;
-    matches.set(key, { itemGuid: row.item_guid, uri: row.record_uri });
+  for (let i = 0; i < prefixes.length; i += MATCH_CHUNK) {
+    const chunk = prefixes.slice(i, i + MATCH_CHUNK);
+    const clauses = chunk.map(() => `url LIKE ? ESCAPE '\\'`).join(' OR ');
+    const unkeyed = await env.DB.prepare(
+      `SELECT url, item_guid, record_uri FROM saved_articles
+       WHERE user_did = ? AND url_normalized IS NULL AND (${clauses})
+       ORDER BY id`
+    )
+      .bind(did, ...chunk)
+      .all<{ url: string | null; item_guid: string | null; record_uri: string | null }>();
+
+    for (const row of unkeyed.results || []) {
+      const key = row.url ? normalizeArticleUrl(row.url) : null;
+      if (!key || !requested.has(key) || matches.has(key)) continue;
+      matches.set(key, { itemGuid: row.item_guid, uri: row.record_uri });
+    }
   }
   return matches;
 }

--- a/backend/src/services/backing/read.ts
+++ b/backend/src/services/backing/read.ts
@@ -76,7 +76,7 @@ const MAX_PAGES = 50;
 // once (Workers caps them); the per-snapshot caches dedup repeats and cross-repo PDS.
 const RESOLVE_CONCURRENCY = 8;
 
-interface RawRecord<T = Record<string, unknown>> {
+export interface RawRecord<T = Record<string, unknown>> {
   uri: string;
   cid: string;
   value: T;
@@ -86,8 +86,11 @@ interface RawRecord<T = Record<string, unknown>> {
  * Public, auth-free paginated listRecords over a repo+collection. Returns
  * `truncated: true` when it stopped on the page cap with a cursor still pending
  * (an INCOMPLETE snapshot). Mirrors pds-client.ts listAllRecords but needs no session.
+ *
+ * Exported because the Margin highlight import reads the user's own
+ * `at.margin.note` collection the same auth-free way (see routes/integrations.ts).
  */
-async function listAllRecordsPublic<T = Record<string, unknown>>(
+export async function listAllRecordsPublic<T = Record<string, unknown>>(
   pds: string,
   repo: string,
   collection: string

--- a/backend/test/margin-highlights.spec.ts
+++ b/backend/test/margin-highlights.spec.ts
@@ -4,7 +4,9 @@ import worker from '../src/index';
 import {
   MATCH_CHUNK,
   buildMarginNoteRecord,
+  mergeMarginNoteUpdate,
   parseMarginHighlightNote,
+  readProvesAbsence,
 } from '../src/routes/integrations';
 import * as read from '../src/services/backing/read';
 import * as didResolver from '../src/utils/did-resolver';
@@ -295,6 +297,23 @@ describe('GET /api/integrations/margin/highlights', () => {
     expect(res.body.notes[0].match).toBeNull();
   });
 
+  it('skips the un-keyed read when the indexed pass answered every URL', async () => {
+    // A Semble/Margin-backed account has a normalized key on every save, so the
+    // fallback would be one statement per 40 hosts, every poll, over rows that
+    // by definition hold none of them.
+    const url = 'https://example.com/keyed';
+    await seedSave({ rkey: 'k', url, urlNormalized: url, itemGuid: 'guid-k' });
+    mockRecords([highlightNote('one', url)]);
+
+    const prepare = vi.spyOn(env.DB, 'prepare');
+    const res = await call();
+
+    expect(res.body.notes[0].match?.itemGuid).toBe('guid-k');
+    expect(prepare.mock.calls.some(([sql]) => String(sql).includes('url_normalized IS NULL'))).toBe(
+      false
+    );
+  });
+
   it('propagates truncated so the client can say the poll was partial', async () => {
     mockRecords([highlightNote('one', 'https://example.com/a')], true);
     const res = await call();
@@ -321,5 +340,97 @@ describe('Margin highlight records', () => {
     );
 
     expect(record.target.source).toBe('https://chinaunread.substack.com/p/a-post');
+  });
+});
+
+// A note edit reuses the rkey and putRecord replaces the whole record. Now that
+// a reader can annotate a highlight Margin itself made, rebuilding that record
+// from the fields Skyreader models would quietly take it over.
+describe('readProvesAbsence', () => {
+  // mergeMarginNoteUpdate rebuilds when there is nothing to merge onto, and
+  // putRecord replaces — so calling a failed read "absent" would let a transient
+  // PDS error stamp Skyreader's shape over a note Margin wrote.
+  it('accepts a successful read and a definitive miss', () => {
+    expect(readProvesAbsence({ success: true })).toBe(true);
+    expect(readProvesAbsence({ success: false, retryable: false })).toBe(true);
+  });
+
+  it('refuses a read that failed for a reason that might not fail again', () => {
+    expect(readProvesAbsence({ success: false, retryable: true })).toBe(false);
+  });
+});
+
+describe('mergeMarginNoteUpdate', () => {
+  function marginNative(overrides: Record<string, unknown> = {}) {
+    return {
+      $type: 'at.margin.note',
+      motivation: 'highlighting',
+      target: {
+        // Margin's own record, with the query string it chose to keep.
+        source: 'https://example.com/post?ref=margin',
+        selector: { type: 'TextQuoteSelector', exact: 'A passage' },
+      },
+      generator: { name: 'Margin', homepage: 'https://margin.at' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      marginOnlyField: 'keep me',
+      ...overrides,
+    };
+  }
+
+  const edit = {
+    source: 'https://example.com/post?ref=margin&utm_source=x',
+    exact: 'A passage',
+    note: 'my thought',
+  };
+
+  it('changes only the note body of a record Margin wrote', () => {
+    const merged = mergeMarginNoteUpdate(marginNative(), edit, '2026-08-25T00:00:00.000Z');
+
+    expect(merged.body).toEqual({ value: 'my thought', format: 'text/plain' });
+    // Everything that isn't the note survives: the generator stays Margin's,
+    // the source keeps the form Margin stored it in, unmodelled fields persist,
+    // and the original creation time is untouched.
+    expect(merged.generator).toEqual({ name: 'Margin', homepage: 'https://margin.at' });
+    expect(merged.target).toEqual({
+      source: 'https://example.com/post?ref=margin',
+      selector: { type: 'TextQuoteSelector', exact: 'A passage' },
+    });
+    expect(merged.marginOnlyField).toBe('keep me');
+    expect(merged.createdAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('keeps the body format the record already declared', () => {
+    const merged = mergeMarginNoteUpdate(
+      marginNative({ body: { value: 'old', format: 'text/markdown' } }),
+      edit,
+      '2026-08-25T00:00:00.000Z'
+    );
+    expect(merged.body).toEqual({ value: 'my thought', format: 'text/markdown' });
+  });
+
+  it('drops the body when the note is cleared, and nothing else', () => {
+    const merged = mergeMarginNoteUpdate(
+      marginNative({ body: { value: 'old', format: 'text/plain' } }),
+      { source: edit.source, exact: edit.exact },
+      '2026-08-25T00:00:00.000Z'
+    );
+    expect(merged).not.toHaveProperty('body');
+    expect(merged.marginOnlyField).toBe('keep me');
+  });
+
+  it('falls back to building the record when there is nothing to merge onto', () => {
+    // putRecord is creating it here, so Skyreader's own shape is the right one.
+    const merged = mergeMarginNoteUpdate(null, edit, '2026-08-25T00:00:00.000Z');
+    expect(merged.generator).toEqual({ name: 'Skyreader', homepage: 'https://skyreader.app' });
+    expect(merged.createdAt).toBe('2026-08-25T00:00:00.000Z');
+  });
+
+  it('rebuilds rather than merging onto a record of some other type', () => {
+    const merged = mergeMarginNoteUpdate(
+      { $type: 'at.margin.bookmark', createdAt: '2020-01-01T00:00:00.000Z' },
+      edit,
+      '2026-08-25T00:00:00.000Z'
+    );
+    expect(merged.$type).toBe('at.margin.note');
   });
 });

--- a/backend/test/margin-highlights.spec.ts
+++ b/backend/test/margin-highlights.spec.ts
@@ -215,7 +215,9 @@ describe('GET /api/integrations/margin/highlights', () => {
     });
   });
 
-  it('matches legacy saves that predate url_normalized', async () => {
+  // url_normalized is only written on the backed-save path, so an un-keyed row is
+  // the normal state for a default-backing account — not a legacy tail.
+  it('matches un-keyed saves whose raw URL carries tracking params and a fragment', async () => {
     await seedSave({
       rkey: 'save2',
       url: 'https://example.com/legacy?utm_source=newsletter#section',
@@ -225,6 +227,46 @@ describe('GET /api/integrations/margin/highlights', () => {
 
     const res = await call();
     expect(res.body.notes[0].match?.uri).toBe(`at://${DID}/app.skyreader.feed.saved/save2`);
+  });
+
+  it('narrows the un-keyed read by host without dropping same-host matches', async () => {
+    // Same path on another host: reachable only if the host filter is per-host,
+    // and proof the filter doesn't leak a match across hosts.
+    await seedSave({ rkey: 'other', url: 'https://elsewhere.test/legacy', urlNormalized: null });
+    await seedSave({
+      rkey: 'same',
+      url: 'https://example.com/legacy?ref=twitter',
+      urlNormalized: null,
+    });
+    mockRecords([
+      highlightNote('one', 'https://example.com/legacy'),
+      highlightNote('two', 'https://nowhere.test/legacy'),
+    ]);
+
+    const res = await call();
+    expect(res.body.notes[0].match?.uri).toBe(`at://${DID}/app.skyreader.feed.saved/same`);
+    expect(res.body.notes[1].match).toBeNull();
+  });
+
+  it('resolves duplicate un-keyed saves of one article to the oldest row, every time', async () => {
+    // Two saves of the same article with different tracking params normalize to
+    // one key; ORDER BY id keeps the winner stable across polls.
+    await seedSave({
+      rkey: 'first',
+      url: 'https://example.com/dupe?utm_source=a',
+      urlNormalized: null,
+    });
+    await seedSave({
+      rkey: 'second',
+      url: 'https://example.com/dupe?fbclid=b',
+      urlNormalized: null,
+    });
+    mockRecords([highlightNote('one', 'https://example.com/dupe')]);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await call();
+      expect(res.body.notes[0].match?.uri).toBe(`at://${DID}/app.skyreader.feed.saved/first`);
+    }
   });
 
   it('reports match: null when nothing is saved for that URL', async () => {

--- a/backend/test/margin-highlights.spec.ts
+++ b/backend/test/margin-highlights.spec.ts
@@ -1,5 +1,267 @@
-import { describe, expect, it } from 'vitest';
-import { buildMarginNoteRecord } from '../src/routes/integrations';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src/index';
+import {
+  MATCH_CHUNK,
+  buildMarginNoteRecord,
+  parseMarginHighlightNote,
+} from '../src/routes/integrations';
+import * as read from '../src/services/backing/read';
+import * as didResolver from '../src/utils/did-resolver';
+import { GRANULAR_SCOPES, MARGIN_SCOPES } from '../src/config/scopes';
+
+// GET /api/integrations/margin/highlights — the read direction of the Margin
+// integration. at.margin.note is a third-party lexicon that has already changed
+// shape once, so parseMarginHighlightNote pins the shape we consume today:
+// drift shows up as a test failure rather than silently importing nothing.
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+const DID = 'did:plc:marginhighlights';
+const SESSION = 'sess-margin-highlights';
+const FULL_SCOPES = `${GRANULAR_SCOPES} ${MARGIN_SCOPES.join(' ')}`;
+
+function noteRecord(rkey: string, value: Record<string, unknown>) {
+  return { uri: `at://${DID}/at.margin.note/${rkey}`, cid: `cid-${rkey}`, value };
+}
+
+function highlightNote(
+  rkey: string,
+  source: string,
+  overrides: Record<string, unknown> = {}
+): { uri: string; cid: string; value: Record<string, unknown> } {
+  return noteRecord(rkey, {
+    $type: 'at.margin.note',
+    motivation: 'highlighting',
+    target: {
+      source,
+      title: 'A Title',
+      selector: { type: 'TextQuoteSelector', exact: `quote ${rkey}`, prefix: 'be', suffix: 'af' },
+    },
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  });
+}
+
+async function reset(grantedScopes = FULL_SCOPES) {
+  await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM sessions WHERE did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(DID).run();
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url, tier, created_at)
+     VALUES (?, 'mh.bsky.social', 'https://pds.test', 'free', unixepoch())`
+  )
+    .bind(DID)
+    .run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at, granted_scopes)
+     VALUES (?, ?, 'mh.bsky.social', 'https://pds.test', 'tok', 'rtok', ?, ?, ?)`
+  )
+    .bind(SESSION, DID, JSON.stringify({ kty: 'EC' }), Date.now() + 3_600_000, grantedScopes)
+    .run();
+}
+
+async function seedSave(opts: {
+  rkey: string;
+  url: string;
+  urlNormalized: string | null;
+  itemGuid?: string | null;
+}) {
+  await env.DB.prepare(
+    `INSERT INTO saved_articles (user_did, rkey, record_uri, url, url_normalized, item_guid, saved_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      DID,
+      opts.rkey,
+      `at://${DID}/app.skyreader.feed.saved/${opts.rkey}`,
+      opts.url,
+      opts.urlNormalized,
+      opts.itemGuid ?? null,
+      Date.now()
+    )
+    .run();
+}
+
+async function call(): Promise<{ status: number; body: any }> {
+  const req = new IncomingRequest('http://localhost/api/integrations/margin/highlights', {
+    headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+  });
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+function mockRecords(records: unknown[], truncated = false) {
+  vi.spyOn(didResolver, 'resolvePdsUrl').mockResolvedValue('https://pds.test');
+  vi.spyOn(read, 'listAllRecordsPublic').mockResolvedValue({
+    records: records as never,
+    truncated,
+  });
+}
+
+describe('parseMarginHighlightNote — the at.margin.note shape we consume', () => {
+  const uri = `at://${DID}/at.margin.note/abc`;
+
+  it('maps a highlighting note to a highlight', () => {
+    const parsed = parseMarginHighlightNote(
+      uri,
+      highlightNote('abc', 'https://example.com/a').value
+    );
+    expect(parsed).toMatchObject({
+      rkey: 'abc',
+      url: 'https://example.com/a',
+      urlNormalized: 'https://example.com/a',
+      title: 'A Title',
+      selector: { type: 'TextQuoteSelector', exact: 'quote abc', prefix: 'be', suffix: 'af' },
+      createdAt: '2026-08-01T00:00:00.000Z',
+    });
+  });
+
+  it('reads the note body from the W3C comment shape, and from a bare string', () => {
+    const structured = parseMarginHighlightNote(
+      uri,
+      highlightNote('abc', 'https://example.com/a', {
+        body: { value: 'my note', format: 'text/plain' },
+      }).value
+    );
+    expect(structured?.note).toBe('my note');
+
+    const bare = parseMarginHighlightNote(
+      uri,
+      highlightNote('abc', 'https://example.com/a', { body: 'legacy note' }).value
+    );
+    expect(bare?.note).toBe('legacy note');
+  });
+
+  it('skips bookmarking notes — those are saves, not highlights', () => {
+    expect(
+      parseMarginHighlightNote(uri, {
+        $type: 'at.margin.note',
+        motivation: 'bookmarking',
+        target: { source: 'https://example.com/a' },
+      })
+    ).toBeNull();
+  });
+
+  it('skips malformed records instead of throwing', () => {
+    const bad: unknown[] = [
+      null,
+      'not an object',
+      { motivation: 'highlighting' }, // no target
+      { motivation: 'highlighting', target: { source: 'https://x.test' } }, // no selector
+      {
+        motivation: 'highlighting',
+        target: { source: 'https://x.test', selector: { type: 'TextPositionSelector', start: 1 } },
+      },
+      {
+        motivation: 'highlighting',
+        target: { source: 'https://x.test', selector: { type: 'TextQuoteSelector', exact: '' } },
+      },
+      {
+        motivation: 'highlighting',
+        target: {
+          source: 'at://did:plc:x/y/z', // not an http(s) URL
+          selector: { type: 'TextQuoteSelector', exact: 'q' },
+        },
+      },
+    ];
+    for (const value of bad) expect(parseMarginHighlightNote(uri, value)).toBeNull();
+  });
+});
+
+describe('GET /api/integrations/margin/highlights', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('403s without the margin scopes', async () => {
+    await reset(GRANULAR_SCOPES);
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('scope_upgrade_required');
+  });
+
+  it('returns highlighting notes and drops everything else', async () => {
+    mockRecords([
+      highlightNote('one', 'https://example.com/a'),
+      noteRecord('two', {
+        motivation: 'bookmarking',
+        target: { source: 'https://example.com/b' },
+      }),
+      noteRecord('three', { motivation: 'highlighting' }),
+    ]);
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.body.notes).toHaveLength(1);
+    expect(res.body.notes[0].rkey).toBe('one');
+    expect(res.body.truncated).toBe(false);
+  });
+
+  it('joins a note onto the matching save by normalized URL', async () => {
+    await seedSave({
+      rkey: 'save1',
+      url: 'https://example.com/post?utm_source=x',
+      urlNormalized: 'https://example.com/post',
+      itemGuid: 'guid-1',
+    });
+    mockRecords([highlightNote('one', 'https://example.com/post/#section')]);
+
+    const res = await call();
+    expect(res.body.notes[0].match).toEqual({
+      itemGuid: 'guid-1',
+      uri: `at://${DID}/app.skyreader.feed.saved/save1`,
+    });
+  });
+
+  it('matches legacy saves that predate url_normalized', async () => {
+    await seedSave({ rkey: 'save2', url: 'https://example.com/legacy', urlNormalized: null });
+    mockRecords([highlightNote('one', 'https://example.com/legacy')]);
+
+    const res = await call();
+    expect(res.body.notes[0].match?.uri).toBe(`at://${DID}/app.skyreader.feed.saved/save2`);
+  });
+
+  it('reports match: null when nothing is saved for that URL', async () => {
+    mockRecords([highlightNote('one', 'https://example.com/unsaved')]);
+    const res = await call();
+    expect(res.body.notes[0].match).toBeNull();
+  });
+
+  it('matches across the chunk boundary (D1 caps bound params per statement)', async () => {
+    const count = MATCH_CHUNK * 2 + 5;
+    const notes = [];
+    for (let i = 0; i < count; i++) {
+      const url = `https://example.com/bulk/${i}`;
+      notes.push(highlightNote(`rk${i}`, url));
+      // Save only the last one, well past the first chunk.
+      if (i === count - 1) {
+        await seedSave({ rkey: `s${i}`, url, urlNormalized: url, itemGuid: `guid-${i}` });
+      }
+    }
+    mockRecords(notes);
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.body.notes).toHaveLength(count);
+    expect(res.body.notes[count - 1].match?.itemGuid).toBe(`guid-${count - 1}`);
+    expect(res.body.notes[0].match).toBeNull();
+  });
+
+  it('propagates truncated so the client can say the poll was partial', async () => {
+    mockRecords([highlightNote('one', 'https://example.com/a')], true);
+    const res = await call();
+    expect(res.body.truncated).toBe(true);
+  });
+
+  it('502s when the PDS read fails, rather than reporting an empty set', async () => {
+    vi.spyOn(didResolver, 'resolvePdsUrl').mockResolvedValue('https://pds.test');
+    vi.spyOn(read, 'listAllRecordsPublic').mockRejectedValue(new Error('listRecords -> 503'));
+    const res = await call();
+    expect(res.status).toBe(502);
+  });
+});
 
 describe('Margin highlight records', () => {
   it('writes a canonical source so later exact backlink lookups can find it', () => {

--- a/backend/test/margin-highlights.spec.ts
+++ b/backend/test/margin-highlights.spec.ts
@@ -216,8 +216,12 @@ describe('GET /api/integrations/margin/highlights', () => {
   });
 
   it('matches legacy saves that predate url_normalized', async () => {
-    await seedSave({ rkey: 'save2', url: 'https://example.com/legacy', urlNormalized: null });
-    mockRecords([highlightNote('one', 'https://example.com/legacy')]);
+    await seedSave({
+      rkey: 'save2',
+      url: 'https://example.com/legacy?utm_source=newsletter#section',
+      urlNormalized: null,
+    });
+    mockRecords([highlightNote('one', 'https://example.com/legacy#quote')]);
 
     const res = await call();
     expect(res.body.notes[0].match?.uri).toBe(`at://${DID}/app.skyreader.feed.saved/save2`);

--- a/docs/plans/HIGHLIGHT_REVIEW.md
+++ b/docs/plans/HIGHLIGHT_REVIEW.md
@@ -16,7 +16,11 @@ Review link in the `/highlights` header, and the `8` shortcut. A reader who neve
 never reminded — that gap is the price of not building Web Push, and it's what a follow-up would
 close.
 
-The nav entry is the standing one, so it carries the only count: today's deck size, in the same
+All of them appear on the same predicate — `hasHighlights`, "is there anything the deck could ever
+deal" — rather than on today's deck being non-empty. The `8` shortcut is gated on it too, so a new
+account that presses it doesn't land on a page with nothing to deal. A link that vanishes once the day's portion is
+spent would take the encore state ("That's today's review") with it, which is the state it exists
+for. The nav entry is the standing one, so it carries the only count: today's deck size, in the same
 muted `.nav-count` the unread counts use. It is a badge you clear by reading and nothing else —
 no streak, no lifetime total, no "unreviewed" backlog that can only grow. It goes quiet the moment
 the deck is done, and the entry hides entirely until the reader has highlighted something, so a new
@@ -25,7 +29,10 @@ had; it still hides itself once the deck is done.
 
 All four entry points read one derived summary (`highlightReviewStore`, over
 `summarizeHighlightDeck`) rather than each walking the corpus, so they can't disagree about the
-number and the scan is paid once. The Home panel additionally reads the ranked deck
+number and the scan is paid once. The local day is `$state` inside that store, re-armed on a timer to
+the next local midnight and re-checked on focus and visibility: a `$derived` recomputes only when
+something it read changes, and the wall clock is not something it read, so an installed PWA left open
+overnight would otherwise keep showing yesterday's count. The Home panel additionally reads the ranked deck
 (`highlightReviewStore.cards`, a separate `$derived` so the nav badge never pays to rank) and names
 _who_ it draws from: a person is a better reason to open the deck than a description of how it works.
 
@@ -50,35 +57,62 @@ session is a few minutes over a handful of cards, so the mid-read-shift and cros
 problems that forced magazines to be durable don't apply. `buildHighlightDeck`
 (`frontend/src/lib/utils/highlightReview.ts`) derives the deck at open:
 
-- **Eligibility** — exclude anything already reviewed today (local calendar day, not UTC), and
-  anything created in the last 24 h (reviewing what you just made is noise). The freshness filter
-  _relaxes_ rather than emptying a non-empty pool, so a reader whose only highlights are from this
-  morning still gets a deck.
-- **Order** — `lastReviewedAt` ascending, never-reviewed first. Ties (which is most of the
-  never-reviewed bucket) break on the magazine's FNV-1a `dailyScore(dateKey, id)`, so the same day
-  deals the same deck and tomorrow rotates.
-- **No spaced repetition.** Least-recently-reviewed-first is the whole algorithm in v1. The field
-  shape leaves room to add scheduling later.
+- **Eligibility** — exclude anything the reader has retired (`reviewIntent: 'never'`), anything
+  already reviewed today (local calendar day, not UTC), and anything created in the last 24 h
+  (reviewing what you just made is noise). The freshness filter _relaxes_ rather than emptying a
+  non-empty pool, so a reader whose only highlights are from this morning still gets a deck.
+  Retirement is the one permanent exclusion, so it's checked before the pool is built.
+- **Order** — `reviewPriority` ascending: `lastReviewedAt`, shifted by the reader's intent,
+  never-reviewed first. Ties (which is most of the never-reviewed bucket) break on the magazine's
+  FNV-1a `dailyScore(dateKey, id)`, so the same day deals the same deck and tomorrow rotates.
+- **Frequency is a bias on that order, not a schedule.** `reviewIntent` — `soon` / `later` /
+  `someday` / `never`, one control per card — ranks a highlight as though it had been reviewed 30
+  days earlier or 120 days later than it actually was. A hard interval you had to wait out would let
+  a small library go empty for weeks, which is the same "nothing to review" dead end the freshness
+  filter bends over backwards to avoid; biasing the order means the deck always deals the same
+  number of cards and tuning only changes _which_ ones come first. `later` is the neutral middle and
+  the default, so an untuned highlight and an explicit `later` rank identically. Never-reviewed
+  still beats reviewed unconditionally: the stand-in timestamp for "never" sits far enough below any
+  real one that no offset can lift a seen highlight above an unseen one, so intent orders within
+  those two classes rather than across them.
+- **`never` retires, it does not delete.** The highlight stays in the list and on Margin; it just
+  stops being dealt, on every device, until the reader puts it back (the `/highlights` list is where
+  they can). It's the only intent that acts on the session in progress, so it's the only one with an
+  undo — a ten-second notice that restores both the card and the pace it was on. Undo reads that
+  pace from the live store rather than the dealt deck, or setting `soon` and then `never` on one
+  card would undo to the default.
+- **No scheduling beyond that.** No intervals, no ease factors, no grading a recall. The field shape
+  leaves room if it ever earns its way in.
 
 The component holds the dealt deck in `$state`, not a `$derived` — deriving it would rebuild the
-deck the moment the first card is stamped and pull the ground out from under the reader.
+deck the moment the first card is stamped and pull the ground out from under the reader. It also
+re-reads the current highlight from the store (`live`) for anything that has to be current — a note
+just typed, a pace just set — because the deck entry is the highlight as it was dealt.
 
-**Review state lives inside the `Highlight` object.** `lastReviewedAt?: number` (epoch ms) rides the
-existing label sync, tombstone and offline machinery for free — no migration, no Dexie version bump
-(`props` isn't indexed). The `reviewed` mutation in `highlightAliases.ts` only ever moves the stamp
-forward, so a slow device flushing an older review can't make a highlight look due again.
+**Review state lives inside the `Highlight` object.** `lastReviewedAt?: number` (epoch ms) and
+`reviewIntent?: ReviewIntent` ride the existing label sync, tombstone and offline machinery for free
+— no migration, no Dexie version bump (`props` isn't indexed), and the pace a reader sets on one
+device reaches the others with the highlight. The `reviewed` mutation in `highlightAliases.ts` only
+ever moves the stamp forward, so a slow device flushing an older review can't make a highlight look
+due again; the `intent` mutation writes `null` as an absent field rather than a stored `'later'`, so
+an untuned highlight stays untouched.
 
 **Deck size is device-local** (`highlightReviewCount`, default 5, options 3/5/10), same posture as
 `dailyMagazineMinutes`.
 
-**The settings live with the deck, not in Settings.** Deck size and the Margin ingest toggle are
-behind a gear in the review header (`HighlightSettings.svelte`, rendered inline in the review body
-rather than in an overlay — the page is one card tall, so there's nothing for a modal to protect).
-Both configure a thing that is on screen while you change it, which is the whole argument for moving
-them: you can see what "5" means. `/settings` keeps no pointer to them — its Highlights section is
-now only the statement of where a highlight lives, which is the app's one place saying it. The Home
-panel's own deck-size select went with them; the count in its button already says how big the deck
-is.
+**Deck size lives with the deck; the Margin toggle can't.** Both are in `HighlightSettings.svelte`,
+behind a gear in the review header (rendered inline in the review body rather than in an overlay —
+the page is one card tall, so there's nothing for a modal to protect). Deck size belongs there and
+only there: it configures a thing that is on screen while you change it, which is the whole argument
+for moving it out of `/settings` — you can see what "5" means. The Home panel's own deck-size select
+went with it; the count in its button already says how big the deck is.
+
+Margin ingest is the exception, because every entry point to the deck is gated on the reader already
+having a highlight. A reader with a Margin library and nothing highlighted in Skyreader has no Review
+entry in the nav, no link in the `/highlights` header and no Home panel, so a toggle that lives only
+behind the deck's gear is a toggle they cannot reach — and it is precisely the toggle that would give
+them a deck. So `/settings` renders the same component with `showDeckSize={false}`: the ingest switch
+and nothing else, under the statement of where a highlight lives.
 
 **"Review more" is offered wherever the deck runs out**, in two shapes, both as a secondary button:
 another hand is offered, never urged.
@@ -100,10 +134,27 @@ That exhausted state is also now a state of its own — "That's today's review",
 back after finishing rather than by finishing here. It used to share "Nothing to review right now"
 with the genuinely-empty case, which read as "you have no highlights" to a reader who has plenty.
 
+"Nothing to review right now" then splits once more, on whether the corpus is empty at all. A reader
+who has retired every highlight they own falls through the same branch as a reader who has never
+made one, and "highlight a passage while reading" is the wrong instruction for a full list where
+every card says never — so that case says "Nothing in rotation" and points at the list, which is
+where a highlight comes back from.
+
 The session tally (`reviewed`) spans every hand, so a reader who takes three says "13 highlights
-revisited" rather than restarting the count. `index` and `interacted` are per hand, which is what
+revisited" rather than restarting the count. Within a hand it moves on a high-water mark, not on
+every advance: stepping back and coming forward again is navigation, so the card you already passed
+is not counted twice. `index` and `interacted` are per hand, which is what
 `deckUntouched` reads — a fresh hand at index 0 is untouched no matter what came before it, so
 resizing the deck there redeals rather than silently waiting.
+
+`interacted` is set by **every** card action, not just the ones that write: setting a pace, opening
+the note editor, saving to Margin, confirming a removal, and opening the source article. It is set on
+the _gesture_, in `commitSwipe`, not in the `advance`/`stepBack` those defer by a frame — an import
+resolving inside that window would otherwise find the deck untouched and redeal it out from under a
+card already flying off screen. Opening the
+source is the easiest one to forget and the worst one to miss — the reader is off reading, which is
+precisely when a late import must not redeal underneath them, or they come back to a different card
+than they left.
 
 Changing either mid-session is governed by `deckUntouched`: an untouched deck redeals immediately —
 resizing a deck and watching nothing happen would make the control look broken — and a deck the
@@ -133,23 +184,66 @@ Skyreader has always pushed highlights _out_ as `at.margin.note` records. `GET
 - **Server-side URL match.** The backend normalizes each `target.source` and joins it against the
   user's `saved_articles`, attaching `match: {itemGuid, uri} | null`. Two passes, because
   `url_normalized` is only written on the backed-save path: an indexed `url_normalized IN (…)` lookup
-  (what a Semble/Margin-backed account has), then a host-prefix-narrowed `url_normalized IS NULL`
-  read normalized in-process (what a default-backing account has — every save, not a legacy tail).
+  (what a Semble/Margin-backed account has), then — only for the URLs that pass didn't answer — a
+  host-prefix-narrowed `url_normalized IS NULL` read normalized in-process (what a default-backing
+  account has — every save, not a legacy tail).
   The second pass filters by scheme+host in SQL, the one part a raw and a normalized URL always
   share, so the poll never reads the whole saves table; `ORDER BY id` makes duplicate URLs resolve to
   the same save every time. The client has neither the normalization logic nor the saves table.
 - **A partial poll says so.** `truncated` propagates from the page cap all the way to a quiet notice
-  on `/highlights` — otherwise "these are your highlights" would be a lie.
+  on `/highlights` — otherwise "these are your highlights" would be a lie. The service remembers the
+  last poll that actually reached the PDS (`marginImportTruncated()`) rather than the surface reading
+  its own call's return: most calls short-circuit on the 15-minute gate, and the corpus is no less
+  partial for some other surface having done the fetching.
+- **The store gate lives in the service.** The import unions against the highlights it can see and
+  writes the result back as the item's whole set, so running before the local read has landed would
+  import against an empty corpus and overwrite an item's existing highlights with only the imported
+  ones — locally _and_ in D1. Every caller shares one in-flight poll, so a single ungated caller
+  defeats everyone else's gate; the gate therefore sits in `maybeImportMarginHighlights` itself,
+  where nothing can walk past it, rather than being re-implemented at each surface. It sits above the
+  interval stamp, so an attempt that arrives too early doesn't burn the next fifteen minutes. The
+  list and the deck keep their own `storesReady` effects, which is what makes the call happen at the
+  right moment; the service's gate is what makes it safe.
+- **Every outcome has a name.** `MarginImportOutcome` distinguishes `imported` from `skipped`
+  (`disabled` / `offline` / `throttled` / `stores-loading`), `scope-expired` and `failed`. It used to
+  be one `null` covering all of them, and the settings toggle read that `null` as a network problem —
+  so a reader whose Margin grant had lapsed watched the switch flip itself back off and got told to
+  try again later, with no prompt to log back in. Surfaces now say the true thing, and the toggle
+  keeps its own promise: told the stores are still loading, it retries when they land, because
+  `/settings` has no deck or list effect that would do it for them.
+- **An imported highlight's id is its rkey** (`margin:<rkey>`), and that prefix is also the only
+  mark of an imported highlight — `marginRkey` is not, since Skyreader stamps it on its own
+  highlights the moment they are pushed out. The re-key pass reads the id, not the rkey: a highlight
+  Skyreader made is keyed to the article it was made on, and moving it onto a later save of the same
+  URL would tear it off that article. The id is not a random string, either. Two devices can
+  both poll before either one's label write has synced down, so both see an empty `knownRkeys` and
+  both import the same note; ids are what `unionHighlightSources` merges on, so a random id would
+  leave two copies of the same passage alive forever.
 - **Symmetric lifecycle.** Imported highlights carry `marginUri`/`marginRkey` exactly like one
   Skyreader pushed out, so re-polls dedup on the rkey, note edits update the same record, and
   deletion deletes the Margin record. That last one is what stops a deleted highlight resurrecting on
   the next poll — and it is a cross-app delete, so `RemoveHighlightModal` always says "This also
   removes it from Margin" before it happens.
-- **Unmatched imports still render.** A note whose article isn't in any local cache is keyed by its
-  normalized URL and carries `sourceUrl`/`sourceTitle`; `resolveHighlightSource`
-  (`frontend/src/lib/utils/highlightSource.ts`) falls back to those, shared by the list and the deck
-  so the two degrade identically. Re-anchoring needs no work: if the user later opens the article,
-  `findTextInDOM` anchors by `exact`/`prefix`/`suffix` as usual.
+- **A note edit merges, it doesn't rebuild.** That symmetry cuts both ways: the update path can now
+  reach a record _Margin_ wrote, and `putRecord` replaces the whole thing. Rebuilding it from the
+  fields Skyreader models would stamp our `generator` onto the reader's own record, swap
+  `target.source` for our normalized URL and drop every field of this third-party lexicon we don't
+  know about. So `mergeMarginNoteUpdate` reads the record first and changes only the comment body,
+  keeping even the `format` the record declared. `buildMarginNoteRecord` is the fallback for when
+  there's nothing to merge onto, where `putRecord` is creating the record and our shape is the right
+  one.
+- **Unmatched imports still render, and stop being unmatched.** A note whose article isn't in any
+  local cache is keyed by its normalized URL and carries `sourceUrl`/`sourceTitle`;
+  `resolveHighlightSource` (`frontend/src/lib/utils/highlightSource.ts`) falls back to those, shared
+  by the list and the deck so the two degrade identically. Re-anchoring needs no work: if the user
+  later opens the article, `findTextInDOM` anchors by `exact`/`prefix`/`suffix` as usual. But the
+  import is idempotent on the rkey, so a note imported _before_ its article was saved would sit under
+  that URL key forever — no highlight on the article in the reader, and a group of its own in the
+  list — even once the server could match it. So each poll runs a second pass,
+  `planMarginHighlightRekeys`, that moves known notes onto the canonical key their save now has,
+  adding before removing so an interruption leaves a visible duplicate rather than nothing. Only ever
+  _toward_ a match: a note that loses one (the reader unsaved the article) stays put instead of
+  shuttling back and forth every fifteen minutes.
 
 The toggle is device-local. Once one device imports, the highlights sync everywhere as normal label
 rows.

--- a/docs/plans/HIGHLIGHT_REVIEW.md
+++ b/docs/plans/HIGHLIGHT_REVIEW.md
@@ -61,9 +61,13 @@ Skyreader has always pushed highlights _out_ as `at.margin.note` records. `GET
   `backend/test/margin-highlights.spec.ts` pins the shape, so drift shows up as a test failure rather
   than a silent import of nothing.
 - **Server-side URL match.** The backend normalizes each `target.source` and joins it against the
-  user's `saved_articles` (`url_normalized`, plus the raw `url` for rows predating migration 0057),
-  attaching `match: {itemGuid, uri} | null`. The client has neither the normalization logic nor the
-  saves table.
+  user's `saved_articles`, attaching `match: {itemGuid, uri} | null`. Two passes, because
+  `url_normalized` is only written on the backed-save path: an indexed `url_normalized IN (…)` lookup
+  (what a Semble/Margin-backed account has), then a host-prefix-narrowed `url_normalized IS NULL`
+  read normalized in-process (what a default-backing account has — every save, not a legacy tail).
+  The second pass filters by scheme+host in SQL, the one part a raw and a normalized URL always
+  share, so the poll never reads the whole saves table; `ORDER BY id` makes duplicate URLs resolve to
+  the same save every time. The client has neither the normalization logic nor the saves table.
 - **A partial poll says so.** `truncated` propagates from the page cap all the way to a quiet notice
   on `/highlights` — otherwise "these are your highlights" would be a lie.
 - **Symmetric lifecycle.** Imported highlights carry `marginUri`/`marginRkey` exactly like one

--- a/docs/plans/HIGHLIGHT_REVIEW.md
+++ b/docs/plans/HIGHLIGHT_REVIEW.md
@@ -10,11 +10,30 @@ This records the decisions the implementation rests on. For where highlights the
 ## The shape of a review
 
 **The view is the reminder.** V1 has no push and no email — that delivery stack is entirely
-greenfield. Instead the deck surfaces through calm in-app entry points: a Home panel
-(`HighlightReviewCard.svelte`), a Review link in the `/highlights` header, a switcher entry, and the
-`8` shortcut. The Home panel hides itself once the deck is done or empty: no streaks, no badges,
-nothing to clear. A reader who never opens the app is never reminded — that gap is the price of not
-building Web Push, and it's what a follow-up would close.
+greenfield. Instead the deck surfaces through calm in-app entry points: a **Review entry in the
+nav** (sidebar, mobile switcher and nav dropdown), a Home panel (`HighlightReviewCard.svelte`), a
+Review link in the `/highlights` header, and the `8` shortcut. A reader who never opens the app is
+never reminded — that gap is the price of not building Web Push, and it's what a follow-up would
+close.
+
+The nav entry is the standing one, so it carries the only count: today's deck size, in the same
+muted `.nav-count` the unread counts use. It is a badge you clear by reading and nothing else —
+no streak, no lifetime total, no "unreviewed" backlog that can only grow. It goes quiet the moment
+the deck is done, and the entry hides entirely until the reader has highlighted something, so a new
+account never sees a dead tab. The Home panel keeps no count of its own beyond the button it already
+had; it still hides itself once the deck is done.
+
+All four entry points read one derived summary (`highlightReviewStore`, over
+`summarizeHighlightDeck`) rather than each walking the corpus, so they can't disagree about the
+number and the scan is paid once.
+
+**The deck is a page, so it wears the app's chrome.** On mobile it mounts `MobileBottomBar` and its
+switcher/notification sheets exactly as `/highlights` does — in the installed PWA there is no
+browser back button, so the bar's switcher is the only in-app way off the deck. The bar stays put
+rather than riding scroll direction (`controlsVisible={true}`): a card fits a screen, so there's no
+scroll to read intent from. Its desktop header drops the nav dropdown down there, keeping only the
+one thing the bar can't carry — `1 of 5` — and hides outright on the end-of-deck states, where
+there's no progress to show.
 
 **The deck is ephemeral and deterministic, not a frozen issue.** Unlike the daily magazine, a review
 session is a few minutes over a handful of cards, so the mid-read-shift and cross-device resume
@@ -41,6 +60,22 @@ forward, so a slow device flushing an older review can't make a highlight look d
 
 **Deck size is device-local** (`highlightReviewCount`, default 5, options 3/5/10), same posture as
 `dailyMagazineMinutes`.
+
+**The settings live with the deck, not in Settings.** Deck size and the Margin ingest toggle are
+behind a gear in the review header (`HighlightSettings.svelte`, rendered inline in the review body
+rather than in an overlay — the page is one card tall, so there's nothing for a modal to protect).
+Both configure a thing that is on screen while you change it, which is the whole argument for moving
+them: you can see what "5" means. `/settings` keeps no pointer to them — its Highlights section is
+now only the statement of where a highlight lives, which is the app's one place saying it. The Home
+panel's own deck-size select went with them; the count in its button already says how big the deck
+is.
+
+Changing either mid-session is governed by `deckUntouched`: an untouched deck redeals immediately —
+resizing a deck and watching nothing happen would make the control look broken — and a deck the
+reader has started keeps the hand it was dealt, with the change applying next session. That is the
+same predicate the open-time Margin poll uses (`shouldRedealAfterImport`), which is why they share
+it; turning ingest on from the panel redeals under exactly the same rule, so switching it on while
+staring at "Nothing to review right now" doesn't leave you staring at it.
 
 Two devices opening the deck before `lastReviewedAt` syncs will show overlapping decks. Harmless
 (you see a highlight twice), self-healing after sync; not worth a lock.
@@ -87,7 +122,7 @@ rows.
 ## Copy
 
 Highlights are private to Skyreader (D1 + IndexedDB). Saving one to Margin publishes _that note_ to
-the user's PDS; the highlight itself stays here. Never say highlights live on the PDS, and Margin
+the user's PDS. Never say highlights live on the PDS, and Margin
 ingest copy must surface that the source records are public. See the Copy & Voice rules in the root
 `CLAUDE.md`.
 

--- a/docs/plans/HIGHLIGHT_REVIEW.md
+++ b/docs/plans/HIGHLIGHT_REVIEW.md
@@ -1,0 +1,102 @@
+# Highlight review mode
+
+A recurring, finite surface — "revisit a handful of your highlights" — plus opt-in ingest of the
+reader's own Margin (`at.margin.note`) highlights, so the review pool covers everything they've
+highlighted across the Atmosphere rather than only what they highlighted in Skyreader.
+
+This records the decisions the implementation rests on. For where highlights themselves live, see
+[the Reader FDR](../../DESIGN.md) and `frontend/src/lib/stores/itemLabels.svelte.ts`.
+
+## The shape of a review
+
+**The view is the reminder.** V1 has no push and no email — that delivery stack is entirely
+greenfield. Instead the deck surfaces through calm in-app entry points: a Home panel
+(`HighlightReviewCard.svelte`), a Review link in the `/highlights` header, a switcher entry, and the
+`8` shortcut. The Home panel hides itself once the deck is done or empty: no streaks, no badges,
+nothing to clear. A reader who never opens the app is never reminded — that gap is the price of not
+building Web Push, and it's what a follow-up would close.
+
+**The deck is ephemeral and deterministic, not a frozen issue.** Unlike the daily magazine, a review
+session is a few minutes over a handful of cards, so the mid-read-shift and cross-device resume
+problems that forced magazines to be durable don't apply. `buildHighlightDeck`
+(`frontend/src/lib/utils/highlightReview.ts`) derives the deck at open:
+
+- **Eligibility** — exclude anything already reviewed today (local calendar day, not UTC), and
+  anything created in the last 24 h (reviewing what you just made is noise). The freshness filter
+  _relaxes_ rather than emptying a non-empty pool, so a reader whose only highlights are from this
+  morning still gets a deck.
+- **Order** — `lastReviewedAt` ascending, never-reviewed first. Ties (which is most of the
+  never-reviewed bucket) break on the magazine's FNV-1a `dailyScore(dateKey, id)`, so the same day
+  deals the same deck and tomorrow rotates.
+- **No spaced repetition.** Least-recently-reviewed-first is the whole algorithm in v1. The field
+  shape leaves room to add scheduling later.
+
+The component holds the dealt deck in `$state`, not a `$derived` — deriving it would rebuild the
+deck the moment the first card is stamped and pull the ground out from under the reader.
+
+**Review state lives inside the `Highlight` object.** `lastReviewedAt?: number` (epoch ms) rides the
+existing label sync, tombstone and offline machinery for free — no migration, no Dexie version bump
+(`props` isn't indexed). The `reviewed` mutation in `highlightAliases.ts` only ever moves the stamp
+forward, so a slow device flushing an older review can't make a highlight look due again.
+
+**Deck size is device-local** (`highlightReviewCount`, default 5, options 3/5/10), same posture as
+`dailyMagazineMinutes`.
+
+Two devices opening the deck before `lastReviewedAt` syncs will show overlapping decks. Harmless
+(you see a highlight twice), self-healing after sync; not worth a lock.
+
+## Margin ingest
+
+Skyreader has always pushed highlights _out_ as `at.margin.note` records. `GET
+/api/integrations/margin/highlights` is the only path that reads the user's own notes back.
+
+- **Public read, scoped gate.** The read is auth-free public XRPC against the user's own repo (the
+  same `listAllRecordsPublic` primitive the backed-saves snapshot uses). It is still gated on the
+  margin scopes: without them, editing an imported highlight's note would queue a PDS write the
+  session can't perform — a worse state than not importing at all.
+- **Defensive parsing.** `at.margin.note` is a third-party lexicon that has already changed shape
+  once (see [EXTERNAL_BACKED_SAVES_PLAN.md](EXTERNAL_BACKED_SAVES_PLAN.md)). `parseMarginHighlightNote`
+  skips anything it can't use — a bookmarking note, a missing or non-`TextQuoteSelector` selector, an
+  empty quote, a non-http source — and never throws the whole poll away on one bad record.
+  `backend/test/margin-highlights.spec.ts` pins the shape, so drift shows up as a test failure rather
+  than a silent import of nothing.
+- **Server-side URL match.** The backend normalizes each `target.source` and joins it against the
+  user's `saved_articles` (`url_normalized`, plus the raw `url` for rows predating migration 0057),
+  attaching `match: {itemGuid, uri} | null`. The client has neither the normalization logic nor the
+  saves table.
+- **A partial poll says so.** `truncated` propagates from the page cap all the way to a quiet notice
+  on `/highlights` — otherwise "these are your highlights" would be a lie.
+- **Symmetric lifecycle.** Imported highlights carry `marginUri`/`marginRkey` exactly like one
+  Skyreader pushed out, so re-polls dedup on the rkey, note edits update the same record, and
+  deletion deletes the Margin record. That last one is what stops a deleted highlight resurrecting on
+  the next poll — and it is a cross-app delete, so `RemoveHighlightModal` always says "This also
+  removes it from Margin" before it happens.
+- **Unmatched imports still render.** A note whose article isn't in any local cache is keyed by its
+  normalized URL and carries `sourceUrl`/`sourceTitle`; `resolveHighlightSource`
+  (`frontend/src/lib/utils/highlightSource.ts`) falls back to those, shared by the list and the deck
+  so the two degrade identically. Re-anchoring needs no work: if the user later opens the article,
+  `findTextInDOM` anchors by `exact`/`prefix`/`suffix` as usual.
+
+The toggle is device-local. Once one device imports, the highlights sync everywhere as normal label
+rows.
+
+## Copy
+
+Highlights are private to Skyreader (D1 + IndexedDB). Saving one to Margin publishes _that note_ to
+the user's PDS; the highlight itself stays here. Never say highlights live on the PDS, and Margin
+ingest copy must surface that the source records are public. See the Copy & Voice rules in the root
+`CLAUDE.md`.
+
+## Known gaps
+
+- **Row-level sync races get more frequent.** `lastReviewedAt` bumps rewrite the whole per-item
+  `highlights` array, and the documented gap stands: removing a single highlight from a
+  multi-highlight item may not propagate to a device that already cached it
+  (`itemLabels.svelte.ts`). More writers means more chances to resurrect a deleted highlight on a
+  stale device. The per-id union merge keeps this rare and non-destructive — worst case a ghost
+  highlight reappears until re-deleted. Per-highlight tombstones are the known fix, deferred here as
+  in the Reader FDR.
+- **Volume.** A heavy Margin user could import hundreds of notes. The import groups by item and does
+  one union write per item (`itemLabelsStore.addHighlights`), which keeps writes bounded, but one
+  heavily-annotated article becomes one large `props` blob. Acceptable at realistic scale.
+- **No reminder without the app.** See "the view is the reminder" above.

--- a/docs/plans/HIGHLIGHT_REVIEW.md
+++ b/docs/plans/HIGHLIGHT_REVIEW.md
@@ -25,7 +25,17 @@ had; it still hides itself once the deck is done.
 
 All four entry points read one derived summary (`highlightReviewStore`, over
 `summarizeHighlightDeck`) rather than each walking the corpus, so they can't disagree about the
-number and the scan is paid once.
+number and the scan is paid once. The Home panel additionally reads the ranked deck
+(`highlightReviewStore.cards`, a separate `$derived` so the nav badge never pays to rank) and names
+_who_ it draws from: a person is a better reason to open the deck than a description of how it works.
+
+Bylines are missing more often than not — RSS rarely carries one, and a Margin import never does —
+so `resolveHighlightSource` returns `author` unguessed (null) and the panel falls back to the domain,
+then the title, rather than letting a source drop out of the sentence. A document carries only its
+author's DID, and resolving that to a profile is an async fetch, so the lookups map DID to the name
+the reader subscribed under: same name, already on the device.
+`describeHighlightSources` caps the list at two names plus a count, naming a third rather than
+writing "and 1 more" — that costs the same room as the name it hides.
 
 **The deck is a page, so it wears the app's chrome.** On mobile it mounts `MobileBottomBar` and its
 switcher/notification sheets exactly as `/highlights` does — in the installed PWA there is no
@@ -69,6 +79,31 @@ them: you can see what "5" means. `/settings` keeps no pointer to them — its H
 now only the statement of where a highlight lives, which is the app's one place saying it. The Home
 panel's own deck-size select went with them; the count in its button already says how big the deck
 is.
+
+**"Review more" is offered wherever the deck runs out**, in two shapes, both as a secondary button:
+another hand is offered, never urged.
+
+While highlights are still due today, it reads "Review N more" and deals from what's left. That one
+costs nothing to make honest — the hand just finished stamped its own cards, so they're ineligible
+and the next hand is genuinely the next ones due.
+
+Once the day's portion is spent, "more" can only mean going around again, so `DeckOptions
+.includeReviewedToday` lifts the daily filter for that one deal. The button drops its count (a count
+would imply new material) and says what it does: "This brings back the ones you saw earliest today."
+The existing rank order needs no special case — least-recently-reviewed-first means an encore starts
+with the morning's cards, and anything never reviewed still sorts ahead of every repeat. The lifted
+filter is sticky for the visit (`encoreMode`), so a settings-driven redeal can't quietly drop an
+encore hand back to the empty daily pool. Nothing but the button ever sets it: the daily filter is
+what keeps the deck from nagging, and only the reader may waive it.
+
+That exhausted state is also now a state of its own — "That's today's review", reached by coming
+back after finishing rather than by finishing here. It used to share "Nothing to review right now"
+with the genuinely-empty case, which read as "you have no highlights" to a reader who has plenty.
+
+The session tally (`reviewed`) spans every hand, so a reader who takes three says "13 highlights
+revisited" rather than restarting the count. `index` and `interacted` are per hand, which is what
+`deckUntouched` reads — a fresh hand at index 0 is untouched no matter what came before it, so
+resizing the deck there redeals rather than silently waiting.
 
 Changing either mid-session is governed by `deckUntouched`: an untouched deck redeals immediately —
 resizing a deck and watching nothing happen would make the control look broken — and a deck the

--- a/e2e/highlight-review.spec.ts
+++ b/e2e/highlight-review.spec.ts
@@ -359,7 +359,7 @@ test.describe('highlight review', () => {
     await expect(authedPage.getByText('An Essay Elsewhere')).toBeVisible();
     await expect(authedPage.getByText('Worth coming back to')).toBeVisible();
   });
-  test('"Don\'t show again" retires a highlight without deleting it', async ({
+  test('setting a highlight to Never hides it from the deck without deleting it', async ({
     authedPage,
     testUser,
   }) => {
@@ -368,10 +368,15 @@ test.describe('highlight review', () => {
     await authedPage.goto('/highlights/review');
     await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
 
+    // The control names where the highlight currently sits: untuned reads Later.
+    const control = authedPage.getByRole('button', { name: /When should this come back/ });
+    await expect(control).toContainText('Later');
+
     const written = authedPage.waitForResponse(
       (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
     );
-    await authedPage.getByRole('button', { name: "Don't show again" }).click();
+    await control.click();
+    await authedPage.getByRole('button', { name: /^Never/ }).click();
     await written;
 
     // The card is gone and the deck is one shorter — no card was "reviewed".
@@ -383,12 +388,128 @@ test.describe('highlight review', () => {
     await expect(authedPage.getByText('3 highlights')).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText('Not in review')).toHaveCount(1);
 
-    // And the stamp survived the round trip: reopening deals two, not three.
+    // And it survived the round trip through D1: reopening deals two, not three.
     await authedPage.goto('/highlights/review');
     await expect(authedPage.getByText('1 of 2')).toBeVisible({ timeout: 15_000 });
   });
 
-  test('the highlights list puts a retired highlight back in rotation', async ({
+  test('retiring the last highlight says so, rather than "highlight a passage"', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 1);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 1')).toBeVisible({ timeout: 15_000 });
+
+    const written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await authedPage.getByRole('button', { name: /When should this come back/ }).click();
+    await authedPage.getByRole('button', { name: /^Never/ }).click();
+    await written;
+
+    // The highlight is still in the list, so the empty-corpus copy would be a lie.
+    await expect(authedPage.getByRole('heading', { name: 'Nothing in rotation' })).toBeVisible();
+    await expect(authedPage.getByText('Highlight a passage while reading')).toHaveCount(0);
+  });
+
+  test('undoing Never restores the pace it replaced, not the default', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 3);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+
+    const control = authedPage.getByRole('button', { name: /When should this come back/ });
+
+    // Set a pace first. The deck holds the highlight as it was dealt, so undo
+    // has to read this back from the store rather than from its own card.
+    let written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await control.click();
+    await authedPage.getByRole('button', { name: /^Soon/ }).click();
+    await written;
+    await expect(control).toContainText('Soon');
+
+    // Then retire it on the same card, without moving on.
+    written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await control.click();
+    await authedPage.getByRole('button', { name: /^Never/ }).click();
+    await written;
+    await expect(authedPage.getByText('1 of 2')).toBeVisible();
+
+    written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await authedPage.getByRole('button', { name: 'Undo' }).click();
+    await written;
+
+    // Back where it was, still on Soon — undo means "as you were".
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
+    await expect(
+      authedPage.getByRole('button', { name: /When should this come back/ })
+    ).toContainText('Soon');
+
+    // And that's what reached D1, not a reset to the default pace.
+    await authedPage.goto('/highlights');
+    await expect(authedPage.getByText('Soon', { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText('Not in review')).toHaveCount(0);
+  });
+
+  test('Someday persists and sinks the highlight down the deck', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 3);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+
+    const passage = authedPage.locator('.passage');
+    const first = (await passage.textContent())!.trim();
+
+    const control = authedPage.getByRole('button', { name: /When should this come back/ });
+    const written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await control.click();
+    await authedPage.getByRole('button', { name: /^Someday/ }).click();
+    await written;
+
+    // Unlike Never, a pace setting doesn't change this session: the card stays
+    // put, and the control reports the new setting.
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
+    await expect(control).toContainText('Someday');
+
+    // It reached D1, and the ranking acts on it: on the next deal the same three
+    // highlights are dealt, but this one is now last instead of first.
+    await authedPage.reload();
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+    await expect(passage).not.toHaveText(first);
+
+    await authedPage.getByRole('button', { name: 'Next' }).click();
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+    await authedPage.getByRole('button', { name: 'Next' }).click();
+    await expect(authedPage.getByText('3 of 3')).toBeVisible();
+    await expect(passage).toHaveText(first);
+    await expect(
+      authedPage.getByRole('button', { name: /When should this come back/ })
+    ).toContainText('Someday');
+
+    // The list reports it too.
+    await authedPage.goto('/highlights');
+    await expect(authedPage.getByText('Someday', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('the highlights list puts a hidden highlight back in rotation', async ({
     authedPage,
     testUser,
   }) => {
@@ -396,11 +517,12 @@ test.describe('highlight review', () => {
 
     await authedPage.goto('/highlights/review');
     await expect(authedPage.getByText('1 of 2')).toBeVisible({ timeout: 15_000 });
-    const retired = authedPage.waitForResponse(
+    const hidden = authedPage.waitForResponse(
       (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
     );
-    await authedPage.getByRole('button', { name: "Don't show again" }).click();
-    await retired;
+    await authedPage.getByRole('button', { name: /When should this come back/ }).click();
+    await authedPage.getByRole('button', { name: /^Never/ }).click();
+    await hidden;
 
     await authedPage.goto('/highlights');
     const restore = authedPage.getByRole('button', { name: 'Put back in the review deck' });
@@ -432,5 +554,32 @@ test.describe('highlight review', () => {
 
     await back.click();
     await expect(authedPage.getByText('1 of 3')).toBeVisible();
+  });
+
+  // Going back is navigation, not un-reviewing, so coming forward over a card
+  // you already passed must not tally it a second time.
+  test('stepping back and forward again does not double-count the tally', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 3);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+
+    const next = authedPage.getByRole('button', { name: 'Next' });
+    await next.click();
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+
+    await authedPage.getByRole('button', { name: 'Previous highlight' }).click();
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
+
+    await next.click();
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+    await next.click();
+    await expect(authedPage.getByText('3 of 3')).toBeVisible();
+    await authedPage.getByRole('button', { name: 'Finish' }).click();
+
+    await expect(authedPage.getByText('3 highlights revisited.')).toBeVisible();
   });
 });

--- a/e2e/highlight-review.spec.ts
+++ b/e2e/highlight-review.spec.ts
@@ -25,6 +25,7 @@ async function seedHighlights(user: TestUser, count: number) {
   await seedSavedArticle(user, {
     url: ARTICLE_URL,
     title: 'The Highlighted Article',
+    author: 'Ada Lovelace',
     itemGuid: ARTICLE_GUID,
     source: 'feed',
     domain: 'example.com',
@@ -105,9 +106,133 @@ test.describe('highlight review', () => {
 
     // The deck itself reports it, calmly, rather than dealing the same cards again.
     await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByRole('heading', { name: "That's today's review" })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('the Home card names who the deck draws from', async ({ authedPage, testUser }) => {
+    await seedHighlights(testUser, 3);
+    await seedSavedArticle(testUser, {
+      url: 'https://elsewhere.test/review/other',
+      title: 'Another Article',
+      // No byline: this one falls back to where it came from rather than
+      // dropping out of the sentence.
+      itemGuid: 'review-other-guid',
+      source: 'feed',
+      domain: 'elsewhere.test',
+      contentType: 'article',
+    });
+    await seedItemLabel(testUser, {
+      itemKey: 'review-other-guid',
+      itemType: 'article',
+      label: 'highlights',
+      props: JSON.stringify({
+        highlights: [
+          {
+            id: 'hl-other',
+            selector: { type: 'TextQuoteSelector', exact: 'A passage from the other article' },
+            createdAt: OLD,
+          },
+        ],
+      }).replaceAll("'", "''"),
+    });
+
+    await authedPage.goto('/home');
+    // Both sources are named; which comes first is the deck's date-seeded order.
+    await expect(
+      authedPage.getByText(
+        /^Highlights from (Ada Lovelace and elsewhere\.test|elsewhere\.test and Ada Lovelace)\.$/
+      )
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('finishing a deck offers another hand of what is still due', async ({
+    authedPage,
+    testUser,
+  }) => {
+    // Two full decks' worth plus one, so the second hand is short.
+    await seedHighlights(testUser, DECK_SIZE * 2 + 1);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText(`1 of ${DECK_SIZE}`)).toBeVisible({ timeout: 15_000 });
+
+    async function finishHand(size: number) {
+      for (let card = 1; card <= size; card++) {
+        const written = authedPage.waitForResponse(
+          (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+        );
+        await authedPage.getByRole('button', { name: card === size ? 'Finish' : 'Next' }).click();
+        await written;
+      }
+    }
+
+    await finishHand(DECK_SIZE);
+    await expect(authedPage.getByText(`${DECK_SIZE} highlights revisited.`)).toBeVisible();
+
+    const more = authedPage.getByRole('button', { name: `Review ${DECK_SIZE} more` });
+    await expect(more).toBeVisible();
+    await more.click();
+
+    // The stamps from the first hand make its cards ineligible, so this is the
+    // next ones due rather than the same deck again.
+    await expect(authedPage.getByText(`1 of ${DECK_SIZE}`)).toBeVisible();
+    await expect(authedPage.getByText('Seeded highlight number 1')).toHaveCount(0);
+
+    await finishHand(DECK_SIZE);
+    // The tally is the session's, not the hand's.
+    await expect(authedPage.getByText(`${DECK_SIZE * 2} highlights revisited.`)).toBeVisible();
+
+    // One highlight left: the offer says so, and disappears once it's spent.
+    await authedPage.getByRole('button', { name: 'Review 1 more' }).click();
+    await expect(authedPage.getByText('1 of 1')).toBeVisible();
+    await finishHand(1);
+    await expect(authedPage.getByText(`${DECK_SIZE * 2 + 1} highlights revisited.`)).toBeVisible();
+    await expect(authedPage.getByRole('button', { name: /^Review \d+ more$/ })).toHaveCount(0);
+  });
+
+  test('an exhausted deck still offers to keep going', async ({ authedPage, testUser }) => {
+    // Everything already reviewed today: what a reader sees on coming back after
+    // finishing, rather than by finishing in this session.
+    const reviewedToday = Date.now();
+    await seedSavedArticle(testUser, {
+      url: ARTICLE_URL,
+      title: 'The Highlighted Article',
+      author: 'Ada Lovelace',
+      itemGuid: ARTICLE_GUID,
+      source: 'feed',
+      domain: 'example.com',
+      contentType: 'article',
+    });
+    await seedItemLabel(testUser, {
+      itemKey: ARTICLE_GUID,
+      itemType: 'article',
+      label: 'highlights',
+      props: JSON.stringify({
+        highlights: highlights(3).map((h) => ({ ...h, lastReviewedAt: reviewedToday })),
+      }).replaceAll("'", "''"),
+    });
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByRole('heading', { name: "That's today's review" })).toBeVisible({
+      timeout: 15_000,
+    });
+    // Not the empty state: there are highlights, they're just spent for today.
     await expect(
       authedPage.getByRole('heading', { name: 'Nothing to review right now' })
-    ).toBeVisible({ timeout: 15_000 });
+    ).toHaveCount(0);
+
+    // No count on the offer — going around again isn't new material, and it says so.
+    const more = authedPage.getByRole('button', { name: 'Review more', exact: true });
+    await expect(more).toBeVisible();
+    await expect(
+      authedPage.getByText('This brings back the ones you saw earliest today.')
+    ).toBeVisible();
+
+    await more.click();
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
+    // Which of the three leads is the date-seeded tie-break; that one is back.
+    await expect(authedPage.getByText(/^Seeded highlight number [123]$/)).toBeVisible();
   });
 
   test('the nav carries a quiet count that clears when the deck is done', async ({

--- a/e2e/highlight-review.spec.ts
+++ b/e2e/highlight-review.spec.ts
@@ -276,7 +276,7 @@ test.describe('highlight review', () => {
 
     // The card clears the bar rather than sitting under it.
     const gap = await authedPage.evaluate(() => {
-      const card = document.querySelector('.review-body .card');
+      const card = document.querySelector('.review-body .deck-card');
       const chrome = document.querySelector('.mobile-bottom-bar');
       if (!card || !chrome) return null;
       return chrome.getBoundingClientRect().top - card.getBoundingClientRect().bottom;
@@ -358,5 +358,79 @@ test.describe('highlight review', () => {
     });
     await expect(authedPage.getByText('An Essay Elsewhere')).toBeVisible();
     await expect(authedPage.getByText('Worth coming back to')).toBeVisible();
+  });
+  test('"Don\'t show again" retires a highlight without deleting it', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 3);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+
+    const written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await authedPage.getByRole('button', { name: "Don't show again" }).click();
+    await written;
+
+    // The card is gone and the deck is one shorter — no card was "reviewed".
+    await expect(authedPage.getByText('1 of 2')).toBeVisible();
+    await expect(authedPage.getByText("won't come up in review again")).toBeVisible();
+
+    // Nothing was deleted: all three are still in the list, one marked.
+    await authedPage.goto('/highlights');
+    await expect(authedPage.getByText('3 highlights')).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText('Not in review')).toHaveCount(1);
+
+    // And the stamp survived the round trip: reopening deals two, not three.
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 2')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('the highlights list puts a retired highlight back in rotation', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 2);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 2')).toBeVisible({ timeout: 15_000 });
+    const retired = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await authedPage.getByRole('button', { name: "Don't show again" }).click();
+    await retired;
+
+    await authedPage.goto('/highlights');
+    const restore = authedPage.getByRole('button', { name: 'Put back in the review deck' });
+    await expect(restore).toBeVisible({ timeout: 15_000 });
+    const restored = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await restore.click();
+    await restored;
+    await expect(authedPage.getByText('Not in review')).toHaveCount(0);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 2')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('the deck steps backward as well as forward', async ({ authedPage, testUser }) => {
+    await seedHighlights(testUser, 3);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible({ timeout: 15_000 });
+
+    // Nothing behind the first card, so back is offered but inert.
+    const back = authedPage.getByRole('button', { name: 'Previous highlight' });
+    await expect(back).toBeDisabled();
+
+    await authedPage.getByRole('button', { name: 'Next' }).click();
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+    await expect(back).toBeEnabled();
+
+    await back.click();
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
   });
 });

--- a/e2e/highlight-review.spec.ts
+++ b/e2e/highlight-review.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from './fixtures';
+import { seedItemLabel, seedSavedArticle, type TestUser } from './seed';
+
+// Highlight review: the deck is derived at open from the least-recently-reviewed
+// highlights, and "already reviewed today" is a `lastReviewedAt` stamp written
+// back into the highlights label. These cover the loop end to end — Home entry
+// card → session → the stamp reaching D1 → deck gone on reload.
+
+const ARTICLE_URL = 'https://example.com/review/source';
+const ARTICLE_GUID = 'review-article-guid';
+const DECK_SIZE = 5;
+
+// Well past the 24 h freshness filter, so every seeded highlight is eligible.
+const OLD = Date.now() - 30 * 24 * 60 * 60 * 1000;
+
+function highlights(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `hl-${i + 1}`,
+    selector: { type: 'TextQuoteSelector', exact: `Seeded highlight number ${i + 1}` },
+    createdAt: OLD + i,
+  }));
+}
+
+async function seedHighlights(user: TestUser, count: number) {
+  await seedSavedArticle(user, {
+    url: ARTICLE_URL,
+    title: 'The Highlighted Article',
+    itemGuid: ARTICLE_GUID,
+    source: 'feed',
+    domain: 'example.com',
+    contentType: 'article',
+  });
+  await seedItemLabel(user, {
+    itemKey: ARTICLE_GUID,
+    itemType: 'article',
+    label: 'highlights',
+    props: JSON.stringify({ highlights: highlights(count) }).replaceAll("'", "''"),
+  });
+}
+
+test.describe('highlight review', () => {
+  test('Home offers a deck, the session completes, and the stamp lands in D1', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, DECK_SIZE + 2);
+
+    await authedPage.goto('/home');
+    const start = authedPage.getByRole('link', { name: `Review ${DECK_SIZE} highlights` });
+    await expect(start).toBeVisible({ timeout: 15_000 });
+    await start.click();
+
+    await expect(authedPage.getByText(`1 of ${DECK_SIZE}`)).toBeVisible();
+
+    // Advancing writes the whole highlights array back through PATCH-equivalent
+    // POST /api/labels. Wait on the response so D1 has the stamp before reload.
+    for (let card = 1; card <= DECK_SIZE; card++) {
+      await expect(authedPage.getByText(`${card} of ${DECK_SIZE}`)).toBeVisible();
+      const written = authedPage.waitForResponse(
+        (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+      );
+      await authedPage
+        .getByRole('button', { name: card === DECK_SIZE ? 'Finish' : 'Next' })
+        .click();
+      await written;
+    }
+
+    await expect(authedPage.getByRole('heading', { name: "That's your review" })).toBeVisible();
+    await expect(
+      authedPage.getByText(`${DECK_SIZE} highlights revisited`, { exact: false })
+    ).toBeVisible();
+
+    // Only 2 highlights are left unreviewed today, so the next deck is smaller —
+    // proof the stamp survived the round trip rather than the deck resetting.
+    await authedPage.goto('/home');
+    await expect(authedPage.getByRole('link', { name: 'Review 2 highlights' })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('the Home card disappears once every highlight was reviewed today', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, 2);
+
+    await authedPage.goto('/home');
+    const start = authedPage.getByRole('link', { name: 'Review 2 highlights' });
+    await expect(start).toBeVisible({ timeout: 15_000 });
+    await start.click();
+
+    for (const label of ['Next', 'Finish']) {
+      const written = authedPage.waitForResponse(
+        (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+      );
+      await authedPage.getByRole('button', { name: label }).click();
+      await written;
+    }
+
+    await expect(authedPage.getByRole('heading', { name: "That's your review" })).toBeVisible();
+
+    await authedPage.goto('/home');
+    // Give the lanes time to render, then assert the review panel is absent.
+    await expect(authedPage.getByRole('link', { name: /^Review \d+ highlight/ })).toHaveCount(0);
+
+    // The deck itself reports it, calmly, rather than dealing the same cards again.
+    await authedPage.goto('/highlights/review');
+    await expect(
+      authedPage.getByRole('heading', { name: 'Nothing to review right now' })
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('a highlight with no local article still shows its source and quote', async ({
+    authedPage,
+    testUser,
+  }) => {
+    // An imported Margin highlight: keyed by its normalized URL, carrying its own
+    // source metadata because no article/save in the local cache matches.
+    await seedItemLabel(testUser, {
+      itemKey: 'https://elsewhere.test/essay',
+      itemType: 'article',
+      label: 'highlights',
+      props: JSON.stringify({
+        highlights: [
+          {
+            id: 'imported-1',
+            selector: { type: 'TextQuoteSelector', exact: 'A passage highlighted in Margin' },
+            createdAt: OLD,
+            note: 'Worth coming back to',
+            marginUri: 'at://did:plc:someone/at.margin.note/abc',
+            marginRkey: 'abc',
+            sourceUrl: 'https://elsewhere.test/essay',
+            sourceTitle: 'An Essay Elsewhere',
+          },
+        ],
+      }).replaceAll("'", "''"),
+    });
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText('A passage highlighted in Margin')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText('An Essay Elsewhere')).toBeVisible();
+    await expect(authedPage.getByText('Worth coming back to')).toBeVisible();
+  });
+});

--- a/e2e/highlight-review.spec.ts
+++ b/e2e/highlight-review.spec.ts
@@ -110,6 +110,97 @@ test.describe('highlight review', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
+  test('the nav carries a quiet count that clears when the deck is done', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, DECK_SIZE + 2);
+
+    await authedPage.goto('/home');
+    // Label + count: today's deck, not the whole corpus (7 highlights seeded).
+    const nav = authedPage.getByRole('link', { name: `Review ${DECK_SIZE}`, exact: true });
+    await expect(nav).toBeVisible({ timeout: 15_000 });
+    await nav.click();
+
+    for (let card = 1; card <= DECK_SIZE; card++) {
+      const written = authedPage.waitForResponse(
+        (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+      );
+      await authedPage
+        .getByRole('button', { name: card === DECK_SIZE ? 'Finish' : 'Next' })
+        .click();
+      await written;
+    }
+
+    // 2 highlights still unreviewed today, so the count shrinks rather than clearing.
+    await expect(authedPage.getByRole('link', { name: 'Review 2', exact: true })).toBeVisible();
+  });
+
+  test('the mobile bottom bar is the way off the deck', async ({ authedPage, testUser }) => {
+    await seedHighlights(testUser, DECK_SIZE);
+    await authedPage.setViewportSize({ width: 390, height: 844 });
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText(`1 of ${DECK_SIZE}`)).toBeVisible({ timeout: 15_000 });
+
+    // The installed PWA has no back button, so the bar's switcher is the only
+    // in-app way out of the deck.
+    const bar = authedPage.locator('.mobile-bottom-bar');
+    await expect(bar).toBeVisible();
+    await expect(bar.getByRole('button', { name: 'Switch feed' })).toContainText('Review');
+
+    // The card clears the bar rather than sitting under it.
+    const gap = await authedPage.evaluate(() => {
+      const card = document.querySelector('.review-body .card');
+      const chrome = document.querySelector('.mobile-bottom-bar');
+      if (!card || !chrome) return null;
+      return chrome.getBoundingClientRect().top - card.getBoundingClientRect().bottom;
+    });
+    expect(gap).not.toBeNull();
+    expect(gap!).toBeGreaterThan(0);
+
+    await bar.getByRole('button', { name: 'Switch feed' }).click();
+    await authedPage.getByRole('button', { name: 'Highlights', exact: true }).click();
+    await expect(authedPage).toHaveURL(/\/highlights$/);
+  });
+
+  test('the gear opens the deck settings, and resizing redeals an untouched deck', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHighlights(testUser, DECK_SIZE + 2);
+
+    await authedPage.goto('/highlights/review');
+    await expect(authedPage.getByText(`1 of ${DECK_SIZE}`)).toBeVisible({ timeout: 15_000 });
+
+    const gear = authedPage.getByRole('button', { name: 'Review settings' });
+    await expect(gear).toHaveAttribute('aria-expanded', 'false');
+    await gear.click();
+
+    const deckSize = authedPage.getByLabel('Review deck');
+    await expect(deckSize).toBeVisible();
+    await expect(authedPage.getByText('Bring in highlights from Margin')).toBeVisible();
+
+    // Nothing has been reviewed yet, so a resize applies to the hand on screen
+    // rather than silently waiting for the next session.
+    await deckSize.selectOption('3');
+    await expect(authedPage.getByText('1 of 3')).toBeVisible();
+
+    // Once the reader is under way the dealt deck is theirs to finish: the new
+    // size waits for the next session instead of reshuffling mid-deck.
+    await gear.click();
+    const written = authedPage.waitForResponse(
+      (res) => res.url().includes('/api/labels') && res.request().method() === 'POST'
+    );
+    await authedPage.getByRole('button', { name: 'Next' }).click();
+    await written;
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+
+    await gear.click();
+    await authedPage.getByLabel('Review deck').selectOption('10');
+    await expect(authedPage.getByText('2 of 3')).toBeVisible();
+  });
+
   test('a highlight with no local article still shows its source and quote', async ({
     authedPage,
     testUser,

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -78,16 +78,27 @@ See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) for sampling and recovery details.
 
 ### Key Routes
 
-| Route            | Purpose                                        |
-| ---------------- | ---------------------------------------------- |
-| `/`              | Main feed (all articles from subscribed feeds) |
-| `/social`        | Shares from followed users                     |
-| `/starred`       | Starred articles                               |
-| `/feeds`         | Manage feed subscriptions                      |
-| `/discover`      | Discover new feeds                             |
-| `/settings`      | Account and sync status                        |
-| `/auth/login`    | Bluesky handle input                           |
-| `/auth/callback` | OAuth callback handler                         |
+| Route                | Purpose                                        |
+| -------------------- | ---------------------------------------------- |
+| `/`                  | Main feed (all articles from subscribed feeds) |
+| `/social`            | Shares from followed users                     |
+| `/starred`           | Starred articles                               |
+| `/feeds`             | Manage feed subscriptions                      |
+| `/discover`          | Discover new feeds                             |
+| `/highlights`        | Every highlight, grouped by source article     |
+| `/highlights/review` | Review deck — a few highlights, one at a time  |
+| `/settings`          | Account and sync status                        |
+| `/auth/login`        | Bluesky handle input                           |
+| `/auth/callback`     | OAuth callback handler                         |
+
+### Highlights
+
+Highlights live in the `highlights` label's opaque `props.highlights` array, merged per-highlight by
+id across alias rows (`utils/highlightAliases.ts`). Two things ride that array beyond the quote
+itself: `lastReviewedAt` (the review deck's repeat-avoidance, synced for free) and
+`sourceUrl`/`sourceTitle` (source metadata for highlights imported from Margin whose article isn't in
+any local cache). `utils/highlightSource.ts` is the shared resolver both the list and the deck use so
+they degrade identically. See [`docs/plans/HIGHLIGHT_REVIEW.md`](../docs/plans/HIGHLIGHT_REVIEW.md).
 
 #### The `?read=` contract
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -94,10 +94,11 @@ See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) for sampling and recovery details.
 ### Highlights
 
 Highlights live in the `highlights` label's opaque `props.highlights` array, merged per-highlight by
-id across alias rows (`utils/highlightAliases.ts`). Two things ride that array beyond the quote
-itself: `lastReviewedAt` (the review deck's repeat-avoidance, synced for free) and
-`sourceUrl`/`sourceTitle` (source metadata for highlights imported from Margin whose article isn't in
-any local cache). `utils/highlightSource.ts` is the shared resolver both the list and the deck use so
+id across alias rows (`utils/highlightAliases.ts`). Three things ride that array beyond the quote
+itself: `lastReviewedAt` (the review deck's repeat-avoidance, synced for free), `reviewRetiredAt`
+(the deck's "Don't show again" — the highlight stays in the list and on Margin, it just stops being
+dealt; cleared from the highlights list to put it back), and `sourceUrl`/`sourceTitle` (source
+metadata for highlights imported from Margin whose article isn't in any local cache). `utils/highlightSource.ts` is the shared resolver both the list and the deck use so
 they degrade identically. See [`docs/plans/HIGHLIGHT_REVIEW.md`](../docs/plans/HIGHLIGHT_REVIEW.md).
 
 #### The `?read=` contract

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -95,10 +95,12 @@ See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) for sampling and recovery details.
 
 Highlights live in the `highlights` label's opaque `props.highlights` array, merged per-highlight by
 id across alias rows (`utils/highlightAliases.ts`). Three things ride that array beyond the quote
-itself: `lastReviewedAt` (the review deck's repeat-avoidance, synced for free), `reviewRetiredAt`
-(the deck's "Don't show again" — the highlight stays in the list and on Margin, it just stops being
-dealt; cleared from the highlights list to put it back), and `sourceUrl`/`sourceTitle` (source
-metadata for highlights imported from Margin whose article isn't in any local cache). `utils/highlightSource.ts` is the shared resolver both the list and the deck use so
+itself: `lastReviewedAt` (the review deck's repeat-avoidance, synced for free), `reviewIntent`
+(`soon`/`later`/`someday`/`never` — the deck's frequency tuning; `later` is the neutral default, and
+even `never` only stops the highlight being dealt, it stays in the list and on Margin), and
+`sourceUrl`/`sourceTitle` (source metadata for highlights imported from Margin whose article isn't
+in any local cache). Because the whole array is written to `item_labels_cache.props` as opaque JSON,
+any new per-highlight field reaches D1 and syncs across devices with no migration. `utils/highlightSource.ts` is the shared resolver both the list and the deck use so
 they degrade identically. See [`docs/plans/HIGHLIGHT_REVIEW.md`](../docs/plans/HIGHLIGHT_REVIEW.md).
 
 #### The `?read=` contract

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -121,6 +121,14 @@
     });
 
     keyboardStore.register({
+      key: '8',
+      description: 'Review highlights',
+      category: 'Views',
+      action: () => goto('/highlights/review'),
+      condition: () => auth.isAuthenticated,
+    });
+
+    keyboardStore.register({
       key: '5',
       description: 'Discover',
       category: 'Views',

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -14,6 +14,7 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { keyboardStore } from '$lib/stores/keyboard.svelte';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { feedPath, FEEDS_PATH, SAVED_PATH } from '$lib/utils/viewNav';
@@ -121,14 +122,6 @@
     });
 
     keyboardStore.register({
-      key: '8',
-      description: 'Review highlights',
-      category: 'Views',
-      action: () => goto('/highlights/review'),
-      condition: () => auth.isAuthenticated,
-    });
-
-    keyboardStore.register({
       key: '5',
       description: 'Discover',
       category: 'Views',
@@ -150,6 +143,16 @@
       category: 'Views',
       action: () => goto('/settings'),
       condition: () => auth.isAuthenticated,
+    });
+
+    // Gated on the corpus like every other Review entry point: a new account
+    // pressing 8 would otherwise land on a page with nothing to deal.
+    keyboardStore.register({
+      key: '8',
+      description: 'Review highlights',
+      category: 'Views',
+      action: () => goto('/highlights/review'),
+      condition: () => auth.isAuthenticated && highlightReviewStore.hasHighlights,
     });
 
     // Feed/user cycling shortcuts

--- a/frontend/src/lib/components/Icon.svelte
+++ b/frontend/src/lib/components/Icon.svelte
@@ -62,6 +62,7 @@
     | 'standard-site'
     | 'book-open'
     | 'align-justify'
+    | 'circle-slash'
     | 'bluesky';
 
   interface Props {
@@ -361,6 +362,9 @@
     <path d="M3 12h18" />
     <path d="M3 6h18" />
     <path d="M3 18h18" />
+  {:else if name === 'circle-slash'}
+    <circle cx="12" cy="12" r="10" />
+    <path d="m4.9 4.9 14.2 14.2" />
   {/if}
 </svg>
 

--- a/frontend/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/frontend/src/lib/components/KeyboardShortcutsModal.svelte
@@ -26,6 +26,7 @@
     { category: 'Views', key: '5', description: 'Discover' },
     { category: 'Views', key: '6', description: 'Manage Sources' },
     { category: 'Views', key: '7', description: 'Settings' },
+    { category: 'Views', key: '8', description: 'Review highlights' },
 
     // Feed cycling
     { category: 'Feed', key: '[', description: 'Previous feed' },

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -155,7 +155,8 @@
     | 'layers'
     | 'folder'
     | 'users'
-    | 'highlighter';
+    | 'highlighter'
+    | 'quote';
 
   // Navigation item type
   type NavItem =
@@ -235,6 +236,13 @@
         ? [{ type: 'utility' as const, id: 'linkblog', label: 'Linkblog', icon: 'share' as const }]
         : []),
       { type: 'utility', id: 'highlights', label: 'Highlights', icon: 'highlighter' },
+      {
+        type: 'utility',
+        id: 'highlights/review',
+        label: 'Review highlights',
+        icon: 'quote',
+        indent: true,
+      },
       { type: 'utility', id: 'discover', label: 'Discover', icon: 'users' },
       { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' },

--- a/frontend/src/lib/components/NavigationDropdown.svelte
+++ b/frontend/src/lib/components/NavigationDropdown.svelte
@@ -6,6 +6,7 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
@@ -236,13 +237,19 @@
         ? [{ type: 'utility' as const, id: 'linkblog', label: 'Linkblog', icon: 'share' as const }]
         : []),
       { type: 'utility', id: 'highlights', label: 'Highlights', icon: 'highlighter' },
-      {
-        type: 'utility',
-        id: 'highlights/review',
-        label: 'Review highlights',
-        icon: 'quote',
-        indent: true,
-      },
+      // Review is its own destination; the count is today's deck, and it goes
+      // quiet once the deck is done. Hidden until there's a corpus to review.
+      ...(highlightReviewStore.hasHighlights
+        ? [
+            {
+              type: 'utility' as const,
+              id: 'highlights/review',
+              label: 'Review',
+              count: highlightReviewStore.dueCount,
+              icon: 'quote' as const,
+            },
+          ]
+        : []),
       { type: 'utility', id: 'discover', label: 'Discover', icon: 'users' },
       { type: 'utility', id: 'sources', label: 'Manage Sources', icon: 'rss' },
       { type: 'utility', id: 'settings', label: 'Settings', icon: 'settings' },

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -10,6 +10,7 @@
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { syncAutoRuleChannels } from '$lib/stores/channelAutoUpdate.svelte';
   import { onMount, onDestroy } from 'svelte';
   import AddFeedModal from './AddFeedModal.svelte';
@@ -468,6 +469,24 @@
       <span class="nav-icon"><Icon name="highlighter" /></span>
       <span class="nav-label">Highlights</span>
     </a>
+
+    <!-- Review: its own destination, not a mode of /highlights. The count is
+         today's deck and disappears when the deck is done — a badge you clear by
+         reading, never a streak. Hidden entirely until there's a corpus. -->
+    {#if highlightReviewStore.hasHighlights}
+      <a
+        href="/highlights/review"
+        class="nav-item nav-link"
+        class:active={$page.url.pathname === '/highlights/review'}
+        onclick={() => sidebarStore.closeMobile()}
+      >
+        <span class="nav-icon"><Icon name="quote" /></span>
+        <span class="nav-label">Review</span>
+        {#if highlightReviewStore.dueCount > 0}
+          <span class="nav-count">{highlightReviewStore.dueCount}</span>
+        {/if}
+      </a>
+    {/if}
 
     <a
       href="/discover"

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -7,7 +7,12 @@
   import { page } from '$app/state';
   import NavigationDropdown from '$lib/components/NavigationDropdown.svelte';
   import Icon from '$lib/components/Icon.svelte';
+  import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
+  import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
+  import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+  import NotificationList from '$lib/components/NotificationList.svelte';
   import SavedReader from '$lib/components/feed/SavedReader.svelte';
+  import HighlightSettings from '$lib/components/settings/HighlightSettings.svelte';
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
   import RemoveHighlightModal from '$lib/components/feed/RemoveHighlightModal.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
@@ -15,6 +20,9 @@
   import { socialStore } from '$lib/stores/social.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
+  import { notificationsStore } from '$lib/stores/notifications.svelte';
+  import { sidebarStore } from '$lib/stores/sidebar.svelte';
+  import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import {
     saveHighlightToMargin,
@@ -24,6 +32,7 @@
   import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
   import {
     buildHighlightDeck,
+    deckUntouched,
     shouldRedealAfterImport,
     type HighlightEntry,
   } from '$lib/utils/highlightReview';
@@ -71,11 +80,13 @@
   // deck can't be mistaken for "the local pool was empty".
   let emptyOnDeal = $state(false);
 
+  // The deck size this hand was dealt at. Plain, not `$state`: the redeal effect
+  // writes it, and it exists only to notice a change in the preference.
+  let dealtCount = 0;
+
   function dealDeck() {
-    deck = buildHighlightDeck(
-      itemLabelsStore.allHighlights,
-      preferences.highlightReviewCount
-    ).cards;
+    dealtCount = preferences.highlightReviewCount;
+    deck = buildHighlightDeck(itemLabelsStore.allHighlights, dealtCount).cards;
     emptyOnDeal = deck.length === 0;
   }
 
@@ -83,6 +94,16 @@
     if (dealt || !storesReady) return;
     dealt = true;
     dealDeck();
+  });
+
+  // Resizing the deck from the settings panel takes effect now if the reader
+  // hasn't started — otherwise it would look like the control did nothing — and
+  // waits for the next session once they have.
+  $effect(() => {
+    const size = preferences.highlightReviewCount;
+    if (!dealt || size === dealtCount) return;
+    if (deckUntouched({ index, reviewed, interacted })) dealDeck();
+    else dealtCount = size;
   });
 
   // An empty deck is the one case worth waiting on: the local pool has nothing to
@@ -244,6 +265,36 @@
       noteAnchor = button?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
     }
   }
+
+  // --- Settings, in reach of the deck they configure (deck size, Margin
+  // ingest). An inline disclosure rather than an overlay: the page is one card
+  // tall, so there's nothing for a modal to protect.
+  let settingsOpen = $state(false);
+
+  // An import that lands while the reader hasn't started should join this
+  // session — turning the toggle on and still reading "nothing to review" is
+  // the opposite of what the control promised.
+  function handleSettingsImport() {
+    if (deckUntouched({ index, reviewed, interacted })) dealDeck();
+  }
+
+  // --- Mobile chrome. The installed PWA has no browser back button, so the
+  // bottom bar's switcher is the only way off this page down here. The deck
+  // doesn't scroll, so the bar stays put rather than riding scroll direction.
+  let feedSwitcherOpen = $state(false);
+  let notifSheetOpen = $state(false);
+
+  // Channel create/edit routes through the always-mounted sidebar modal, the
+  // same way the highlights list does it.
+  function handleCreateChannel(type: 'feed' | 'saved' = 'feed') {
+    feedSwitcherOpen = false;
+    sidebarStore.openChannelModal(null, type);
+  }
+
+  function handleEditChannel(id: number) {
+    feedSwitcherOpen = false;
+    sidebarStore.openChannelModal(id);
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -251,14 +302,33 @@
 <div class="review-page">
   <header class="review-header">
     <div class="header-inner">
-      <NavigationDropdown currentTitle="Review" />
-      {#if current}
-        <span class="progress">{index + 1} of {total}</span>
-      {/if}
+      <div class="header-nav"><NavigationDropdown currentTitle="Review" /></div>
+      <div class="header-actions">
+        {#if current}
+          <span class="progress">{index + 1} of {total}</span>
+        {/if}
+        <button
+          class="gear"
+          class:open={settingsOpen}
+          onclick={() => (settingsOpen = !settingsOpen)}
+          aria-expanded={settingsOpen}
+          aria-controls="review-settings"
+          title="Review settings"
+          aria-label="Review settings"
+        >
+          <Icon name="settings" size={16} />
+        </button>
+      </div>
     </div>
   </header>
 
   <div class="review-body">
+    {#if settingsOpen}
+      <section id="review-settings" class="settings-panel" aria-label="Review settings">
+        <HighlightSettings returnUrl="/highlights/review" onImported={handleSettingsImport} />
+      </section>
+    {/if}
+
     {#if !ready || !deck}
       <p class="state-note" aria-live="polite">Gathering your highlights…</p>
     {:else if current && source && live}
@@ -340,6 +410,46 @@
       </section>
     {/if}
   </div>
+
+  {#if mobileStore.isMobile && !readerItem}
+    <MobileBottomBar
+      controlsVisible={true}
+      currentTitle="Review"
+      onScrollToTop={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onOpenFeedSwitcher={() => (feedSwitcherOpen = true)}
+      onOpenNotifications={() => {
+        notifSheetOpen = true;
+        void notificationsStore.load();
+      }}
+      onOpenFilterSheet={() => {}}
+      hasActiveFilters={false}
+      hideFilterButton={true}
+    />
+
+    <BottomSheet
+      open={feedSwitcherOpen}
+      onclose={() => (feedSwitcherOpen = false)}
+      title="Switch Feed"
+    >
+      <MobileFeedSwitcher
+        onclose={() => (feedSwitcherOpen = false)}
+        currentTitle="Review"
+        onEditChannel={handleEditChannel}
+        onCreateChannel={handleCreateChannel}
+      />
+    </BottomSheet>
+
+    <BottomSheet
+      open={notifSheetOpen}
+      onclose={() => {
+        notifSheetOpen = false;
+        void notificationsStore.markAllSeen();
+      }}
+      title="Notifications"
+    >
+      <NotificationList onItemClick={() => (notifSheetOpen = false)} />
+    </BottomSheet>
+  {/if}
 </div>
 
 {#if noteAnchor}
@@ -387,16 +497,76 @@
     padding: 0.75rem 1rem;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
   .progress {
     font-size: var(--text-sm);
     color: var(--color-text-secondary);
     font-variant-numeric: tabular-nums;
   }
 
+  .gear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .gear:hover,
+  .gear.open {
+    color: var(--color-text);
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  /* Flat by default: a bordered panel in the column, not a floating sheet. */
+  .settings-panel {
+    margin-bottom: 1.5rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+
   .review-body {
     max-width: 680px;
     margin: 0 auto;
     padding: 1.5rem 1rem 4rem;
+  }
+
+  @media (max-width: 1000px) {
+    /* The bottom bar owns navigation down here, so the header keeps only what
+       the bar can't carry: where you are in the deck, and the settings for it.
+       Those two take the full width rather than huddling on one side. */
+    .header-nav {
+      display: none;
+    }
+
+    .header-actions {
+      flex: 1;
+    }
+
+    /* Right-aligned whether or not there's a progress count beside it — the
+       end-of-deck states have no progress but still want their settings. */
+    .gear {
+      margin-left: auto;
+    }
+
+    .review-body {
+      padding-bottom: calc(var(--bottom-bar-height) + var(--safe-area-bottom) + 1rem);
+    }
   }
 
   .card {

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -169,6 +169,9 @@
   let noteAnchor = $state<DOMRect | null>(null);
 
   function openNoteEditor(event: MouseEvent) {
+    // Freeze before opening the editor: the import can finish while the reader
+    // is typing, and the saved note must still belong to the selected card.
+    interacted = true;
     noteAnchor = (event.currentTarget as HTMLElement).getBoundingClientRect();
   }
 
@@ -192,11 +195,19 @@
     const entry = current;
     const target = source;
     if (!entry || !target || !live) return;
+    interacted = true;
     void saveHighlightToMargin(entry.itemKey, live, target.url, target.title);
   }
 
   // --- Remove (destructive across apps when the highlight is on Margin) ---
   let removePrompt = $state(false);
+
+  function openRemovePrompt() {
+    // Freeze before confirmation opens so a late import cannot swap the card
+    // underneath this destructive action.
+    interacted = true;
+    removePrompt = true;
+  }
 
   function confirmRemove() {
     const entry = current;
@@ -228,6 +239,7 @@
       openSource();
     } else if (event.key === 'e') {
       event.preventDefault();
+      interacted = true;
       const button = document.querySelector<HTMLElement>('[data-review-note]');
       noteAnchor = button?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
     }
@@ -300,7 +312,7 @@
             </button>
             <button
               class="action-btn danger"
-              onclick={() => (removePrompt = true)}
+              onclick={openRemovePrompt}
               title="Remove highlight"
               aria-label="Remove highlight"
             >

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -53,6 +53,7 @@
   let deck = $state<HighlightEntry[] | null>(null);
   let index = $state(0);
   let reviewed = $state(0);
+  let interacted = $state(false);
 
   // Deal as soon as the local stores hydrate — everything needed for a session is
   // already on the device, so a Margin poll must never stand between the reader
@@ -96,7 +97,7 @@
     const timer = setTimeout(() => (importWaitElapsed = true), EMPTY_DECK_IMPORT_WAIT_MS);
     void maybeImportMarginHighlights()
       .then((result) => {
-        if (shouldRedealAfterImport(result, { index, reviewed })) dealDeck();
+        if (shouldRedealAfterImport(result, { index, reviewed, interacted })) dealDeck();
       })
       .catch(() => {})
       .finally(() => {
@@ -129,6 +130,7 @@
   function advance() {
     const entry = current;
     if (!entry) return;
+    interacted = true;
     void itemLabelsStore.markHighlightReviewed(entry.itemKey, entry.highlight.id);
     reviewed += 1;
     index += 1;
@@ -201,6 +203,10 @@
     const highlight = live;
     removePrompt = false;
     if (!entry || !highlight) return;
+    // Freeze the session before starting the cross-app deletion. The opening
+    // import can finish while that request is in flight and must not redeal the
+    // card the reader just confirmed removing.
+    interacted = true;
     void deleteHighlight(entry.itemKey, highlight);
     // Drop the card without stamping it reviewed — it no longer exists.
     if (deck) deck = deck.filter((card) => card.highlight.id !== entry.highlight.id);

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -1,0 +1,516 @@
+<script lang="ts">
+  // Highlight review — a finite deck of a handful of highlights, one card at a
+  // time. Deliberately not a durable issue like the daily magazine: a session is
+  // a few minutes, so the deck is derived at open and repeat-avoidance rides the
+  // per-highlight `lastReviewedAt` stamp, which syncs with the highlight itself.
+  import { onMount } from 'svelte';
+  import { pushState } from '$app/navigation';
+  import { page } from '$app/state';
+  import NavigationDropdown from '$lib/components/NavigationDropdown.svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import SavedReader from '$lib/components/feed/SavedReader.svelte';
+  import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
+  import RemoveHighlightModal from '$lib/components/feed/RemoveHighlightModal.svelte';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { articlesStore } from '$lib/stores/articles.svelte';
+  import { socialStore } from '$lib/stores/social.svelte';
+  import { savesStore } from '$lib/stores/saves.svelte';
+  import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
+  import { preferences } from '$lib/stores/preferences.svelte';
+  import {
+    saveHighlightToMargin,
+    deleteHighlight,
+    updateHighlightNoteOnMargin,
+  } from '$lib/services/marginHighlights';
+  import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
+  import { buildHighlightDeck, type HighlightEntry } from '$lib/utils/highlightReview';
+  import {
+    buildHighlightSourceLookups,
+    resolveHighlightSource,
+    type HighlightSource,
+  } from '$lib/utils/highlightSource';
+  import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
+
+  $effect(() => {
+    viewTitleStore.set('Review');
+    return () => viewTitleStore.set('');
+  });
+
+  let sourceLookups = $derived(
+    buildHighlightSourceLookups(
+      articlesStore.allArticles,
+      socialStore.documents,
+      savesStore.articles
+    )
+  );
+
+  // The deck is fixed for the session: it's built once, from the corpus as it
+  // stood at open. Deriving it would rebuild the deck the moment the first card
+  // is marked reviewed and pull the ground out from under the reader.
+  let deck = $state<HighlightEntry[] | null>(null);
+  let index = $state(0);
+  let reviewed = $state(0);
+
+  // Wait for the stores to hydrate before drawing, or a cold load deals an empty
+  // deck and immediately declares the review done.
+  let ready = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
+
+  // Plain flag, not the `deck` state itself: the effect writes `deck`, so reading
+  // it here as the guard would make the effect depend on its own write.
+  let dealt = false;
+
+  $effect(() => {
+    if (dealt || !ready) return;
+    dealt = true;
+    deck = buildHighlightDeck(
+      itemLabelsStore.allHighlights,
+      preferences.highlightReviewCount
+    ).cards;
+  });
+
+  onMount(() => {
+    // Opening the deck is a natural moment to pick up anything new from Margin.
+    // Minute-gated and silent when the toggle is off or the device is offline.
+    void maybeImportMarginHighlights();
+  });
+
+  let total = $derived(deck?.length ?? 0);
+  let current = $derived(deck && index < deck.length ? deck[index] : null);
+  // Re-read from the store so a note edit or Margin save shows immediately —
+  // the deck itself holds the highlight as it was when the deck was dealt.
+  let live = $derived.by(() => {
+    if (!current) return null;
+    const found = itemLabelsStore
+      .getHighlights(current.itemKey)
+      .find((entry) => entry.id === current.highlight.id);
+    return found ?? current.highlight;
+  });
+  let source = $derived.by((): HighlightSource | null =>
+    current
+      ? resolveHighlightSource(current.itemKey, current.itemType, sourceLookups, live ?? undefined)
+      : null
+  );
+  let done = $derived(Boolean(deck) && ready && index >= total);
+
+  function advance() {
+    const entry = current;
+    if (!entry) return;
+    void itemLabelsStore.markHighlightReviewed(entry.itemKey, entry.highlight.id);
+    reviewed += 1;
+    index += 1;
+  }
+
+  // --- Open the source article (in-app when we have it, else the web) ---
+  let readerItem = $state<FeedDisplayItem | null>(null);
+  let savedScrollY = 0;
+
+  $effect(() => {
+    if (!page.state.readerOpen && readerItem) {
+      readerItem = null;
+      requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
+    }
+  });
+
+  function openSource() {
+    const target = source;
+    if (!target) return;
+    if (target.displayItem) {
+      savedScrollY = window.scrollY;
+      readerItem = target.displayItem;
+      pushState('', { readerOpen: true });
+    } else if (target.url) {
+      window.open(target.url, '_blank', 'noopener,noreferrer');
+    }
+  }
+
+  function closeReader() {
+    readerItem = null;
+    history.back();
+    requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
+  }
+
+  // --- Note editing (same popover the reader and the highlights list use) ---
+  let noteAnchor = $state<DOMRect | null>(null);
+
+  function openNoteEditor(event: MouseEvent) {
+    noteAnchor = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  }
+
+  function handleSaveNote(note: string) {
+    const entry = current;
+    const target = source;
+    noteAnchor = null;
+    if (!entry || !target) return;
+    void (async () => {
+      await itemLabelsStore.setHighlightNote(entry.itemKey, entry.highlight.id, note);
+      const updated = itemLabelsStore
+        .getHighlights(entry.itemKey)
+        .find((h) => h.id === entry.highlight.id);
+      if (updated?.marginRkey) {
+        await updateHighlightNoteOnMargin(entry.itemKey, updated, target.url, target.title);
+      }
+    })();
+  }
+
+  function handleSaveToMargin() {
+    const entry = current;
+    const target = source;
+    if (!entry || !target || !live) return;
+    void saveHighlightToMargin(entry.itemKey, live, target.url, target.title);
+  }
+
+  // --- Remove (destructive across apps when the highlight is on Margin) ---
+  let removePrompt = $state(false);
+
+  function confirmRemove() {
+    const entry = current;
+    const highlight = live;
+    removePrompt = false;
+    if (!entry || !highlight) return;
+    void deleteHighlight(entry.itemKey, highlight);
+    // Drop the card without stamping it reviewed — it no longer exists.
+    if (deck) deck = deck.filter((card) => card.highlight.id !== entry.highlight.id);
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (readerItem || noteAnchor || removePrompt || !current) return;
+    const target = event.target as HTMLElement | null;
+    if (target && (target.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) {
+      return;
+    }
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+    if (event.key === 'ArrowRight' || event.key === ' ') {
+      event.preventDefault();
+      advance();
+    } else if (event.key === 'o') {
+      event.preventDefault();
+      openSource();
+    } else if (event.key === 'e') {
+      event.preventDefault();
+      const button = document.querySelector<HTMLElement>('[data-review-note]');
+      noteAnchor = button?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="review-page">
+  <header class="review-header">
+    <div class="header-inner">
+      <NavigationDropdown currentTitle="Review" />
+      {#if current}
+        <span class="progress">{index + 1} of {total}</span>
+      {/if}
+    </div>
+  </header>
+
+  <div class="review-body">
+    {#if !ready || !deck}
+      <p class="state-note" aria-live="polite">Gathering your highlights…</p>
+    {:else if current && source && live}
+      <article class="card">
+        <blockquote class="quote"><mark>{live.selector.exact}</mark></blockquote>
+
+        {#if live.note}
+          <p class="note">{live.note}</p>
+        {/if}
+
+        <button class="source" onclick={openSource}>
+          <span class="source-title">{source.title}</span>
+          {#if source.domain}
+            <span class="source-domain">{source.domain}</span>
+          {/if}
+        </button>
+
+        <div class="actions">
+          <button class="next" onclick={advance}>
+            <span>{index + 1 === total ? 'Finish' : 'Next'}</span>
+            <Icon name="arrow-right" size={16} />
+          </button>
+
+          <div class="secondary">
+            <button
+              class="action-btn"
+              data-review-note
+              onclick={openNoteEditor}
+              title={live.note ? 'Edit note (e)' : 'Add a note (e)'}
+              aria-label={live.note ? 'Edit note' : 'Add a note'}
+            >
+              <Icon name="message-circle" size={16} />
+            </button>
+            {#if !live.marginUri}
+              <button
+                class="action-btn"
+                onclick={handleSaveToMargin}
+                title="Save to Margin"
+                aria-label="Save to Margin"
+              >
+                <Icon name="margin" size={16} />
+              </button>
+            {/if}
+            <button
+              class="action-btn"
+              onclick={openSource}
+              title="Open the article (o)"
+              aria-label="Open the article"
+            >
+              <Icon name="external-link" size={16} />
+            </button>
+            <button
+              class="action-btn danger"
+              onclick={() => (removePrompt = true)}
+              title="Remove highlight"
+              aria-label="Remove highlight"
+            >
+              <Icon name="trash" size={16} />
+            </button>
+          </div>
+        </div>
+      </article>
+
+      <p class="hint">→ next · o open · e note</p>
+    {:else if done && reviewed > 0}
+      <section class="state" aria-live="polite">
+        <h1>That's your review</h1>
+        <p>{reviewed} highlight{reviewed === 1 ? '' : 's'} revisited.</p>
+        <a href="/highlights">All highlights</a>
+      </section>
+    {:else}
+      <section class="state" aria-live="polite">
+        <h1>Nothing to review right now</h1>
+        <p>
+          Highlight a passage while reading and it joins the deck. Come back tomorrow for another
+          handful.
+        </p>
+        <a href="/highlights">All highlights</a>
+      </section>
+    {/if}
+  </div>
+</div>
+
+{#if noteAnchor}
+  <HighlightPopover
+    mode="view"
+    initialView="note"
+    anchorRect={noteAnchor}
+    existingNote={live?.note ?? ''}
+    onSaveNote={handleSaveNote}
+    onClose={() => (noteAnchor = null)}
+  />
+{/if}
+
+<RemoveHighlightModal
+  open={removePrompt}
+  onMargin={Boolean(live?.marginUri)}
+  onRemove={confirmRemove}
+  onclose={() => (removePrompt = false)}
+/>
+
+{#if readerItem}
+  <SavedReader {readerItem} onClose={closeReader} />
+{/if}
+
+<style>
+  .review-page {
+    width: 100%;
+  }
+
+  /* Flat header matching the highlights page: no border at rest, no shadow. */
+  .review-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--color-bg);
+  }
+
+  .header-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 0.75rem 1rem;
+  }
+
+  .progress {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .review-body {
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  /* The 3px gold rule on a quoted highlight — the one sanctioned colored
+     side-border, as a quotation convention (DESIGN.md). */
+  .quote {
+    margin: 0;
+    padding: 0.125rem 0 0.125rem 1rem;
+    border-left: 3px solid color-mix(in srgb, #f5c518 70%, transparent);
+  }
+
+  .quote mark {
+    background-color: color-mix(in srgb, #f5c518 25%, transparent);
+    color: inherit;
+    border-radius: 1px;
+    font-size: var(--text-lg);
+    line-height: var(--leading-relaxed, 1.6);
+  }
+
+  .note {
+    margin: 0;
+    padding-left: 1rem;
+    font-size: var(--text-md);
+    line-height: var(--leading-relaxed, 1.6);
+    color: var(--color-text-secondary);
+    white-space: pre-wrap;
+  }
+
+  .source {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.125rem;
+    width: 100%;
+    padding: 0 0 0 1rem;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .source-title {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    color: var(--color-text);
+  }
+
+  .source:hover .source-title {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+
+  .source-domain {
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  /* One primary action per card, in the one interaction blue. */
+  .next {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 44px;
+    padding: 0.5rem 1.1rem;
+    border: 0;
+    border-radius: 6px;
+    background: var(--color-primary);
+    color: #fff;
+    font: inherit;
+    font-weight: var(--weight-semibold);
+    cursor: pointer;
+    transition: filter 0.2s ease;
+  }
+
+  .next:hover {
+    filter: brightness(0.95);
+  }
+
+  .secondary {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .action-btn:hover {
+    color: var(--color-text);
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  .action-btn.danger:hover {
+    color: var(--color-error, #cc0000);
+  }
+
+  .hint {
+    margin: 1.5rem 0 0;
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .state {
+    display: grid;
+    gap: 0.5rem;
+    padding: 2rem 0;
+  }
+
+  .state h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: var(--leading-tight);
+  }
+
+  .state p {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .state a {
+    width: fit-content;
+    margin-top: 0.5rem;
+    color: var(--color-primary);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+  }
+
+  .state-note {
+    margin: 2rem 0 0;
+    color: var(--color-text-secondary);
+  }
+
+  /* The keyboard hint is meaningless without a keyboard. */
+  @media (hover: none) {
+    .hint {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -160,10 +160,241 @@
     const entry = current;
     if (!entry) return;
     interacted = true;
+    dismissRetireNotice();
     void itemLabelsStore.markHighlightReviewed(entry.itemKey, entry.highlight.id);
     reviewed += 1;
     index += 1;
   }
+
+  // Going back is navigation, not un-reviewing: the card you already advanced
+  // past keeps its stamp, so stepping back to re-read it and moving on again
+  // doesn't double-count or resurrect it tomorrow. It exists so a mis-swipe
+  // costs a gesture rather than the passage.
+  function stepBack() {
+    if (index === 0) return;
+    interacted = true;
+    dismissRetireNotice();
+    index -= 1;
+  }
+
+  // --- Don't show again: retire from the deck without deleting anything ------
+  //
+  // The highlight stays in the highlights list and on Margin; it just stops
+  // being dealt, on every device. Not destructive, so it takes no confirmation
+  // — but the card vanishes on the press, so the undo below is what tells the
+  // reader it worked and what makes the choice cheap to make.
+  const RETIRE_UNDO_MS = 10000;
+  let retireNotice = $state<{ entry: HighlightEntry; position: number } | null>(null);
+  let retireTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function dismissRetireNotice() {
+    clearTimeout(retireTimer);
+    retireNotice = null;
+  }
+
+  function retireCurrent() {
+    const entry = current;
+    if (!entry) return;
+    interacted = true;
+    void itemLabelsStore.setHighlightReviewRetired(entry.itemKey, entry.highlight.id, true);
+    // Drop it without stamping it reviewed — it isn't a review, it's a recusal.
+    // The index stays put, so the next card slides into this one's place.
+    if (deck) deck = deck.filter((card) => card.highlight.id !== entry.highlight.id);
+    clearTimeout(retireTimer);
+    retireNotice = { entry, position: index };
+    retireTimer = setTimeout(() => (retireNotice = null), RETIRE_UNDO_MS);
+  }
+
+  function undoRetire() {
+    const pending = retireNotice;
+    dismissRetireNotice();
+    if (!pending) return;
+    void itemLabelsStore.setHighlightReviewRetired(
+      pending.entry.itemKey,
+      pending.entry.highlight.id,
+      false
+    );
+    if (!deck) return;
+    const restored = [...deck];
+    const at = Math.min(pending.position, restored.length);
+    restored.splice(at, 0, pending.entry);
+    deck = restored;
+    index = at;
+  }
+
+  // --- Swipe: the deck is a deck, so it should move like one -----------------
+  //
+  // Right carries you forward and left brings the last card back, matching the
+  // arrow keys and the Next button rather than inventing a second grammar. The
+  // card follows the finger and commits on release, so a half-swipe shows you
+  // what it would do and springs back when you don't mean it. Touch only: on a
+  // pointer, dragging a passage is how you select it.
+  const AXIS_DECIDE_PX = 8;
+  const COMMIT_RATIO = 0.22;
+  const FLICK_VELOCITY = 0.4; // px per ms
+  const EXIT_MS = 190;
+  const ENTER_MS = 260;
+  const SETTLE_MS = 240;
+
+  let cardEl = $state<HTMLElement | null>(null);
+  let dragX = $state(0);
+  let travelMs = $state(0);
+  let animating = $state(false);
+
+  // The card thins out as it leaves rather than sliding at full strength, so the
+  // passage reads as handed off instead of yanked away.
+  let cardOpacity = $derived(
+    dragX === 0 ? 1 : Math.max(0.25, 1 - Math.abs(dragX) / ((cardEl?.offsetWidth || 480) * 0.9))
+  );
+
+  function prefersReducedMotion(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+    );
+  }
+
+  function resetTravel() {
+    travelMs = 0;
+    dragX = 0;
+    animating = false;
+  }
+
+  function settleBack() {
+    travelMs = prefersReducedMotion() ? 0 : SETTLE_MS;
+    dragX = 0;
+  }
+
+  /** Commit a swipe: 1 moves forward through the deck, -1 steps back. */
+  function commitSwipe(direction: 1 | -1) {
+    if (animating) return;
+    if (direction === -1 && index === 0) {
+      settleBack();
+      return;
+    }
+    if (prefersReducedMotion()) {
+      resetTravel();
+      if (direction === 1) advance();
+      else stepBack();
+      return;
+    }
+    animating = true;
+    travelMs = EXIT_MS;
+    dragX = direction * ((cardEl?.offsetWidth || 480) + 64);
+    setTimeout(() => {
+      if (direction === 1) advance();
+      else stepBack();
+      // Nothing left to fly in — the end-of-deck state takes the column.
+      if (!deck || index >= deck.length) {
+        resetTravel();
+        return;
+      }
+      // Land the incoming card from the side the outgoing one left toward.
+      travelMs = 0;
+      dragX = -direction * Math.min((cardEl?.offsetWidth || 480) * 0.18, 88);
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          travelMs = ENTER_MS;
+          dragX = 0;
+          setTimeout(() => (animating = false), ENTER_MS);
+        })
+      );
+    }, EXIT_MS);
+  }
+
+  let touchStartX = 0;
+  let touchStartY = 0;
+  let touchLastX = 0;
+  let touchLastT = 0;
+  let touchVelocity = 0;
+  let touchDecided = false;
+  let dragging = false;
+
+  function hasActiveSelection(): boolean {
+    const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+    return !!selection && !selection.isCollapsed && selection.toString().trim().length > 0;
+  }
+
+  function onTouchStart(event: TouchEvent) {
+    if (animating || event.touches.length !== 1) {
+      dragging = false;
+      touchDecided = false;
+      return;
+    }
+    touchStartX = event.touches[0].clientX;
+    touchStartY = event.touches[0].clientY;
+    touchLastX = touchStartX;
+    touchLastT = performance.now();
+    touchVelocity = 0;
+    touchDecided = false;
+    dragging = false;
+  }
+
+  function onTouchMove(event: TouchEvent) {
+    if (animating || event.touches.length !== 1) return;
+    const x = event.touches[0].clientX;
+    const dx = x - touchStartX;
+    const dy = event.touches[0].clientY - touchStartY;
+    if (!touchDecided) {
+      if (Math.abs(dx) < AXIS_DECIDE_PX && Math.abs(dy) < AXIS_DECIDE_PX) return;
+      touchDecided = true;
+      // Vertical intent scrolls the page; a live selection belongs to the
+      // browser's own handles, not to us.
+      if (Math.abs(dx) > Math.abs(dy) && !hasActiveSelection()) {
+        dragging = true;
+        travelMs = 0;
+      }
+    }
+    if (!dragging) return;
+    if (hasActiveSelection()) {
+      dragging = false;
+      settleBack();
+      return;
+    }
+    if (event.cancelable) event.preventDefault();
+    // There's nothing behind the first card, so a leftward pull resists rather
+    // than promising a move that can't happen.
+    dragX = dx < 0 && index === 0 ? dx * 0.28 : dx;
+    const now = performance.now();
+    const dt = now - touchLastT;
+    if (dt > 0) touchVelocity = (x - touchLastX) / dt;
+    touchLastX = x;
+    touchLastT = now;
+  }
+
+  function onTouchEnd() {
+    const wasDragging = dragging;
+    dragging = false;
+    touchDecided = false;
+    if (!wasDragging) return;
+    const width = cardEl?.offsetWidth || 480;
+    const far = Math.abs(dragX) > width * COMMIT_RATIO;
+    const flicked = Math.abs(touchVelocity) > FLICK_VELOCITY && Math.abs(dragX) > 24;
+    if (!far && !flicked) {
+      settleBack();
+      return;
+    }
+    commitSwipe(dragX > 0 ? 1 : -1);
+  }
+
+  // touchmove has to be non-passive to claim the horizontal gesture, so it's
+  // attached by hand rather than through the (passive) on* attributes.
+  $effect(() => {
+    const el = cardEl;
+    if (!el) return;
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', onTouchEnd, { passive: true });
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', onTouchEnd);
+    };
+  });
+
+  $effect(() => () => clearTimeout(retireTimer));
 
   // --- Open the source article (in-app when we have it, else the web) ---
   let readerItem = $state<FeedDisplayItem | null>(null);
@@ -262,7 +493,10 @@
 
     if (event.key === 'ArrowRight' || event.key === ' ') {
       event.preventDefault();
-      advance();
+      if (!animating) commitSwipe(1);
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      if (!animating && index > 0) commitSwipe(-1);
     } else if (event.key === 'o') {
       event.preventDefault();
       openSource();
@@ -290,6 +524,8 @@
     encoreMode = isEncore;
     index = 0;
     interacted = false;
+    dismissRetireNotice();
+    resetTravel();
     dealDeck();
   }
 
@@ -344,6 +580,15 @@
       <div class="header-nav"><NavigationDropdown currentTitle="Review" /></div>
       <div class="header-actions">
         {#if current}
+          <button
+            class="step-back"
+            onclick={() => commitSwipe(-1)}
+            disabled={index === 0 || animating}
+            title="Previous highlight (left arrow)"
+            aria-label="Previous highlight"
+          >
+            <Icon name="chevron-left" size={16} />
+          </button>
           <span class="progress">{index + 1} of {total}</span>
         {/if}
         <button
@@ -371,8 +616,16 @@
     {#if !ready || !deck}
       <p class="state-note" aria-live="polite">Gathering your highlights…</p>
     {:else if current && source && live}
-      <article class="card">
-        <blockquote class="quote"><mark>{live.selector.exact}</mark></blockquote>
+      <article
+        class="deck-card"
+        bind:this={cardEl}
+        style:transform={dragX === 0 ? undefined : `translate3d(${dragX}px, 0, 0)`}
+        style:opacity={cardOpacity === 1 ? undefined : cardOpacity}
+        style:transition={travelMs === 0
+          ? 'none'
+          : `transform ${travelMs}ms cubic-bezier(0.22, 1, 0.36, 1), opacity ${travelMs}ms ease`}
+      >
+        <blockquote class="passage">{live.selector.exact}</blockquote>
 
         {#if live.note}
           <p class="note">{live.note}</p>
@@ -386,10 +639,21 @@
         </button>
 
         <div class="actions">
-          <button class="next" onclick={advance}>
-            <span>{index + 1 === total ? 'Finish' : 'Next'}</span>
-            <Icon name="arrow-right" size={16} />
-          </button>
+          <div class="lead">
+            <button class="next" onclick={() => commitSwipe(1)} disabled={animating}>
+              <span>{index + 1 === total ? 'Finish' : 'Next'}</span>
+              <Icon name="arrow-right" size={16} />
+            </button>
+
+            <button
+              class="retire"
+              onclick={retireCurrent}
+              title="Keep the highlight, stop dealing it in review"
+            >
+              <Icon name="circle-slash" size={15} />
+              <span>Don't show again</span>
+            </button>
+          </div>
 
           <div class="secondary">
             <button
@@ -431,7 +695,10 @@
         </div>
       </article>
 
-      <p class="hint">→ next · o open · e note</p>
+      <p class="hint">→ next · ← back · o open · e note</p>
+      {#if index === 0 && total > 1}
+        <p class="swipe-hint">Swipe to move through the deck.</p>
+      {/if}
     {:else if done && reviewed > 0}
       <section class="state" aria-live="polite">
         <h1>That's your review</h1>
@@ -454,6 +721,13 @@
         <p>Highlight a passage while reading and it joins the deck.</p>
         <a href="/highlights">All highlights</a>
       </section>
+    {/if}
+
+    {#if retireNotice}
+      <p class="retired-note" aria-live="polite">
+        <span>Kept, but it won't come up in review again.</span>
+        <button onclick={undoRetire}>Undo</button>
+      </p>
     {/if}
   </div>
 
@@ -555,6 +829,37 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* Where you are in the deck and how to go back belong together, so the back
+     control sits with the count rather than in the card. */
+  .step-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    margin-right: -0.375rem;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease,
+      opacity 0.15s ease;
+  }
+
+  .step-back:hover:not(:disabled) {
+    color: var(--color-text);
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  .step-back:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
   .gear {
     display: inline-flex;
     align-items: center;
@@ -586,10 +891,13 @@
     border-radius: 8px;
   }
 
+  /* `overflow-x: clip` gives the card somewhere to go on a swipe without turning
+     the column into a scroll container. */
   .review-body {
     max-width: 680px;
     margin: 0 auto;
     padding: 1.5rem 1rem 4rem;
+    overflow-x: clip;
   }
 
   @media (max-width: 1000px) {
@@ -615,31 +923,31 @@
     }
   }
 
-  .card {
+  /* The card is the highlight, so marking the passage would be marking the whole
+     surface. No gold, no chrome: the reader's own article face at reading size,
+     alone in the column, with everything else stepping back to metadata scale.
+     `touch-action: pan-y` leaves vertical scrolling to the page and claims the
+     horizontal axis for the swipe. */
+  .deck-card {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    padding-top: clamp(0.5rem, 3vh, 1.5rem);
+    touch-action: pan-y;
   }
 
-  /* The 3px gold rule on a quoted highlight — the one sanctioned colored
-     side-border, as a quotation convention (DESIGN.md). */
-  .quote {
+  .passage {
     margin: 0;
-    padding: 0.125rem 0 0.125rem 1rem;
-    border-left: 3px solid color-mix(in srgb, #f5c518 70%, transparent);
-  }
-
-  .quote mark {
-    background-color: color-mix(in srgb, #f5c518 25%, transparent);
-    color: inherit;
-    border-radius: 1px;
-    font-size: var(--text-lg);
-    line-height: var(--leading-relaxed, 1.6);
+    font-family: var(--article-font);
+    font-size: calc(var(--article-font-size, 1.125rem) * 1.15);
+    line-height: 1.55;
+    color: var(--color-text);
+    text-wrap: pretty;
   }
 
   .note {
-    margin: 0;
-    padding-left: 1rem;
+    margin: 1.25rem 0 0;
+    padding-left: 0.875rem;
+    border-left: 1px solid var(--color-border);
     font-size: var(--text-md);
     line-height: var(--leading-relaxed, 1.6);
     color: var(--color-text-secondary);
@@ -652,7 +960,8 @@
     align-items: flex-start;
     gap: 0.125rem;
     width: 100%;
-    padding: 0 0 0 1rem;
+    margin-top: 2rem;
+    padding: 0;
     background: none;
     border: none;
     text-align: left;
@@ -680,10 +989,19 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    margin-top: 0.5rem;
+    gap: 0.75rem 1rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
     padding-top: 1rem;
     border-top: 1px solid var(--color-border);
+  }
+
+  /* The two decisions a card asks for — move on, or stop asking — sit together;
+     the icon cluster stays what it was, tools rather than decisions. */
+  .lead {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   /* One primary action per card, in the one interaction blue. */
@@ -703,8 +1021,39 @@
     transition: filter 0.2s ease;
   }
 
-  .next:hover {
+  .next:hover:not(:disabled) {
     filter: brightness(0.95);
+  }
+
+  .next:disabled {
+    cursor: default;
+  }
+
+  /* Not destructive and not urgent: nothing is deleted, so it stays a quiet
+     bordered control rather than borrowing the danger red. */
+  .retire {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 44px;
+    padding: 0.5rem 0.9rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .retire:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-secondary);
   }
 
   .secondary {
@@ -739,10 +1088,37 @@
     color: var(--color-error, #cc0000);
   }
 
-  .hint {
+  .hint,
+  .swipe-hint {
     margin: 1.5rem 0 0;
     font-size: var(--text-xs);
     color: var(--color-text-secondary);
+  }
+
+  /* Retiring makes the card disappear, so this line is the only proof the press
+     did what it said — and the only cheap way back from a mis-tap. */
+  .retired-note {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.75rem;
+    margin: 1.5rem 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .retired-note button {
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--color-primary);
+    font: inherit;
+    font-weight: var(--weight-semibold);
+    cursor: pointer;
+  }
+
+  .retired-note button:hover {
+    text-decoration: underline;
   }
 
   .state {
@@ -806,10 +1182,47 @@
     color: var(--color-text-secondary);
   }
 
-  /* The keyboard hint is meaningless without a keyboard. */
+  /* The keyboard hint is meaningless without a keyboard, and the swipe cue is
+     meaningless with one. */
   @media (hover: none) {
     .hint {
       display: none;
+    }
+  }
+
+  @media (hover: hover) {
+    .swipe-hint {
+      display: none;
+    }
+  }
+
+  @media (max-width: 560px) {
+    /* Two decisions deserve the full width down here; the tools follow beneath. */
+    .lead {
+      width: 100%;
+    }
+
+    .retire {
+      flex: 1;
+      justify-content: center;
+    }
+
+    .secondary {
+      width: 100%;
+    }
+  }
+
+  /* The card's travel is driven from script (it follows a finger), so the
+     reduced-motion path lives there too — commits jump rather than slide. This
+     covers the declarative transitions around it. */
+  @media (prefers-reduced-motion: reduce) {
+    .step-back,
+    .next,
+    .retire,
+    .action-btn,
+    .gear,
+    .more {
+      transition: none;
     }
   }
 </style>

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -3,8 +3,6 @@
   // time. Deliberately not a durable issue like the daily magazine: a session is
   // a few minutes, so the deck is derived at open and repeat-avoidance rides the
   // per-highlight `lastReviewedAt` stamp, which syncs with the highlight itself.
-  import { pushState } from '$app/navigation';
-  import { page } from '$app/state';
   import NavigationDropdown from '$lib/components/NavigationDropdown.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
@@ -24,6 +22,7 @@
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import {
     saveHighlightToMargin,
@@ -34,15 +33,17 @@
   import {
     buildHighlightDeck,
     deckUntouched,
+    REVIEW_INTENT_DEFAULT,
     shouldRedealAfterImport,
     type HighlightEntry,
   } from '$lib/utils/highlightReview';
+  import type { ReviewIntent } from '$lib/types';
   import {
     buildHighlightSourceLookups,
     resolveHighlightSource,
     type HighlightSource,
   } from '$lib/utils/highlightSource';
-  import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
+  import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
 
   $effect(() => {
     viewTitleStore.set('Review');
@@ -53,7 +54,8 @@
     buildHighlightSourceLookups(
       articlesStore.allArticles,
       socialStore.documents,
-      savesStore.articles
+      savesStore.articles,
+      subscriptionsStore.subscriptions
     )
   );
 
@@ -65,6 +67,12 @@
   // Session tally, across every hand — `index` and `interacted` are per hand.
   let reviewed = $state(0);
   let interacted = $state(false);
+  // What this hand has already tallied. Stepping back and coming forward again
+  // is navigation, not a second review — and the deck can shrink underneath the
+  // reader (a retire, a removal), so a position high-water mark would then skip
+  // the card that slid into a place already passed. The highlight is the mark.
+  // Plain, not `$state`: `reviewed` is the reactive half, this only gates it.
+  let countedThisHand = new Set<string>();
 
   // Deal as soon as the local stores hydrate — everything needed for a session is
   // already on the device, so a Margin poll must never stand between the reader
@@ -160,9 +168,13 @@
     const entry = current;
     if (!entry) return;
     interacted = true;
+    intentOpen = false;
     dismissRetireNotice();
     void itemLabelsStore.markHighlightReviewed(entry.itemKey, entry.highlight.id);
-    reviewed += 1;
+    if (!countedThisHand.has(entry.highlight.id)) {
+      countedThisHand.add(entry.highlight.id);
+      reviewed += 1;
+    }
     index += 1;
   }
 
@@ -173,18 +185,68 @@
   function stepBack() {
     if (index === 0) return;
     interacted = true;
+    intentOpen = false;
     dismissRetireNotice();
     index -= 1;
   }
 
-  // --- Don't show again: retire from the deck without deleting anything ------
+  // --- Frequency tuning: when should this one come back? --------------------
   //
-  // The highlight stays in the highlights list and on Margin; it just stops
-  // being dealt, on every device. Not destructive, so it takes no confirmation
-  // — but the card vanishes on the press, so the undo below is what tells the
-  // reader it worked and what makes the choice cheap to make.
+  // One control per card answering one question. 'later' is the neutral middle
+  // and the default, so an untuned highlight reads as "Later" rather than as an
+  // empty setting. 'never' is the only choice that changes this session: it
+  // drops the card, which is why it alone gets the undo below.
+  const REVIEW_INTENTS: { value: ReviewIntent; label: string; hint: string }[] = [
+    { value: 'soon', label: 'Soon', hint: 'ahead of the rest' },
+    { value: 'later', label: 'Later', hint: 'the usual pace' },
+    { value: 'someday', label: 'Someday', hint: 'now and then' },
+    { value: 'never', label: 'Never', hint: 'stop showing it' },
+  ];
+
+  let intentOpen = $state(false);
+  let intentAnchor = $state<HTMLElement | null>(null);
+  let currentIntent = $derived<ReviewIntent>(live?.reviewIntent ?? REVIEW_INTENT_DEFAULT);
+  let currentIntentLabel = $derived(
+    REVIEW_INTENTS.find((option) => option.value === currentIntent)?.label ?? 'Later'
+  );
+
+  function openIntentMenu() {
+    // Freeze before the menu opens: the import can finish while it's up, and the
+    // setting must land on the card the reader was looking at.
+    interacted = true;
+    intentOpen = true;
+  }
+
+  function chooseIntent(intent: ReviewIntent) {
+    const entry = current;
+    intentOpen = false;
+    if (!entry) return;
+    interacted = true;
+    // Captured before the write, because undo has to put back the pace the
+    // reader was on, not the default. Read from `live`, not the deck entry: the
+    // deck holds the highlight as it was dealt, so a reader who sets Soon and
+    // then Never on the same card would otherwise undo to the default.
+    const previous = (live ?? entry.highlight).reviewIntent ?? null;
+    // Passing null for the default keeps an untuned highlight untouched rather
+    // than writing a field that means "unset" anyway.
+    void itemLabelsStore.setHighlightReviewIntent(
+      entry.itemKey,
+      entry.highlight.id,
+      intent === REVIEW_INTENT_DEFAULT ? null : intent
+    );
+    if (intent === 'never') dropCurrentCard(entry, previous);
+  }
+
+  // 'never' is the one setting that acts on this session. The card vanishes on
+  // the press, so this notice is the only proof it worked and the only cheap way
+  // back from a mis-tap.
   const RETIRE_UNDO_MS = 10000;
-  let retireNotice = $state<{ entry: HighlightEntry; position: number } | null>(null);
+  let retireNotice = $state<{
+    entry: HighlightEntry;
+    position: number;
+    /** The pace the highlight was on before Never, so undo can put it back. */
+    previous: ReviewIntent | null;
+  } | null>(null);
   let retireTimer: ReturnType<typeof setTimeout> | undefined;
 
   function dismissRetireNotice() {
@@ -192,16 +254,12 @@
     retireNotice = null;
   }
 
-  function retireCurrent() {
-    const entry = current;
-    if (!entry) return;
-    interacted = true;
-    void itemLabelsStore.setHighlightReviewRetired(entry.itemKey, entry.highlight.id, true);
-    // Drop it without stamping it reviewed — it isn't a review, it's a recusal.
-    // The index stays put, so the next card slides into this one's place.
+  function dropCurrentCard(entry: HighlightEntry, previous: ReviewIntent | null) {
+    // Dropped without a reviewed stamp — it isn't a review, it's a recusal. The
+    // index stays put, so the next card slides into this one's place.
     if (deck) deck = deck.filter((card) => card.highlight.id !== entry.highlight.id);
     clearTimeout(retireTimer);
-    retireNotice = { entry, position: index };
+    retireNotice = { entry, position: index, previous };
     retireTimer = setTimeout(() => (retireNotice = null), RETIRE_UNDO_MS);
   }
 
@@ -209,10 +267,12 @@
     const pending = retireNotice;
     dismissRetireNotice();
     if (!pending) return;
-    void itemLabelsStore.setHighlightReviewRetired(
+    // Undo means "as you were", so restore the pace Never replaced. Writing null
+    // here would quietly reset a 'soon' or 'someday' highlight to the default.
+    void itemLabelsStore.setHighlightReviewIntent(
       pending.entry.itemKey,
       pending.entry.highlight.id,
-      false
+      pending.previous
     );
     if (!deck) return;
     const restored = [...deck];
@@ -224,8 +284,8 @@
 
   // --- Swipe: the deck is a deck, so it should move like one -----------------
   //
-  // Right carries you forward and left brings the last card back, matching the
-  // arrow keys and the Next button rather than inventing a second grammar. The
+  // Left carries you forward and right brings the last card back: the deck
+  // moves the way the cards do, sliding off toward where you pushed it. The
   // card follows the finger and commits on release, so a half-swipe shows you
   // what it would do and springs back when you don't mean it. Touch only: on a
   // pointer, dragging a passage is how you select it.
@@ -265,6 +325,19 @@
     dragX = 0;
   }
 
+  // Leaving the deck mid-flight would otherwise leave three callbacks queued
+  // against a component that no longer exists, the last of them clearing a
+  // freeze flag the next mount never set.
+  let exitTimer: ReturnType<typeof setTimeout> | undefined;
+  let enterTimer: ReturnType<typeof setTimeout> | undefined;
+  let enterFrame = 0;
+
+  $effect(() => () => {
+    clearTimeout(exitTimer);
+    clearTimeout(enterTimer);
+    cancelAnimationFrame(enterFrame);
+  });
+
   /** Commit a swipe: 1 moves forward through the deck, -1 steps back. */
   function commitSwipe(direction: 1 | -1) {
     if (animating) return;
@@ -272,6 +345,10 @@
       settleBack();
       return;
     }
+    // Freeze here rather than in advance()/stepBack(): those run a frame-time
+    // later, and an import resolving inside that window would find the deck
+    // untouched and redeal it out from under the card already flying off.
+    interacted = true;
     if (prefersReducedMotion()) {
       resetTravel();
       if (direction === 1) advance();
@@ -280,8 +357,9 @@
     }
     animating = true;
     travelMs = EXIT_MS;
-    dragX = direction * ((cardEl?.offsetWidth || 480) + 64);
-    setTimeout(() => {
+    // Forward sends the card off to the left, back sends it off to the right.
+    dragX = -direction * ((cardEl?.offsetWidth || 480) + 64);
+    exitTimer = setTimeout(() => {
       if (direction === 1) advance();
       else stepBack();
       // Nothing left to fly in — the end-of-deck state takes the column.
@@ -289,16 +367,16 @@
         resetTravel();
         return;
       }
-      // Land the incoming card from the side the outgoing one left toward.
+      // Land the incoming card from the side opposite the one that just left.
       travelMs = 0;
-      dragX = -direction * Math.min((cardEl?.offsetWidth || 480) * 0.18, 88);
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => {
+      dragX = direction * Math.min((cardEl?.offsetWidth || 480) * 0.18, 88);
+      enterFrame = requestAnimationFrame(() => {
+        enterFrame = requestAnimationFrame(() => {
           travelMs = ENTER_MS;
           dragX = 0;
-          setTimeout(() => (animating = false), ENTER_MS);
-        })
-      );
+          enterTimer = setTimeout(() => (animating = false), ENTER_MS);
+        });
+      });
     }, EXIT_MS);
   }
 
@@ -316,7 +394,7 @@
   }
 
   function onTouchStart(event: TouchEvent) {
-    if (animating || event.touches.length !== 1) {
+    if (animating || intentOpen || event.touches.length !== 1) {
       dragging = false;
       touchDecided = false;
       return;
@@ -331,7 +409,7 @@
   }
 
   function onTouchMove(event: TouchEvent) {
-    if (animating || event.touches.length !== 1) return;
+    if (animating || intentOpen || event.touches.length !== 1) return;
     const x = event.touches[0].clientX;
     const dx = x - touchStartX;
     const dy = event.touches[0].clientY - touchStartY;
@@ -352,9 +430,9 @@
       return;
     }
     if (event.cancelable) event.preventDefault();
-    // There's nothing behind the first card, so a leftward pull resists rather
+    // There's nothing behind the first card, so a rightward pull resists rather
     // than promising a move that can't happen.
-    dragX = dx < 0 && index === 0 ? dx * 0.28 : dx;
+    dragX = dx > 0 && index === 0 ? dx * 0.28 : dx;
     const now = performance.now();
     const dt = now - touchLastT;
     if (dt > 0) touchVelocity = (x - touchLastX) / dt;
@@ -374,7 +452,7 @@
       settleBack();
       return;
     }
-    commitSwipe(dragX > 0 ? 1 : -1);
+    commitSwipe(dragX < 0 ? 1 : -1);
   }
 
   // touchmove has to be non-passive to claim the horizontal gesture, so it's
@@ -397,32 +475,23 @@
   $effect(() => () => clearTimeout(retireTimer));
 
   // --- Open the source article (in-app when we have it, else the web) ---
-  let readerItem = $state<FeedDisplayItem | null>(null);
-  let savedScrollY = 0;
-
-  $effect(() => {
-    if (!page.state.readerOpen && readerItem) {
-      readerItem = null;
-      requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
-    }
-  });
+  // The shared reader stack, so the deck gets Back-to-close, scroll restore and a
+  // `?read=` URL on the same terms as every other surface.
+  const reader = useReaderStack();
+  let readerItem = $derived(reader.readerItem);
 
   function openSource() {
     const target = source;
     if (!target) return;
+    // Freeze like every other card action: going off to read the article is
+    // exactly when a late import must not redeal the deck, or closing the
+    // reader would land the reader on a different card than they left.
+    interacted = true;
     if (target.displayItem) {
-      savedScrollY = window.scrollY;
-      readerItem = target.displayItem;
-      pushState('', { readerOpen: true });
+      reader.openReader(target.displayItem);
     } else if (target.url) {
       window.open(target.url, '_blank', 'noopener,noreferrer');
     }
-  }
-
-  function closeReader() {
-    readerItem = null;
-    history.back();
-    requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
   }
 
   // --- Note editing (same popover the reader and the highlights list use) ---
@@ -484,14 +553,30 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (readerItem || noteAnchor || removePrompt || !current) return;
+    if (intentOpen && event.key === 'Escape') {
+      intentOpen = false;
+      intentAnchor?.focus();
+      return;
+    }
+    // Every surface this component can put over the deck suppresses the deck's
+    // own shortcuts — the mobile sheets included, or an arrow key would advance
+    // and stamp a card the reader can't even see.
+    if (readerItem || noteAnchor || removePrompt || intentOpen) return;
+    if (feedSwitcherOpen || notifSheetOpen || !current) return;
     const target = event.target as HTMLElement | null;
     if (target && (target.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) {
       return;
     }
     if (event.metaKey || event.ctrlKey || event.altKey) return;
 
-    if (event.key === 'ArrowRight' || event.key === ' ') {
+    // Space already belongs to whatever control has focus — it's how a button or
+    // link is pressed. Claiming it here would advance the deck instead of
+    // activating the button, leaving a keyboard-only reader unable to work any of
+    // the deck's own controls. The arrows and letter shortcuts have no such
+    // owner, so they stay live wherever focus sits.
+    const activatable = target ? /^(BUTTON|A)$/.test(target.tagName) : false;
+
+    if (event.key === 'ArrowRight' || (event.key === ' ' && !activatable)) {
       event.preventDefault();
       if (!animating) commitSwipe(1);
     } else if (event.key === 'ArrowLeft') {
@@ -519,10 +604,17 @@
   let moreDue = $derived(highlightReviewStore.dueCount);
   let isEncore = $derived(moreDue === 0);
   let canReviewMore = $derived(highlightReviewStore.hasHighlights);
+  // A corpus that is entirely retired has nothing to deal, so it takes the same
+  // branch as no highlights at all — but "highlight a passage" is the wrong
+  // instruction for a reader whose list is full and whose every card says never.
+  let corpusEmpty = $derived(itemLabelsStore.allHighlights.length === 0);
 
   function reviewMore() {
     encoreMode = isEncore;
     index = 0;
+    // Per hand, not per session: an encore deals cards seen earlier today, and
+    // revisiting one again really is another review.
+    countedThisHand = new Set();
     interacted = false;
     dismissRetireNotice();
     resetTravel();
@@ -561,6 +653,28 @@
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
+
+{#snippet intentChoices()}
+  {#each REVIEW_INTENTS as option (option.value)}
+    <!-- Never is not a pace, it's an exit: the rule says so before the label has
+         to. -->
+    {#if option.value === 'never'}
+      <div class="intent-divider"></div>
+    {/if}
+    <button
+      class="intent-option"
+      class:selected={option.value === currentIntent}
+      onclick={() => chooseIntent(option.value)}
+      aria-pressed={option.value === currentIntent}
+    >
+      <span class="intent-check">
+        {#if option.value === currentIntent}<Icon name="check" size={14} />{/if}
+      </span>
+      <span class="intent-label">{option.label}</span>
+      <span class="intent-hint">{option.hint}</span>
+    </button>
+  {/each}
+{/snippet}
 
 {#snippet moreButton()}
   {#if canReviewMore}
@@ -639,20 +753,32 @@
         </button>
 
         <div class="actions">
-          <div class="lead">
+          <div class="lead" class:menu-open={intentOpen}>
             <button class="next" onclick={() => commitSwipe(1)} disabled={animating}>
               <span>{index + 1 === total ? 'Finish' : 'Next'}</span>
               <Icon name="arrow-right" size={16} />
             </button>
 
             <button
-              class="retire"
-              onclick={retireCurrent}
-              title="Keep the highlight, stop dealing it in review"
+              class="intent"
+              class:open={intentOpen}
+              bind:this={intentAnchor}
+              onclick={() => (intentOpen ? (intentOpen = false) : openIntentMenu())}
+              aria-expanded={intentOpen}
+              aria-haspopup="true"
+              aria-label="When should this come back? Currently {currentIntentLabel}"
+              title="When should this come back?"
             >
-              <Icon name="circle-slash" size={15} />
-              <span>Don't show again</span>
+              <Icon name="clock" size={15} />
+              <span>{currentIntentLabel}</span>
+              <Icon name="chevron-down" size={14} />
             </button>
+
+            {#if intentOpen && !mobileStore.isMobile}
+              <div class="intent-menu" role="group" aria-label="When should this come back?">
+                {@render intentChoices()}
+              </div>
+            {/if}
           </div>
 
           <div class="secondary">
@@ -695,10 +821,8 @@
         </div>
       </article>
 
-      <p class="hint">→ next · ← back · o open · e note</p>
-      {#if index === 0 && total > 1}
-        <p class="swipe-hint">Swipe to move through the deck.</p>
-      {/if}
+      <p class="hint">→ or space next · ← back · o open · e note</p>
+      <p class="swipe-hint">Swipe to move through the deck.</p>
     {:else if done && reviewed > 0}
       <section class="state" aria-live="polite">
         <h1>That's your review</h1>
@@ -715,10 +839,17 @@
         {@render moreButton()}
         <a href="/highlights">All highlights</a>
       </section>
-    {:else}
+    {:else if corpusEmpty}
       <section class="state" aria-live="polite">
         <h1>Nothing to review right now</h1>
         <p>Highlight a passage while reading and it joins the deck.</p>
+        <a href="/highlights">All highlights</a>
+      </section>
+    {:else}
+      <!-- Highlights exist; every one of them is set to never come back. -->
+      <section class="state" aria-live="polite">
+        <h1>Nothing in rotation</h1>
+        <p>Every highlight is set to never come back. Put one back to start again.</p>
         <a href="/highlights">All highlights</a>
       </section>
     {/if}
@@ -772,6 +903,25 @@
   {/if}
 </div>
 
+{#if intentOpen && !mobileStore.isMobile}
+  <!-- Click-away for the popover. Transparent, and it never covers the trigger,
+       so a second press on the button closes rather than reopening. -->
+  <button class="intent-scrim" onclick={() => (intentOpen = false)} tabindex="-1" aria-hidden="true"
+  ></button>
+{/if}
+
+{#if mobileStore.isMobile}
+  <BottomSheet
+    open={intentOpen}
+    onclose={() => (intentOpen = false)}
+    title="When should this come back?"
+  >
+    <div class="intent-sheet">
+      {@render intentChoices()}
+    </div>
+  </BottomSheet>
+{/if}
+
 {#if noteAnchor}
   <HighlightPopover
     mode="view"
@@ -791,7 +941,7 @@
 />
 
 {#if readerItem}
-  <SavedReader {readerItem} onClose={closeReader} />
+  <SavedReader {readerItem} onClose={reader.closeReader} />
 {/if}
 
 <style>
@@ -1029,14 +1179,15 @@
     cursor: default;
   }
 
-  /* Not destructive and not urgent: nothing is deleted, so it stays a quiet
-     bordered control rather than borrowing the danger red. */
-  .retire {
+  /* Nothing here is destructive, so the control stays a quiet bordered button
+     rather than borrowing the danger red. It carries its own state as its
+     label: the card always says where this highlight sits on the scale. */
+  .intent {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
     min-height: 44px;
-    padding: 0.5rem 0.9rem;
+    padding: 0.5rem 0.75rem 0.5rem 0.9rem;
     border: 1px solid var(--color-border);
     border-radius: 6px;
     background: none;
@@ -1051,9 +1202,118 @@
       border-color 0.15s ease;
   }
 
-  .retire:hover {
+  .intent:hover,
+  .intent.open {
     color: var(--color-text);
     border-color: var(--color-text-secondary);
+  }
+
+  /* The popover floats above the page, so it is one of the few things in this
+     system that earns a shadow. */
+  .lead {
+    position: relative;
+  }
+
+  .lead.menu-open {
+    z-index: 2;
+  }
+
+  .intent-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 2;
+    min-width: 240px;
+    padding: 0.25rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  }
+
+  /* Diffuse shadow reads weakly on a dark surface, so it carries a night value
+     at roughly triple the alpha. */
+  @media (prefers-color-scheme: dark) {
+    .intent-menu {
+      box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
+    }
+  }
+
+  .intent-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: default;
+  }
+
+  .intent-sheet {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 0.5rem;
+  }
+
+  /* A fixed label track rather than a content-sized one, so the hints line up
+     across rows. Subgrid would express the intent better but its tracks are
+     placed on the parent's content box, which stops coinciding the moment the
+     row carries padding of its own. */
+  .intent-option {
+    display: grid;
+    grid-template-columns: 14px 5.5rem 1fr;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: var(--color-text);
+    font: inherit;
+    font-size: var(--text-md);
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  .intent-divider {
+    height: 1px;
+    margin: 0.25rem 0.625rem;
+    background: var(--color-border);
+  }
+
+  .intent-option:hover {
+    background: var(--color-bg-secondary, #f5f5f5);
+  }
+
+  /* Fixed-width gutter so the labels stay on one axis whether or not a row is
+     the selected one. */
+  .intent-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    flex-shrink: 0;
+    color: var(--color-primary);
+  }
+
+  .intent-option.selected .intent-label {
+    font-weight: var(--weight-semibold);
+  }
+
+  .intent-hint {
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    white-space: nowrap;
+  }
+
+  /* A sheet has room the popover doesn't, and a finger needs the target. */
+  @media (max-width: 1000px) {
+    .intent-option {
+      min-height: 48px;
+      padding-inline: 0.25rem;
+    }
   }
 
   .secondary {
@@ -1085,7 +1345,7 @@
   }
 
   .action-btn.danger:hover {
-    color: var(--color-error, #cc0000);
+    color: var(--color-error, #f44336);
   }
 
   .hint,
@@ -1197,18 +1457,37 @@
   }
 
   @media (max-width: 560px) {
-    /* Two decisions deserve the full width down here; the tools follow beneath. */
+    /* Two rows down here, and they line up: the decisions take the full width,
+       the tools sit under them on the same left and right edges. The icons are
+       optically inset by their own padding, so the row is pulled back out by
+       that much to make the columns read as columns. */
+    .actions {
+      row-gap: 1rem;
+    }
+
     .lead {
       width: 100%;
     }
 
-    .retire {
+    /* The primary action takes what the state chip doesn't need. */
+    .next {
       flex: 1;
       justify-content: center;
     }
 
+    .intent {
+      flex: 0 0 auto;
+    }
+
     .secondary {
       width: 100%;
+      margin-inline: -10px;
+    }
+
+    /* Removal is the one action here you can't undo by moving on, so it keeps
+       its distance from the three that are just tools. */
+    .secondary .action-btn.danger {
+      margin-left: auto;
     }
   }
 
@@ -1218,7 +1497,8 @@
   @media (prefers-reduced-motion: reduce) {
     .step-back,
     .next,
-    .retire,
+    .intent,
+    .intent-option,
     .action-btn,
     .gear,
     .more {

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -3,7 +3,6 @@
   // time. Deliberately not a durable issue like the daily magazine: a session is
   // a few minutes, so the deck is derived at open and repeat-avoidance rides the
   // per-highlight `lastReviewedAt` stamp, which syncs with the highlight itself.
-  import { onMount } from 'svelte';
   import { pushState } from '$app/navigation';
   import { page } from '$app/state';
   import NavigationDropdown from '$lib/components/NavigationDropdown.svelte';
@@ -51,9 +50,22 @@
   let index = $state(0);
   let reviewed = $state(0);
 
-  // Wait for the stores to hydrate before drawing, or a cold load deals an empty
-  // deck and immediately declares the review done.
-  let ready = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
+  // Wait for the stores to hydrate and the initial Margin poll to finish before
+  // drawing. The deck remains fixed after that first draw, but highlights the
+  // poll imports on open must be eligible for this session.
+  let storesReady = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
+  let initialImportComplete = $state(false);
+  let importStarted = false;
+
+  $effect(() => {
+    if (!storesReady || importStarted) return;
+    importStarted = true;
+    void maybeImportMarginHighlights().finally(() => {
+      initialImportComplete = true;
+    });
+  });
+
+  let ready = $derived(storesReady && initialImportComplete);
 
   // Plain flag, not the `deck` state itself: the effect writes `deck`, so reading
   // it here as the guard would make the effect depend on its own write.
@@ -66,12 +78,6 @@
       itemLabelsStore.allHighlights,
       preferences.highlightReviewCount
     ).cards;
-  });
-
-  onMount(() => {
-    // Opening the deck is a natural moment to pick up anything new from Margin.
-    // Minute-gated and silent when the toggle is off or the device is offline.
-    void maybeImportMarginHighlights();
   });
 
   let total = $derived(deck?.length ?? 0);

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -16,6 +16,7 @@
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
   import RemoveHighlightModal from '$lib/components/feed/RemoveHighlightModal.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import { socialStore } from '$lib/stores/social.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
@@ -61,6 +62,7 @@
   // is marked reviewed and pull the ground out from under the reader.
   let deck = $state<HighlightEntry[] | null>(null);
   let index = $state(0);
+  // Session tally, across every hand — `index` and `interacted` are per hand.
   let reviewed = $state(0);
   let interacted = $state(false);
 
@@ -84,9 +86,15 @@
   // writes it, and it exists only to notice a change in the preference.
   let dealtCount = 0;
 
+  // Sticky for the rest of the visit: a redeal triggered by a settings change
+  // must not quietly drop an encore hand back to the (empty) daily pool.
+  let encoreMode = false;
+
   function dealDeck() {
     dealtCount = preferences.highlightReviewCount;
-    deck = buildHighlightDeck(itemLabelsStore.allHighlights, dealtCount).cards;
+    deck = buildHighlightDeck(itemLabelsStore.allHighlights, dealtCount, new Date(), {
+      includeReviewedToday: encoreMode,
+    }).cards;
     emptyOnDeal = deck.length === 0;
   }
 
@@ -102,7 +110,7 @@
   $effect(() => {
     const size = preferences.highlightReviewCount;
     if (!dealt || size === dealtCount) return;
-    if (deckUntouched({ index, reviewed, interacted })) dealDeck();
+    if (deckUntouched({ index, interacted })) dealDeck();
     else dealtCount = size;
   });
 
@@ -118,7 +126,7 @@
     const timer = setTimeout(() => (importWaitElapsed = true), EMPTY_DECK_IMPORT_WAIT_MS);
     void maybeImportMarginHighlights()
       .then((result) => {
-        if (shouldRedealAfterImport(result, { index, reviewed, interacted })) dealDeck();
+        if (shouldRedealAfterImport(result, { index, interacted })) dealDeck();
       })
       .catch(() => {})
       .finally(() => {
@@ -266,6 +274,25 @@
     }
   }
 
+  // Finishing the deck is where the day's review ends by design, but a reader
+  // who wants to keep going shouldn't have to leave and come back to do it.
+  //
+  // Two shapes of "more". While highlights are still due today, another hand is
+  // genuinely the next ones due — the hand just finished stamped its own cards,
+  // so they can't come back. Once the day's portion is spent, "more" can only
+  // mean going around again, which the button says plainly rather than dressing
+  // up with a count.
+  let moreDue = $derived(highlightReviewStore.dueCount);
+  let isEncore = $derived(moreDue === 0);
+  let canReviewMore = $derived(highlightReviewStore.hasHighlights);
+
+  function reviewMore() {
+    encoreMode = isEncore;
+    index = 0;
+    interacted = false;
+    dealDeck();
+  }
+
   // --- Settings, in reach of the deck they configure (deck size, Margin
   // ingest). An inline disclosure rather than an overlay: the page is one card
   // tall, so there's nothing for a modal to protect.
@@ -275,7 +302,7 @@
   // session — turning the toggle on and still reading "nothing to review" is
   // the opposite of what the control promised.
   function handleSettingsImport() {
-    if (deckUntouched({ index, reviewed, interacted })) dealDeck();
+    if (deckUntouched({ index, interacted })) dealDeck();
   }
 
   // --- Mobile chrome. The installed PWA has no browser back button, so the
@@ -298,6 +325,18 @@
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
+
+{#snippet moreButton()}
+  {#if canReviewMore}
+    <button class="more" onclick={reviewMore}>
+      <span>{isEncore ? 'Review more' : `Review ${moreDue} more`}</span>
+      <Icon name="arrow-right" size={16} />
+    </button>
+    {#if isEncore}
+      <p class="more-note">This brings back the ones you saw earliest today.</p>
+    {/if}
+  {/if}
+{/snippet}
 
 <div class="review-page">
   <header class="review-header">
@@ -397,15 +436,22 @@
       <section class="state" aria-live="polite">
         <h1>That's your review</h1>
         <p>{reviewed} highlight{reviewed === 1 ? '' : 's'} revisited.</p>
+        {@render moreButton()}
+        <a href="/highlights">All highlights</a>
+      </section>
+    {:else if canReviewMore}
+      <!-- Highlights exist, but today's portion is already spent — arrived at by
+           coming back after a session rather than by finishing one here. -->
+      <section class="state" aria-live="polite">
+        <h1>That's today's review</h1>
+        <p>Come back tomorrow for the next handful.</p>
+        {@render moreButton()}
         <a href="/highlights">All highlights</a>
       </section>
     {:else}
       <section class="state" aria-live="polite">
         <h1>Nothing to review right now</h1>
-        <p>
-          Highlight a passage while reading and it joins the deck. Come back tomorrow for another
-          handful.
-        </p>
+        <p>Highlight a passage while reading and it joins the deck.</p>
         <a href="/highlights">All highlights</a>
       </section>
     {/if}
@@ -714,6 +760,37 @@
   .state p {
     margin: 0;
     color: var(--color-text-secondary);
+  }
+
+  /* Quiet: another hand is offered, not urged. The primary button belongs to
+     the card you're reading, not to going around again. */
+  .more {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: fit-content;
+    min-height: 44px;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1.1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: none;
+    color: var(--color-text);
+    font: inherit;
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .more:hover {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  .more-note {
+    font-size: var(--text-sm);
   }
 
   .state a {

--- a/frontend/src/lib/components/feed/HighlightReview.svelte
+++ b/frontend/src/lib/components/feed/HighlightReview.svelte
@@ -22,7 +22,11 @@
     updateHighlightNoteOnMargin,
   } from '$lib/services/marginHighlights';
   import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
-  import { buildHighlightDeck, type HighlightEntry } from '$lib/utils/highlightReview';
+  import {
+    buildHighlightDeck,
+    shouldRedealAfterImport,
+    type HighlightEntry,
+  } from '$lib/utils/highlightReview';
   import {
     buildHighlightSourceLookups,
     resolveHighlightSource,
@@ -50,35 +54,59 @@
   let index = $state(0);
   let reviewed = $state(0);
 
-  // Wait for the stores to hydrate and the initial Margin poll to finish before
-  // drawing. The deck remains fixed after that first draw, but highlights the
-  // poll imports on open must be eligible for this session.
+  // Deal as soon as the local stores hydrate — everything needed for a session is
+  // already on the device, so a Margin poll must never stand between the reader
+  // and their first card. The poll runs alongside it and redeals exactly once, if
+  // it actually imported something and the reader hasn't started yet.
   let storesReady = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
   let initialImportComplete = $state(false);
   let importStarted = false;
-
-  $effect(() => {
-    if (!storesReady || importStarted) return;
-    importStarted = true;
-    void maybeImportMarginHighlights().finally(() => {
-      initialImportComplete = true;
-    });
-  });
-
-  let ready = $derived(storesReady && initialImportComplete);
 
   // Plain flag, not the `deck` state itself: the effect writes `deck`, so reading
   // it here as the guard would make the effect depend on its own write.
   let dealt = false;
 
-  $effect(() => {
-    if (dealt || !ready) return;
-    dealt = true;
+  // Tracked separately from `deck.length` so removing the last card of a real
+  // deck can't be mistaken for "the local pool was empty".
+  let emptyOnDeal = $state(false);
+
+  function dealDeck() {
     deck = buildHighlightDeck(
       itemLabelsStore.allHighlights,
       preferences.highlightReviewCount
     ).cards;
+    emptyOnDeal = deck.length === 0;
+  }
+
+  $effect(() => {
+    if (dealt || !storesReady) return;
+    dealt = true;
+    dealDeck();
   });
+
+  // An empty deck is the one case worth waiting on: the local pool has nothing to
+  // show, so the in-flight poll may be the whole session. The wait is bounded, so
+  // a stalled poll lands on the empty state instead of spinning forever.
+  const EMPTY_DECK_IMPORT_WAIT_MS = 6000;
+  let importWaitElapsed = $state(false);
+
+  $effect(() => {
+    if (!storesReady || importStarted) return;
+    importStarted = true;
+    const timer = setTimeout(() => (importWaitElapsed = true), EMPTY_DECK_IMPORT_WAIT_MS);
+    void maybeImportMarginHighlights()
+      .then((result) => {
+        if (shouldRedealAfterImport(result, { index, reviewed })) dealDeck();
+      })
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timer);
+        initialImportComplete = true;
+      });
+  });
+
+  let awaitingImport = $derived(emptyOnDeal && !initialImportComplete && !importWaitElapsed);
+  let ready = $derived(storesReady && !awaitingImport);
 
   let total = $derived(deck?.length ?? 0);
   let current = $derived(deck && index < deck.length ? deck[index] : null);

--- a/frontend/src/lib/components/feed/HighlightReviewCard.svelte
+++ b/frontend/src/lib/components/feed/HighlightReviewCard.svelte
@@ -1,29 +1,14 @@
 <script lang="ts">
-  // The Home entry into the review deck. In v1 the view IS the reminder — there
-  // is no push/email stack — so this card is the thing that says "you have a few
-  // highlights to revisit." It hides itself once the deck is done or empty:
-  // calm, no streaks, no badges, nothing to clear.
+  // The Home entry into the review deck. In v1 the view IS the reminder — there is no push/email stack — so this card says
+  // "you have a few highlights to revisit." It hides itself once the deck is
+  // done or empty: calm, no streaks, nothing that lingers after you've read.
   import Icon from '$lib/components/Icon.svelte';
-  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
-  import {
-    HIGHLIGHT_REVIEW_COUNT_OPTIONS,
-    preferences,
-    type HighlightReviewCount,
-  } from '$lib/stores/preferences.svelte';
-  import { buildHighlightDeck } from '$lib/utils/highlightReview';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
 
-  let deck = $derived(
-    buildHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount)
-  );
-  let count = $derived(deck.cards.length);
-
-  function updateCount(event: Event) {
-    const value = Number((event.currentTarget as HTMLSelectElement).value);
-    preferences.setHighlightReviewCount(value as HighlightReviewCount);
-  }
+  let count = $derived(highlightReviewStore.dueCount);
 </script>
 
-{#if deck.status === 'available' && count > 0}
+{#if highlightReviewStore.status === 'available' && count > 0}
   <section class="review-card" aria-label="Highlight review">
     <div class="text">
       <h2>
@@ -33,20 +18,10 @@
       <p>A few passages you've marked, one at a time.</p>
     </div>
 
-    <div class="controls">
-      <label class="control">
-        <span>Deck</span>
-        <select value={preferences.highlightReviewCount} onchange={updateCount}>
-          {#each HIGHLIGHT_REVIEW_COUNT_OPTIONS as option}
-            <option value={option}>{option}</option>
-          {/each}
-        </select>
-      </label>
-      <a class="start" href="/highlights/review">
-        <span>Review {count} highlight{count === 1 ? '' : 's'}</span>
-        <Icon name="arrow-right" size={15} />
-      </a>
-    </div>
+    <a class="start" href="/highlights/review">
+      <span>Review {count} highlight{count === 1 ? '' : 's'}</span>
+      <Icon name="arrow-right" size={15} />
+    </a>
   </section>
 {/if}
 
@@ -85,33 +60,6 @@
     color: var(--color-text-secondary);
   }
 
-  .controls {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  /* Matches MagazineRail's `.control` so the two Home panels read as one
-     control vocabulary. */
-  .control {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: var(--text-xs);
-    color: var(--color-text-secondary);
-  }
-
-  .control select {
-    min-height: 2rem;
-    padding: 0.2rem 1.5rem 0.2rem 0.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg);
-    color: var(--color-text);
-    font: inherit;
-    font-size: var(--text-xs);
-  }
-
   .start {
     display: inline-flex;
     align-items: center;
@@ -135,9 +83,9 @@
   }
 
   @media (max-width: 640px) {
-    .controls {
+    .start {
       width: 100%;
-      justify-content: space-between;
+      justify-content: center;
     }
   }
 </style>

--- a/frontend/src/lib/components/feed/HighlightReviewCard.svelte
+++ b/frontend/src/lib/components/feed/HighlightReviewCard.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  // The Home entry into the review deck. In v1 the view IS the reminder — there
+  // is no push/email stack — so this card is the thing that says "you have a few
+  // highlights to revisit." It hides itself once the deck is done or empty:
+  // calm, no streaks, no badges, nothing to clear.
+  import Icon from '$lib/components/Icon.svelte';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import {
+    HIGHLIGHT_REVIEW_COUNT_OPTIONS,
+    preferences,
+    type HighlightReviewCount,
+  } from '$lib/stores/preferences.svelte';
+  import { buildHighlightDeck } from '$lib/utils/highlightReview';
+
+  let deck = $derived(
+    buildHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount)
+  );
+  let count = $derived(deck.cards.length);
+
+  function updateCount(event: Event) {
+    const value = Number((event.currentTarget as HTMLSelectElement).value);
+    preferences.setHighlightReviewCount(value as HighlightReviewCount);
+  }
+</script>
+
+{#if deck.status === 'available' && count > 0}
+  <section class="review-card" aria-label="Highlight review">
+    <div class="text">
+      <h2>
+        <span class="icon"><Icon name="highlighter" size={16} /></span>
+        Revisit your highlights
+      </h2>
+      <p>A few passages you've marked, one at a time.</p>
+    </div>
+
+    <div class="controls">
+      <label class="control">
+        <span>Deck</span>
+        <select value={preferences.highlightReviewCount} onchange={updateCount}>
+          {#each HIGHLIGHT_REVIEW_COUNT_OPTIONS as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+      <a class="start" href="/highlights/review">
+        <span>Review {count} highlight{count === 1 ? '' : 's'}</span>
+        <Icon name="arrow-right" size={15} />
+      </a>
+    </div>
+  </section>
+{/if}
+
+<style>
+  /* Flat by default: a bordered panel, not a floating card. */
+  .review-card {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 0 0 1.5rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+
+  .text h2 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: var(--text-md);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-tight);
+  }
+
+  .icon {
+    display: inline-flex;
+    color: var(--color-text-secondary);
+  }
+
+  .text p {
+    margin: 0.25rem 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  /* Matches MagazineRail's `.control` so the two Home panels read as one
+     control vocabulary. */
+  .control {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .control select {
+    min-height: 2rem;
+    padding: 0.2rem 1.5rem 0.2rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    font-size: var(--text-xs);
+  }
+
+  .start {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 36px;
+    padding: 0.35rem 0.9rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .start:hover {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  @media (max-width: 640px) {
+    .controls {
+      width: 100%;
+      justify-content: space-between;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/feed/HighlightReviewCard.svelte
+++ b/frontend/src/lib/components/feed/HighlightReviewCard.svelte
@@ -4,8 +4,46 @@
   // done or empty: calm, no streaks, nothing that lingers after you've read.
   import Icon from '$lib/components/Icon.svelte';
   import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
+  import { articlesStore } from '$lib/stores/articles.svelte';
+  import { socialStore } from '$lib/stores/social.svelte';
+  import { savesStore } from '$lib/stores/saves.svelte';
+  import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
+  import { describeHighlightSources } from '$lib/utils/highlightReview';
+  import { buildHighlightSourceLookups, resolveHighlightSource } from '$lib/utils/highlightSource';
 
   let count = $derived(highlightReviewStore.dueCount);
+
+  let sourceLookups = $derived(
+    buildHighlightSourceLookups(
+      articlesStore.allArticles,
+      socialStore.documents,
+      savesStore.articles,
+      subscriptionsStore.subscriptions
+    )
+  );
+
+  // Naming who's waiting is the pitch: a person is a better reason to open the
+  // deck than a description of how it works. Bylines are often missing (RSS
+  // rarely carries one, a Margin import never does), so each source falls back
+  // to where it came from rather than dropping out of the sentence. Deduped in
+  // deck order, so the first name is the first card dealt.
+  let sources = $derived.by(() => {
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (const entry of highlightReviewStore.cards) {
+      const source = resolveHighlightSource(
+        entry.itemKey,
+        entry.itemType,
+        sourceLookups,
+        entry.highlight
+      );
+      const name = source.author || source.domain || source.title;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      names.push(name);
+    }
+    return describeHighlightSources(names);
+  });
 </script>
 
 {#if highlightReviewStore.status === 'available' && count > 0}
@@ -15,7 +53,7 @@
         <span class="icon"><Icon name="highlighter" size={16} /></span>
         Revisit your highlights
       </h2>
-      <p>A few passages you've marked, one at a time.</p>
+      <p>Highlights from {sources}.</p>
     </div>
 
     <a class="start" href="/highlights/review">

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -28,7 +28,7 @@
   } from '$lib/services/marginHighlights';
   import { formatRelativeTime } from '$lib/utils/date';
   import { buildHighlightSourceLookups, resolveHighlightSource } from '$lib/utils/highlightSource';
-  import { highlightDeckStatus } from '$lib/utils/highlightReview';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
   import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
   import type { Highlight, ItemLabelType } from '$lib/types';
@@ -59,9 +59,6 @@
 
   // A partial poll must say so — otherwise "these are my highlights" is a lie.
   let importTruncated = $state(false);
-
-  // Drives the header's Review entry; hidden once today's deck is done.
-  let deckStatus = $derived(highlightDeckStatus(itemLabelsStore.allHighlights));
 
   interface HighlightRow {
     id: string;
@@ -234,7 +231,7 @@
   <header class="highlights-header" class:scrolled>
     <div class="header-inner">
       <NavigationDropdown currentTitle="Highlights" />
-      {#if deckStatus === 'available'}
+      {#if highlightReviewStore.status === 'available'}
         <a class="review-link" href="/highlights/review">
           <Icon name="highlighter" size={15} />
           <span>Review</span>

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -29,6 +29,7 @@
   import { formatRelativeTime } from '$lib/utils/date';
   import { buildHighlightSourceLookups, resolveHighlightSource } from '$lib/utils/highlightSource';
   import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
+  import { isReviewable } from '$lib/utils/highlightReview';
   import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
   import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
   import type { Highlight, ItemLabelType } from '$lib/types';
@@ -66,6 +67,7 @@
     note?: string;
     createdAt: number;
     isMargin: boolean;
+    retired: boolean;
     highlight: Highlight;
   }
 
@@ -130,6 +132,7 @@
         note: highlight.note,
         createdAt: highlight.createdAt,
         isMargin: Boolean(highlight.marginUri),
+        retired: !isReviewable(highlight),
         highlight,
       });
       if (highlight.createdAt > group.latest) group.latest = highlight.createdAt;
@@ -176,6 +179,13 @@
 
   function handleSaveToMargin(group: HighlightGroup, row: HighlightRow) {
     void saveHighlightToMargin(group.itemKey, row.highlight, group.url, group.title);
+  }
+
+  // The review deck can retire a highlight ("Don't show again"). This is where
+  // that comes back: the list is the whole corpus, so it's the honest place to
+  // see what's been set aside and to put it back in rotation.
+  function toggleReviewRetired(group: HighlightGroup, row: HighlightRow) {
+    void itemLabelsStore.setHighlightReviewRetired(group.itemKey, row.id, !row.retired);
   }
 
   // Note editor — a floating popover anchored to the "add a note" button, opened
@@ -287,6 +297,12 @@
                       {:else}
                         <span class="badge badge-private">Private</span>
                       {/if}
+                      {#if row.retired}
+                        <span class="badge badge-retired">
+                          <Icon name="circle-slash" size={12} />
+                          Not in review
+                        </span>
+                      {/if}
                     </span>
                     <span class="row-actions">
                       <button
@@ -307,6 +323,20 @@
                           <Icon name="margin" size={15} />
                         </button>
                       {/if}
+                      <button
+                        class="action-btn"
+                        class:on={row.retired}
+                        onclick={() => toggleReviewRetired(group, row)}
+                        title={row.retired
+                          ? 'Put back in the review deck'
+                          : "Don't show in review again"}
+                        aria-label={row.retired
+                          ? 'Put back in the review deck'
+                          : "Don't show in review again"}
+                        aria-pressed={row.retired}
+                      >
+                        <Icon name="circle-slash" size={15} />
+                      </button>
                       <button
                         class="action-btn danger"
                         onclick={() => (removePrompt = { group, row })}
@@ -649,6 +679,13 @@
     background: var(--color-bg-secondary, #f0f0f0);
   }
 
+  /* Set aside from the review deck. Reads as a state on the highlight, not as a
+     warning: nothing was deleted. */
+  .badge-retired {
+    color: var(--color-text-secondary);
+    background: var(--color-bg-secondary, #f0f0f0);
+  }
+
   .row-actions {
     display: flex;
     align-items: center;
@@ -682,14 +719,26 @@
     background: rgba(220, 38, 38, 0.1);
   }
 
+  /* A toggle that's on, not a selected row: the tint says the state, the badge
+     beside it says what the state means. */
+  .action-btn.on {
+    color: var(--color-primary);
+    background: var(--color-sidebar-active, rgba(0, 102, 204, 0.1));
+  }
+
   @media (prefers-color-scheme: dark) {
     .group-card:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.03));
     }
 
     .badge-private,
+    .badge-retired,
     .action-btn:hover {
       background: rgba(255, 255, 255, 0.08);
+    }
+
+    .action-btn.on {
+      background: var(--color-sidebar-active, rgba(77, 166, 255, 0.15));
     }
   }
 </style>

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -8,6 +8,7 @@
   import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
   import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
+  import RemoveHighlightModal from '$lib/components/feed/RemoveHighlightModal.svelte';
   import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import NotificationList from '$lib/components/NotificationList.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
@@ -26,9 +27,11 @@
     updateHighlightNoteOnMargin,
   } from '$lib/services/marginHighlights';
   import { formatRelativeTime } from '$lib/utils/date';
-  import { decodeEntities } from '$lib/utils/entities';
+  import { buildHighlightSourceLookups, resolveHighlightSource } from '$lib/utils/highlightSource';
+  import { highlightDeckStatus } from '$lib/utils/highlightReview';
+  import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
   import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
-  import type { Highlight, ItemLabelType, SavedItem } from '$lib/types';
+  import type { Highlight, ItemLabelType } from '$lib/types';
 
   // Set the browser-tab title while this page is mounted.
   $effect(() => {
@@ -46,8 +49,19 @@
   onMount(() => {
     window.addEventListener('scroll', handleWindowScroll, { passive: true });
     handleWindowScroll();
+    // Opening the list is one of the two moments we poll Margin for highlights
+    // the reader made elsewhere. Minute-gated; silent when off or offline.
+    void maybeImportMarginHighlights().then((result) => {
+      if (result?.truncated) importTruncated = true;
+    });
   });
   onDestroy(() => window.removeEventListener('scroll', handleWindowScroll));
+
+  // A partial poll must say so — otherwise "these are my highlights" is a lie.
+  let importTruncated = $state(false);
+
+  // Drives the header's Review entry; hidden once today's deck is done.
+  let deckStatus = $derived(highlightDeckStatus(itemLabelsStore.allHighlights));
 
   interface HighlightRow {
     id: string;
@@ -72,26 +86,14 @@
     latest: number;
   }
 
-  function domainFromUrl(url: string | null | undefined): string | null {
-    if (!url) return null;
-    try {
-      return new URL(url).hostname.replace(/^www\./, '');
-    } catch {
-      return null;
-    }
-  }
-
   // Lookups for enriching a highlight's parent item with title/url/body.
-  let articlesByGuid = $derived(new Map(articlesStore.allArticles.map((a) => [a.guid, a])));
-  let documentsByUri = $derived(new Map(socialStore.documents.map((d) => [d.recordUri, d])));
-  let savedByKey = $derived.by(() => {
-    const m = new Map<string, SavedItem>();
-    for (const s of savesStore.articles) {
-      if (s.itemGuid) m.set(s.itemGuid, s);
-      if (s.uri) m.set(s.uri, s);
-    }
-    return m;
-  });
+  let sourceLookups = $derived(
+    buildHighlightSourceLookups(
+      articlesStore.allArticles,
+      socialStore.documents,
+      savesStore.articles
+    )
+  );
 
   // Group every highlight under its source item, newest-source first.
   let groups = $derived.by((): HighlightGroup[] => {
@@ -107,43 +109,18 @@
       const groupKey = itemLabelsStore.canonicalKey(itemKey);
       let group = byKey.get(groupKey);
       if (!group) {
-        let title = '';
-        let url: string | null = null;
-        let displayItem: FeedDisplayItem | null = null;
-
-        if (itemType === 'article') {
-          const a = articlesByGuid.get(groupKey);
-          if (a) {
-            title = a.title;
-            url = a.url;
-            displayItem = { type: 'article', item: a, key: a.guid };
-          }
-        } else if (itemType === 'document') {
-          const d = documentsByUri.get(groupKey);
-          if (d) {
-            title = d.title;
-            url = d.canonicalUrl ?? null;
-            displayItem = { type: 'document', item: d, key: d.recordUri };
-          }
-        }
-
-        // Fall back to a saved copy (carries title/url, and can open in the reader).
-        if (!displayItem) {
-          const s = savedByKey.get(groupKey);
-          if (s) {
-            title = title || s.title || '';
-            url = url || s.url || null;
-            displayItem = { type: 'saved', item: s, key: s.itemGuid || s.uri };
-          }
-        }
+        // Imported Margin highlights may have no local article at all — the
+        // resolver falls back to the metadata carried on the highlight so the
+        // group still renders a title and stays openable.
+        const source = resolveHighlightSource(groupKey, itemType, sourceLookups, highlight);
 
         group = {
           itemKey: groupKey,
           itemType,
-          title: decodeEntities(title) || 'Untitled',
-          url,
-          domain: domainFromUrl(url),
-          displayItem,
+          title: source.title,
+          url: source.url,
+          domain: source.domain,
+          displayItem: source.displayItem,
           rows: [],
           latest: 0,
         };
@@ -189,8 +166,15 @@
     }
   }
 
-  function handleRemove(group: HighlightGroup, row: HighlightRow) {
-    void deleteHighlight(group.itemKey, row.highlight);
+  // Removing a Margin-backed highlight deletes the user's own PDS record too —
+  // always confirm, so a cross-app delete can't happen on a stray tap.
+  let removePrompt = $state<{ group: HighlightGroup; row: HighlightRow } | null>(null);
+
+  function confirmRemove() {
+    const pending = removePrompt;
+    removePrompt = null;
+    if (!pending) return;
+    void deleteHighlight(pending.group.itemKey, pending.row.highlight);
   }
 
   function handleSaveToMargin(group: HighlightGroup, row: HighlightRow) {
@@ -250,10 +234,19 @@
   <header class="highlights-header" class:scrolled>
     <div class="header-inner">
       <NavigationDropdown currentTitle="Highlights" />
+      {#if deckStatus === 'available'}
+        <a class="review-link" href="/highlights/review">
+          <Icon name="highlighter" size={15} />
+          <span>Review</span>
+        </a>
+      {/if}
     </div>
   </header>
 
   <div class="highlights-body">
+    {#if importTruncated}
+      <p class="import-notice">Some Margin highlights couldn't be fetched yet.</p>
+    {/if}
     {#if totalHighlights === 0}
       <EmptyState
         title="No highlights yet"
@@ -319,7 +312,7 @@
                       {/if}
                       <button
                         class="action-btn danger"
-                        onclick={() => handleRemove(group, row)}
+                        onclick={() => (removePrompt = { group, row })}
                         title="Remove highlight"
                         aria-label="Remove highlight"
                       >
@@ -398,6 +391,13 @@
   />
 {/if}
 
+<RemoveHighlightModal
+  open={Boolean(removePrompt)}
+  onMargin={Boolean(removePrompt?.row.isMargin)}
+  onRemove={confirmRemove}
+  onclose={() => (removePrompt = null)}
+/>
+
 <style>
   .highlights-page {
     width: 100%;
@@ -454,12 +454,43 @@
     padding: 0.625rem 1rem;
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  /* Quiet entry into the review deck — a link, not a call to action. */
+  .review-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 36px;
+    padding: 0.25rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .review-link:hover {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
   }
 
   .highlights-body {
     max-width: 800px;
     margin: 0 auto;
     padding: 0.5rem;
+  }
+
+  .import-notice {
+    margin: 0.5rem 0.5rem 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
   }
 
   .group-list {

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -12,6 +12,7 @@
   import BottomSheet from '$lib/components/common/BottomSheet.svelte';
   import NotificationList from '$lib/components/NotificationList.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { articlesStore } from '$lib/stores/articles.svelte';
   import { socialStore } from '$lib/stores/social.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
@@ -29,10 +30,13 @@
   import { formatRelativeTime } from '$lib/utils/date';
   import { buildHighlightSourceLookups, resolveHighlightSource } from '$lib/utils/highlightSource';
   import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
-  import { isReviewable } from '$lib/utils/highlightReview';
-  import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
+  import { REVIEW_INTENT_DEFAULT } from '$lib/utils/highlightReview';
+  import {
+    maybeImportMarginHighlights,
+    marginImportTruncated,
+  } from '$lib/services/marginHighlightImport';
   import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
-  import type { Highlight, ItemLabelType } from '$lib/types';
+  import type { Highlight, ItemLabelType, ReviewIntent } from '$lib/types';
 
   // Set the browser-tab title while this page is mounted.
   $effect(() => {
@@ -50,16 +54,34 @@
   onMount(() => {
     window.addEventListener('scroll', handleWindowScroll, { passive: true });
     handleWindowScroll();
-    // Opening the list is one of the two moments we poll Margin for highlights
-    // the reader made elsewhere. Minute-gated; silent when off or offline.
-    void maybeImportMarginHighlights().then((result) => {
-      if (result?.truncated) importTruncated = true;
-    });
   });
   onDestroy(() => window.removeEventListener('scroll', handleWindowScroll));
 
   // A partial poll must say so — otherwise "these are my highlights" is a lie.
   let importTruncated = $state(false);
+
+  // Opening the list is one of the two moments we poll Margin for highlights the
+  // reader made elsewhere. Minute-gated; silent when off or offline.
+  //
+  // Gated on the stores, exactly as the review deck is: the import unions against
+  // the highlights it can see and writes the result back as the item's whole set,
+  // so polling before the local read has landed would import against an empty
+  // corpus and overwrite the item's existing highlights with only the imported
+  // ones. The two surfaces also share one in-flight poll, so an ungated caller
+  // here would defeat the deck's gate as well as its own.
+  let storesReady = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
+  let importStarted = false;
+
+  $effect(() => {
+    if (!storesReady || importStarted) return;
+    importStarted = true;
+    void maybeImportMarginHighlights()
+      .catch(() => {})
+      // Read the flag the service kept rather than this call's return: a poll
+      // that short-circuits on the interval gate reports `skipped`, and the
+      // corpus is no less partial for someone else having done the fetching.
+      .finally(() => (importTruncated = marginImportTruncated()));
+  });
 
   interface HighlightRow {
     id: string;
@@ -67,7 +89,7 @@
     note?: string;
     createdAt: number;
     isMargin: boolean;
-    retired: boolean;
+    intent: ReviewIntent;
     highlight: Highlight;
   }
 
@@ -90,7 +112,8 @@
     buildHighlightSourceLookups(
       articlesStore.allArticles,
       socialStore.documents,
-      savesStore.articles
+      savesStore.articles,
+      subscriptionsStore.subscriptions
     )
   );
 
@@ -132,7 +155,7 @@
         note: highlight.note,
         createdAt: highlight.createdAt,
         isMargin: Boolean(highlight.marginUri),
-        retired: !isReviewable(highlight),
+        intent: highlight.reviewIntent ?? REVIEW_INTENT_DEFAULT,
         highlight,
       });
       if (highlight.createdAt > group.latest) group.latest = highlight.createdAt;
@@ -181,12 +204,24 @@
     void saveHighlightToMargin(group.itemKey, row.highlight, group.url, group.title);
   }
 
-  // The review deck can retire a highlight ("Don't show again"). This is where
-  // that comes back: the list is the whole corpus, so it's the honest place to
-  // see what's been set aside and to put it back in rotation.
-  function toggleReviewRetired(group: HighlightGroup, row: HighlightRow) {
-    void itemLabelsStore.setHighlightReviewRetired(group.itemKey, row.id, !row.retired);
+  // Frequency tuning happens in the review deck, one card at a time. The list
+  // is where you can see what you've set and get back out of 'never', which is
+  // the only setting that hides a highlight from the deck entirely. Clearing it
+  // returns to the default pace rather than to a previous 'soon'/'someday' —
+  // the list reports the state, the deck is where you tune it.
+  function toggleNeverReview(group: HighlightGroup, row: HighlightRow) {
+    void itemLabelsStore.setHighlightReviewIntent(
+      group.itemKey,
+      row.id,
+      row.intent === 'never' ? null : 'never'
+    );
   }
+
+  const REVIEW_INTENT_BADGE: Partial<Record<ReviewIntent, string>> = {
+    soon: 'Soon',
+    someday: 'Someday',
+    never: 'Not in review',
+  };
 
   // Note editor — a floating popover anchored to the "add a note" button, opened
   // straight into its note view. Mirrors the reader's note-editing UX.
@@ -241,9 +276,9 @@
   <header class="highlights-header" class:scrolled>
     <div class="header-inner">
       <NavigationDropdown currentTitle="Highlights" />
-      {#if highlightReviewStore.status === 'available'}
+      {#if highlightReviewStore.hasHighlights}
         <a class="review-link" href="/highlights/review">
-          <Icon name="highlighter" size={15} />
+          <Icon name="quote" size={15} />
           <span>Review</span>
         </a>
       {/if}
@@ -297,10 +332,13 @@
                       {:else}
                         <span class="badge badge-private">Private</span>
                       {/if}
-                      {#if row.retired}
-                        <span class="badge badge-retired">
-                          <Icon name="circle-slash" size={12} />
-                          Not in review
+                      {#if REVIEW_INTENT_BADGE[row.intent]}
+                        <span class="badge badge-intent">
+                          <Icon
+                            name={row.intent === 'never' ? 'circle-slash' : 'clock'}
+                            size={12}
+                          />
+                          {REVIEW_INTENT_BADGE[row.intent]}
                         </span>
                       {/if}
                     </span>
@@ -325,15 +363,15 @@
                       {/if}
                       <button
                         class="action-btn"
-                        class:on={row.retired}
-                        onclick={() => toggleReviewRetired(group, row)}
-                        title={row.retired
+                        class:on={row.intent === 'never'}
+                        onclick={() => toggleNeverReview(group, row)}
+                        title={row.intent === 'never'
                           ? 'Put back in the review deck'
-                          : "Don't show in review again"}
-                        aria-label={row.retired
+                          : 'Never show this in review'}
+                        aria-label={row.intent === 'never'
                           ? 'Put back in the review deck'
-                          : "Don't show in review again"}
-                        aria-pressed={row.retired}
+                          : 'Never show this in review'}
+                        aria-pressed={row.intent === 'never'}
                       >
                         <Icon name="circle-slash" size={15} />
                       </button>
@@ -679,9 +717,9 @@
     background: var(--color-bg-secondary, #f0f0f0);
   }
 
-  /* Set aside from the review deck. Reads as a state on the highlight, not as a
-     warning: nothing was deleted. */
-  .badge-retired {
+  /* A review-pace setting the reader chose. Reads as a state on the highlight,
+     not as a warning: nothing was deleted, even for 'never'. */
+  .badge-intent {
     color: var(--color-text-secondary);
     background: var(--color-bg-secondary, #f0f0f0);
   }
@@ -732,7 +770,7 @@
     }
 
     .badge-private,
-    .badge-retired,
+    .badge-intent,
     .action-btn:hover {
       background: rgba(255, 255, 255, 0.08);
     }

--- a/frontend/src/lib/components/feed/HomePage.svelte
+++ b/frontend/src/lib/components/feed/HomePage.svelte
@@ -15,6 +15,7 @@
   import NotificationList from '$lib/components/NotificationList.svelte';
   import HomeLane from '$lib/components/feed/HomeLane.svelte';
   import MagazineRail from '$lib/components/feed/MagazineRail.svelte';
+  import HighlightReviewCard from '$lib/components/feed/HighlightReviewCard.svelte';
   import { goto } from '$app/navigation';
   import type { LaneCardVM } from '$lib/components/feed/homeLane';
   import { savesStore } from '$lib/stores/saves.svelte';
@@ -401,6 +402,7 @@
     </div>
 
     {#if !isLoading}
+      <HighlightReviewCard />
       <MagazineRail
         issues={magazineStore.magazines}
         generating={magazineStore.generating}

--- a/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
+++ b/frontend/src/lib/components/feed/MobileFeedSwitcher.svelte
@@ -5,6 +5,7 @@
   import { getSourceDisplay } from '$lib/utils/sourceDisplay';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { highlightReviewStore } from '$lib/stores/highlightReview.svelte';
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
@@ -67,7 +68,8 @@
     | 'file-text'
     | 'folder'
     | 'users'
-    | 'highlighter';
+    | 'highlighter'
+    | 'quote';
 
   type NavItem =
     | {
@@ -202,6 +204,19 @@
         label: 'Highlights',
         icon: 'highlighter' as IconName,
       },
+      // Review is its own destination; the count is today's deck, and it goes
+      // quiet once the deck is done. Hidden until there's a corpus to review.
+      ...(highlightReviewStore.hasHighlights
+        ? [
+            {
+              type: 'utility',
+              id: 'highlights/review',
+              label: 'Review',
+              count: highlightReviewStore.dueCount,
+              icon: 'quote' as IconName,
+            } as NavItem,
+          ]
+        : []),
       {
         type: 'utility',
         id: 'discover',

--- a/frontend/src/lib/components/feed/RemoveHighlightModal.svelte
+++ b/frontend/src/lib/components/feed/RemoveHighlightModal.svelte
@@ -19,7 +19,7 @@
 <Modal {open} {onclose} title="Remove this highlight?" maxWidth="400px" zIndex={300}>
   <p class="prompt">
     {#if onMargin}
-      This also removes it from Margin — the note on your PDS is deleted.
+      This also removes it from Margin. The note on your PDS is deleted.
     {:else}
       It disappears from every device you read on.
     {/if}

--- a/frontend/src/lib/components/feed/RemoveHighlightModal.svelte
+++ b/frontend/src/lib/components/feed/RemoveHighlightModal.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  // Removing a highlight that's backed by an at.margin.note deletes that record
+  // from the user's PDS too — which is correct (it's what stops a deleted
+  // highlight resurrecting on the next Margin poll) but is a cross-app delete.
+  // It must not be possible to do without seeing that said out loud.
+  import Modal from '$lib/components/common/Modal.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The highlight is backed by a Margin record, so this deletes that too. */
+    onMargin: boolean;
+    onclose: () => void;
+    onRemove: () => void;
+  }
+
+  let { open, onMargin, onclose, onRemove }: Props = $props();
+</script>
+
+<Modal {open} {onclose} title="Remove this highlight?" maxWidth="400px" zIndex={300}>
+  <p class="prompt">
+    {#if onMargin}
+      This also removes it from Margin — the note on your PDS is deleted.
+    {:else}
+      It disappears from every device you read on.
+    {/if}
+  </p>
+
+  {#snippet footer()}
+    <button type="button" class="btn-text" onclick={onclose}>Cancel</button>
+    <button type="button" class="btn-danger" onclick={onRemove}>Remove</button>
+  {/snippet}
+</Modal>
+
+<style>
+  .prompt {
+    margin: 0;
+    font-size: var(--text-md);
+    line-height: var(--leading-relaxed, 1.5);
+    color: var(--color-text);
+  }
+
+  .btn-danger,
+  .btn-text {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+
+  .btn-danger {
+    background: var(--color-error, #cc0000);
+    color: white;
+    border: none;
+  }
+
+  .btn-danger:hover {
+    filter: brightness(0.92);
+  }
+
+  .btn-text {
+    background: none;
+    border: none;
+    color: var(--color-text-secondary);
+  }
+
+  .btn-text:hover {
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/src/lib/components/settings/HighlightSettings.svelte
+++ b/frontend/src/lib/components/settings/HighlightSettings.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  // Highlight preferences: how big a review deck is, and whether Skyreader
+  // pulls the reader's own Margin highlights in.
+  //
+  // The Margin toggle is gated on the margin scopes even though the read itself
+  // is public XRPC: without them, editing an imported highlight's note would
+  // queue a PDS write the session can't perform. Same posture as
+  // SaveBackingPicker — disabled plus a re-auth prompt, never a broken half-state.
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { auth } from '$lib/stores/auth.svelte';
+  import { api } from '$lib/services/api';
+  import { syncStore } from '$lib/stores/sync.svelte';
+  import {
+    HIGHLIGHT_REVIEW_COUNT_OPTIONS,
+    preferences,
+    type HighlightReviewCount,
+  } from '$lib/stores/preferences.svelte';
+  import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
+
+  let { returnUrl = '/settings' }: { returnUrl?: string } = $props();
+
+  let loaded = $state(false);
+  let hasMarginScopes = $state(false);
+  let importing = $state(false);
+  let importNote = $state<string | null>(null);
+
+  onMount(async () => {
+    if (!syncStore.isOnline) {
+      loaded = true;
+      return;
+    }
+    try {
+      const status = await api.getIntegrationStatus();
+      hasMarginScopes = status.scopeStatus.margin;
+    } catch (error) {
+      console.error('Failed to load integration status:', error);
+    }
+    loaded = true;
+  });
+
+  async function reauthForScopes() {
+    await auth.logout();
+    goto(`/auth/login?returnUrl=${encodeURIComponent(returnUrl)}`);
+  }
+
+  async function toggleImport(enabled: boolean) {
+    preferences.setMarginHighlightImport(enabled);
+    importNote = null;
+    if (!enabled) return;
+    // Turning it on should do something visible right away, not in 15 minutes.
+    importing = true;
+    try {
+      const result = await maybeImportMarginHighlights({ force: true });
+      if (!result) importNote = 'Couldn’t reach Margin just now. Skyreader will try again later.';
+      else if (result.truncated) {
+        importNote = `Brought in ${result.imported}. Some highlights couldn’t be fetched yet.`;
+      } else if (result.imported === 0) {
+        importNote = 'Nothing new to bring in.';
+      } else {
+        importNote = `Brought in ${result.imported} highlight${result.imported === 1 ? '' : 's'}.`;
+      }
+    } finally {
+      importing = false;
+    }
+  }
+</script>
+
+<div class="setting-row">
+  <label for="review-count">Review deck</label>
+  <select
+    id="review-count"
+    value={preferences.highlightReviewCount}
+    onchange={(e) =>
+      preferences.setHighlightReviewCount(Number(e.currentTarget.value) as HighlightReviewCount)}
+  >
+    {#each HIGHLIGHT_REVIEW_COUNT_OPTIONS as option}
+      <option value={option}>{option} highlights</option>
+    {/each}
+  </select>
+</div>
+<p class="setting-description">
+  How many highlights a review session brings back. Least recently revisited first.
+</p>
+
+{#if loaded}
+  <label class="toggle-setting">
+    <input
+      type="checkbox"
+      checked={preferences.marginHighlightImport}
+      disabled={!hasMarginScopes || importing}
+      onchange={(e) => toggleImport(e.currentTarget.checked)}
+    />
+    <span>Bring in highlights from Margin</span>
+  </label>
+  <p class="setting-description">
+    Highlights you've made in Margin join your review deck here. They stay private on Skyreader —
+    the notes they came from stay public on your PDS.
+  </p>
+  {#if !hasMarginScopes}
+    <p class="setting-description">
+      This needs permission to read and write your Margin notes.
+      <button class="link-btn" onclick={reauthForScopes} type="button">
+        Log in again to grant access
+      </button>
+    </p>
+  {/if}
+  {#if importing}
+    <p class="setting-description">Looking for highlights…</p>
+  {:else if importNote}
+    <p class="setting-description">{importNote}</p>
+  {/if}
+{/if}
+
+<style>
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .setting-row label {
+    font-weight: var(--weight-medium);
+  }
+
+  select {
+    min-height: 2.25rem;
+    padding: 0.35rem 1.8rem 0.35rem 0.6rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+  }
+
+  .toggle-setting {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    cursor: pointer;
+  }
+
+  .toggle-setting input:disabled {
+    cursor: default;
+  }
+
+  .setting-description {
+    margin: 0.5rem 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-relaxed, 1.5);
+  }
+
+  .link-btn {
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--color-primary);
+    font: inherit;
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+    text-decoration: underline;
+  }
+</style>

--- a/frontend/src/lib/components/settings/HighlightSettings.svelte
+++ b/frontend/src/lib/components/settings/HighlightSettings.svelte
@@ -11,6 +11,8 @@
   import { auth } from '$lib/stores/auth.svelte';
   import { api } from '$lib/services/api';
   import { syncStore } from '$lib/stores/sync.svelte';
+  import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+  import { savesStore } from '$lib/stores/saves.svelte';
   import {
     HIGHLIGHT_REVIEW_COUNT_OPTIONS,
     preferences,
@@ -23,12 +25,25 @@
     /** Fired when switching the toggle on actually brought highlights in, so a
         host showing those highlights (the review deck) can react. */
     onImported?: (imported: number) => void;
+    /**
+     * Deck size only makes sense where the deck is: "5" means something when
+     * you can see it. `/settings` renders the Margin toggle alone, because that
+     * one has to be reachable *before* there's a deck to configure — a reader
+     * with a Margin library and no Skyreader highlights has no Review entry in
+     * the nav at all, so the deck's own gear can't be its only home.
+     */
+    showDeckSize?: boolean;
   }
 
-  let { returnUrl = '/settings', onImported }: Props = $props();
+  let { returnUrl = '/settings', onImported, showDeckSize = true }: Props = $props();
 
   let loaded = $state(false);
-  let hasMarginScopes = $state(false);
+  // Three states, not two. Offline and a failed status call both leave the grant
+  // unknown, and treating unknown as missing tells a reader who granted the
+  // scopes months ago to log in again — while offline, where the re-auth button
+  // logs them out and can't log them back in. It also locks the toggle, so they
+  // can't even switch the import off.
+  let marginScopes = $state<'unknown' | 'granted' | 'missing'>('unknown');
   let importing = $state(false);
   let importNote = $state<string | null>(null);
 
@@ -39,7 +54,7 @@
     }
     try {
       const status = await api.getIntegrationStatus();
-      hasMarginScopes = status.scopeStatus.margin;
+      marginScopes = status.scopeStatus.margin ? 'granted' : 'missing';
     } catch (error) {
       console.error('Failed to load integration status:', error);
     }
@@ -51,66 +66,104 @@
     goto(`/auth/login?returnUrl=${encodeURIComponent(returnUrl)}`);
   }
 
+  // Keeping the promise the toggle makes when it lands mid-hydration. The deck
+  // and the list each have an effect that calls the import once their stores are
+  // ready; the panel can be mounted on /settings, where nothing else will.
+  let storesReady = $derived(!itemLabelsStore.isLoading && !savesStore.loading);
+  let awaitingStores = $state(false);
+
+  $effect(() => {
+    if (!awaitingStores || !storesReady) return;
+    awaitingStores = false;
+    void toggleImport(true);
+  });
+
   async function toggleImport(enabled: boolean) {
     preferences.setMarginHighlightImport(enabled);
     importNote = null;
-    if (!enabled) return;
+    if (!enabled) {
+      // Switching off has to cancel the deferred retry too. Without this, a
+      // reader who turned it on mid-hydration and changed their mind before the
+      // stores landed would watch the effect below switch it back on for them.
+      awaitingStores = false;
+      return;
+    }
     // Turning it on should do something visible right away, not in 15 minutes.
     importing = true;
     try {
-      const result = await maybeImportMarginHighlights({ force: true });
-      if (!result) importNote = 'Couldn’t reach Margin just now. Skyreader will try again later.';
-      else if (result.truncated) {
-        importNote = `Brought in ${result.imported}. Some highlights couldn’t be fetched yet.`;
-      } else if (result.imported === 0) {
-        importNote = 'Nothing new to bring in.';
+      const outcome = await maybeImportMarginHighlights({ force: true });
+      if (outcome.status === 'imported') {
+        if (outcome.truncated) {
+          importNote = `Brought in ${outcome.imported}. Some highlights couldn’t be fetched yet.`;
+        } else if (outcome.imported === 0) {
+          importNote = 'Nothing new to bring in.';
+        } else {
+          importNote = `Brought in ${outcome.imported} highlight${
+            outcome.imported === 1 ? '' : 's'
+          }.`;
+        }
+        if (outcome.imported > 0) onImported?.(outcome.imported);
+      } else if (outcome.status === 'scope-expired') {
+        // The grant is gone and the import switched itself back off. Say that,
+        // rather than blaming the network for a permissions problem — and let
+        // the re-auth prompt below appear, which is the only way out of it.
+        marginScopes = 'missing';
+        importNote = null;
+      } else if (outcome.status === 'skipped' && outcome.reason === 'stores-loading') {
+        // The import is gated on the local highlights being read: it writes each
+        // item's whole set, so running early would overwrite what it can't see.
+        awaitingStores = true;
+        importNote = 'Bringing them in as soon as your highlights finish loading.';
+      } else if (outcome.status === 'skipped' && outcome.reason === 'offline') {
+        importNote = 'Offline. Skyreader will bring them in once you’re back.';
       } else {
-        importNote = `Brought in ${result.imported} highlight${result.imported === 1 ? '' : 's'}.`;
+        importNote = 'Couldn’t reach Margin just now. Skyreader will try again later.';
       }
-      if (result && result.imported > 0) onImported?.(result.imported);
     } finally {
       importing = false;
     }
   }
 </script>
 
-<div class="setting-row">
-  <label for="review-count">Review deck</label>
-  <select
-    id="review-count"
-    value={preferences.highlightReviewCount}
-    onchange={(e) =>
-      preferences.setHighlightReviewCount(Number(e.currentTarget.value) as HighlightReviewCount)}
-  >
-    {#each HIGHLIGHT_REVIEW_COUNT_OPTIONS as option}
-      <option value={option}>{option} highlights</option>
-    {/each}
-  </select>
-</div>
-<p class="setting-description">
-  How many highlights a review session brings back. Least recently revisited first.
-</p>
+{#if showDeckSize}
+  <div class="setting-row">
+    <label for="review-count">Review deck</label>
+    <select
+      id="review-count"
+      value={preferences.highlightReviewCount}
+      onchange={(e) =>
+        preferences.setHighlightReviewCount(Number(e.currentTarget.value) as HighlightReviewCount)}
+    >
+      {#each HIGHLIGHT_REVIEW_COUNT_OPTIONS as option}
+        <option value={option}>{option} highlights</option>
+      {/each}
+    </select>
+  </div>
+  <p class="setting-description">How many highlights a review session brings back.</p>
+{/if}
 
 {#if loaded}
   <label class="toggle-setting">
     <input
       type="checkbox"
       checked={preferences.marginHighlightImport}
-      disabled={!hasMarginScopes || importing}
+      disabled={marginScopes === 'missing' || importing}
       onchange={(e) => toggleImport(e.currentTarget.checked)}
     />
     <span>Bring in highlights from Margin</span>
   </label>
-  <p class="setting-description">
-    Highlights you've made in Margin join your review deck here. They stay private on Skyreader —
-    the notes they came from stay public on your PDS.
-  </p>
-  {#if !hasMarginScopes}
+  <p class="setting-description">Highlights you've made in Margin join your review deck here.</p>
+  {#if marginScopes === 'missing'}
     <p class="setting-description">
       This needs permission to read and write your Margin notes.
       <button class="link-btn" onclick={reauthForScopes} type="button">
         Log in again to grant access
       </button>
+    </p>
+  {:else if marginScopes === 'unknown'}
+    <p class="setting-description">
+      Couldn't check your Margin permissions just now. The import will start once you're back
+      online.
     </p>
   {/if}
   {#if importing}

--- a/frontend/src/lib/components/settings/HighlightSettings.svelte
+++ b/frontend/src/lib/components/settings/HighlightSettings.svelte
@@ -18,7 +18,14 @@
   } from '$lib/stores/preferences.svelte';
   import { maybeImportMarginHighlights } from '$lib/services/marginHighlightImport';
 
-  let { returnUrl = '/settings' }: { returnUrl?: string } = $props();
+  interface Props {
+    returnUrl?: string;
+    /** Fired when switching the toggle on actually brought highlights in, so a
+        host showing those highlights (the review deck) can react. */
+    onImported?: (imported: number) => void;
+  }
+
+  let { returnUrl = '/settings', onImported }: Props = $props();
 
   let loaded = $state(false);
   let hasMarginScopes = $state(false);
@@ -60,6 +67,7 @@
       } else {
         importNote = `Brought in ${result.imported} highlight${result.imported === 1 ? '' : 's'}.`;
       }
+      if (result && result.imported > 0) onImported?.(result.imported);
     } finally {
       importing = false;
     }

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -12,6 +12,7 @@ import type {
   MagazineParams,
   MagazinePosition,
   MarginCollection,
+  MarginHighlightNote,
   ParsedFeed,
   SaveBacking,
   SembleCollection,
@@ -1154,6 +1155,14 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify(data),
     });
+  }
+
+  /** The user's own Margin highlights, matched against their saves server-side. */
+  async listMarginHighlights(): Promise<{
+    notes: MarginHighlightNote[];
+    truncated: boolean;
+  }> {
+    return this.fetch('/api/integrations/margin/highlights');
   }
 
   async createMarginNote(data: {

--- a/frontend/src/lib/services/marginHighlightImport.ts
+++ b/frontend/src/lib/services/marginHighlightImport.ts
@@ -1,0 +1,83 @@
+import { api, ScopeUpgradeError } from '$lib/services/api';
+import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
+import { preferences } from '$lib/stores/preferences.svelte';
+import { savesStore } from '$lib/stores/saves.svelte';
+import { syncStore } from '$lib/stores/sync.svelte';
+import { planMarginHighlightImport } from '$lib/utils/marginHighlightImport';
+
+// Opt-in ingest of the reader's own Margin highlights, so the review deck covers
+// everything they've highlighted across the Atmosphere and not only what they
+// highlighted in Skyreader.
+//
+// Imported highlights carry `marginUri`/`marginRkey` exactly like one Skyreader
+// pushed out, which is what makes the lifecycle symmetric: re-polls dedup on the
+// rkey, note edits update the same record, and deleting one deletes the Margin
+// record (so it doesn't resurrect on the next poll).
+
+/** Don't re-poll the PDS more than this often, however many surfaces ask. */
+const POLL_INTERVAL_MS = 15 * 60 * 1000;
+
+let lastPollAt = 0;
+let inFlight: Promise<MarginImportResult | null> | null = null;
+
+export interface MarginImportResult {
+  imported: number;
+  /** The poll hit the page cap — some Margin highlights weren't read yet. */
+  truncated: boolean;
+}
+
+/**
+ * Poll Margin and merge anything new into the highlight store. Minute-gated, so
+ * every surface that cares can call it on mount. Returns null when it didn't
+ * run (disabled, offline, or polled recently).
+ */
+export async function maybeImportMarginHighlights(
+  options: { force?: boolean } = {}
+): Promise<MarginImportResult | null> {
+  if (!preferences.marginHighlightImport) return null;
+  if (!syncStore.isOnline) return null;
+  if (!options.force && Date.now() - lastPollAt < POLL_INTERVAL_MS) return null;
+  // Concurrent callers (the list and the deck mount together) share one poll.
+  if (inFlight) return inFlight;
+
+  lastPollAt = Date.now();
+  inFlight = (async () => {
+    try {
+      const { notes, truncated } = await api.listMarginHighlights();
+      const groups = planMarginHighlightImport(
+        notes,
+        itemLabelsStore.allHighlights,
+        savesStore.articles
+      );
+
+      let imported = 0;
+      for (const group of groups) {
+        // One union write per item, not per highlight — a heavily-annotated
+        // article can arrive with dozens at once.
+        await itemLabelsStore.addHighlights(group.itemKey, group.itemType, group.highlights);
+        imported += group.highlights.length;
+      }
+      return { imported, truncated };
+    } catch (error) {
+      if (error instanceof ScopeUpgradeError) {
+        // The grant lapsed — stop asking until the user turns it back on.
+        preferences.setMarginHighlightImport(false);
+        return null;
+      }
+      console.error('Failed to import Margin highlights:', error);
+      // Let the next surface retry rather than sitting out the whole interval.
+      lastPollAt = 0;
+      return null;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/** Test seam: forget the poll gate. */
+export function resetMarginHighlightImportGate(): void {
+  lastPollAt = 0;
+  inFlight = null;
+}

--- a/frontend/src/lib/services/marginHighlightImport.ts
+++ b/frontend/src/lib/services/marginHighlightImport.ts
@@ -3,7 +3,11 @@ import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
 import { preferences } from '$lib/stores/preferences.svelte';
 import { savesStore } from '$lib/stores/saves.svelte';
 import { syncStore } from '$lib/stores/sync.svelte';
-import { planMarginHighlightImport } from '$lib/utils/marginHighlightImport';
+import {
+  planMarginHighlightImport,
+  planMarginHighlightRekeys,
+  type MarginImportOutcome,
+} from '$lib/utils/marginHighlightImport';
 
 // Opt-in ingest of the reader's own Margin highlights, so the review deck covers
 // everything they've highlighted across the Atmosphere and not only what they
@@ -18,32 +22,59 @@ import { planMarginHighlightImport } from '$lib/utils/marginHighlightImport';
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 
 let lastPollAt = 0;
-let inFlight: Promise<MarginImportResult | null> | null = null;
+let inFlight: Promise<MarginImportOutcome> | null = null;
+let lastTruncated = false;
 
-export interface MarginImportResult {
-  imported: number;
-  /** The poll hit the page cap — some Margin highlights weren't read yet. */
-  truncated: boolean;
-}
+export type { MarginImportOutcome };
 
 /**
  * Poll Margin and merge anything new into the highlight store. Minute-gated, so
- * every surface that cares can call it on mount. Returns null when it didn't
- * run (disabled, offline, or polled recently).
+ * every surface that cares can call it on mount. Every non-import outcome says
+ * which one it was, so a surface can tell "polled recently" from "your Margin
+ * grant lapsed" instead of blaming the network for both.
  */
 export async function maybeImportMarginHighlights(
   options: { force?: boolean } = {}
-): Promise<MarginImportResult | null> {
-  if (!preferences.marginHighlightImport) return null;
-  if (!syncStore.isOnline) return null;
-  if (!options.force && Date.now() - lastPollAt < POLL_INTERVAL_MS) return null;
-  // Concurrent callers (the list and the deck mount together) share one poll.
+): Promise<MarginImportOutcome> {
+  if (!preferences.marginHighlightImport) {
+    // Nothing is being imported, so nothing is partial.
+    lastTruncated = false;
+    return { status: 'skipped', reason: 'disabled' };
+  }
+  if (!syncStore.isOnline) return { status: 'skipped', reason: 'offline' };
+
+  // The import unions against the highlights it can see and writes the result
+  // back as the item's whole set, so running before the local read has landed
+  // would import against an empty corpus and overwrite an item's existing
+  // highlights with only the imported ones.
+  //
+  // The gate lives here rather than in each caller because every caller shares
+  // one in-flight poll, so a single ungated one defeats everybody else's gate —
+  // which is exactly how the settings toggle got past it. It sits above the
+  // interval stamp so a skipped attempt doesn't burn the next fifteen minutes:
+  // whichever surface is waiting on the stores will call again once they land.
+  if (itemLabelsStore.isLoading || savesStore.loading) {
+    return { status: 'skipped', reason: 'stores-loading' };
+  }
+
+  // Concurrent callers share one poll. This has to sit above the interval gate,
+  // not below it: `lastPollAt` is stamped before the request goes out, so a
+  // second caller arriving while the first is still in flight would otherwise be
+  // told it was throttled and go on to report a stale `truncated`, skip its
+  // redeal, or — from the settings toggle — say Margin was unreachable while the
+  // poll it should have joined was succeeding.
   if (inFlight) return inFlight;
 
+  if (!options.force && Date.now() - lastPollAt < POLL_INTERVAL_MS) {
+    return { status: 'skipped', reason: 'throttled' };
+  }
+
   lastPollAt = Date.now();
-  inFlight = (async () => {
+  inFlight = (async (): Promise<MarginImportOutcome> => {
     try {
       const { notes, truncated } = await api.listMarginHighlights();
+      lastTruncated = truncated;
+
       const groups = planMarginHighlightImport(
         notes,
         itemLabelsStore.allHighlights,
@@ -57,17 +88,37 @@ export async function maybeImportMarginHighlights(
         await itemLabelsStore.addHighlights(group.itemKey, group.itemType, group.highlights);
         imported += group.highlights.length;
       }
-      return { imported, truncated };
+
+      // Notes imported before their article was saved landed on a URL key. Now
+      // that the server can join them to a save, move them onto it. Read the
+      // corpus again rather than reusing the snapshot above: the writes just
+      // made are part of what may need moving.
+      const rekeys = planMarginHighlightRekeys(
+        notes,
+        itemLabelsStore.allHighlights,
+        savesStore.articles
+      );
+      for (const group of rekeys) {
+        // Add before remove. Interrupted halfway, a duplicate is visible and
+        // heals on the next poll; the other order can lose the only copy.
+        await itemLabelsStore.addHighlights(group.to, group.itemType, group.highlights);
+        for (const highlight of group.highlights) {
+          await itemLabelsStore.removeHighlight(group.from, highlight.id);
+        }
+      }
+
+      return { status: 'imported', imported, truncated };
     } catch (error) {
       if (error instanceof ScopeUpgradeError) {
-        // The grant lapsed — stop asking until the user turns it back on.
+        // The grant lapsed — stop asking until the user turns it back on, and
+        // say so, so the surface that asked doesn't call it a network blip.
         preferences.setMarginHighlightImport(false);
-        return null;
+        return { status: 'scope-expired' };
       }
       console.error('Failed to import Margin highlights:', error);
       // Let the next surface retry rather than sitting out the whole interval.
       lastPollAt = 0;
-      return null;
+      return { status: 'failed' };
     } finally {
       inFlight = null;
     }
@@ -76,8 +127,21 @@ export async function maybeImportMarginHighlights(
   return inFlight;
 }
 
+/**
+ * Did the last poll that actually reached the PDS hit the page cap?
+ *
+ * Kept here rather than read off a single call's return, because most calls
+ * short-circuit on the interval gate — and the corpus is no less partial for
+ * some other surface having done the fetching. Without this, the notice on
+ * `/highlights` would stay hidden in exactly the case it exists for.
+ */
+export function marginImportTruncated(): boolean {
+  return lastTruncated;
+}
+
 /** Test seam: forget the poll gate. */
 export function resetMarginHighlightImportGate(): void {
   lastPollAt = 0;
   inFlight = null;
+  lastTruncated = false;
 }

--- a/frontend/src/lib/stores/highlightReview.svelte.ts
+++ b/frontend/src/lib/stores/highlightReview.svelte.ts
@@ -1,6 +1,6 @@
 import { itemLabelsStore } from './itemLabels.svelte';
 import { preferences } from './preferences.svelte';
-import { summarizeHighlightDeck } from '$lib/utils/highlightReview';
+import { buildHighlightDeck, summarizeHighlightDeck } from '$lib/utils/highlightReview';
 
 /**
  * One shared read of "what does today's review deck hold?".
@@ -15,6 +15,25 @@ function createHighlightReviewStore() {
     summarizeHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount)
   );
 
+  // Kept separate from `summary` so the nav badge, which only needs a number,
+  // never pays to rank the pool. `$derived` is lazy, so this costs nothing until
+  // something actually asks which highlights are in today's deck.
+  let cards = $derived(
+    buildHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount).cards
+  );
+
+  // What a "Review more" would deal once today's portion is spent: the same pool
+  // with the daily filter lifted, so it counts highlights already seen today.
+  // Only the end-of-deck states read it.
+  let encore = $derived(
+    summarizeHighlightDeck(
+      itemLabelsStore.allHighlights,
+      preferences.highlightReviewCount,
+      new Date(),
+      { includeReviewedToday: true }
+    )
+  );
+
   return {
     get status() {
       return summary.status;
@@ -22,6 +41,14 @@ function createHighlightReviewStore() {
     /** Cards today's deck would deal — the quiet nav badge. 0 once it's done. */
     get dueCount() {
       return summary.dueCount;
+    },
+    /** Cards an encore hand would deal after today's portion is spent. */
+    get encoreCount() {
+      return encore.dueCount;
+    },
+    /** Today's deck itself, ranked. For entry points that name what's in it. */
+    get cards() {
+      return cards;
     },
     /** Does the reader have any highlights at all? False hides the nav entry. */
     get hasHighlights() {

--- a/frontend/src/lib/stores/highlightReview.svelte.ts
+++ b/frontend/src/lib/stores/highlightReview.svelte.ts
@@ -1,0 +1,33 @@
+import { itemLabelsStore } from './itemLabels.svelte';
+import { preferences } from './preferences.svelte';
+import { summarizeHighlightDeck } from '$lib/utils/highlightReview';
+
+/**
+ * One shared read of "what does today's review deck hold?".
+ *
+ * The sidebar, the mobile switcher, the nav dropdown and the Home card all ask
+ * the same question, and each would otherwise walk the whole highlight corpus on
+ * its own. Deriving it once here keeps every entry point showing the same number
+ * and pays for the scan once.
+ */
+function createHighlightReviewStore() {
+  let summary = $derived(
+    summarizeHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount)
+  );
+
+  return {
+    get status() {
+      return summary.status;
+    },
+    /** Cards today's deck would deal — the quiet nav badge. 0 once it's done. */
+    get dueCount() {
+      return summary.dueCount;
+    },
+    /** Does the reader have any highlights at all? False hides the nav entry. */
+    get hasHighlights() {
+      return itemLabelsStore.allHighlights.length > 0;
+    },
+  };
+}
+
+export const highlightReviewStore = createHighlightReviewStore();

--- a/frontend/src/lib/stores/highlightReview.svelte.ts
+++ b/frontend/src/lib/stores/highlightReview.svelte.ts
@@ -1,6 +1,10 @@
 import { itemLabelsStore } from './itemLabels.svelte';
 import { preferences } from './preferences.svelte';
-import { buildHighlightDeck, summarizeHighlightDeck } from '$lib/utils/highlightReview';
+import {
+  buildHighlightDeck,
+  isReviewable,
+  summarizeHighlightDeck,
+} from '$lib/utils/highlightReview';
 
 /**
  * One shared read of "what does today's review deck hold?".
@@ -50,9 +54,14 @@ function createHighlightReviewStore() {
     get cards() {
       return cards;
     },
-    /** Does the reader have any highlights at all? False hides the nav entry. */
+    /**
+     * Does the reader have any highlight the deck could ever deal? False hides
+     * the nav entry and the "Review more" offer. Retired highlights don't count:
+     * a corpus that's entirely been told "don't show again" has nothing to
+     * offer, however many highlights the list holds.
+     */
     get hasHighlights() {
-      return itemLabelsStore.allHighlights.length > 0;
+      return itemLabelsStore.allHighlights.some((entry) => isReviewable(entry.highlight));
     },
   };
 }

--- a/frontend/src/lib/stores/highlightReview.svelte.ts
+++ b/frontend/src/lib/stores/highlightReview.svelte.ts
@@ -1,8 +1,10 @@
+import { browser } from '$app/environment';
 import { itemLabelsStore } from './itemLabels.svelte';
 import { preferences } from './preferences.svelte';
 import {
   buildHighlightDeck,
   isReviewable,
+  startOfLocalDay,
   summarizeHighlightDeck,
 } from '$lib/utils/highlightReview';
 
@@ -15,27 +17,68 @@ import {
  * and pays for the scan once.
  */
 function createHighlightReviewStore() {
+  // The deck is scoped to the local calendar day, but a `$derived` recomputes
+  // only when something it read changes, and the wall clock is not something it
+  // read. Left as-is, an installed PWA open across midnight would keep showing
+  // yesterday's count in the sidebar, the dropdown, the switcher and the Home
+  // card until a highlight happened to change.
+  //
+  // So the day is state, and midnight is an invalidation like any other.
+  let dayStart = $state(startOfLocalDay(new Date()));
+  let rollover: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * "Now" for every derivation below. The value is the real clock, which the
+   * 24-hour freshness window needs; reading `dayStart` on the way is what
+   * subscribes the derivation to the day rolling over.
+   */
+  function reviewNow(): Date {
+    return new Date(Math.max(Date.now(), dayStart));
+  }
+
+  function syncDay() {
+    const start = startOfLocalDay(new Date());
+    if (start !== dayStart) dayStart = start;
+    scheduleRollover();
+  }
+
+  function scheduleRollover() {
+    if (!browser) return;
+    clearTimeout(rollover);
+    // setHours(24, …) lands on the next local midnight, which is what we want
+    // across a DST boundary — that day is 23 or 25 hours long, not 24.
+    const next = new Date();
+    next.setHours(24, 0, 0, 0);
+    // A second past the boundary, so the timer can't fire a hair early and
+    // re-arm itself for the same day.
+    rollover = setTimeout(syncDay, Math.max(1000, next.getTime() - Date.now() + 1000));
+  }
+
+  if (browser) {
+    scheduleRollover();
+    // Background tabs get their timers throttled and a sleeping device stops
+    // them outright, so coming back to the app re-checks rather than trusting
+    // that the rollover fired.
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) syncDay();
+    });
+    window.addEventListener('focus', syncDay);
+  }
+
   let summary = $derived(
-    summarizeHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount)
+    summarizeHighlightDeck(
+      itemLabelsStore.allHighlights,
+      preferences.highlightReviewCount,
+      reviewNow()
+    )
   );
 
   // Kept separate from `summary` so the nav badge, which only needs a number,
   // never pays to rank the pool. `$derived` is lazy, so this costs nothing until
   // something actually asks which highlights are in today's deck.
   let cards = $derived(
-    buildHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount).cards
-  );
-
-  // What a "Review more" would deal once today's portion is spent: the same pool
-  // with the daily filter lifted, so it counts highlights already seen today.
-  // Only the end-of-deck states read it.
-  let encore = $derived(
-    summarizeHighlightDeck(
-      itemLabelsStore.allHighlights,
-      preferences.highlightReviewCount,
-      new Date(),
-      { includeReviewedToday: true }
-    )
+    buildHighlightDeck(itemLabelsStore.allHighlights, preferences.highlightReviewCount, reviewNow())
+      .cards
   );
 
   return {
@@ -45,10 +88,6 @@ function createHighlightReviewStore() {
     /** Cards today's deck would deal — the quiet nav badge. 0 once it's done. */
     get dueCount() {
       return summary.dueCount;
-    },
-    /** Cards an encore hand would deal after today's portion is spent. */
-    get encoreCount() {
-      return encore.dueCount;
     },
     /** Today's deck itself, ranked. For entry points that name what's in it. */
     get cards() {

--- a/frontend/src/lib/stores/itemLabels.svelte.ts
+++ b/frontend/src/lib/stores/itemLabels.svelte.ts
@@ -14,9 +14,10 @@ import { generateTid } from '$lib/utils/tid';
 import {
   mutateHighlightUnion,
   resolveHighlightAliases,
+  savedItemLabelType,
   unionHighlightSources,
 } from '$lib/utils/highlightAliases';
-import type { ItemLabel, ItemLabelType, SocialItemType, Highlight } from '$lib/types';
+import type { ItemLabel, ItemLabelType, SocialItemType, Highlight, ReviewIntent } from '$lib/types';
 
 const BULK_BATCH_SIZE = 500;
 
@@ -1662,22 +1663,23 @@ function createItemLabelsStore() {
   }
 
   /**
-   * Retire a highlight from the review deck, or put it back ("Don't show
-   * again"). Nothing is deleted: the highlight stays in the highlights list and
-   * on Margin, it just stops being dealt. Rides the same union write as every
-   * other highlight mutation, so it syncs across devices and queues offline.
+   * Set how often a highlight should come back around in the review deck, or
+   * pass null to put it back at the default pace. Nothing is deleted, even for
+   * 'never': the highlight stays in the highlights list and on Margin, it just
+   * stops being dealt. Rides the same union write as every other highlight
+   * mutation, so it reaches D1 with the rest of the highlights array (and so
+   * syncs across devices, and queues when offline) for free.
    */
-  async function setHighlightReviewRetired(
+  async function setHighlightReviewIntent(
     itemKey: string,
     highlightId: string,
-    retired: boolean,
-    at = Date.now()
+    intent: ReviewIntent | null
   ) {
     const context = highlightContext(itemKey);
     const mutation = mutateHighlightUnion(context.highlights, {
-      type: 'retire',
+      type: 'intent',
       highlightId,
-      at: retired ? at : null,
+      intent,
     });
     if (!mutation.changed) return;
     await persistHighlightUnion(
@@ -1704,8 +1706,7 @@ function createItemLabelsStore() {
   function getSavedItemKeys(): Map<ItemLabelType, Set<string>> {
     const result = new Map<ItemLabelType, Set<string>>();
     for (const bm of savesStore.articles) {
-      const type: ItemLabelType =
-        bm.source === 'document' ? 'document' : bm.source === 'feed' ? 'article' : 'saved';
+      const type = savedItemLabelType(bm);
       let set = result.get(type);
       if (!set) {
         set = new Set();
@@ -1802,7 +1803,7 @@ function createItemLabelsStore() {
     setHighlightMargin,
     setHighlightNote,
     markHighlightReviewed,
-    setHighlightReviewRetired,
+    setHighlightReviewIntent,
     // Derived helpers
     getSavedArticles,
     getSavedItemKeys,

--- a/frontend/src/lib/stores/itemLabels.svelte.ts
+++ b/frontend/src/lib/stores/itemLabels.svelte.ts
@@ -1571,6 +1571,21 @@ function createItemLabelsStore() {
     await persistHighlightUnion(itemKey, itemType, mutation.highlights);
   }
 
+  /**
+   * Add several highlights to one item in a single union write. Used by the
+   * Margin import, where a heavily-annotated article can arrive with dozens of
+   * highlights at once and one write per highlight would mean one API round trip
+   * (and one full-array rewrite) each.
+   */
+  async function addHighlights(itemKey: string, itemType: ItemLabelType, highlights: Highlight[]) {
+    if (highlights.length === 0) return;
+    let merged = getHighlights(itemKey);
+    for (const highlight of highlights) {
+      merged = mutateHighlightUnion(merged, { type: 'add', highlight }).highlights;
+    }
+    await persistHighlightUnion(itemKey, itemType, merged);
+  }
+
   async function removeHighlight(itemKey: string, highlightId: string) {
     const context = highlightContext(itemKey);
     const mutation = mutateHighlightUnion(context.highlights, { type: 'remove', highlightId });
@@ -1617,6 +1632,26 @@ function createItemLabelsStore() {
       type: 'note',
       highlightId,
       note,
+    });
+    if (!mutation.changed) return;
+    await persistHighlightUnion(
+      itemKey,
+      context.labels[0]?.itemType || 'saved',
+      mutation.highlights
+    );
+  }
+
+  /**
+   * Stamp a highlight as reviewed (review deck). Rides the same union write as
+   * every other highlight mutation, so it syncs and queues offline for free.
+   * No-op when the stamp wouldn't move forward.
+   */
+  async function markHighlightReviewed(itemKey: string, highlightId: string, at = Date.now()) {
+    const context = highlightContext(itemKey);
+    const mutation = mutateHighlightUnion(context.highlights, {
+      type: 'reviewed',
+      highlightId,
+      at,
     });
     if (!mutation.changed) return;
     await persistHighlightUnion(
@@ -1736,9 +1771,11 @@ function createItemLabelsStore() {
     canonicalKey,
     hasHighlights,
     addHighlight,
+    addHighlights,
     removeHighlight,
     setHighlightMargin,
     setHighlightNote,
+    markHighlightReviewed,
     // Derived helpers
     getSavedArticles,
     getSavedItemKeys,

--- a/frontend/src/lib/stores/itemLabels.svelte.ts
+++ b/frontend/src/lib/stores/itemLabels.svelte.ts
@@ -1661,6 +1661,32 @@ function createItemLabelsStore() {
     );
   }
 
+  /**
+   * Retire a highlight from the review deck, or put it back ("Don't show
+   * again"). Nothing is deleted: the highlight stays in the highlights list and
+   * on Margin, it just stops being dealt. Rides the same union write as every
+   * other highlight mutation, so it syncs across devices and queues offline.
+   */
+  async function setHighlightReviewRetired(
+    itemKey: string,
+    highlightId: string,
+    retired: boolean,
+    at = Date.now()
+  ) {
+    const context = highlightContext(itemKey);
+    const mutation = mutateHighlightUnion(context.highlights, {
+      type: 'retire',
+      highlightId,
+      at: retired ? at : null,
+    });
+    if (!mutation.changed) return;
+    await persistHighlightUnion(
+      itemKey,
+      context.labels[0]?.itemType || 'saved',
+      mutation.highlights
+    );
+  }
+
   // --- Derived helpers ---
 
   function getSavedArticles(): SavedArticle[] {
@@ -1776,6 +1802,7 @@ function createItemLabelsStore() {
     setHighlightMargin,
     setHighlightNote,
     markHighlightReviewed,
+    setHighlightReviewRetired,
     // Derived helpers
     getSavedArticles,
     getSavedItemKeys,

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -1,5 +1,12 @@
 import { browser } from '$app/environment';
 import { auth } from '$lib/stores/auth.svelte';
+import {
+  HIGHLIGHT_REVIEW_COUNT_DEFAULT,
+  HIGHLIGHT_REVIEW_COUNT_OPTIONS,
+  type HighlightReviewCount,
+} from '$lib/utils/highlightReview';
+
+export { HIGHLIGHT_REVIEW_COUNT_OPTIONS, type HighlightReviewCount };
 
 export type ArticleFont = 'sans-serif' | 'serif' | 'mono' | 'literata';
 // Reader body size, in CSS pixels. Was a fixed xs…xl scale (12–20px); now a
@@ -78,6 +85,11 @@ interface PreferencesState {
   // Distinguishes an explicit opt-out from the former default-off value that
   // was written whenever any preference was saved.
   communityHighlightsConfigured: boolean;
+  // How many highlights one review session serves up.
+  highlightReviewCount: HighlightReviewCount;
+  // Pull the reader's own Margin highlights into Skyreader. Device-local: once
+  // one device imports, the highlights sync everywhere as normal label rows.
+  marginHighlightImport: boolean;
 }
 
 const STORAGE_KEY = 'skyreader-preferences';
@@ -104,6 +116,8 @@ function createPreferencesStore() {
     dailyMagazineOrder: 'shuffle',
     communityHighlights: true,
     communityHighlightsConfigured: false,
+    highlightReviewCount: HIGHLIGHT_REVIEW_COUNT_DEFAULT,
+    marginHighlightImport: false,
   });
 
   // Restore from localStorage on init
@@ -164,6 +178,12 @@ function createPreferencesStore() {
         ) {
           state.communityHighlights = parsed.communityHighlights;
           state.communityHighlightsConfigured = true;
+        }
+        if (HIGHLIGHT_REVIEW_COUNT_OPTIONS.includes(parsed.highlightReviewCount)) {
+          state.highlightReviewCount = parsed.highlightReviewCount;
+        }
+        if (typeof parsed.marginHighlightImport === 'boolean') {
+          state.marginHighlightImport = parsed.marginHighlightImport;
         }
       } catch {
         localStorage.removeItem(STORAGE_KEY);
@@ -281,6 +301,17 @@ function createPreferencesStore() {
     save();
   }
 
+  function setHighlightReviewCount(count: HighlightReviewCount) {
+    if (!HIGHLIGHT_REVIEW_COUNT_OPTIONS.includes(count)) return;
+    state.highlightReviewCount = count;
+    save();
+  }
+
+  function setMarginHighlightImport(enabled: boolean) {
+    state.marginHighlightImport = enabled;
+    save();
+  }
+
   return {
     get articleFont() {
       return state.articleFont;
@@ -325,6 +356,14 @@ function createPreferencesStore() {
     get communityHighlights() {
       return state.communityHighlights;
     },
+    get highlightReviewCount() {
+      return state.highlightReviewCount;
+    },
+    get marginHighlightImport() {
+      return state.marginHighlightImport;
+    },
+    setHighlightReviewCount,
+    setMarginHighlightImport,
     confirmLinkblogShare,
     setLinkblogDisabled,
     setDefaultView,

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1249,6 +1249,24 @@ export interface MarginCollection {
   createdAt?: string;
 }
 
+/**
+ * One of the user's own `at.margin.note` highlights, as returned by
+ * `GET /api/integrations/margin/highlights`. `match` is the save the note's URL
+ * landed on (server-side join on the normalized URL); null when the article
+ * isn't in the user's Saved list.
+ */
+export interface MarginHighlightNote {
+  uri: string;
+  rkey: string;
+  url: string;
+  urlNormalized: string;
+  title?: string;
+  selector: TextQuoteSelector;
+  note?: string;
+  createdAt?: string;
+  match: { itemGuid: string | null; uri: string | null } | null;
+}
+
 export interface TextQuoteSelector {
   type: 'TextQuoteSelector';
   exact: string;
@@ -1266,4 +1284,12 @@ export interface Highlight {
   // Set once the highlight has been pushed to Margin (at.margin.note on the user's PDS).
   marginUri?: string;
   marginRkey?: string;
+  // Last time this highlight came up in the review deck (epoch ms). Rides the
+  // normal label sync, so "already reviewed" follows the reader across devices.
+  lastReviewedAt?: number;
+  // Source metadata carried on the highlight itself, for highlights imported
+  // from Margin whose article isn't in any local cache — without these the
+  // highlight has no title or link to show.
+  sourceUrl?: string;
+  sourceTitle?: string;
 }

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1267,6 +1267,13 @@ export interface MarginHighlightNote {
   match: { itemGuid: string | null; uri: string | null } | null;
 }
 
+/**
+ * The reader's answer to "when should this come back?" — the review deck's
+ * frequency tuning. 'later' is the neutral middle and the default, so an
+ * untuned highlight and an explicit 'later' behave identically.
+ */
+export type ReviewIntent = 'soon' | 'later' | 'someday' | 'never';
+
 export interface TextQuoteSelector {
   type: 'TextQuoteSelector';
   exact: string;
@@ -1287,11 +1294,11 @@ export interface Highlight {
   // Last time this highlight came up in the review deck (epoch ms). Rides the
   // normal label sync, so "already reviewed" follows the reader across devices.
   lastReviewedAt?: number;
-  // Set when the reader retires a highlight from the review deck ("Don't show
-  // again", epoch ms). The highlight itself is untouched — it stays in the
-  // highlights list and on Margin; it just stops being dealt. Clearing the field
-  // puts it back in rotation.
-  reviewRetiredAt?: number;
+  // How often the reader wants this one to come back around in the review deck.
+  // Unset means the default pace, which is what 'later' names explicitly. The
+  // highlight itself is never touched by this — even 'never' leaves it in the
+  // highlights list and on Margin, it just stops being dealt.
+  reviewIntent?: ReviewIntent;
   // Source metadata carried on the highlight itself, for highlights imported
   // from Margin whose article isn't in any local cache — without these the
   // highlight has no title or link to show.

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1287,6 +1287,11 @@ export interface Highlight {
   // Last time this highlight came up in the review deck (epoch ms). Rides the
   // normal label sync, so "already reviewed" follows the reader across devices.
   lastReviewedAt?: number;
+  // Set when the reader retires a highlight from the review deck ("Don't show
+  // again", epoch ms). The highlight itself is untouched — it stays in the
+  // highlights list and on Margin; it just stops being dealt. Clearing the field
+  // puts it back in rotation.
+  reviewRetiredAt?: number;
   // Source metadata carried on the highlight itself, for highlights imported
   // from Margin whose article isn't in any local cache — without these the
   // highlight has no title or link to show.

--- a/frontend/src/lib/utils/dailyMagazine.ts
+++ b/frontend/src/lib/utils/dailyMagazine.ts
@@ -70,8 +70,9 @@ export function savedItemLabelKeys(item: SavedItem): string[] {
 
 // FNV-1a gives each stable key a repeatable daily sort score. It is not used
 // for security or randomness; it simply rotates the pile without persisting an
-// issue record.
-function dailyScore(dateKey: string, key: string): number {
+// issue record. Shared with the highlight review deck, which rotates its own
+// pile the same way.
+export function dailyScore(dateKey: string, key: string): number {
   const value = `${dateKey}\0${key}`;
   let hash = 0x811c9dc5;
   for (let i = 0; i < value.length; i += 1) {

--- a/frontend/src/lib/utils/highlightAliases.test.ts
+++ b/frontend/src/lib/utils/highlightAliases.test.ts
@@ -60,3 +60,47 @@ describe('saved highlight aliases', () => {
     expect(union[0].note).toBe('current');
   });
 });
+
+describe('reviewed mutation', () => {
+  const base = [highlight('one'), highlight('two')];
+
+  it('stamps only the named highlight', () => {
+    const result = mutateHighlightUnion(base, { type: 'reviewed', highlightId: 'one', at: 500 });
+    expect(result.changed).toBe(true);
+    expect(result.highlights.find((h) => h.id === 'one')?.lastReviewedAt).toBe(500);
+    expect(result.highlights.find((h) => h.id === 'two')?.lastReviewedAt).toBeUndefined();
+  });
+
+  it('moves the stamp forward but never back', () => {
+    const stamped = mutateHighlightUnion(base, {
+      type: 'reviewed',
+      highlightId: 'one',
+      at: 500,
+    }).highlights;
+
+    // A slow device flushing an older review must not make it look due again.
+    const stale = mutateHighlightUnion(stamped, { type: 'reviewed', highlightId: 'one', at: 100 });
+    expect(stale.changed).toBe(false);
+    expect(stale.highlights.find((h) => h.id === 'one')?.lastReviewedAt).toBe(500);
+
+    const newer = mutateHighlightUnion(stamped, { type: 'reviewed', highlightId: 'one', at: 900 });
+    expect(newer.changed).toBe(true);
+    expect(newer.highlights.find((h) => h.id === 'one')?.lastReviewedAt).toBe(900);
+  });
+
+  it('is a no-op for an unknown highlight', () => {
+    const result = mutateHighlightUnion(base, { type: 'reviewed', highlightId: 'gone', at: 1 });
+    expect(result.changed).toBe(false);
+    expect(result.highlights).toBe(base);
+  });
+
+  it('leaves the note and Margin linkage alone', () => {
+    const withNote = [{ ...highlight('one'), note: 'kept', marginRkey: 'rk1' }];
+    const result = mutateHighlightUnion(withNote, {
+      type: 'reviewed',
+      highlightId: 'one',
+      at: 5,
+    });
+    expect(result.highlights[0]).toMatchObject({ note: 'kept', marginRkey: 'rk1' });
+  });
+});

--- a/frontend/src/lib/utils/highlightAliases.ts
+++ b/frontend/src/lib/utils/highlightAliases.ts
@@ -20,7 +20,8 @@ export type HighlightMutation =
       highlightId: string;
       margin: { uri: string; rkey: string } | null;
     }
-  | { type: 'reviewed'; highlightId: string; at: number };
+  | { type: 'reviewed'; highlightId: string; at: number }
+  | { type: 'retire'; highlightId: string; at: number | null };
 
 /** Resolve every persisted key for one save, preferring its article guid. */
 export function resolveHighlightAliases(
@@ -77,6 +78,15 @@ export function mutateHighlightUnion(
     else {
       const { note: _note, ...withoutNote } = current;
       next[index] = withoutNote;
+    }
+  } else if (mutation.type === 'retire') {
+    const retired = typeof current.reviewRetiredAt === 'number';
+    if (retired === (mutation.at !== null)) return { highlights, changed: false };
+    if (mutation.at === null) {
+      const { reviewRetiredAt: _retired, ...backInRotation } = current;
+      next[index] = backInRotation;
+    } else {
+      next[index] = { ...current, reviewRetiredAt: mutation.at };
     }
   } else if (mutation.type === 'reviewed') {
     // Only ever moves forward: an out-of-order write (a slow device flushing an

--- a/frontend/src/lib/utils/highlightAliases.ts
+++ b/frontend/src/lib/utils/highlightAliases.ts
@@ -1,4 +1,16 @@
-import type { Highlight, SavedItem } from '$lib/types';
+import type { Highlight, ItemLabelType, ReviewIntent, SavedItem } from '$lib/types';
+
+/**
+ * What kind of label row a save's highlights belong on. A save is the same
+ * item the reader met in the feed, in the reader or as a bare URL, and the
+ * label type has to name which — `resolveHighlightSource` looks in a different
+ * cache for each.
+ */
+export function savedItemLabelType(save: Pick<SavedItem, 'source'>): ItemLabelType {
+  if (save.source === 'document') return 'document';
+  if (save.source === 'feed') return 'article';
+  return 'saved';
+}
 
 export interface HighlightAliasResolution {
   canonicalKey: string;
@@ -21,7 +33,7 @@ export type HighlightMutation =
       margin: { uri: string; rkey: string } | null;
     }
   | { type: 'reviewed'; highlightId: string; at: number }
-  | { type: 'retire'; highlightId: string; at: number | null };
+  | { type: 'intent'; highlightId: string; intent: ReviewIntent | null };
 
 /** Resolve every persisted key for one save, preferring its article guid. */
 export function resolveHighlightAliases(
@@ -79,14 +91,15 @@ export function mutateHighlightUnion(
       const { note: _note, ...withoutNote } = current;
       next[index] = withoutNote;
     }
-  } else if (mutation.type === 'retire') {
-    const retired = typeof current.reviewRetiredAt === 'number';
-    if (retired === (mutation.at !== null)) return { highlights, changed: false };
-    if (mutation.at === null) {
-      const { reviewRetiredAt: _retired, ...backInRotation } = current;
-      next[index] = backInRotation;
+  } else if (mutation.type === 'intent') {
+    if ((current.reviewIntent ?? null) === mutation.intent) {
+      return { highlights, changed: false };
+    }
+    if (mutation.intent === null) {
+      const { reviewIntent: _intent, ...atDefaultPace } = current;
+      next[index] = atDefaultPace;
     } else {
-      next[index] = { ...current, reviewRetiredAt: mutation.at };
+      next[index] = { ...current, reviewIntent: mutation.intent };
     }
   } else if (mutation.type === 'reviewed') {
     // Only ever moves forward: an out-of-order write (a slow device flushing an

--- a/frontend/src/lib/utils/highlightAliases.ts
+++ b/frontend/src/lib/utils/highlightAliases.ts
@@ -19,7 +19,8 @@ export type HighlightMutation =
       type: 'margin';
       highlightId: string;
       margin: { uri: string; rkey: string } | null;
-    };
+    }
+  | { type: 'reviewed'; highlightId: string; at: number };
 
 /** Resolve every persisted key for one save, preferring its article guid. */
 export function resolveHighlightAliases(
@@ -77,6 +78,13 @@ export function mutateHighlightUnion(
       const { note: _note, ...withoutNote } = current;
       next[index] = withoutNote;
     }
+  } else if (mutation.type === 'reviewed') {
+    // Only ever moves forward: an out-of-order write (a slow device flushing an
+    // older review) must not make a highlight look due again.
+    if (typeof current.lastReviewedAt === 'number' && current.lastReviewedAt >= mutation.at) {
+      return { highlights, changed: false };
+    }
+    next[index] = { ...current, lastReviewedAt: mutation.at };
   } else if (mutation.margin) {
     next[index] = {
       ...current,

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -120,4 +120,10 @@ describe('shouldRedealAfterImport', () => {
     expect(shouldRedealAfterImport({ imported: 2 }, { index: 1, reviewed: 1 })).toBe(false);
     expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 3 })).toBe(false);
   });
+
+  it('does not redeal after a removal while the import is still in flight', () => {
+    expect(
+      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0, interacted: true })
+    ).toBe(false);
+  });
 });

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -5,6 +5,7 @@ import {
   deckUntouched,
   describeHighlightSources,
   highlightDeckStatus,
+  isReviewable,
   shouldRedealAfterImport,
   startOfLocalDay,
   summarizeHighlightDeck,
@@ -32,6 +33,48 @@ function entry(id: string, extra: Partial<Highlight> = {}): HighlightEntry {
 function ids(entries: HighlightEntry[]): string[] {
   return entries.map((e) => e.highlight.id);
 }
+
+describe('retired highlights', () => {
+  const RETIRED = { reviewRetiredAt: NOW.getTime() - DAY };
+
+  it('never deals a retired highlight', () => {
+    const pool = [entry('kept'), entry('retired', RETIRED)];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['kept']);
+  });
+
+  it('keeps them out of an encore hand too', () => {
+    const pool = [entry('retired', { ...RETIRED, lastReviewedAt: startOfLocalDay(NOW) + 60_000 })];
+    const deck = buildHighlightDeck(pool, 5, NOW, { includeReviewedToday: true });
+    expect(deck.cards).toHaveLength(0);
+  });
+
+  it('does not let a retired highlight relax the freshness filter', () => {
+    // The only seasoned highlight is retired: the fresh one should still deal
+    // (freshness relaxes) rather than the retired one sneaking back in.
+    const pool = [entry('retired', RETIRED), entry('fresh', { createdAt: NOW.getTime() - 60_000 })];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['fresh']);
+  });
+
+  it('reads an all-retired corpus as empty, not as a finished session', () => {
+    const pool = [entry('a', RETIRED), entry('b', RETIRED)];
+    expect(buildHighlightDeck(pool, 5, NOW).status).toBe('empty');
+    expect(summarizeHighlightDeck(pool, 5, NOW).status).toBe('empty');
+    expect(highlightDeckStatus(pool, NOW)).toBe('empty');
+  });
+
+  it('still reads as completed when something in rotation was seen today', () => {
+    const pool = [
+      entry('retired', RETIRED),
+      entry('seen', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 }),
+    ];
+    expect(summarizeHighlightDeck(pool, 5, NOW).status).toBe('completed');
+  });
+
+  it('flags reviewability off the retired stamp alone', () => {
+    expect(isReviewable(entry('a').highlight)).toBe(true);
+    expect(isReviewable(entry('b', RETIRED).highlight)).toBe(false);
+  });
+});
 
 describe('buildHighlightDeck', () => {
   it('is deterministic for a given day and pool', () => {

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -108,17 +108,25 @@ describe('highlightDeckStatus', () => {
 
 describe('shouldRedealAfterImport', () => {
   it('redeals when the open-time poll imported into an untouched deck', () => {
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0 })).toBe(true);
+    expect(
+      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0, interacted: false })
+    ).toBe(true);
   });
 
   it("doesn't redeal when the poll didn't run or brought nothing new", () => {
-    expect(shouldRedealAfterImport(null, { index: 0, reviewed: 0 })).toBe(false);
-    expect(shouldRedealAfterImport({ imported: 0 }, { index: 0, reviewed: 0 })).toBe(false);
+    expect(shouldRedealAfterImport(null, { index: 0, reviewed: 0, interacted: false })).toBe(false);
+    expect(
+      shouldRedealAfterImport({ imported: 0 }, { index: 0, reviewed: 0, interacted: false })
+    ).toBe(false);
   });
 
   it('leaves a session in progress alone — the dealt deck is fixed', () => {
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 1, reviewed: 1 })).toBe(false);
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 3 })).toBe(false);
+    expect(
+      shouldRedealAfterImport({ imported: 2 }, { index: 1, reviewed: 1, interacted: false })
+    ).toBe(false);
+    expect(
+      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 3, interacted: false })
+    ).toBe(false);
   });
 
   it('does not redeal after a removal while the import is still in flight', () => {

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -3,6 +3,7 @@ import type { Highlight } from '$lib/types';
 import {
   buildHighlightDeck,
   deckUntouched,
+  describeHighlightSources,
   highlightDeckStatus,
   shouldRedealAfterImport,
   startOfLocalDay,
@@ -110,31 +111,20 @@ describe('highlightDeckStatus', () => {
 
 describe('shouldRedealAfterImport', () => {
   it('redeals when the open-time poll imported into an untouched deck', () => {
-    expect(
-      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0, interacted: false })
-    ).toBe(true);
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, interacted: false })).toBe(true);
   });
 
   it("doesn't redeal when the poll didn't run or brought nothing new", () => {
-    expect(shouldRedealAfterImport(null, { index: 0, reviewed: 0, interacted: false })).toBe(false);
-    expect(
-      shouldRedealAfterImport({ imported: 0 }, { index: 0, reviewed: 0, interacted: false })
-    ).toBe(false);
+    expect(shouldRedealAfterImport(null, { index: 0, interacted: false })).toBe(false);
+    expect(shouldRedealAfterImport({ imported: 0 }, { index: 0, interacted: false })).toBe(false);
   });
 
-  it('leaves a session in progress alone — the dealt deck is fixed', () => {
-    expect(
-      shouldRedealAfterImport({ imported: 2 }, { index: 1, reviewed: 1, interacted: false })
-    ).toBe(false);
-    expect(
-      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 3, interacted: false })
-    ).toBe(false);
+  it('leaves a hand in progress alone — the dealt deck is fixed', () => {
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 1, interacted: false })).toBe(false);
   });
 
   it('does not redeal after a removal while the import is still in flight', () => {
-    expect(
-      shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0, interacted: true })
-    ).toBe(false);
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, interacted: true })).toBe(false);
   });
 });
 
@@ -172,11 +162,63 @@ describe('summarizeHighlightDeck', () => {
 });
 
 describe('deckUntouched', () => {
-  it('is true only before the reader has done anything with the deck', () => {
-    expect(deckUntouched({ index: 0, reviewed: 0, interacted: false })).toBe(true);
-    expect(deckUntouched({ index: 1, reviewed: 0, interacted: false })).toBe(false);
-    expect(deckUntouched({ index: 0, reviewed: 1, interacted: false })).toBe(false);
+  it('is true only before the reader has done anything with the hand', () => {
+    expect(deckUntouched({ index: 0, interacted: false })).toBe(true);
+    expect(deckUntouched({ index: 1, interacted: false })).toBe(false);
     // Opening the article or the note editor counts, even with no card advanced.
-    expect(deckUntouched({ index: 0, reviewed: 0, interacted: true })).toBe(false);
+    expect(deckUntouched({ index: 0, interacted: true })).toBe(false);
+  });
+});
+
+describe('describeHighlightSources', () => {
+  it("names the articles, and only counts what it can't fit", () => {
+    expect(describeHighlightSources([])).toBe('');
+    expect(describeHighlightSources(['One Essay'])).toBe('One Essay');
+    expect(describeHighlightSources(['One Essay', 'Two Essay'])).toBe('One Essay and Two Essay');
+    // Exactly one over the cap is named rather than counted: "and 1 more" costs
+    // the same room as the title it hides.
+    expect(describeHighlightSources(['A', 'B', 'C'])).toBe('A, B and C');
+    expect(describeHighlightSources(['A', 'B', 'C', 'D'])).toBe('A, B and 2 more');
+    expect(describeHighlightSources(['A', 'B', 'C', 'D'], 3)).toBe('A, B, C and D');
+  });
+});
+
+describe("reviewing more than the day's portion", () => {
+  it('deals nothing once everything eligible was reviewed today', () => {
+    const pool = ['a', 'b'].map((id) =>
+      entry(id, { lastReviewedAt: startOfLocalDay(NOW) + 60_000 })
+    );
+    expect(buildHighlightDeck(pool, 5, NOW).cards).toHaveLength(0);
+    expect(summarizeHighlightDeck(pool, 5, NOW).status).toBe('completed');
+  });
+
+  it('lifts the daily filter when the reader asks to keep going', () => {
+    const pool = ['a', 'b'].map((id) =>
+      entry(id, { lastReviewedAt: startOfLocalDay(NOW) + 60_000 })
+    );
+    const encore = buildHighlightDeck(pool, 5, NOW, { includeReviewedToday: true });
+    expect(ids(encore.cards).sort()).toEqual(['a', 'b']);
+    expect(summarizeHighlightDeck(pool, 5, NOW, { includeReviewedToday: true }).dueCount).toBe(2);
+  });
+
+  it('brings back what was seen earliest, not what was seen last', () => {
+    const dayStart = startOfLocalDay(NOW);
+    const pool = [
+      entry('late', { lastReviewedAt: dayStart + 5 * 60 * 60 * 1000 }),
+      entry('early', { lastReviewedAt: dayStart + 60_000 }),
+    ];
+    const encore = buildHighlightDeck(pool, 1, NOW, { includeReviewedToday: true });
+    expect(ids(encore.cards)).toEqual(['early']);
+  });
+
+  it('still prefers what is genuinely due over a repeat', () => {
+    const pool = [
+      entry('fresh-eyes'),
+      entry('seen', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 }),
+    ];
+    // Never-reviewed sorts ahead of everything, encore or not.
+    expect(ids(buildHighlightDeck(pool, 1, NOW, { includeReviewedToday: true }).cards)).toEqual([
+      'fresh-eyes',
+    ]);
   });
 });

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -3,6 +3,7 @@ import type { Highlight } from '$lib/types';
 import {
   buildHighlightDeck,
   highlightDeckStatus,
+  shouldRedealAfterImport,
   startOfLocalDay,
   type HighlightEntry,
 } from './highlightReview';
@@ -102,5 +103,21 @@ describe('highlightDeckStatus', () => {
     expect(
       highlightDeckStatus([entry('a', { lastReviewedAt: startOfLocalDay(NOW) + 1 })], NOW)
     ).toBe('completed');
+  });
+});
+
+describe('shouldRedealAfterImport', () => {
+  it('redeals when the open-time poll imported into an untouched deck', () => {
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0 })).toBe(true);
+  });
+
+  it("doesn't redeal when the poll didn't run or brought nothing new", () => {
+    expect(shouldRedealAfterImport(null, { index: 0, reviewed: 0 })).toBe(false);
+    expect(shouldRedealAfterImport({ imported: 0 }, { index: 0, reviewed: 0 })).toBe(false);
+  });
+
+  it('leaves a session in progress alone — the dealt deck is fixed', () => {
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 1, reviewed: 1 })).toBe(false);
+    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 3 })).toBe(false);
   });
 });

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { Highlight } from '$lib/types';
 import {
   buildHighlightDeck,
+  deckUntouched,
   highlightDeckStatus,
   shouldRedealAfterImport,
   startOfLocalDay,
+  summarizeHighlightDeck,
   type HighlightEntry,
 } from './highlightReview';
 
@@ -133,5 +135,48 @@ describe('shouldRedealAfterImport', () => {
     expect(
       shouldRedealAfterImport({ imported: 2 }, { index: 0, reviewed: 0, interacted: true })
     ).toBe(false);
+  });
+});
+
+describe('summarizeHighlightDeck', () => {
+  it('counts what the deck would deal, capped by deck size', () => {
+    const pool = ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((id) => entry(id));
+    expect(summarizeHighlightDeck(pool, 5, NOW)).toEqual({
+      status: 'available',
+      dueCount: 5,
+      poolSize: 7,
+    });
+    expect(summarizeHighlightDeck(pool.slice(0, 2), 5, NOW).dueCount).toBe(2);
+  });
+
+  it('agrees with the deck it summarizes', () => {
+    const pool = ['a', 'b', 'c'].map((id) => entry(id));
+    for (const size of [1, 3, 10]) {
+      const summary = summarizeHighlightDeck(pool, size, NOW);
+      const deck = buildHighlightDeck(pool, size, NOW);
+      expect(summary.dueCount).toBe(deck.cards.length);
+      expect(summary.status).toBe(deck.status);
+      expect(summary.poolSize).toBe(deck.poolSize);
+    }
+  });
+
+  it('goes quiet once everything eligible was reviewed today', () => {
+    const reviewed = entry('a', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 });
+    expect(summarizeHighlightDeck([reviewed], 5, NOW)).toEqual({
+      status: 'completed',
+      dueCount: 0,
+      poolSize: 0,
+    });
+    expect(summarizeHighlightDeck([], 5, NOW).status).toBe('empty');
+  });
+});
+
+describe('deckUntouched', () => {
+  it('is true only before the reader has done anything with the deck', () => {
+    expect(deckUntouched({ index: 0, reviewed: 0, interacted: false })).toBe(true);
+    expect(deckUntouched({ index: 1, reviewed: 0, interacted: false })).toBe(false);
+    expect(deckUntouched({ index: 0, reviewed: 1, interacted: false })).toBe(false);
+    // Opening the article or the note editor counts, even with no card advanced.
+    expect(deckUntouched({ index: 0, reviewed: 0, interacted: true })).toBe(false);
   });
 });

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { Highlight } from '$lib/types';
+import type { MarginImportOutcome } from './marginHighlightImport';
 import {
   buildHighlightDeck,
   deckUntouched,
   describeHighlightSources,
   highlightDeckStatus,
   isReviewable,
+  reviewPriority,
   shouldRedealAfterImport,
   startOfLocalDay,
   summarizeHighlightDeck,
@@ -34,29 +36,29 @@ function ids(entries: HighlightEntry[]): string[] {
   return entries.map((e) => e.highlight.id);
 }
 
-describe('retired highlights', () => {
-  const RETIRED = { reviewRetiredAt: NOW.getTime() - DAY };
+describe('review intent', () => {
+  const NEVER = { reviewIntent: 'never' as const };
 
-  it('never deals a retired highlight', () => {
-    const pool = [entry('kept'), entry('retired', RETIRED)];
+  it('never deals a highlight set to never', () => {
+    const pool = [entry('kept'), entry('hidden', NEVER)];
     expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['kept']);
   });
 
   it('keeps them out of an encore hand too', () => {
-    const pool = [entry('retired', { ...RETIRED, lastReviewedAt: startOfLocalDay(NOW) + 60_000 })];
+    const pool = [entry('hidden', { ...NEVER, lastReviewedAt: startOfLocalDay(NOW) + 60_000 })];
     const deck = buildHighlightDeck(pool, 5, NOW, { includeReviewedToday: true });
     expect(deck.cards).toHaveLength(0);
   });
 
-  it('does not let a retired highlight relax the freshness filter', () => {
-    // The only seasoned highlight is retired: the fresh one should still deal
-    // (freshness relaxes) rather than the retired one sneaking back in.
-    const pool = [entry('retired', RETIRED), entry('fresh', { createdAt: NOW.getTime() - 60_000 })];
+  it('does not let a hidden highlight relax the freshness filter', () => {
+    // The only seasoned highlight is hidden: the fresh one should still deal
+    // (freshness relaxes) rather than the hidden one sneaking back in.
+    const pool = [entry('hidden', NEVER), entry('fresh', { createdAt: NOW.getTime() - 60_000 })];
     expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['fresh']);
   });
 
-  it('reads an all-retired corpus as empty, not as a finished session', () => {
-    const pool = [entry('a', RETIRED), entry('b', RETIRED)];
+  it('reads an all-hidden corpus as empty, not as a finished session', () => {
+    const pool = [entry('a', NEVER), entry('b', NEVER)];
     expect(buildHighlightDeck(pool, 5, NOW).status).toBe('empty');
     expect(summarizeHighlightDeck(pool, 5, NOW).status).toBe('empty');
     expect(highlightDeckStatus(pool, NOW)).toBe('empty');
@@ -64,15 +66,61 @@ describe('retired highlights', () => {
 
   it('still reads as completed when something in rotation was seen today', () => {
     const pool = [
-      entry('retired', RETIRED),
+      entry('hidden', NEVER),
       entry('seen', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 }),
     ];
     expect(summarizeHighlightDeck(pool, 5, NOW).status).toBe('completed');
   });
 
-  it('flags reviewability off the retired stamp alone', () => {
+  it('flags reviewability off the never setting alone', () => {
     expect(isReviewable(entry('a').highlight)).toBe(true);
-    expect(isReviewable(entry('b', RETIRED).highlight)).toBe(false);
+    expect(isReviewable(entry('b', { reviewIntent: 'soon' }).highlight)).toBe(true);
+    expect(isReviewable(entry('c', { reviewIntent: 'someday' }).highlight)).toBe(true);
+    expect(isReviewable(entry('d', NEVER).highlight)).toBe(false);
+  });
+
+  it('treats an unset intent and an explicit later identically', () => {
+    const at = NOW.getTime() - 5 * DAY;
+    expect(reviewPriority(entry('a', { lastReviewedAt: at }).highlight)).toBe(
+      reviewPriority(entry('b', { lastReviewedAt: at, reviewIntent: 'later' }).highlight)
+    );
+  });
+
+  it('pulls soon ahead of the queue and sinks someday to the back', () => {
+    const at = NOW.getTime() - 5 * DAY;
+    const pool = [
+      entry('someday', { lastReviewedAt: at, reviewIntent: 'someday' }),
+      entry('default', { lastReviewedAt: at }),
+      entry('soon', { lastReviewedAt: at, reviewIntent: 'soon' }),
+    ];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['soon', 'default', 'someday']);
+  });
+
+  it('orders never-reviewed highlights by intent too', () => {
+    const pool = [
+      entry('someday', { reviewIntent: 'someday' }),
+      entry('soon', { reviewIntent: 'soon' }),
+      entry('default'),
+    ];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['soon', 'default', 'someday']);
+  });
+
+  it('never lets intent lift a reviewed highlight above a never-reviewed one', () => {
+    // Even the strongest pull forward loses to having never been seen, and even
+    // the strongest push back keeps its place ahead of anything already seen.
+    const pool = [
+      entry('seen-soon', { lastReviewedAt: NOW.getTime() - 3650 * DAY, reviewIntent: 'soon' }),
+      entry('unseen-someday', { reviewIntent: 'someday' }),
+    ];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['unseen-someday', 'seen-soon']);
+  });
+
+  it('deals the same number of cards however the pool is tuned', () => {
+    const tuned = ['a', 'b', 'c', 'd', 'e'].map((id) => entry(id, { reviewIntent: 'someday' }));
+    const untuned = ['a', 'b', 'c', 'd', 'e'].map((id) => entry(id));
+    expect(buildHighlightDeck(tuned, 3, NOW).cards).toHaveLength(
+      buildHighlightDeck(untuned, 3, NOW).cards.length
+    );
   });
 });
 
@@ -153,21 +201,38 @@ describe('highlightDeckStatus', () => {
 });
 
 describe('shouldRedealAfterImport', () => {
+  const brought = (imported: number): MarginImportOutcome => ({
+    status: 'imported',
+    imported,
+    truncated: false,
+  });
+
   it('redeals when the open-time poll imported into an untouched deck', () => {
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, interacted: false })).toBe(true);
+    expect(shouldRedealAfterImport(brought(2), { index: 0, interacted: false })).toBe(true);
   });
 
   it("doesn't redeal when the poll didn't run or brought nothing new", () => {
-    expect(shouldRedealAfterImport(null, { index: 0, interacted: false })).toBe(false);
-    expect(shouldRedealAfterImport({ imported: 0 }, { index: 0, interacted: false })).toBe(false);
+    expect(
+      shouldRedealAfterImport(
+        { status: 'skipped', reason: 'throttled' },
+        { index: 0, interacted: false }
+      )
+    ).toBe(false);
+    expect(shouldRedealAfterImport({ status: 'failed' }, { index: 0, interacted: false })).toBe(
+      false
+    );
+    expect(
+      shouldRedealAfterImport({ status: 'scope-expired' }, { index: 0, interacted: false })
+    ).toBe(false);
+    expect(shouldRedealAfterImport(brought(0), { index: 0, interacted: false })).toBe(false);
   });
 
   it('leaves a hand in progress alone — the dealt deck is fixed', () => {
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 1, interacted: false })).toBe(false);
+    expect(shouldRedealAfterImport(brought(2), { index: 1, interacted: false })).toBe(false);
   });
 
   it('does not redeal after a removal while the import is still in flight', () => {
-    expect(shouldRedealAfterImport({ imported: 2 }, { index: 0, interacted: true })).toBe(false);
+    expect(shouldRedealAfterImport(brought(2), { index: 0, interacted: true })).toBe(false);
   });
 });
 

--- a/frontend/src/lib/utils/highlightReview.test.ts
+++ b/frontend/src/lib/utils/highlightReview.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { Highlight } from '$lib/types';
+import {
+  buildHighlightDeck,
+  highlightDeckStatus,
+  startOfLocalDay,
+  type HighlightEntry,
+} from './highlightReview';
+
+const NOW = new Date('2026-08-25T10:00:00');
+const DAY = 24 * 60 * 60 * 1000;
+// Old enough to clear the 24 h freshness filter.
+const SEASONED = NOW.getTime() - 30 * DAY;
+
+function entry(id: string, extra: Partial<Highlight> = {}): HighlightEntry {
+  return {
+    itemKey: `item-${id}`,
+    itemType: 'article',
+    highlight: {
+      id,
+      selector: { type: 'TextQuoteSelector', exact: `quote ${id}` },
+      createdAt: SEASONED,
+      ...extra,
+    },
+  };
+}
+
+function ids(entries: HighlightEntry[]): string[] {
+  return entries.map((e) => e.highlight.id);
+}
+
+describe('buildHighlightDeck', () => {
+  it('is deterministic for a given day and pool', () => {
+    const pool = ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((id) => entry(id));
+    const first = buildHighlightDeck(pool, 3, NOW);
+    const second = buildHighlightDeck([...pool].reverse(), 3, NOW);
+    expect(ids(first.cards)).toEqual(ids(second.cards));
+    expect(first.cards).toHaveLength(3);
+  });
+
+  it('rotates the tie-break ordering on a different day', () => {
+    const pool = Array.from({ length: 30 }, (_, i) => entry(`h${i}`));
+    const today = ids(buildHighlightDeck(pool, 5, NOW).cards);
+    const later = ids(buildHighlightDeck(pool, 5, new Date('2026-09-14T10:00:00')).cards);
+    expect(later).not.toEqual(today);
+  });
+
+  it('orders least-recently-reviewed first, never-reviewed ahead of all', () => {
+    const pool = [
+      entry('recent', { lastReviewedAt: NOW.getTime() - 2 * DAY }),
+      entry('ancient', { lastReviewedAt: NOW.getTime() - 90 * DAY }),
+      entry('never'),
+    ];
+    expect(ids(buildHighlightDeck(pool, 3, NOW).cards)).toEqual(['never', 'ancient', 'recent']);
+  });
+
+  it('excludes highlights already reviewed today', () => {
+    const pool = [
+      entry('done', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 }),
+      entry('due', { lastReviewedAt: NOW.getTime() - 5 * DAY }),
+    ];
+    const deck = buildHighlightDeck(pool, 5, NOW);
+    expect(ids(deck.cards)).toEqual(['due']);
+    expect(deck.poolSize).toBe(1);
+  });
+
+  it('reports "completed" once every highlight was reviewed today', () => {
+    const pool = [entry('done', { lastReviewedAt: startOfLocalDay(NOW) + 60_000 })];
+    const deck = buildHighlightDeck(pool, 5, NOW);
+    expect(deck.status).toBe('completed');
+    expect(deck.cards).toEqual([]);
+  });
+
+  it('reports "empty" with no highlights at all', () => {
+    expect(buildHighlightDeck([], 5, NOW).status).toBe('empty');
+  });
+
+  it('skips highlights created in the last 24 h when older ones exist', () => {
+    const pool = [entry('fresh', { createdAt: NOW.getTime() - 60_000 }), entry('old')];
+    expect(ids(buildHighlightDeck(pool, 5, NOW).cards)).toEqual(['old']);
+  });
+
+  it('relaxes the freshness filter rather than showing an empty deck', () => {
+    const pool = [entry('fresh', { createdAt: NOW.getTime() - 60_000 })];
+    const deck = buildHighlightDeck(pool, 5, NOW);
+    expect(deck.status).toBe('available');
+    expect(ids(deck.cards)).toEqual(['fresh']);
+  });
+
+  it('caps the deck at the requested count', () => {
+    const pool = Array.from({ length: 12 }, (_, i) => entry(`h${i}`));
+    expect(buildHighlightDeck(pool, 3, NOW).cards).toHaveLength(3);
+    expect(buildHighlightDeck(pool, 10, NOW).cards).toHaveLength(10);
+    expect(buildHighlightDeck(pool, 10, NOW).poolSize).toBe(12);
+  });
+});
+
+describe('highlightDeckStatus', () => {
+  it('matches the deck it summarizes', () => {
+    expect(highlightDeckStatus([], NOW)).toBe('empty');
+    expect(highlightDeckStatus([entry('a')], NOW)).toBe('available');
+    expect(
+      highlightDeckStatus([entry('a', { lastReviewedAt: startOfLocalDay(NOW) + 1 })], NOW)
+    ).toBe('completed');
+  });
+});

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -118,7 +118,7 @@ export function buildHighlightDeck(
  */
 export function shouldRedealAfterImport(
   result: { imported: number } | null,
-  progress: { index: number; reviewed: number; interacted?: boolean }
+  progress: { index: number; reviewed: number; interacted: boolean }
 ): boolean {
   if (!result || result.imported <= 0) return false;
   return !progress.interacted && progress.index === 0 && progress.reviewed === 0;

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -1,4 +1,5 @@
-import type { Highlight, ItemLabelType } from '$lib/types';
+import type { Highlight, ItemLabelType, ReviewIntent } from '$lib/types';
+import type { MarginImportOutcome } from '$lib/utils/marginHighlightImport';
 import { dailyScore, localDateKey } from '$lib/utils/dailyMagazine';
 
 // The review deck: "revisit a handful of your highlights." Deliberately NOT a
@@ -15,17 +16,59 @@ export const HIGHLIGHT_REVIEW_COUNT_DEFAULT: HighlightReviewCount = 5;
 /** Reviewing something you highlighted minutes ago is noise, not a review. */
 export const HIGHLIGHT_REVIEW_FRESHNESS_MS = 24 * 60 * 60 * 1000;
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Frequency tuning, as a shift in the least-recently-reviewed ranking rather
+ * than as a waiting period.
+ *
+ * A highlight is ranked as though it had been reviewed this much earlier or
+ * later than it actually was: 'soon' jumps the queue, 'someday' sinks to the
+ * back. The alternative — a hard interval you have to wait out — would let a
+ * small library go empty for weeks, which is exactly the "nothing to review"
+ * dead end the freshness filter already bends over backwards to avoid. Biasing
+ * the order instead means the deck deals the same number of cards it always
+ * would; tuning only changes *which* ones come first.
+ *
+ * 'later' is the neutral middle, so an untuned highlight and an explicit
+ * 'later' rank identically. 'never' is filtered out before ranking and its
+ * offset is never read.
+ */
+export const REVIEW_INTENT_OFFSET_MS: Record<ReviewIntent, number> = {
+  soon: -30 * DAY_MS,
+  later: 0,
+  someday: 120 * DAY_MS,
+  never: 0,
+};
+
+export const REVIEW_INTENT_DEFAULT: ReviewIntent = 'later';
+
+/**
+ * Stand-in review time for a highlight that has never been reviewed, far enough
+ * below any real timestamp that even the largest offset can't lift one above a
+ * highlight that has been. Never-seen still beats seen, always; intent orders
+ * within each of those two classes rather than across them.
+ */
+const NEVER_REVIEWED_AT = -100 * 365 * DAY_MS;
+
+/** Where a highlight sits in the queue once its intent is taken into account. */
+export function reviewPriority(highlight: Highlight): number {
+  const base =
+    typeof highlight.lastReviewedAt === 'number' ? highlight.lastReviewedAt : NEVER_REVIEWED_AT;
+  return base + REVIEW_INTENT_OFFSET_MS[highlight.reviewIntent ?? REVIEW_INTENT_DEFAULT];
+}
+
 /**
  * Is this highlight still part of the review corpus at all?
  *
- * Retiring ("Don't show again") is the reader saying a highlight isn't worth
- * revisiting — not that it's worth deleting. It stays in the highlights list and
- * on Margin; it just never comes up again, on any device, until they put it
- * back. Unlike the daily filter this is permanent, so it's checked before the
- * pool is built rather than inside it.
+ * 'never' is the reader saying a highlight isn't worth revisiting — not that
+ * it's worth deleting. It stays in the highlights list and on Margin; it just
+ * never comes up again, on any device, until they set it back. Unlike the daily
+ * filter this is permanent, so it's checked before the pool is built rather
+ * than inside it.
  */
 export function isReviewable(highlight: Highlight): boolean {
-  return typeof highlight.reviewRetiredAt !== 'number';
+  return highlight.reviewIntent !== 'never';
 }
 
 /** One entry of the flattened highlight corpus (matches `itemLabelsStore.allHighlights`). */
@@ -38,7 +81,7 @@ export interface HighlightEntry {
 export type HighlightDeckStatus =
   | 'available' // there are cards to review right now
   | 'completed' // the pool is non-empty but everything eligible was reviewed today
-  | 'empty'; // no highlights at all (or only ones too fresh to review)
+  | 'empty'; // nothing in rotation at all — no highlights, or every one retired
 
 export function startOfLocalDay(date: Date): number {
   const start = new Date(date);
@@ -52,19 +95,17 @@ function reviewedToday(highlight: Highlight, dayStart: number): boolean {
 
 /**
  * Rank the eligible pool: least-recently-reviewed first, never-reviewed ahead of
- * everything, ties broken by a date-seeded hash so the ordering is stable for
- * the whole day but rotates tomorrow.
+ * everything, shifted by the reader's per-highlight intent, ties broken by a
+ * date-seeded hash so the ordering is stable for the whole day but rotates
+ * tomorrow.
+ *
+ * The first three rules collapse into one comparable number (`reviewPriority`),
+ * which is why the never-reviewed case needs no branch of its own.
  */
 function rankPool(pool: HighlightEntry[], dateKey: string): HighlightEntry[] {
   return [...pool].sort((a, b) => {
-    const aReviewed = a.highlight.lastReviewedAt;
-    const bReviewed = b.highlight.lastReviewedAt;
-    const aNever = typeof aReviewed !== 'number';
-    const bNever = typeof bReviewed !== 'number';
-    if (aNever !== bNever) return aNever ? -1 : 1;
-    if (!aNever && !bNever && aReviewed !== bReviewed) {
-      return (aReviewed as number) - (bReviewed as number);
-    }
+    const byPriority = reviewPriority(a.highlight) - reviewPriority(b.highlight);
+    if (byPriority !== 0) return byPriority;
     const byScore = dailyScore(dateKey, a.highlight.id) - dailyScore(dateKey, b.highlight.id);
     return byScore || a.highlight.id.localeCompare(b.highlight.id);
   });
@@ -191,10 +232,10 @@ export function buildHighlightDeck(
  * reshuffling mid-session pulls the ground out from under the reader.
  */
 export function shouldRedealAfterImport(
-  result: { imported: number } | null,
+  outcome: MarginImportOutcome,
   progress: DeckProgress
 ): boolean {
-  if (!result || result.imported <= 0) return false;
+  if (outcome.status !== 'imported' || outcome.imported <= 0) return false;
   return deckUntouched(progress);
 }
 

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -1,0 +1,115 @@
+import type { Highlight, ItemLabelType } from '$lib/types';
+import { dailyScore, localDateKey } from '$lib/utils/dailyMagazine';
+
+// The review deck: "revisit a handful of your highlights." Deliberately NOT a
+// durable issue like the daily magazine — a session is a few minutes over a
+// handful of cards, so the deck is derived at open and repeat-avoidance comes
+// from the per-highlight `lastReviewedAt` stamp that syncs with the highlight
+// itself. Same day + same pool => same deck, so opening the deck twice on one
+// device doesn't reshuffle mid-session.
+
+export const HIGHLIGHT_REVIEW_COUNT_OPTIONS = [3, 5, 10] as const;
+export type HighlightReviewCount = (typeof HIGHLIGHT_REVIEW_COUNT_OPTIONS)[number];
+export const HIGHLIGHT_REVIEW_COUNT_DEFAULT: HighlightReviewCount = 5;
+
+/** Reviewing something you highlighted minutes ago is noise, not a review. */
+export const HIGHLIGHT_REVIEW_FRESHNESS_MS = 24 * 60 * 60 * 1000;
+
+/** One entry of the flattened highlight corpus (matches `itemLabelsStore.allHighlights`). */
+export interface HighlightEntry {
+  itemKey: string;
+  itemType: ItemLabelType;
+  highlight: Highlight;
+}
+
+export type HighlightDeckStatus =
+  | 'available' // there are cards to review right now
+  | 'completed' // the pool is non-empty but everything eligible was reviewed today
+  | 'empty'; // no highlights at all (or only ones too fresh to review)
+
+export function startOfLocalDay(date: Date): number {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start.getTime();
+}
+
+function reviewedToday(highlight: Highlight, dayStart: number): boolean {
+  return typeof highlight.lastReviewedAt === 'number' && highlight.lastReviewedAt >= dayStart;
+}
+
+/**
+ * Rank the eligible pool: least-recently-reviewed first, never-reviewed ahead of
+ * everything, ties broken by a date-seeded hash so the ordering is stable for
+ * the whole day but rotates tomorrow.
+ */
+function rankPool(pool: HighlightEntry[], dateKey: string): HighlightEntry[] {
+  return [...pool].sort((a, b) => {
+    const aReviewed = a.highlight.lastReviewedAt;
+    const bReviewed = b.highlight.lastReviewedAt;
+    const aNever = typeof aReviewed !== 'number';
+    const bNever = typeof bReviewed !== 'number';
+    if (aNever !== bNever) return aNever ? -1 : 1;
+    if (!aNever && !bNever && aReviewed !== bReviewed) {
+      return (aReviewed as number) - (bReviewed as number);
+    }
+    const byScore = dailyScore(dateKey, a.highlight.id) - dailyScore(dateKey, b.highlight.id);
+    return byScore || a.highlight.id.localeCompare(b.highlight.id);
+  });
+}
+
+export interface HighlightDeck {
+  dateKey: string;
+  status: HighlightDeckStatus;
+  cards: HighlightEntry[];
+  /** Size of the eligible pool the deck was drawn from (>= cards.length). */
+  poolSize: number;
+}
+
+/**
+ * Build today's deck from the whole highlight corpus.
+ *
+ * Eligibility: not already reviewed today, and not created in the last 24 h. The
+ * freshness filter RELAXES when it would empty an otherwise non-empty pool — a
+ * reader whose only highlights are from this morning still gets a deck rather
+ * than a confusing "nothing to review."
+ */
+export function buildHighlightDeck(
+  entries: HighlightEntry[],
+  count: number,
+  now: Date = new Date()
+): HighlightDeck {
+  const dateKey = localDateKey(now);
+  const size = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
+  const dayStart = startOfLocalDay(now);
+  const nowMs = now.getTime();
+
+  const unreviewedToday = entries.filter((entry) => !reviewedToday(entry.highlight, dayStart));
+  const seasoned = unreviewedToday.filter(
+    (entry) => nowMs - entry.highlight.createdAt >= HIGHLIGHT_REVIEW_FRESHNESS_MS
+  );
+  const pool = seasoned.length > 0 ? seasoned : unreviewedToday;
+
+  if (pool.length === 0) {
+    return {
+      dateKey,
+      status: entries.length > 0 ? 'completed' : 'empty',
+      cards: [],
+      poolSize: 0,
+    };
+  }
+
+  return {
+    dateKey,
+    status: 'available',
+    cards: rankPool(pool, dateKey).slice(0, size),
+    poolSize: pool.length,
+  };
+}
+
+/** Cheap status probe for entry points that only need "is there a deck?". */
+export function highlightDeckStatus(
+  entries: HighlightEntry[],
+  now: Date = new Date()
+): HighlightDeckStatus {
+  return buildHighlightDeck(entries, 1, now).status;
+}

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -65,21 +65,17 @@ export interface HighlightDeck {
   poolSize: number;
 }
 
+function deckSize(count: number): number {
+  return Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
+}
+
 /**
- * Build today's deck from the whole highlight corpus.
- *
- * Eligibility: not already reviewed today, and not created in the last 24 h. The
- * freshness filter RELAXES when it would empty an otherwise non-empty pool — a
- * reader whose only highlights are from this morning still gets a deck rather
- * than a confusing "nothing to review."
+ * The pool today's deck deals from: not already reviewed today, and not created
+ * in the last 24 h. The freshness filter RELAXES when it would empty an
+ * otherwise non-empty pool — a reader whose only highlights are from this
+ * morning still gets a deck rather than a confusing "nothing to review."
  */
-export function buildHighlightDeck(
-  entries: HighlightEntry[],
-  count: number,
-  now: Date = new Date()
-): HighlightDeck {
-  const dateKey = localDateKey(now);
-  const size = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
+function eligiblePool(entries: HighlightEntry[], now: Date): HighlightEntry[] {
   const dayStart = startOfLocalDay(now);
   const nowMs = now.getTime();
 
@@ -87,7 +83,48 @@ export function buildHighlightDeck(
   const seasoned = unreviewedToday.filter(
     (entry) => nowMs - entry.highlight.createdAt >= HIGHLIGHT_REVIEW_FRESHNESS_MS
   );
-  const pool = seasoned.length > 0 ? seasoned : unreviewedToday;
+  return seasoned.length > 0 ? seasoned : unreviewedToday;
+}
+
+export interface HighlightDeckSummary {
+  status: HighlightDeckStatus;
+  /** Cards today's deck would deal right now — what the nav badge counts. */
+  dueCount: number;
+  /** Size of the eligible pool (>= dueCount). */
+  poolSize: number;
+}
+
+/**
+ * What today's deck holds, without paying to rank it. Entry points that only
+ * show a count or a presence use this; only the deck itself needs the order.
+ */
+export function summarizeHighlightDeck(
+  entries: HighlightEntry[],
+  count: number,
+  now: Date = new Date()
+): HighlightDeckSummary {
+  const pool = eligiblePool(entries, now);
+  if (pool.length === 0) {
+    return { status: entries.length > 0 ? 'completed' : 'empty', dueCount: 0, poolSize: 0 };
+  }
+  return {
+    status: 'available',
+    dueCount: Math.min(pool.length, deckSize(count)),
+    poolSize: pool.length,
+  };
+}
+
+/**
+ * Build today's deck from the whole highlight corpus. Eligibility is
+ * `eligiblePool`; order is least-recently-reviewed first.
+ */
+export function buildHighlightDeck(
+  entries: HighlightEntry[],
+  count: number,
+  now: Date = new Date()
+): HighlightDeck {
+  const dateKey = localDateKey(now);
+  const pool = eligiblePool(entries, now);
 
   if (pool.length === 0) {
     return {
@@ -101,7 +138,7 @@ export function buildHighlightDeck(
   return {
     dateKey,
     status: 'available',
-    cards: rankPool(pool, dateKey).slice(0, size),
+    cards: rankPool(pool, dateKey).slice(0, deckSize(count)),
     poolSize: pool.length,
   };
 }
@@ -118,9 +155,25 @@ export function buildHighlightDeck(
  */
 export function shouldRedealAfterImport(
   result: { imported: number } | null,
-  progress: { index: number; reviewed: number; interacted: boolean }
+  progress: DeckProgress
 ): boolean {
   if (!result || result.imported <= 0) return false;
+  return deckUntouched(progress);
+}
+
+export interface DeckProgress {
+  index: number;
+  reviewed: number;
+  interacted: boolean;
+}
+
+/**
+ * A deck the reader hasn't started yet is free to redeal — nothing is pulled out
+ * from under them. Once a card has been reviewed, opened or annotated, the deck
+ * they were dealt is the deck they keep, and a change (a Margin import, a new
+ * deck size) applies to the next session instead.
+ */
+export function deckUntouched(progress: DeckProgress): boolean {
   return !progress.interacted && progress.index === 0 && progress.reviewed === 0;
 }
 
@@ -129,5 +182,5 @@ export function highlightDeckStatus(
   entries: HighlightEntry[],
   now: Date = new Date()
 ): HighlightDeckStatus {
-  return buildHighlightDeck(entries, 1, now).status;
+  return summarizeHighlightDeck(entries, 1, now).status;
 }

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -69,21 +69,39 @@ function deckSize(count: number): number {
   return Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
 }
 
+export interface DeckOptions {
+  /**
+   * Deal past the day's portion, from highlights already reviewed today.
+   *
+   * This is only ever the reader asking to keep going after the deck ran out
+   * ("Review more"), never something the app does on its own — the daily filter
+   * is what stops the deck nagging. Ranking is unchanged, so an encore brings
+   * back what was seen earliest, not what was seen last.
+   */
+  includeReviewedToday?: boolean;
+}
+
 /**
  * The pool today's deck deals from: not already reviewed today, and not created
  * in the last 24 h. The freshness filter RELAXES when it would empty an
  * otherwise non-empty pool — a reader whose only highlights are from this
  * morning still gets a deck rather than a confusing "nothing to review."
  */
-function eligiblePool(entries: HighlightEntry[], now: Date): HighlightEntry[] {
+function eligiblePool(
+  entries: HighlightEntry[],
+  now: Date,
+  options: DeckOptions = {}
+): HighlightEntry[] {
   const dayStart = startOfLocalDay(now);
   const nowMs = now.getTime();
 
-  const unreviewedToday = entries.filter((entry) => !reviewedToday(entry.highlight, dayStart));
-  const seasoned = unreviewedToday.filter(
+  const due = options.includeReviewedToday
+    ? entries
+    : entries.filter((entry) => !reviewedToday(entry.highlight, dayStart));
+  const seasoned = due.filter(
     (entry) => nowMs - entry.highlight.createdAt >= HIGHLIGHT_REVIEW_FRESHNESS_MS
   );
-  return seasoned.length > 0 ? seasoned : unreviewedToday;
+  return seasoned.length > 0 ? seasoned : due;
 }
 
 export interface HighlightDeckSummary {
@@ -101,9 +119,10 @@ export interface HighlightDeckSummary {
 export function summarizeHighlightDeck(
   entries: HighlightEntry[],
   count: number,
-  now: Date = new Date()
+  now: Date = new Date(),
+  options: DeckOptions = {}
 ): HighlightDeckSummary {
-  const pool = eligiblePool(entries, now);
+  const pool = eligiblePool(entries, now, options);
   if (pool.length === 0) {
     return { status: entries.length > 0 ? 'completed' : 'empty', dueCount: 0, poolSize: 0 };
   }
@@ -121,10 +140,11 @@ export function summarizeHighlightDeck(
 export function buildHighlightDeck(
   entries: HighlightEntry[],
   count: number,
-  now: Date = new Date()
+  now: Date = new Date(),
+  options: DeckOptions = {}
 ): HighlightDeck {
   const dateKey = localDateKey(now);
-  const pool = eligiblePool(entries, now);
+  const pool = eligiblePool(entries, now, options);
 
   if (pool.length === 0) {
     return {
@@ -163,18 +183,34 @@ export function shouldRedealAfterImport(
 
 export interface DeckProgress {
   index: number;
-  reviewed: number;
   interacted: boolean;
 }
 
 /**
  * A deck the reader hasn't started yet is free to redeal — nothing is pulled out
- * from under them. Once a card has been reviewed, opened or annotated, the deck
+ * from under them. Once a card has been advanced, opened or annotated, the deck
  * they were dealt is the deck they keep, and a change (a Margin import, a new
- * deck size) applies to the next session instead.
+ * deck size) applies to the next hand instead.
+ *
+ * Per hand, not per session: a reader who asks for another hand after finishing
+ * one is back at an untouched deck, whatever they've already reviewed today.
  */
 export function deckUntouched(progress: DeckProgress): boolean {
-  return !progress.interacted && progress.index === 0 && progress.reviewed === 0;
+  return !progress.interacted && progress.index === 0;
+}
+
+/**
+ * Name the articles a deck draws from: "A", "A and B", "A, B and C", then
+ * "A, B and 3 more". The overflow only kicks in past `max + 1`, because "and 1
+ * more" costs the same room as the title it's hiding.
+ */
+export function describeHighlightSources(titles: string[], max = 2): string {
+  if (titles.length === 0) return '';
+  if (titles.length === 1) return titles[0];
+  if (titles.length <= max + 1) {
+    return `${titles.slice(0, -1).join(', ')} and ${titles[titles.length - 1]}`;
+  }
+  return `${titles.slice(0, max).join(', ')} and ${titles.length - max} more`;
 }
 
 /** Cheap status probe for entry points that only need "is there a deck?". */

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -106,6 +106,24 @@ export function buildHighlightDeck(
   };
 }
 
+/**
+ * Should the open-time Margin poll redeal the deck it raced?
+ *
+ * The deck deals from the local pool the moment the stores hydrate — a network
+ * round-trip must never stand between the reader and their first card — so the
+ * poll can land after the deal. When it imported something and the reader hasn't
+ * touched a card yet, redealing is free and makes the poll count for this
+ * session. Once a card has been reviewed or dropped, the fixed deck wins:
+ * reshuffling mid-session pulls the ground out from under the reader.
+ */
+export function shouldRedealAfterImport(
+  result: { imported: number } | null,
+  progress: { index: number; reviewed: number }
+): boolean {
+  if (!result || result.imported <= 0) return false;
+  return progress.index === 0 && progress.reviewed === 0;
+}
+
 /** Cheap status probe for entry points that only need "is there a deck?". */
 export function highlightDeckStatus(
   entries: HighlightEntry[],

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -15,6 +15,19 @@ export const HIGHLIGHT_REVIEW_COUNT_DEFAULT: HighlightReviewCount = 5;
 /** Reviewing something you highlighted minutes ago is noise, not a review. */
 export const HIGHLIGHT_REVIEW_FRESHNESS_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Is this highlight still part of the review corpus at all?
+ *
+ * Retiring ("Don't show again") is the reader saying a highlight isn't worth
+ * revisiting — not that it's worth deleting. It stays in the highlights list and
+ * on Margin; it just never comes up again, on any device, until they put it
+ * back. Unlike the daily filter this is permanent, so it's checked before the
+ * pool is built rather than inside it.
+ */
+export function isReviewable(highlight: Highlight): boolean {
+  return typeof highlight.reviewRetiredAt !== 'number';
+}
+
 /** One entry of the flattened highlight corpus (matches `itemLabelsStore.allHighlights`). */
 export interface HighlightEntry {
   itemKey: string;
@@ -95,9 +108,10 @@ function eligiblePool(
   const dayStart = startOfLocalDay(now);
   const nowMs = now.getTime();
 
+  const inRotation = entries.filter((entry) => isReviewable(entry.highlight));
   const due = options.includeReviewedToday
-    ? entries
-    : entries.filter((entry) => !reviewedToday(entry.highlight, dayStart));
+    ? inRotation
+    : inRotation.filter((entry) => !reviewedToday(entry.highlight, dayStart));
   const seasoned = due.filter(
     (entry) => nowMs - entry.highlight.createdAt >= HIGHLIGHT_REVIEW_FRESHNESS_MS
   );
@@ -124,7 +138,10 @@ export function summarizeHighlightDeck(
 ): HighlightDeckSummary {
   const pool = eligiblePool(entries, now, options);
   if (pool.length === 0) {
-    return { status: entries.length > 0 ? 'completed' : 'empty', dueCount: 0, poolSize: 0 };
+    // "Completed" has to mean "you've seen today's portion", so a corpus that is
+    // entirely retired reads as empty, not as a finished session.
+    const inRotation = entries.some((entry) => isReviewable(entry.highlight));
+    return { status: inRotation ? 'completed' : 'empty', dueCount: 0, poolSize: 0 };
   }
   return {
     status: 'available',
@@ -149,7 +166,7 @@ export function buildHighlightDeck(
   if (pool.length === 0) {
     return {
       dateKey,
-      status: entries.length > 0 ? 'completed' : 'empty',
+      status: entries.some((entry) => isReviewable(entry.highlight)) ? 'completed' : 'empty',
       cards: [],
       poolSize: 0,
     };

--- a/frontend/src/lib/utils/highlightReview.ts
+++ b/frontend/src/lib/utils/highlightReview.ts
@@ -118,10 +118,10 @@ export function buildHighlightDeck(
  */
 export function shouldRedealAfterImport(
   result: { imported: number } | null,
-  progress: { index: number; reviewed: number }
+  progress: { index: number; reviewed: number; interacted?: boolean }
 ): boolean {
   if (!result || result.imported <= 0) return false;
-  return progress.index === 0 && progress.reviewed === 0;
+  return !progress.interacted && progress.index === 0 && progress.reviewed === 0;
 }
 
 /** Cheap status probe for entry points that only need "is there a deck?". */

--- a/frontend/src/lib/utils/highlightSource.test.ts
+++ b/frontend/src/lib/utils/highlightSource.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Article, SavedItem, SocialDocument, Subscription } from '$lib/types';
+import { buildHighlightSourceLookups, resolveHighlightSource } from './highlightSource';
+
+const article = {
+  guid: 'article-guid',
+  title: 'An Essay',
+  url: 'https://example.com/essay',
+  author: 'Ada Lovelace',
+} as Article;
+
+const anonymous = {
+  guid: 'anon-guid',
+  title: 'No Byline Here',
+  url: 'https://elsewhere.test/piece',
+} as Article;
+
+const document = {
+  recordUri: 'at://did:plc:writer/pub.leaflet.document/abc',
+  title: 'A Post',
+  authorDid: 'did:plc:writer',
+  canonicalUrl: 'https://leaflet.pub/abc',
+} as SocialDocument;
+
+const save = {
+  itemGuid: 'save-guid',
+  uri: 'at://did:plc:me/app.skyreader.feed.saved/xyz',
+  title: 'Something Saved',
+  url: 'https://saved.test/thing',
+  author: 'Grace Hopper',
+} as SavedItem;
+
+const subscription = {
+  title: 'The Writer',
+  subjectDid: 'did:plc:writer',
+} as Subscription;
+
+const lookups = buildHighlightSourceLookups(
+  [article, anonymous],
+  [document],
+  [save],
+  [subscription]
+);
+
+describe('resolveHighlightSource author', () => {
+  it('takes the byline off an article', () => {
+    expect(resolveHighlightSource('article-guid', 'article', lookups).author).toBe('Ada Lovelace');
+  });
+
+  it('names a document by the subscription it arrived under', () => {
+    // A document carries only its author's DID, and resolving that to a profile
+    // is an async fetch; the subscription is the same name, already on device.
+    expect(resolveHighlightSource(document.recordUri, 'document', lookups).author).toBe(
+      'The Writer'
+    );
+  });
+
+  it('falls back to a saved copy for a highlight with no local article', () => {
+    expect(resolveHighlightSource('save-guid', 'article', lookups).author).toBe('Grace Hopper');
+  });
+
+  it('is null rather than guessing when nothing carries a byline', () => {
+    const source = resolveHighlightSource('anon-guid', 'article', lookups);
+    expect(source.author).toBeNull();
+    // The caller still has somewhere to fall back to.
+    expect(source.domain).toBe('elsewhere.test');
+  });
+
+  it('is null for an imported highlight, which carries a title but no byline', () => {
+    const source = resolveHighlightSource('https://margin.test/read', 'article', lookups, {
+      sourceTitle: 'Read In Margin',
+      sourceUrl: 'https://margin.test/read',
+    });
+    expect(source.author).toBeNull();
+    expect(source.title).toBe('Read In Margin');
+    expect(source.domain).toBe('margin.test');
+  });
+});

--- a/frontend/src/lib/utils/highlightSource.ts
+++ b/frontend/src/lib/utils/highlightSource.ts
@@ -1,0 +1,102 @@
+import type { Article, Highlight, ItemLabelType, SavedItem, SocialDocument } from '$lib/types';
+import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
+import { decodeEntities } from '$lib/utils/entities';
+
+// Resolving "what article is this highlight from" is shared by the Highlights
+// list and the review deck, and the two must degrade identically: a highlight
+// imported from Margin whose article was never cached locally has no article,
+// document or save to hang a title on — only the `sourceTitle`/`sourceUrl`
+// carried on the highlight itself. Keeping this in one place is what stops the
+// review deck rendering a blank source line where the list shows a real one.
+
+export interface HighlightSourceLookups {
+  articlesByGuid: Map<string, Article>;
+  documentsByUri: Map<string, SocialDocument>;
+  savedByKey: Map<string, SavedItem>;
+}
+
+export interface HighlightSource {
+  title: string;
+  url: string | null;
+  domain: string | null;
+  /** The item to open in the in-app reader; null when nothing local backs it. */
+  displayItem: FeedDisplayItem | null;
+}
+
+export function buildHighlightSourceLookups(
+  articles: Article[],
+  documents: SocialDocument[],
+  saves: SavedItem[]
+): HighlightSourceLookups {
+  const savedByKey = new Map<string, SavedItem>();
+  for (const save of saves) {
+    if (save.itemGuid) savedByKey.set(save.itemGuid, save);
+    if (save.uri) savedByKey.set(save.uri, save);
+  }
+  return {
+    articlesByGuid: new Map(articles.map((a) => [a.guid, a])),
+    documentsByUri: new Map(documents.map((d) => [d.recordUri, d])),
+    savedByKey,
+  };
+}
+
+export function domainFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the source article for a highlight: local article → social document →
+ * saved copy → the highlight's own `sourceTitle`/`sourceUrl` (imported
+ * highlights). Only the first three can open in the in-app reader; the last
+ * falls back to the external URL.
+ */
+export function resolveHighlightSource(
+  itemKey: string,
+  itemType: ItemLabelType,
+  lookups: HighlightSourceLookups,
+  highlight?: Pick<Highlight, 'sourceUrl' | 'sourceTitle'>
+): HighlightSource {
+  let title = '';
+  let url: string | null = null;
+  let displayItem: FeedDisplayItem | null = null;
+
+  if (itemType === 'article') {
+    const article = lookups.articlesByGuid.get(itemKey);
+    if (article) {
+      title = article.title;
+      url = article.url;
+      displayItem = { type: 'article', item: article, key: article.guid };
+    }
+  } else if (itemType === 'document') {
+    const document = lookups.documentsByUri.get(itemKey);
+    if (document) {
+      title = document.title;
+      url = document.canonicalUrl ?? null;
+      displayItem = { type: 'document', item: document, key: document.recordUri };
+    }
+  }
+
+  // Fall back to a saved copy (carries title/url, and can open in the reader).
+  if (!displayItem) {
+    const save = lookups.savedByKey.get(itemKey);
+    if (save) {
+      title = title || save.title || '';
+      url = url || save.url || null;
+      displayItem = { type: 'saved', item: save, key: save.itemGuid || save.uri };
+    }
+  }
+
+  // Last resort: metadata carried on the highlight (Margin imports).
+  if (!title && highlight?.sourceTitle) title = highlight.sourceTitle;
+  if (!url && highlight?.sourceUrl) url = highlight.sourceUrl;
+  // An unmatched import keys off its normalized URL, which is a usable link.
+  if (!url && /^https?:\/\//i.test(itemKey)) url = itemKey;
+
+  const resolvedTitle = decodeEntities(title) || domainFromUrl(url) || 'Untitled';
+  return { title: resolvedTitle, url, domain: domainFromUrl(url), displayItem };
+}

--- a/frontend/src/lib/utils/highlightSource.ts
+++ b/frontend/src/lib/utils/highlightSource.ts
@@ -1,4 +1,11 @@
-import type { Article, Highlight, ItemLabelType, SavedItem, SocialDocument } from '$lib/types';
+import type {
+  Article,
+  Highlight,
+  ItemLabelType,
+  SavedItem,
+  SocialDocument,
+  Subscription,
+} from '$lib/types';
 import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
 import { decodeEntities } from '$lib/utils/entities';
 
@@ -13,10 +20,16 @@ export interface HighlightSourceLookups {
   articlesByGuid: Map<string, Article>;
   documentsByUri: Map<string, SocialDocument>;
   savedByKey: Map<string, SavedItem>;
+  /** DID → the name the reader subscribed under. A document carries only its
+      author's DID, and resolving that to a profile is an async fetch; the
+      subscription is the same name, already on the device. */
+  authorsByDid: Map<string, string>;
 }
 
 export interface HighlightSource {
   title: string;
+  /** Who wrote it, when anything on the device says so. */
+  author: string | null;
   url: string | null;
   domain: string | null;
   /** The item to open in the in-app reader; null when nothing local backs it. */
@@ -26,17 +39,24 @@ export interface HighlightSource {
 export function buildHighlightSourceLookups(
   articles: Article[],
   documents: SocialDocument[],
-  saves: SavedItem[]
+  saves: SavedItem[],
+  subscriptions: Subscription[] = []
 ): HighlightSourceLookups {
   const savedByKey = new Map<string, SavedItem>();
   for (const save of saves) {
     if (save.itemGuid) savedByKey.set(save.itemGuid, save);
     if (save.uri) savedByKey.set(save.uri, save);
   }
+  const authorsByDid = new Map<string, string>();
+  for (const sub of subscriptions) {
+    const name = sub.customTitle || sub.title;
+    if (sub.subjectDid && name) authorsByDid.set(sub.subjectDid, name);
+  }
   return {
     articlesByGuid: new Map(articles.map((a) => [a.guid, a])),
     documentsByUri: new Map(documents.map((d) => [d.recordUri, d])),
     savedByKey,
+    authorsByDid,
   };
 }
 
@@ -62,6 +82,7 @@ export function resolveHighlightSource(
   highlight?: Pick<Highlight, 'sourceUrl' | 'sourceTitle'>
 ): HighlightSource {
   let title = '';
+  let author: string | null = null;
   let url: string | null = null;
   let displayItem: FeedDisplayItem | null = null;
 
@@ -69,6 +90,7 @@ export function resolveHighlightSource(
     const article = lookups.articlesByGuid.get(itemKey);
     if (article) {
       title = article.title;
+      author = article.author ?? null;
       url = article.url;
       displayItem = { type: 'article', item: article, key: article.guid };
     }
@@ -76,6 +98,7 @@ export function resolveHighlightSource(
     const document = lookups.documentsByUri.get(itemKey);
     if (document) {
       title = document.title;
+      author = lookups.authorsByDid.get(document.authorDid) ?? null;
       url = document.canonicalUrl ?? null;
       displayItem = { type: 'document', item: document, key: document.recordUri };
     }
@@ -86,6 +109,7 @@ export function resolveHighlightSource(
     const save = lookups.savedByKey.get(itemKey);
     if (save) {
       title = title || save.title || '';
+      author = author || save.author || null;
       url = url || save.url || null;
       displayItem = { type: 'saved', item: save, key: save.itemGuid || save.uri };
     }
@@ -98,5 +122,11 @@ export function resolveHighlightSource(
   if (!url && /^https?:\/\//i.test(itemKey)) url = itemKey;
 
   const resolvedTitle = decodeEntities(title) || domainFromUrl(url) || 'Untitled';
-  return { title: resolvedTitle, url, domain: domainFromUrl(url), displayItem };
+  return {
+    title: resolvedTitle,
+    author: author ? decodeEntities(author) : null,
+    url,
+    domain: domainFromUrl(url),
+    displayItem,
+  };
 }

--- a/frontend/src/lib/utils/marginHighlightImport.test.ts
+++ b/frontend/src/lib/utils/marginHighlightImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { planMarginHighlightImport } from './marginHighlightImport';
+import { planMarginHighlightImport, planMarginHighlightRekeys } from './marginHighlightImport';
 import type { Highlight, MarginHighlightNote } from '$lib/types';
 
 let counter = 0;
@@ -98,6 +98,40 @@ describe('planMarginHighlightImport', () => {
     expect(groups[1].highlights).toHaveLength(1);
   });
 
+  // The group's itemType decides which cache resolveHighlightSource looks in, so
+  // writing every import as 'article' would file a saved document's highlight
+  // under a type the document lookup never reads.
+  it('types a matched group by the kind of save it landed on', () => {
+    const uri = 'at://did:plc:me/app.skyreader.feed.saved/s1';
+    const document = planMarginHighlightImport(
+      [note({ match: { itemGuid: null, uri } })],
+      [],
+      [{ itemGuid: undefined, uri, source: 'document' }],
+      makeId
+    );
+    expect(document[0].itemType).toBe('document');
+
+    const bareUrl = planMarginHighlightImport(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [],
+      [{ itemGuid: 'guid-1', uri, source: 'url' }],
+      makeId
+    );
+    expect(bareUrl[0].itemType).toBe('saved');
+
+    const fromFeed = planMarginHighlightImport(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [],
+      [{ itemGuid: 'guid-1', uri, source: 'feed' }],
+      makeId
+    );
+    expect(fromFeed[0].itemType).toBe('article');
+  });
+
+  it('leaves an unmatched note an article — there is no local item to take a type from', () => {
+    expect(planMarginHighlightImport([note()], [], [], makeId)[0].itemType).toBe('article');
+  });
+
   it('falls back to now when the record carries no usable createdAt', () => {
     const before = Date.now();
     const groups = planMarginHighlightImport([note({ createdAt: 'not a date' })], [], [], makeId);
@@ -113,5 +147,152 @@ describe('planMarginHighlightImport', () => {
     );
     expect(groups[0].highlights[0]).not.toHaveProperty('note');
     expect(groups[0].highlights[0]).not.toHaveProperty('sourceTitle');
+  });
+});
+
+describe('imported highlight ids', () => {
+  // Two devices can both poll before either one's label write has synced down,
+  // so both see an empty `knownRkeys` and both import the same note. Ids are
+  // what the union merges on, so a random id would leave two copies of the same
+  // passage alive forever.
+  it('derives the id from the Margin rkey, so a double import converges', () => {
+    const deviceA = planMarginHighlightImport([note()], [], []);
+    const deviceB = planMarginHighlightImport([note()], [], []);
+    expect(deviceA[0].highlights[0].id).toBe('margin:rk1');
+    expect(deviceB[0].highlights[0].id).toBe(deviceA[0].highlights[0].id);
+  });
+
+  it('gives distinct notes distinct ids', () => {
+    const groups = planMarginHighlightImport(
+      [note(), note({ rkey: 'rk2', uri: 'at://did:plc:me/at.margin.note/rk2' })],
+      [],
+      []
+    );
+    const ids = groups.flatMap((group) => group.highlights.map((h) => h.id));
+    expect(ids).toEqual(['margin:rk1', 'margin:rk2']);
+  });
+});
+
+describe('planMarginHighlightRekeys', () => {
+  const uri = 'at://did:plc:me/app.skyreader.feed.saved/s1';
+  const saves = [{ itemGuid: 'guid-1', uri }];
+
+  /** A highlight already imported under the URL key, before any save existed. */
+  function stranded(rkey = 'rk1', itemKey = 'https://example.com/post') {
+    return {
+      itemKey,
+      highlight: {
+        id: `margin:${rkey}`,
+        selector: { type: 'TextQuoteSelector' as const, exact: 'a quote' },
+        createdAt: 1,
+        marginRkey: rkey,
+        lastReviewedAt: 500,
+      },
+    };
+  }
+
+  // The import is idempotent on the rkey, so without this pass a note imported
+  // before its article was saved would sit under a URL key forever: no
+  // highlight on the article in the reader, and a group of its own in the list.
+  it('moves a URL-keyed import onto the save that now matches it', () => {
+    const rekeys = planMarginHighlightRekeys(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [stranded()],
+      saves
+    );
+    expect(rekeys).toHaveLength(1);
+    expect(rekeys[0].from).toBe('https://example.com/post');
+    expect(rekeys[0].to).toBe('guid-1');
+  });
+
+  it('types the destination group by the save it is moving onto', () => {
+    const rekeys = planMarginHighlightRekeys(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [stranded()],
+      [{ itemGuid: 'guid-1', uri, source: 'document' }]
+    );
+    expect(rekeys[0].itemType).toBe('document');
+  });
+
+  it('carries the local highlight across, not a fresh one built from the note', () => {
+    const rekeys = planMarginHighlightRekeys(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [stranded()],
+      saves
+    );
+    // Review state rides the highlight, so rebuilding it here would silently
+    // make an already-reviewed highlight due again.
+    expect(rekeys[0].highlights[0].lastReviewedAt).toBe(500);
+  });
+
+  it('leaves a highlight that is already home alone, whichever alias it sits on', () => {
+    expect(
+      planMarginHighlightRekeys(
+        [note({ match: { itemGuid: 'guid-1', uri } })],
+        [stranded('rk1', 'guid-1')],
+        saves
+      )
+    ).toEqual([]);
+    // The save's record uri and its guid are the same item — moving between
+    // them is churn, not a fix.
+    expect(
+      planMarginHighlightRekeys(
+        [note({ match: { itemGuid: 'guid-1', uri } })],
+        [stranded('rk1', uri)],
+        saves
+      )
+    ).toEqual([]);
+  });
+
+  it('never moves a highlight off a key just because the match went away', () => {
+    // The reader unsaved the article. Shuttling it back to a URL key would only
+    // undo itself the next time they save it.
+    expect(planMarginHighlightRekeys([note({ match: null })], [stranded()], saves)).toEqual([]);
+  });
+
+  it('ignores notes with nothing local to move', () => {
+    expect(
+      planMarginHighlightRekeys([note({ match: { itemGuid: 'guid-1', uri } })], [], saves)
+    ).toEqual([]);
+  });
+
+  // marginRkey means "there is a record for this", not "this came from there" —
+  // Skyreader stamps it on its own highlights the moment they're pushed out. A
+  // native highlight's key is the article it was made on, so moving it onto a
+  // later save of the same URL would tear it off that article and out of the
+  // reader's view of it.
+  it('never moves a highlight Skyreader made and pushed out', () => {
+    const native = {
+      itemKey: 'feed-article-guid',
+      highlight: {
+        id: 'local-abc',
+        selector: { type: 'TextQuoteSelector' as const, exact: 'a quote' },
+        createdAt: 1,
+        marginRkey: 'rk1',
+        marginUri: 'at://did:plc:me/at.margin.note/rk1',
+      },
+    };
+    // The reader highlighted a feed article, saved that highlight to Margin,
+    // then later saved the same URL — which mints a different itemGuid.
+    expect(
+      planMarginHighlightRekeys([note({ match: { itemGuid: 'guid-1', uri } })], [native], saves)
+    ).toEqual([]);
+  });
+
+  it('groups several stranded highlights of one article into a single move', () => {
+    const rekeys = planMarginHighlightRekeys(
+      [
+        note({ match: { itemGuid: 'guid-1', uri } }),
+        note({
+          rkey: 'rk2',
+          uri: 'at://did:plc:me/at.margin.note/rk2',
+          match: { itemGuid: 'guid-1', uri },
+        }),
+      ],
+      [stranded('rk1'), stranded('rk2')],
+      saves
+    );
+    expect(rekeys).toHaveLength(1);
+    expect(rekeys[0].highlights).toHaveLength(2);
   });
 });

--- a/frontend/src/lib/utils/marginHighlightImport.test.ts
+++ b/frontend/src/lib/utils/marginHighlightImport.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { planMarginHighlightImport } from './marginHighlightImport';
+import type { Highlight, MarginHighlightNote } from '$lib/types';
+
+let counter = 0;
+const makeId = () => `generated-${++counter}`;
+
+function note(overrides: Partial<MarginHighlightNote> = {}): MarginHighlightNote {
+  return {
+    uri: 'at://did:plc:me/at.margin.note/rk1',
+    rkey: 'rk1',
+    url: 'https://example.com/post?utm_source=x',
+    urlNormalized: 'https://example.com/post',
+    title: 'A Post',
+    selector: { type: 'TextQuoteSelector', exact: 'a quote' },
+    createdAt: '2026-08-01T00:00:00.000Z',
+    match: null,
+    ...overrides,
+  };
+}
+
+function existing(marginRkey?: string): { highlight: Highlight } {
+  return {
+    highlight: {
+      id: 'local',
+      selector: { type: 'TextQuoteSelector', exact: 'x' },
+      createdAt: 1,
+      ...(marginRkey ? { marginRkey } : {}),
+    },
+  };
+}
+
+describe('planMarginHighlightImport', () => {
+  it('imports a new note, carrying its Margin identity and source metadata', () => {
+    const groups = planMarginHighlightImport([note()], [], [], makeId);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].itemKey).toBe('https://example.com/post');
+    expect(groups[0].highlights[0]).toMatchObject({
+      selector: { type: 'TextQuoteSelector', exact: 'a quote' },
+      createdAt: Date.parse('2026-08-01T00:00:00.000Z'),
+      marginUri: 'at://did:plc:me/at.margin.note/rk1',
+      marginRkey: 'rk1',
+      sourceUrl: 'https://example.com/post?utm_source=x',
+      sourceTitle: 'A Post',
+    });
+  });
+
+  it('skips notes already present locally — including ones Skyreader pushed out', () => {
+    expect(planMarginHighlightImport([note()], [existing('rk1')], [], makeId)).toEqual([]);
+  });
+
+  it('imports a duplicate rkey in one poll only once', () => {
+    const groups = planMarginHighlightImport([note(), note()], [], [], makeId);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].highlights).toHaveLength(1);
+  });
+
+  it('keys a matched note by the save canonical key, not the URL', () => {
+    const uri = 'at://did:plc:me/app.skyreader.feed.saved/s1';
+    const groups = planMarginHighlightImport(
+      [note({ match: { itemGuid: 'guid-1', uri } })],
+      [],
+      [{ itemGuid: 'guid-1', uri }],
+      makeId
+    );
+    expect(groups[0].itemKey).toBe('guid-1');
+  });
+
+  it('falls back to the record uri when the save has no guid', () => {
+    const uri = 'at://did:plc:me/app.skyreader.feed.saved/s1';
+    const groups = planMarginHighlightImport(
+      [note({ match: { itemGuid: null, uri } })],
+      [],
+      [{ itemGuid: undefined, uri }],
+      makeId
+    );
+    expect(groups[0].itemKey).toBe(uri);
+  });
+
+  it('groups several notes from the same article into one write', () => {
+    const groups = planMarginHighlightImport(
+      [
+        note({ rkey: 'a', uri: 'at://did:plc:me/at.margin.note/a' }),
+        note({ rkey: 'b', uri: 'at://did:plc:me/at.margin.note/b' }),
+        note({
+          rkey: 'c',
+          uri: 'at://did:plc:me/at.margin.note/c',
+          url: 'https://other.test/x',
+          urlNormalized: 'https://other.test/x',
+        }),
+      ],
+      [],
+      [],
+      makeId
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups[0].highlights).toHaveLength(2);
+    expect(groups[1].highlights).toHaveLength(1);
+  });
+
+  it('falls back to now when the record carries no usable createdAt', () => {
+    const before = Date.now();
+    const groups = planMarginHighlightImport([note({ createdAt: 'not a date' })], [], [], makeId);
+    expect(groups[0].highlights[0].createdAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('omits an absent note body and title rather than writing empty fields', () => {
+    const groups = planMarginHighlightImport(
+      [note({ note: undefined, title: undefined })],
+      [],
+      [],
+      makeId
+    );
+    expect(groups[0].highlights[0]).not.toHaveProperty('note');
+    expect(groups[0].highlights[0]).not.toHaveProperty('sourceTitle');
+  });
+});

--- a/frontend/src/lib/utils/marginHighlightImport.ts
+++ b/frontend/src/lib/utils/marginHighlightImport.ts
@@ -1,0 +1,70 @@
+import { resolveHighlightAliases } from '$lib/utils/highlightAliases';
+import type { Highlight, ItemLabelType, MarginHighlightNote, SavedItem } from '$lib/types';
+
+// The pure half of the Margin highlight ingest: notes in, per-item groups of new
+// highlights out. Kept clear of the stores so it is directly unit-testable — the
+// store/network half lives in services/marginHighlightImport.ts.
+
+/** One item's worth of new highlights — written as a single union write. */
+export interface MarginImportGroup {
+  itemKey: string;
+  itemType: ItemLabelType;
+  highlights: Highlight[];
+}
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+}
+
+/**
+ * Turn fetched Margin notes into per-item groups of new highlights.
+ *
+ * - Dedups against every `marginRkey` already known locally, which automatically
+ *   skips everything Skyreader itself pushed out.
+ * - A note matched to a save resolves to that save's canonical highlight key, so
+ *   the import lands on the same row as an in-reader highlight of the same
+ *   article. An unmatched note is keyed by its normalized URL and carries
+ *   `sourceUrl`/`sourceTitle` so it can still render and open.
+ */
+export function planMarginHighlightImport(
+  notes: MarginHighlightNote[],
+  existing: { highlight: Highlight }[],
+  saves: Pick<SavedItem, 'itemGuid' | 'uri'>[],
+  makeId: () => string = generateId
+): MarginImportGroup[] {
+  const knownRkeys = new Set(
+    existing
+      .map((entry) => entry.highlight.marginRkey)
+      .filter((rkey): rkey is string => Boolean(rkey))
+  );
+  const groups = new Map<string, MarginImportGroup>();
+
+  for (const note of notes) {
+    if (!note.rkey || knownRkeys.has(note.rkey)) continue;
+    // A duplicate rkey inside one poll would otherwise import twice.
+    knownRkeys.add(note.rkey);
+
+    const matchKey = note.match?.itemGuid || note.match?.uri || null;
+    const itemKey = matchKey
+      ? resolveHighlightAliases(matchKey, saves).canonicalKey
+      : note.urlNormalized;
+
+    const createdAt = note.createdAt ? Date.parse(note.createdAt) : NaN;
+    const highlight: Highlight = {
+      id: makeId(),
+      selector: note.selector,
+      createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+      ...(note.note ? { note: note.note } : {}),
+      marginUri: note.uri,
+      marginRkey: note.rkey,
+      sourceUrl: note.url,
+      ...(note.title ? { sourceTitle: note.title } : {}),
+    };
+
+    const group = groups.get(itemKey);
+    if (group) group.highlights.push(highlight);
+    else groups.set(itemKey, { itemKey, itemType: 'article', highlights: [highlight] });
+  }
+
+  return [...groups.values()];
+}

--- a/frontend/src/lib/utils/marginHighlightImport.ts
+++ b/frontend/src/lib/utils/marginHighlightImport.ts
@@ -1,9 +1,32 @@
-import { resolveHighlightAliases } from '$lib/utils/highlightAliases';
+import { resolveHighlightAliases, savedItemLabelType } from '$lib/utils/highlightAliases';
 import type { Highlight, ItemLabelType, MarginHighlightNote, SavedItem } from '$lib/types';
 
 // The pure half of the Margin highlight ingest: notes in, per-item groups of new
 // highlights out. Kept clear of the stores so it is directly unit-testable — the
 // store/network half lives in services/marginHighlightImport.ts.
+
+/** The save fields both passes below need: the alias keys, plus its kind. */
+type SaveRef = Pick<SavedItem, 'itemGuid' | 'uri' | 'source'>;
+
+/**
+ * The label type a matched note's group is written under.
+ *
+ * A note matched to a save is the same item that save is, so it gets that
+ * save's label type — writing every import as `'article'` would file a
+ * highlight on a saved document under a type the document lookup never reads.
+ * An unmatched note has no local item of any kind to take a type from, so it
+ * keeps `'article'`; `persistHighlightUnion` will inherit the real type from
+ * the canonical row once the re-key pass finds it a home.
+ */
+function groupItemType(save: SaveRef | undefined): ItemLabelType {
+  return save ? savedItemLabelType(save) : 'article';
+}
+
+/** The save a server-side match points at, if the client still holds it. */
+function findSave(matchKey: string | null, saves: SaveRef[]): SaveRef | undefined {
+  if (!matchKey) return undefined;
+  return saves.find((item) => item.itemGuid === matchKey || item.uri === matchKey);
+}
 
 /** One item's worth of new highlights — written as a single union write. */
 export interface MarginImportGroup {
@@ -12,8 +35,61 @@ export interface MarginImportGroup {
   highlights: Highlight[];
 }
 
-function generateId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+/**
+ * What one call to the import actually did.
+ *
+ * A single `null` used to stand for "off", "offline", "polled recently", "the
+ * grant lapsed" and "the request failed" alike, so every surface had to guess —
+ * and the settings toggle guessed wrong, telling a reader whose Margin grant had
+ * expired that Skyreader couldn't reach the network. Naming the outcomes lets
+ * each surface say the true thing, or stay quiet.
+ */
+export type MarginImportOutcome =
+  | { status: 'imported'; imported: number; truncated: boolean }
+  | { status: 'skipped'; reason: 'disabled' | 'offline' | 'throttled' | 'stores-loading' }
+  /** The Margin grant is gone; the import switched itself off. */
+  | { status: 'scope-expired' }
+  | { status: 'failed' };
+
+/** Where one locally-held highlight lives, for the re-key pass below. */
+export interface MarginHighlightLocation {
+  itemKey: string;
+  highlight: Highlight;
+}
+
+/** Move an already-imported highlight onto the key its article now has. */
+export interface MarginRekeyGroup {
+  from: string;
+  to: string;
+  itemType: ItemLabelType;
+  highlights: Highlight[];
+}
+
+/** The prefix `marginHighlightId` mints, and the only mark of an imported highlight. */
+const MARGIN_IMPORT_ID_PREFIX = 'margin:';
+
+/**
+ * An imported highlight's id is derived from the Margin rkey, not random.
+ *
+ * Two devices can both poll before either one's label write has synced down, so
+ * both see an empty `knownRkeys` for the same note and both import it. Ids are
+ * what `unionHighlightSources` merges on, so a random id would let the two
+ * copies survive each other permanently and show the passage twice. Deriving it
+ * from the rkey makes the import idempotent across devices and re-polls.
+ */
+export function marginHighlightId(note: MarginHighlightNote): string {
+  return `${MARGIN_IMPORT_ID_PREFIX}${note.rkey}`;
+}
+
+/**
+ * Did the import mint this highlight, or did Skyreader make it and push it out?
+ *
+ * `marginRkey` can't answer that — Skyreader stamps it on its own highlights the
+ * moment they're saved to Margin, so it means "there is a record for this", not
+ * "this came from there". The id is what distinguishes them.
+ */
+export function isImportedFromMargin(highlight: Pick<Highlight, 'id'>): boolean {
+  return highlight.id.startsWith(MARGIN_IMPORT_ID_PREFIX);
 }
 
 /**
@@ -29,8 +105,8 @@ function generateId(): string {
 export function planMarginHighlightImport(
   notes: MarginHighlightNote[],
   existing: { highlight: Highlight }[],
-  saves: Pick<SavedItem, 'itemGuid' | 'uri'>[],
-  makeId: () => string = generateId
+  saves: SaveRef[],
+  makeId: (note: MarginHighlightNote) => string = marginHighlightId
 ): MarginImportGroup[] {
   const knownRkeys = new Set(
     existing
@@ -45,13 +121,14 @@ export function planMarginHighlightImport(
     knownRkeys.add(note.rkey);
 
     const matchKey = note.match?.itemGuid || note.match?.uri || null;
+    const save = findSave(matchKey, saves);
     const itemKey = matchKey
       ? resolveHighlightAliases(matchKey, saves).canonicalKey
       : note.urlNormalized;
 
     const createdAt = note.createdAt ? Date.parse(note.createdAt) : NaN;
     const highlight: Highlight = {
-      id: makeId(),
+      id: makeId(note),
       selector: note.selector,
       createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
       ...(note.note ? { note: note.note } : {}),
@@ -63,7 +140,66 @@ export function planMarginHighlightImport(
 
     const group = groups.get(itemKey);
     if (group) group.highlights.push(highlight);
-    else groups.set(itemKey, { itemKey, itemType: 'article', highlights: [highlight] });
+    else groups.set(itemKey, { itemKey, itemType: groupItemType(save), highlights: [highlight] });
+  }
+
+  return [...groups.values()];
+}
+
+/**
+ * Imported highlights whose article has since been saved.
+ *
+ * A note with no `match` is keyed by its normalized URL, because the client has
+ * neither the saves table nor the normalization — the server does that join. If
+ * the reader saves the article later the match does show up on the next poll,
+ * but the import is idempotent on the rkey and would skip the note forever,
+ * stranding the highlight under a URL key: invisible on the article in the
+ * reader, and a group of its own on /highlights.
+ *
+ * So each poll also asks where its known notes actually live, and moves the ones
+ * that now have a canonical home. Only ever *toward* a match — a note that loses
+ * one (the reader unsaved the article) stays put rather than shuttling back and
+ * forth with every poll.
+ */
+export function planMarginHighlightRekeys(
+  notes: MarginHighlightNote[],
+  existing: MarginHighlightLocation[],
+  saves: SaveRef[]
+): MarginRekeyGroup[] {
+  const byRkey = new Map<string, MarginHighlightLocation>();
+  for (const entry of existing) {
+    // Only highlights the import minted are ever moved. One Skyreader made and
+    // pushed out carries a marginRkey too, and its key is the article it was
+    // made on — re-keying that onto a later save of the same URL would tear the
+    // highlight off the article it belongs to and out of the reader's view.
+    if (!isImportedFromMargin(entry.highlight)) continue;
+    const rkey = entry.highlight.marginRkey;
+    if (rkey && !byRkey.has(rkey)) byRkey.set(rkey, entry);
+  }
+
+  const groups = new Map<string, MarginRekeyGroup>();
+  for (const note of notes) {
+    const matchKey = note.match?.itemGuid || note.match?.uri || null;
+    if (!matchKey) continue;
+    const local = byRkey.get(note.rkey);
+    if (!local) continue;
+
+    const to = resolveHighlightAliases(matchKey, saves).canonicalKey;
+    // Resolve the current key too: a highlight sitting on the save's record uri
+    // when `to` is that save's guid is already home, and moving it would be churn.
+    if (resolveHighlightAliases(local.itemKey, saves).canonicalKey === to) continue;
+
+    const key = `${local.itemKey} -> ${to}`;
+    const group = groups.get(key);
+    if (group) group.highlights.push(local.highlight);
+    else {
+      groups.set(key, {
+        from: local.itemKey,
+        to,
+        itemType: groupItemType(findSave(matchKey, saves)),
+        highlights: [local.highlight],
+      });
+    }
   }
 
   return [...groups.values()];

--- a/frontend/src/routes/highlights/review/+page.svelte
+++ b/frontend/src/routes/highlights/review/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import HighlightReview from '$lib/components/feed/HighlightReview.svelte';
+</script>
+
+<svelte:head>
+  <title>Review highlights - Skyreader</title>
+</svelte:head>
+
+<HighlightReview />

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -14,6 +14,7 @@
   } from '$lib/stores/preferences.svelte';
   import ImportOPMLModal from '$lib/components/ImportOPMLModal.svelte';
   import SaveBackingPicker from '$lib/components/settings/SaveBackingPicker.svelte';
+  import HighlightSettings from '$lib/components/settings/HighlightSettings.svelte';
   import LinkblogTargetPicker from '$lib/components/settings/LinkblogTargetPicker.svelte';
   import DeleteLinkblogModal from '$lib/components/settings/DeleteLinkblogModal.svelte';
   import Diagnostics from '$lib/components/settings/Diagnostics.svelte';
@@ -878,6 +879,16 @@
     <p class="setting-description">
       Show passages highlighted by other readers on Margin while reading saved articles.
     </p>
+  </section>
+
+  <!-- Highlights: the review deck, and the Margin ingest that feeds it -->
+  <section class="card">
+    <h2>Highlights</h2>
+    <p class="setting-description" style="margin-top: 0;">
+      Your highlights are private to Skyreader. Saving one to Margin publishes that note to your
+      PDS; the highlight itself stays here.
+    </p>
+    <HighlightSettings />
   </section>
 
   <section class="card">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -14,7 +14,6 @@
   } from '$lib/stores/preferences.svelte';
   import ImportOPMLModal from '$lib/components/ImportOPMLModal.svelte';
   import SaveBackingPicker from '$lib/components/settings/SaveBackingPicker.svelte';
-  import HighlightSettings from '$lib/components/settings/HighlightSettings.svelte';
   import LinkblogTargetPicker from '$lib/components/settings/LinkblogTargetPicker.svelte';
   import DeleteLinkblogModal from '$lib/components/settings/DeleteLinkblogModal.svelte';
   import Diagnostics from '$lib/components/settings/Diagnostics.svelte';
@@ -881,14 +880,14 @@
     </p>
   </section>
 
-  <!-- Highlights: the review deck, and the Margin ingest that feeds it -->
+  <!-- Highlights. Deck size and Margin ingest live with the deck they configure;
+       what stays here is the one place the app states where a highlight lives. -->
   <section class="card">
     <h2>Highlights</h2>
     <p class="setting-description" style="margin-top: 0;">
       Your highlights are private to Skyreader. Saving one to Margin publishes that note to your
-      PDS; the highlight itself stays here.
+      public PDS.
     </p>
-    <HighlightSettings />
   </section>
 
   <section class="card">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -17,6 +17,7 @@
   import LinkblogTargetPicker from '$lib/components/settings/LinkblogTargetPicker.svelte';
   import DeleteLinkblogModal from '$lib/components/settings/DeleteLinkblogModal.svelte';
   import Diagnostics from '$lib/components/settings/Diagnostics.svelte';
+  import HighlightSettings from '$lib/components/settings/HighlightSettings.svelte';
   import StaticPageChrome from '$lib/components/feed/StaticPageChrome.svelte';
   import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
@@ -880,14 +881,16 @@
     </p>
   </section>
 
-  <!-- Highlights. Deck size and Margin ingest live with the deck they configure;
-       what stays here is the one place the app states where a highlight lives. -->
+  <!-- Highlights. Deck size lives with the deck it configures; the Margin toggle
+       cannot, because a reader with a Margin library and no Skyreader highlights
+       has no Review entry in the nav to find the deck's gear behind. -->
   <section class="card">
     <h2>Highlights</h2>
     <p class="setting-description" style="margin-top: 0;">
       Your highlights are private to Skyreader. Saving one to Margin publishes that note to your
       public PDS.
     </p>
+    <HighlightSettings showDeckSize={false} />
   </section>
 
   <section class="card">


### PR DESCRIPTION
Implements highlight review mode and opt-in Margin highlight ingest.

## Delivered

- Adds a deterministic, finite `/highlights/review` deck with review state, source actions, settings, Home and navigation entry points.
- Adds scope-gated Margin highlight ingest, defensive parsing, normalized save matching, deduplication, and explicit cross-app removal confirmation.
- Deals the deck from the local pool as soon as the stores hydrate — a Margin poll never stands between the reader and their first card — and redeals exactly once if that poll imports something before the reader touches a card. Only an empty deck waits on the poll, and that wait is bounded.
- Keeps a removed card out of a late import redeal by freezing the session before its cross-app deletion begins.
- Matches saves whose raw URLs need tracking-parameter and fragment normalization, narrowing that read by scheme+host in SQL instead of loading the user's whole saves table, and ordering by id so duplicate saves of one article resolve to the same row on every poll.

## Checks

- `backend: npm run check` — passed
- `backend: vitest run` — all 53 spec files pass (run in batches of 6; the container can't start ~30 workerd runtimes at once, which fails the single all-files invocation with `ERR_RUNTIME_FAILURE`)
- `frontend: npm run check` — passed (0 errors, 18 pre-existing warnings)
- `frontend: vitest run` — 422 passed on the cumulative branch; latest focused review test 14 passed
- Playwright E2E not executed in this environment.
- Freezes the review deck as soon as note editing, removal confirmation, or Margin saving begins, preventing a late import from retargeting an in-progress action.
- Requires every import-redeal caller to provide the interaction flag, so future omissions fail type checking.

### Latest review checks

- `frontend: npm run check` — passed (0 errors, 18 pre-existing warnings)
- `frontend: npm test` — 30 files, 423 tests passed

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-yvs7lsia43bs4sdlfzmyvhnc)

### CI status (2026-08-25)

The branch was two commits behind `main`, so its last green run had been computed
against a stale merge base. Merged `origin/main` (through "fix ci exclusion", #398)
and re-ran the full matrix. All seven required checks pass on `a00ac37`:
Build, Unit Tests, Typecheck & Format (frontend); Test, Type Check & Format
(backend); Playwright E2E (42 tests, no retries); Service Worker / Offline E2E.

No failing run exists anywhere in this branch's history — no source change was
needed to make CI green.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-k3zdwt7jwx7ctz6pyoo642al)