### PR TITLE
See and edit which Semble/Margin collections a save is in

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -88,6 +88,8 @@ import {
   handleCreateMarginNote,
   handleUpdateMarginNote,
   handleDeleteMarginNote,
+  handleGetIntegrationMemberships,
+  handleEditIntegrationMemberships,
 } from './routes/integrations';
 import { handleFullSync, handleSyncSubscriptions, handleSyncStatus } from './routes/sync';
 import {
@@ -646,6 +648,20 @@ async function route(
         });
       } else {
         response = await handleCreateMarginNote(request, env);
+      }
+      break;
+    case url.pathname === '/api/integrations/semble/memberships':
+    case url.pathname === '/api/integrations/margin/memberships':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method === 'GET') {
+        response = await handleGetIntegrationMemberships(request, env);
+      } else if (request.method === 'POST') {
+        response = await handleEditIntegrationMemberships(request, env);
+      } else {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       break;
     case url.pathname.startsWith('/api/integrations/margin/notes/'):

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -1,6 +1,13 @@
 import type { Env, Session } from '../types';
 import { getSessionFromRequest } from '../services/oauth';
 import { createPDSClient } from '../services/pds-client';
+import { generateTid } from '../utils/tid';
+import {
+  findMemberships,
+  editMemberships,
+  MembershipEditError,
+  type IntegrationProvider,
+} from '../services/integration-membership';
 import { SEMBLE_SCOPES, MARGIN_SCOPES } from './auth';
 
 /**
@@ -57,23 +64,8 @@ function checkIntegrationScopes(
   return null;
 }
 
-// Generate a TID-compatible rkey (AT Protocol timestamp ID)
-function generateTID(): string {
-  // TID format: base32-sortable encoding of microsecond timestamp + clock ID
-  // For simplicity, use a random string that matches the pattern
-  const now = BigInt(Date.now()) * 1000n; // microseconds
-  const clockId = BigInt(Math.floor(Math.random() * 1024));
-  const tid = (now << 10n) | clockId;
-  // Encode as base32-sortable (charset: 234567abcdefghijklmnopqrstuvwxyz)
-  const charset = '234567abcdefghijklmnopqrstuvwxyz';
-  let result = '';
-  let val = tid;
-  for (let i = 0; i < 13; i++) {
-    result = charset[Number(val & 31n)] + result;
-    val >>= 5n;
-  }
-  return result;
-}
+// rkeys come from utils/tid's generateTid — the real spec TID (monotonic within a
+// session, decodes back to a timestamp), shared with the backing write path.
 
 /**
  * POST /api/integrations/semble/cards — create a network.cosmik.card on PDS
@@ -124,7 +116,7 @@ export async function handleCreateSembleCard(request: Request, env: Env): Promis
         ? [{ uri: body.collectionUri, cid: body.collectionCid }]
         : [];
 
-  const rkey = generateTID();
+  const rkey = generateTid();
   const metadata: Record<string, string> = {};
   if (body.title) metadata.title = body.title;
   if (body.description) metadata.description = body.description;
@@ -154,7 +146,7 @@ export async function handleCreateSembleCard(request: Request, env: Env): Promis
   // For each selected collection, create a collectionLink record.
   const collectionResults: { uri: string; error?: string }[] = [];
   for (const col of collections) {
-    const linkRkey = generateTID();
+    const linkRkey = generateTid();
     const collectionLink = {
       $type: 'network.cosmik.collectionLink',
       collection: { uri: col.uri, cid: col.cid },
@@ -225,6 +217,147 @@ export async function handleListSembleCollections(request: Request, env: Env): P
   });
 }
 
+/** `/api/integrations/<provider>/memberships` — the provider segment of the path. */
+function providerFromPath(request: Request): IntegrationProvider | null {
+  const parts = new URL(request.url).pathname.split('/');
+  const provider = parts[3];
+  return provider === 'semble' || provider === 'margin' ? provider : null;
+}
+
+/**
+ * GET /api/integrations/:provider/memberships?url=… — which collections this URL is
+ * already saved to. Read straight from the PDS: the picker opens on live state, not
+ * on a Skyreader-side memory of what it once wrote.
+ */
+export async function handleGetIntegrationMemberships(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const provider = providerFromPath(request);
+  if (!provider) {
+    return new Response(JSON.stringify({ error: 'Unknown integration' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const checkResult = checkIntegrationScopes(session, provider);
+  if (checkResult) return checkResult;
+
+  const url = new URL(request.url).searchParams.get('url');
+  if (!url) {
+    return new Response(JSON.stringify({ error: 'url is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const pdsClient = createPDSClient(session);
+  const result = await findMemberships(pdsClient, provider, url);
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify(result.data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * POST /api/integrations/:provider/memberships — apply a membership diff for one URL.
+ *
+ * Body: `{ url, add: [{ uri, cid? }], remove: [linkUri], title?, description?, … }`.
+ * Removals only ever delete membership records (validated to this provider's lexicon
+ * and the caller's own repo); the card/note itself is never deleted. The metadata
+ * fields are used only when the URL has no item yet and one has to be created.
+ */
+export async function handleEditIntegrationMemberships(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const provider = providerFromPath(request);
+  if (!provider) {
+    return new Response(JSON.stringify({ error: 'Unknown integration' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const checkResult = checkIntegrationScopes(session, provider);
+  if (checkResult) return checkResult;
+
+  let body: {
+    url?: string;
+    add?: { uri: string; cid?: string }[];
+    remove?: string[];
+    title?: string;
+    description?: string;
+    author?: string;
+    publishedAt?: string;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.url) {
+    return new Response(JSON.stringify({ error: 'url is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const add = (body.add ?? []).filter((c) => c && typeof c.uri === 'string');
+  const remove = (body.remove ?? []).filter((uri) => typeof uri === 'string');
+
+  const pdsClient = createPDSClient(session);
+  try {
+    const result = await editMemberships(pdsClient, session.did, provider, {
+      url: body.url,
+      add,
+      remove,
+      title: body.title,
+      description: body.description,
+      author: body.author,
+      publishedAt: body.publishedAt,
+    });
+    return new Response(JSON.stringify(result), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    if (err instanceof MembershipEditError) {
+      return new Response(JSON.stringify({ error: err.message }), {
+        status: err.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw err;
+  }
+}
+
 /**
  * POST /api/integrations/margin/bookmarks — save a page to Margin.
  *
@@ -275,7 +408,7 @@ export async function handleCreateMarginBookmark(request: Request, env: Env): Pr
         ? [body.collectionUri]
         : [];
 
-  const rkey = generateTID();
+  const rkey = generateTid();
   const description = body.description?.trim();
   const record = {
     $type: 'at.margin.note',
@@ -303,7 +436,7 @@ export async function handleCreateMarginBookmark(request: Request, env: Env): Pr
   // For each selected collection, create a collectionItem record.
   const collectionResults: { uri: string; error?: string }[] = [];
   for (const uri of collectionUris) {
-    const itemRkey = generateTID();
+    const itemRkey = generateTid();
     const collectionItem = {
       $type: 'at.margin.collectionItem',
       collection: uri,
@@ -395,7 +528,7 @@ export async function handleCreateMarginNote(request: Request, env: Env): Promis
     });
   }
 
-  const rkey = generateTID();
+  const rkey = generateTid();
   const record = buildMarginNoteRecord(body, new Date().toISOString());
 
   const pdsClient = createPDSClient(session);

--- a/backend/src/services/integration-membership.ts
+++ b/backend/src/services/integration-membership.ts
@@ -1,0 +1,371 @@
+/**
+ * Semble / Margin saves — reading and editing collection membership for one URL.
+ *
+ * The "Save to Semble/Margin" picker used to be write-only: every open created a
+ * fresh card/note, so re-saving an article duplicated it and there was no way to
+ * see (let alone change) which collections it already lived in. This module is the
+ * read-back half plus the membership diff.
+ *
+ * The PDS is the source of truth, queried per-URL when the picker opens — saves
+ * can be created or reorganised in Semble/Margin themselves, so a local cache of
+ * "what Skyreader wrote" would lie. Lookup = list the user's item records, match on
+ * normalizeArticleUrl, then list membership records pointing at those items. That
+ * mirrors `backing/read.ts`'s snapshot, scoped to one URL and to the user's own repo.
+ *
+ * Record shapes (identical to the ones routes/integrations.ts and backing/write.ts
+ * write):
+ *  - Semble: network.cosmik.card + network.cosmik.collectionLink (nested strongRefs
+ *    {uri, cid} to both the card and the collection — sequential writes, the card's
+ *    cid isn't known until it's written).
+ *  - Margin: at.margin.note (motivation 'bookmarking') + at.margin.collectionItem
+ *    (flat at-uri strings, no cids — so a batch applyWrites is safe).
+ *
+ * Editing membership NEVER deletes the item record: the card/note is a shared
+ * object that may carry annotations made elsewhere, same philosophy as
+ * `removeMember` in the backing write path. Unchecking every collection leaves the
+ * item behind with zero links.
+ */
+
+import { generateTid } from '../utils/tid';
+import { parseAtUri } from '../utils/canonical-url';
+import { normalizeArticleUrl } from '../utils/url-normalize';
+import { extractUrlFromRecord } from './backing/read';
+import type { PDSClient } from './pds-client';
+
+export type IntegrationProvider = 'semble' | 'margin';
+
+const SEMBLE_CARD = 'network.cosmik.card';
+const SEMBLE_LINK = 'network.cosmik.collectionLink';
+const MARGIN_NOTE = 'at.margin.note';
+const MARGIN_ITEM = 'at.margin.collectionItem';
+
+/** The membership NSID whose records this module is allowed to delete. */
+export function membershipCollection(provider: IntegrationProvider): string {
+  return provider === 'semble' ? SEMBLE_LINK : MARGIN_ITEM;
+}
+
+export function itemCollection(provider: IntegrationProvider): string {
+  return provider === 'semble' ? SEMBLE_CARD : MARGIN_NOTE;
+}
+
+/** One card/note in the user's repo whose URL matches the one being looked up. */
+export interface MembershipItem {
+  uri: string;
+  cid: string;
+  rkey: string;
+  createdAt?: string;
+}
+
+/** One membership record: an item of ours sitting in a collection. */
+export interface Membership {
+  collectionUri: string;
+  linkUri: string;
+  itemUri: string;
+}
+
+export interface MembershipLookup {
+  items: MembershipItem[];
+  memberships: Membership[];
+  /** true if a listing stopped on the page cap — older saves may be missing. */
+  truncated: boolean;
+}
+
+// One page cap for both listings. 5 pages x 100 records is the same bound the
+// collection listings already use; `truncated` tells the client when it bit.
+const MAX_PAGES = 5;
+
+/** A delete that 404s is a success: the link is gone, which is what was asked. */
+function isRecordNotFound(error: string): boolean {
+  return /recordnotfound|could not locate record/i.test(error);
+}
+
+function rkeyOf(uri: string): string {
+  return parseAtUri(uri)?.rkey ?? '';
+}
+
+/** Newest first: TID rkeys sort by creation time, createdAt is the better signal. */
+function byNewest(a: MembershipItem, b: MembershipItem): number {
+  const at = a.createdAt ?? '';
+  const bt = b.createdAt ?? '';
+  if (at !== bt) return at < bt ? 1 : -1;
+  return a.rkey < b.rkey ? 1 : -1;
+}
+
+/**
+ * Find every card/note in the user's repo for `url`, plus the collections they
+ * currently belong to. Returns empty (not an error) when nothing matches.
+ */
+export async function findMemberships(
+  pds: PDSClient,
+  provider: IntegrationProvider,
+  url: string
+): Promise<{ success: true; data: MembershipLookup } | { success: false; error: string }> {
+  const target = normalizeArticleUrl(url);
+  if (!target) return { success: false, error: 'url is not a usable http(s) URL' };
+
+  const itemsRes = await pds.listAllRecords<{ motivation?: string; createdAt?: string }>(
+    itemCollection(provider),
+    { maxPages: MAX_PAGES }
+  );
+  if (!itemsRes.success) return { success: false, error: itemsRes.error };
+
+  const items: MembershipItem[] = [];
+  for (const rec of itemsRes.data) {
+    // Margin uses one lexicon for bookmarks AND highlights; only `motivation`
+    // separates them, and a highlight on the same article must not read as a save.
+    if (provider === 'margin' && rec.value.motivation !== 'bookmarking') continue;
+    // listRecords only returns this collection, so stamping $type is safe and lets
+    // extractUrlFromRecord pick the right URL field for the shape.
+    const recordUrl = extractUrlFromRecord({ ...rec.value, $type: itemCollection(provider) });
+    if (!recordUrl || normalizeArticleUrl(recordUrl) !== target) continue;
+    items.push({
+      uri: rec.uri,
+      cid: rec.cid,
+      rkey: rkeyOf(rec.uri),
+      createdAt: typeof rec.value.createdAt === 'string' ? rec.value.createdAt : undefined,
+    });
+  }
+  items.sort(byNewest);
+
+  let truncated = itemsRes.truncated === true;
+
+  // No item for this URL means no membership can point at one — skip the second
+  // listing entirely (the common "never saved" case costs one round trip).
+  if (items.length === 0) {
+    return { success: true, data: { items, memberships: [], truncated } };
+  }
+
+  const itemUris = new Set(items.map((i) => i.uri));
+  const memberships: Membership[] = [];
+
+  if (provider === 'semble') {
+    const links = await pds.listAllRecords<{
+      card?: { uri?: string };
+      collection?: { uri?: string };
+    }>(SEMBLE_LINK, { maxPages: MAX_PAGES });
+    if (!links.success) return { success: false, error: links.error };
+    truncated = truncated || links.truncated === true;
+    for (const link of links.data) {
+      const cardUri = link.value.card?.uri;
+      const collectionUri = link.value.collection?.uri;
+      if (!cardUri || !collectionUri || !itemUris.has(cardUri)) continue;
+      memberships.push({ collectionUri, linkUri: link.uri, itemUri: cardUri });
+    }
+  } else {
+    const links = await pds.listAllRecords<{ annotation?: string; collection?: string }>(
+      MARGIN_ITEM,
+      { maxPages: MAX_PAGES }
+    );
+    if (!links.success) return { success: false, error: links.error };
+    truncated = truncated || links.truncated === true;
+    for (const link of links.data) {
+      const noteUri = link.value.annotation;
+      const collectionUri = link.value.collection;
+      if (!noteUri || !collectionUri || !itemUris.has(noteUri)) continue;
+      memberships.push({ collectionUri, linkUri: link.uri, itemUri: noteUri });
+    }
+  }
+
+  return { success: true, data: { items, memberships, truncated } };
+}
+
+export interface MembershipEditInput {
+  url: string;
+  /** collections to add the save to; `cid` is a hint, Semble re-resolves it live */
+  add: Array<{ uri: string; cid?: string }>;
+  /** membership record uris to delete (validated against provider + owner) */
+  remove: string[];
+  /** used only when no item exists yet and we fall back to creating one */
+  title?: string;
+  description?: string;
+  author?: string;
+  publishedAt?: string;
+}
+
+export interface MembershipEditResult {
+  /** the card/note the adds attached to (existing or newly created) */
+  item?: { uri: string; cid: string; created: boolean };
+  added: Array<{ collectionUri: string; linkUri?: string; error?: string }>;
+  removed: Array<{ linkUri: string; error?: string }>;
+}
+
+export class MembershipEditError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Validate a membership uri before it becomes a deleteRecord. This endpoint must
+ * not turn into an arbitrary-record deleter: the uri has to parse, live in the
+ * caller's own repo, and name exactly this provider's membership lexicon.
+ */
+function validateRemoval(provider: IntegrationProvider, did: string, linkUri: string): string {
+  const ref = parseAtUri(linkUri);
+  if (!ref) throw new MembershipEditError(`not an at-uri: ${linkUri}`, 400);
+  if (ref.did !== did) throw new MembershipEditError('cannot remove another repo’s record', 403);
+  if (ref.collection !== membershipCollection(provider)) {
+    throw new MembershipEditError(`not a ${provider} membership record: ${linkUri}`, 400);
+  }
+  return ref.rkey;
+}
+
+/** Create the item record (card/note) for a URL that has none yet. */
+async function createItem(
+  pds: PDSClient,
+  provider: IntegrationProvider,
+  input: MembershipEditInput
+): Promise<{ uri: string; cid: string }> {
+  const rkey = generateTid();
+  const nowIso = new Date().toISOString();
+
+  let record: Record<string, unknown>;
+  if (provider === 'semble') {
+    const metadata: Record<string, string> = {};
+    if (input.title) metadata.title = input.title;
+    if (input.description) metadata.description = input.description;
+    if (input.author) metadata.author = input.author;
+    if (input.publishedAt) metadata.publishedDate = input.publishedAt;
+    record = {
+      $type: SEMBLE_CARD,
+      type: 'URL',
+      content: {
+        url: input.url,
+        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      },
+      url: input.url,
+      createdAt: nowIso,
+    };
+  } else {
+    const description = input.description?.trim();
+    record = {
+      $type: MARGIN_NOTE,
+      motivation: 'bookmarking',
+      target: {
+        source: input.url,
+        ...(input.title ? { title: input.title } : {}),
+      },
+      ...(description ? { body: { value: description, format: 'text/plain' } } : {}),
+      tags: [],
+      generator: { name: 'Skyreader', homepage: 'https://skyreader.app' },
+      createdAt: nowIso,
+    };
+  }
+
+  const res = await pds.putRecord(itemCollection(provider), rkey, record);
+  if (!res.success) throw new MembershipEditError(res.error, 502);
+  return { uri: res.data.uri, cid: res.data.cid };
+}
+
+/**
+ * Apply a membership diff for one URL: delete the named membership records, then
+ * link the item into the added collections (creating the item first if the URL has
+ * never been saved). Per-operation results are returned rather than collapsed —
+ * these are N separate PDS writes and a partial failure is reported, not hidden.
+ * Membership is re-read on the next open, so a partial apply self-heals.
+ */
+export async function editMemberships(
+  pds: PDSClient,
+  did: string,
+  provider: IntegrationProvider,
+  input: MembershipEditInput
+): Promise<MembershipEditResult> {
+  const removeRkeys = input.remove.map((uri) => ({
+    uri,
+    rkey: validateRemoval(provider, did, uri),
+  }));
+
+  const removed: MembershipEditResult['removed'] = [];
+  for (const { uri, rkey } of removeRkeys) {
+    const res = await pds.deleteRecord(membershipCollection(provider), rkey);
+    if (res.success || isRecordNotFound(res.error)) {
+      removed.push({ linkUri: uri });
+    } else {
+      removed.push({ linkUri: uri, error: res.error });
+    }
+  }
+
+  const added: MembershipEditResult['added'] = [];
+  if (input.add.length === 0) {
+    return { added, removed };
+  }
+
+  // The adds need an item to point at. Re-run the lookup server-side rather than
+  // trusting a client-supplied uri — a stale client (or one whose save landed
+  // elsewhere) then still does the right thing instead of linking the wrong card.
+  const lookup = await findMemberships(pds, provider, input.url);
+  if (!lookup.success) throw new MembershipEditError(lookup.error, 502);
+
+  const existing = lookup.data.items[0];
+  const item = existing
+    ? { uri: existing.uri, cid: existing.cid, created: false }
+    : { ...(await createItem(pds, provider, input)), created: true };
+
+  // Don't create a second link for a collection the item is already in — a stale
+  // picker (or a double-click) would otherwise duplicate the membership.
+  const alreadyIn = new Set(
+    lookup.data.memberships.filter((m) => m.itemUri === item.uri).map((m) => m.collectionUri)
+  );
+  const toAdd = input.add.filter((c) => !alreadyIn.has(c.uri));
+
+  if (provider === 'semble') {
+    for (const col of toAdd) {
+      // collectionLink.collection is a strongRef, so a stale cid from the client's
+      // cached picker list would pin an old revision. Re-resolve it live and only
+      // fall back to the client's hint if the collection can't be read.
+      const cid = (await resolveCid(pds, col.uri)) ?? col.cid;
+      if (!cid) {
+        added.push({ collectionUri: col.uri, error: 'could not resolve collection cid' });
+        continue;
+      }
+      const nowIso = new Date().toISOString();
+      const res = await pds.putRecord(SEMBLE_LINK, generateTid(), {
+        $type: SEMBLE_LINK,
+        collection: { uri: col.uri, cid },
+        card: { uri: item.uri, cid: item.cid },
+        addedBy: did,
+        addedAt: nowIso,
+        createdAt: nowIso,
+      });
+      added.push(
+        res.success
+          ? { collectionUri: col.uri, linkUri: res.data.uri }
+          : { collectionUri: col.uri, error: res.error }
+      );
+    }
+  } else if (toAdd.length > 0) {
+    // Margin's collectionItem carries flat at-uris, so every add goes in one batch.
+    const writes = toAdd.map((col) => ({
+      $type: 'com.atproto.repo.applyWrites#create' as const,
+      collection: MARGIN_ITEM,
+      rkey: generateTid(),
+      value: {
+        $type: MARGIN_ITEM,
+        collection: col.uri,
+        annotation: item.uri,
+        createdAt: new Date().toISOString(),
+      },
+    }));
+    const res = await pds.applyWrites(writes);
+    if (res.success) {
+      toAdd.forEach((col, i) => {
+        added.push({ collectionUri: col.uri, linkUri: res.data.results[i]?.uri });
+      });
+    } else {
+      for (const col of toAdd) added.push({ collectionUri: col.uri, error: res.error });
+    }
+  }
+
+  return { item, added, removed };
+}
+
+/** Current cid of a record in the user's own repo (for the collection strongRef). */
+async function resolveCid(pds: PDSClient, uri: string): Promise<string | null> {
+  const ref = parseAtUri(uri);
+  if (!ref) return null;
+  const res = await pds.getRecord(ref.collection, ref.rkey);
+  return res.success ? res.data.cid : null;
+}

--- a/backend/src/services/integration-membership.ts
+++ b/backend/src/services/integration-membership.ts
@@ -285,14 +285,30 @@ export async function editMemberships(
   const lookup = await findMemberships(pds, provider, input.url);
   if (!lookup.success) throw new MembershipEditError(lookup.error, 502);
   const allowedRemovals = new Set(lookup.data.memberships.map((m) => m.linkUri));
+  const alreadyRemoved = new Set<string>();
   for (const { uri } of removeRkeys) {
-    if (!allowedRemovals.has(uri)) {
-      throw new MembershipEditError('membership does not belong to this URL', 403);
+    if (allowedRemovals.has(uri)) continue;
+
+    // A membership can disappear after the picker opens. Preserve idempotency
+    // without weakening URL authorization: only a confirmed 404 is accepted as
+    // already removed; an existing record outside the URL-scoped lookup is still
+    // forbidden, and an inconclusive read is an upstream failure.
+    const ref = parseAtUri(uri)!;
+    const current = await pds.getRecord(ref.collection, ref.rkey);
+    if (!current.success && isRecordNotFound(current.error)) {
+      alreadyRemoved.add(uri);
+      continue;
     }
+    if (!current.success) throw new MembershipEditError(current.error, 502);
+    throw new MembershipEditError('membership does not belong to this URL', 403);
   }
 
   const removed: MembershipEditResult['removed'] = [];
   for (const { uri, rkey } of removeRkeys) {
+    if (alreadyRemoved.has(uri)) {
+      removed.push({ linkUri: uri });
+      continue;
+    }
     const res = await pds.deleteRecord(membershipCollection(provider), rkey);
     if (res.success || isRecordNotFound(res.error)) {
       removed.push({ linkUri: uri });

--- a/backend/src/services/integration-membership.ts
+++ b/backend/src/services/integration-membership.ts
@@ -173,7 +173,7 @@ export interface MembershipEditInput {
   url: string;
   /** collections to add the save to; `cid` is a hint, Semble re-resolves it live */
   add: Array<{ uri: string; cid?: string }>;
-  /** membership record uris to delete (validated against provider + owner) */
+  /** membership record uris to delete (validated against provider, owner, and URL) */
   remove: string[];
   /** used only when no item exists yet and we fall back to creating one */
   title?: string;
@@ -278,6 +278,19 @@ export async function editMemberships(
     rkey: validateRemoval(provider, did, uri),
   }));
 
+  // Authorize removals against the current server-side view for this URL. Repo +
+  // NSID validation alone is insufficient: otherwise a caller could name a link
+  // belonging to another article in their own repo. Do this once, before any
+  // writes, and reuse the same snapshot for duplicate-add protection below.
+  const lookup = await findMemberships(pds, provider, input.url);
+  if (!lookup.success) throw new MembershipEditError(lookup.error, 502);
+  const allowedRemovals = new Set(lookup.data.memberships.map((m) => m.linkUri));
+  for (const { uri } of removeRkeys) {
+    if (!allowedRemovals.has(uri)) {
+      throw new MembershipEditError('membership does not belong to this URL', 403);
+    }
+  }
+
   const removed: MembershipEditResult['removed'] = [];
   for (const { uri, rkey } of removeRkeys) {
     const res = await pds.deleteRecord(membershipCollection(provider), rkey);
@@ -293,12 +306,6 @@ export async function editMemberships(
     return { added, removed };
   }
 
-  // The adds need an item to point at. Re-run the lookup server-side rather than
-  // trusting a client-supplied uri — a stale client (or one whose save landed
-  // elsewhere) then still does the right thing instead of linking the wrong card.
-  const lookup = await findMemberships(pds, provider, input.url);
-  if (!lookup.success) throw new MembershipEditError(lookup.error, 502);
-
   const existing = lookup.data.items[0];
   const item = existing
     ? { uri: existing.uri, cid: existing.cid, created: false }
@@ -306,8 +313,11 @@ export async function editMemberships(
 
   // Don't create a second link for a collection the item is already in — a stale
   // picker (or a double-click) would otherwise duplicate the membership.
+  const removedUris = new Set(removeRkeys.map((r) => r.uri));
   const alreadyIn = new Set(
-    lookup.data.memberships.filter((m) => m.itemUri === item.uri).map((m) => m.collectionUri)
+    lookup.data.memberships
+      .filter((m) => m.itemUri === item.uri && !removedUris.has(m.linkUri))
+      .map((m) => m.collectionUri)
   );
   const toAdd = input.add.filter((c) => !alreadyIn.has(c.uri));
 

--- a/backend/test/integration-membership.spec.ts
+++ b/backend/test/integration-membership.spec.ts
@@ -196,7 +196,7 @@ describe('editMemberships — removal validation', () => {
   }
 
   it('rejects the whole batch before deleting anything', async () => {
-    const pds = fakeClient({});
+    const pds = fakeClient({ [CARD]: [card('c1', URL_A)], [LINK]: [link('l1', 'c1', COL_A)] });
     await expect(
       editMemberships(pds, DID, 'semble', {
         url: URL_A,
@@ -204,6 +204,22 @@ describe('editMemberships — removal validation', () => {
         remove: [`at://${DID}/${LINK}/l1`, `at://did:plc:other/${LINK}/l2`],
       })
     ).rejects.toBeInstanceOf(MembershipEditError);
+    expect(pds.deleteRecord).not.toHaveBeenCalled();
+  });
+
+  it('refuses a valid membership URI that belongs to another URL', async () => {
+    const pds = fakeClient({
+      [CARD]: [card('c1', URL_A), card('c2', 'https://example.test/posts/two')],
+      [LINK]: [link('l1', 'c1', COL_A), link('l2', 'c2', COL_B)],
+    });
+
+    await expect(
+      editMemberships(pds, DID, 'semble', {
+        url: URL_A,
+        add: [],
+        remove: [`at://${DID}/${LINK}/l2`],
+      })
+    ).rejects.toMatchObject({ status: 403 });
     expect(pds.deleteRecord).not.toHaveBeenCalled();
   });
 });
@@ -268,9 +284,26 @@ describe('editMemberships — Semble', () => {
     expect(res.added).toEqual([]);
   });
 
+  it('can replace a removed membership in the same collection', async () => {
+    const pds = fakeClient({
+      [CARD]: [card('c1', URL_A)],
+      [LINK]: [link('l1', 'c1', COL_A)],
+    });
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [{ uri: COL_A, cid: 'x' }],
+      remove: [`at://${DID}/${LINK}/l1`],
+    });
+
+    expect(pds.deleteRecord).toHaveBeenCalledWith(LINK, 'l1');
+    expect(pds.putRecord).toHaveBeenCalledWith(LINK, expect.any(String), expect.any(Object));
+    expect(res.added).toEqual([{ collectionUri: COL_A, linkUri: expect.stringContaining(LINK) }]);
+  });
+
   it('treats a link that is already gone as removed', async () => {
     const pds = fakeClient(
-      {},
+      { [CARD]: [card('c1', URL_A)], [LINK]: [link('gone', 'c1', COL_A)] },
       {
         deleteRecord: vi.fn(async () => ({
           success: false,

--- a/backend/test/integration-membership.spec.ts
+++ b/backend/test/integration-membership.spec.ts
@@ -222,6 +222,33 @@ describe('editMemberships — removal validation', () => {
     ).rejects.toMatchObject({ status: 403 });
     expect(pds.deleteRecord).not.toHaveBeenCalled();
   });
+
+  it('treats a membership missing before authorization as already removed and still adds', async () => {
+    const gone = `at://${DID}/${LINK}/gone`;
+    const pds = fakeClient(
+      { [CARD]: [card('c1', URL_A)], [LINK]: [] },
+      {
+        getRecord: vi.fn(async (collection: string, rkey: string) =>
+          collection === LINK && rkey === 'gone'
+            ? { success: false, error: 'Could not locate record', retryable: false }
+            : {
+                success: true,
+                data: { uri: `at://${DID}/${collection}/${rkey}`, cid: `cid-${rkey}`, value: {} },
+              }
+        ),
+      }
+    );
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [{ uri: COL_A, cid: 'x' }],
+      remove: [gone],
+    });
+
+    expect(pds.deleteRecord).not.toHaveBeenCalled();
+    expect(res.removed).toEqual([{ linkUri: gone }]);
+    expect(res.added).toEqual([{ collectionUri: COL_A, linkUri: expect.stringContaining(LINK) }]);
+  });
 });
 
 describe('editMemberships — Semble', () => {

--- a/backend/test/integration-membership.spec.ts
+++ b/backend/test/integration-membership.spec.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  findMemberships,
+  editMemberships,
+  MembershipEditError,
+} from '../src/services/integration-membership';
+import type { PDSClient } from '../src/services/pds-client';
+
+const DID = 'did:plc:membertest';
+const CARD = 'network.cosmik.card';
+const LINK = 'network.cosmik.collectionLink';
+const NOTE = 'at.margin.note';
+const ITEM = 'at.margin.collectionItem';
+
+const COL_A = `at://${DID}/network.cosmik.collection/a`;
+const COL_B = `at://${DID}/network.cosmik.collection/b`;
+const MCOL_A = `at://${DID}/at.margin.collection/a`;
+
+const URL_A = 'https://example.test/posts/one';
+
+type Records = Record<string, Array<{ uri: string; cid: string; value: Record<string, unknown> }>>;
+
+/**
+ * Fake PDSClient serving canned listRecords per collection. `truncatedFor` marks
+ * collections whose listing hit the page cap.
+ */
+function fakeClient(
+  records: Records,
+  overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {},
+  truncatedFor: string[] = []
+) {
+  return {
+    listAllRecords: vi.fn(async (collection: string) => ({
+      success: true,
+      data: records[collection] ?? [],
+      truncated: truncatedFor.includes(collection),
+    })),
+    getRecord: vi.fn(async (collection: string, rkey: string) => ({
+      success: true,
+      data: { uri: `at://${DID}/${collection}/${rkey}`, cid: `cid-${rkey}`, value: {} },
+    })),
+    putRecord: vi.fn(async (collection: string, rkey: string) => ({
+      success: true,
+      data: { uri: `at://${DID}/${collection}/${rkey}`, cid: `cid-${rkey}` },
+    })),
+    deleteRecord: vi.fn(async () => ({ success: true, data: undefined })),
+    applyWrites: vi.fn(async (writes: Array<{ collection: string; rkey: string }>) => ({
+      success: true,
+      data: {
+        commit: { cid: 'c', rev: 'r' },
+        results: writes.map((w) => ({
+          uri: `at://${DID}/${w.collection}/${w.rkey}`,
+          cid: `cid-${w.rkey}`,
+        })),
+      },
+    })),
+    ...overrides,
+  } as unknown as PDSClient;
+}
+
+const card = (rkey: string, url: string, createdAt?: string) => ({
+  uri: `at://${DID}/${CARD}/${rkey}`,
+  cid: `cid-${rkey}`,
+  value: { type: 'URL', content: { url }, url, createdAt },
+});
+
+const link = (rkey: string, cardRkey: string, collectionUri: string) => ({
+  uri: `at://${DID}/${LINK}/${rkey}`,
+  cid: `cid-${rkey}`,
+  value: {
+    card: { uri: `at://${DID}/${CARD}/${cardRkey}`, cid: `cid-${cardRkey}` },
+    collection: { uri: collectionUri, cid: 'stale-cid' },
+  },
+});
+
+const note = (rkey: string, source: string, motivation = 'bookmarking') => ({
+  uri: `at://${DID}/${NOTE}/${rkey}`,
+  cid: `cid-${rkey}`,
+  value: { motivation, target: { source } },
+});
+
+const collectionItem = (rkey: string, noteRkey: string, collectionUri: string) => ({
+  uri: `at://${DID}/${ITEM}/${rkey}`,
+  cid: `cid-${rkey}`,
+  value: { annotation: `at://${DID}/${NOTE}/${noteRkey}`, collection: collectionUri },
+});
+
+describe('findMemberships — Semble', () => {
+  it('matches cards by normalized URL and returns only their links', async () => {
+    const pds = fakeClient({
+      [CARD]: [
+        card('c1', `${URL_A}/?utm_source=newsletter#intro`),
+        card('c2', 'https://example.test/posts/two'),
+      ],
+      [LINK]: [link('l1', 'c1', COL_A), link('l2', 'c2', COL_B)],
+    });
+
+    const res = await findMemberships(pds, 'semble', URL_A);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data.items.map((i) => i.uri)).toEqual([`at://${DID}/${CARD}/c1`]);
+    expect(res.data.memberships).toEqual([
+      {
+        collectionUri: COL_A,
+        linkUri: `at://${DID}/${LINK}/l1`,
+        itemUri: `at://${DID}/${CARD}/c1`,
+      },
+    ]);
+    expect(res.data.truncated).toBe(false);
+  });
+
+  it('aggregates collections across duplicate cards, newest item first', async () => {
+    const pds = fakeClient({
+      [CARD]: [
+        card('c1', URL_A, '2026-01-01T00:00:00.000Z'),
+        card('c2', URL_A, '2026-05-01T00:00:00.000Z'),
+      ],
+      [LINK]: [link('l1', 'c1', COL_A), link('l2', 'c2', COL_B)],
+    });
+
+    const res = await findMemberships(pds, 'semble', URL_A);
+    if (!res.success) throw new Error('expected success');
+    expect(res.data.items[0].uri).toBe(`at://${DID}/${CARD}/c2`);
+    expect(res.data.memberships.map((m) => m.collectionUri).sort()).toEqual([COL_A, COL_B].sort());
+  });
+
+  it('skips a free-text NOTE card and never lists links when no card matched', async () => {
+    const pds = fakeClient({
+      [CARD]: [
+        {
+          uri: `at://${DID}/${CARD}/n1`,
+          cid: 'cid-n1',
+          value: { type: 'NOTE', content: { url: URL_A } },
+        },
+      ],
+      [LINK]: [link('l1', 'n1', COL_A)],
+    });
+
+    const res = await findMemberships(pds, 'semble', URL_A);
+    if (!res.success) throw new Error('expected success');
+    expect(res.data.items).toEqual([]);
+    expect(res.data.memberships).toEqual([]);
+    expect(pds.listAllRecords).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates truncation from either listing', async () => {
+    const pds = fakeClient({ [CARD]: [card('c1', URL_A)], [LINK]: [link('l1', 'c1', COL_A)] }, {}, [
+      LINK,
+    ]);
+    const res = await findMemberships(pds, 'semble', URL_A);
+    if (!res.success) throw new Error('expected success');
+    expect(res.data.truncated).toBe(true);
+  });
+
+  it('rejects a URL that cannot be normalized', async () => {
+    const res = await findMemberships(fakeClient({}), 'semble', 'not-a-url');
+    expect(res).toEqual({ success: false, error: expect.stringContaining('url') });
+  });
+});
+
+describe('findMemberships — Margin', () => {
+  it('only treats bookmarking notes as saves, not highlights on the same URL', async () => {
+    const pds = fakeClient({
+      [NOTE]: [note('b1', URL_A), note('h1', URL_A, 'highlighting')],
+      [ITEM]: [collectionItem('i1', 'b1', MCOL_A), collectionItem('i2', 'h1', MCOL_A)],
+    });
+
+    const res = await findMemberships(pds, 'margin', URL_A);
+    if (!res.success) throw new Error('expected success');
+    expect(res.data.items.map((i) => i.uri)).toEqual([`at://${DID}/${NOTE}/b1`]);
+    expect(res.data.memberships).toEqual([
+      {
+        collectionUri: MCOL_A,
+        linkUri: `at://${DID}/${ITEM}/i1`,
+        itemUri: `at://${DID}/${NOTE}/b1`,
+      },
+    ]);
+  });
+});
+
+describe('editMemberships — removal validation', () => {
+  const cases: Array<[string, string, number]> = [
+    ['another repo', `at://did:plc:someoneelse/${LINK}/l1`, 403],
+    ['the item lexicon, not the membership one', `at://${DID}/${CARD}/c1`, 400],
+    ['a non-at-uri', 'https://example.test/nope', 400],
+  ];
+
+  for (const [label, uri, status] of cases) {
+    it(`refuses to delete ${label}`, async () => {
+      const pds = fakeClient({});
+      await expect(
+        editMemberships(pds, DID, 'semble', { url: URL_A, add: [], remove: [uri] })
+      ).rejects.toMatchObject({ status });
+      expect(pds.deleteRecord).not.toHaveBeenCalled();
+    });
+  }
+
+  it('rejects the whole batch before deleting anything', async () => {
+    const pds = fakeClient({});
+    await expect(
+      editMemberships(pds, DID, 'semble', {
+        url: URL_A,
+        add: [],
+        remove: [`at://${DID}/${LINK}/l1`, `at://did:plc:other/${LINK}/l2`],
+      })
+    ).rejects.toBeInstanceOf(MembershipEditError);
+    expect(pds.deleteRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('editMemberships — Semble', () => {
+  it('deletes unchecked links and adds new ones with a freshly resolved collection cid', async () => {
+    const pds = fakeClient({
+      [CARD]: [card('c1', URL_A)],
+      [LINK]: [link('l1', 'c1', COL_A)],
+    });
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [{ uri: COL_B, cid: 'stale-client-cid' }],
+      remove: [`at://${DID}/${LINK}/l1`],
+    });
+
+    expect(pds.deleteRecord).toHaveBeenCalledWith(LINK, 'l1');
+    expect(res.removed).toEqual([{ linkUri: `at://${DID}/${LINK}/l1` }]);
+    // the card is NEVER deleted, only the membership
+    expect((pds.deleteRecord as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+
+    const put = (pds.putRecord as ReturnType<typeof vi.fn>).mock.calls;
+    expect(put).toHaveLength(1);
+    expect(put[0][0]).toBe(LINK);
+    expect(put[0][2].collection).toEqual({ uri: COL_B, cid: 'cid-b' });
+    expect(put[0][2].card).toEqual({ uri: `at://${DID}/${CARD}/c1`, cid: 'cid-c1' });
+    expect(res.item).toEqual({ uri: `at://${DID}/${CARD}/c1`, cid: 'cid-c1', created: false });
+    expect(res.added).toEqual([{ collectionUri: COL_B, linkUri: expect.stringContaining(LINK) }]);
+  });
+
+  it('creates the card when the URL has never been saved', async () => {
+    const pds = fakeClient({ [CARD]: [], [LINK]: [] });
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      title: 'One',
+      add: [{ uri: COL_A, cid: 'x' }],
+      remove: [],
+    });
+
+    const put = (pds.putRecord as ReturnType<typeof vi.fn>).mock.calls;
+    expect(put[0][0]).toBe(CARD);
+    expect(put[0][2].content).toEqual({ url: URL_A, metadata: { title: 'One' } });
+    expect(put[1][0]).toBe(LINK);
+    expect(res.item?.created).toBe(true);
+  });
+
+  it('does not duplicate a link for a collection the card is already in', async () => {
+    const pds = fakeClient({
+      [CARD]: [card('c1', URL_A)],
+      [LINK]: [link('l1', 'c1', COL_A)],
+    });
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [{ uri: COL_A, cid: 'x' }],
+      remove: [],
+    });
+
+    expect(pds.putRecord).not.toHaveBeenCalled();
+    expect(res.added).toEqual([]);
+  });
+
+  it('treats a link that is already gone as removed', async () => {
+    const pds = fakeClient(
+      {},
+      {
+        deleteRecord: vi.fn(async () => ({
+          success: false,
+          error: 'Could not locate record',
+          retryable: false,
+        })),
+      }
+    );
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [],
+      remove: [`at://${DID}/${LINK}/gone`],
+    });
+    expect(res.removed).toEqual([{ linkUri: `at://${DID}/${LINK}/gone` }]);
+  });
+
+  it('reports a failed link write instead of hiding it', async () => {
+    const pds = fakeClient(
+      { [CARD]: [card('c1', URL_A)], [LINK]: [] },
+      { putRecord: vi.fn(async () => ({ success: false, error: 'boom', retryable: true })) }
+    );
+
+    const res = await editMemberships(pds, DID, 'semble', {
+      url: URL_A,
+      add: [{ uri: COL_A, cid: 'x' }],
+      remove: [],
+    });
+    expect(res.added).toEqual([{ collectionUri: COL_A, error: 'boom' }]);
+  });
+});
+
+describe('editMemberships — Margin', () => {
+  it('batches collectionItem creates and deletes only membership records', async () => {
+    const pds = fakeClient({
+      [NOTE]: [note('b1', URL_A)],
+      [ITEM]: [collectionItem('i1', 'b1', MCOL_A)],
+    });
+    const COL_C = `at://${DID}/at.margin.collection/c`;
+
+    const res = await editMemberships(pds, DID, 'margin', {
+      url: URL_A,
+      add: [{ uri: COL_C }],
+      remove: [`at://${DID}/${ITEM}/i1`],
+    });
+
+    expect(pds.deleteRecord).toHaveBeenCalledWith(ITEM, 'i1');
+    const writes = (pds.applyWrites as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(writes).toHaveLength(1);
+    expect(writes[0].collection).toBe(ITEM);
+    expect(writes[0].value).toMatchObject({
+      collection: COL_C,
+      annotation: `at://${DID}/${NOTE}/b1`,
+    });
+    expect(res.added[0].linkUri).toContain(ITEM);
+  });
+
+  it('creates a bookmarking note when the URL has none', async () => {
+    const pds = fakeClient({ [NOTE]: [note('h1', URL_A, 'highlighting')], [ITEM]: [] });
+
+    const res = await editMemberships(pds, DID, 'margin', {
+      url: URL_A,
+      title: 'One',
+      add: [{ uri: MCOL_A }],
+      remove: [],
+    });
+
+    const put = (pds.putRecord as ReturnType<typeof vi.fn>).mock.calls;
+    expect(put[0][0]).toBe(NOTE);
+    expect(put[0][2].motivation).toBe('bookmarking');
+    expect(res.item?.created).toBe(true);
+  });
+});

--- a/frontend/src/lib/components/CollectionPicker.component.test.ts
+++ b/frontend/src/lib/components/CollectionPicker.component.test.ts
@@ -4,8 +4,16 @@ import CollectionPickerHost from './CollectionPicker.test-host.svelte';
 
 const pending: Array<{
   url: string;
-  resolve: (value: { items: []; memberships: []; truncated: boolean }) => void;
+  resolve: (value: {
+    items: Array<{ uri: string; cid: string }>;
+    memberships: Array<{ collectionUri: string; linkUri: string }>;
+    truncated: boolean;
+  }) => void;
 }> = [];
+let resolveSettings:
+  ((value: { backing: null | { provider: 'semble'; collectionUri: string } }) => void) | null =
+  null;
+let deferSettings = true;
 
 vi.mock('$lib/services/api', () => ({
   api: {
@@ -13,13 +21,28 @@ vi.mock('$lib/services/api', () => ({
       (_kind: string, url: string) =>
         new Promise((resolve) => pending.push({ url, resolve: resolve as (value: any) => void }))
     ),
-    getSettings: vi.fn(async () => ({ backing: null })),
+    getSettings: vi.fn(() =>
+      deferSettings
+        ? new Promise((resolve) => {
+            resolveSettings = resolve;
+          })
+        : Promise.resolve({ backing: null })
+    ),
   },
 }));
 
 vi.mock('$lib/stores/collections.svelte', () => ({
   collectionsStore: {
-    collections: { semble: [], margin: [] },
+    collections: {
+      semble: [
+        {
+          uri: 'at://did:plc:test/network.cosmik.collection/backing',
+          cid: 'bafycollection',
+          name: 'Saved',
+        },
+      ],
+      margin: [],
+    },
     loading: { semble: false, margin: false },
     refreshing: { semble: false, margin: false },
     error: { semble: null, margin: null },
@@ -35,6 +58,46 @@ describe('CollectionPicker membership requests', () => {
     component = undefined;
     pending.length = 0;
     document.body.innerHTML = '';
+  });
+
+  it('keeps remove-all disabled until the Saved backing is known', async () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    component = mount(CollectionPickerHost, { target });
+    flushSync();
+
+    pending[0].resolve({
+      items: [{ uri: 'at://did:plc:test/network.cosmik.card/item', cid: 'bafyitem' }],
+      memberships: [
+        {
+          collectionUri: 'at://did:plc:test/network.cosmik.collection/backing',
+          linkUri: 'at://did:plc:test/network.cosmik.collectionLink/link',
+        },
+      ],
+      truncated: false,
+    });
+    await vi.waitFor(() => {
+      flushSync();
+      expect(document.body.textContent).toContain('Remove from all collections');
+    });
+
+    const removeAll = document.body.querySelector('.no-collection') as HTMLButtonElement;
+    expect(removeAll.disabled).toBe(true);
+    removeAll.click();
+
+    deferSettings = false;
+    resolveSettings?.({
+      backing: {
+        provider: 'semble',
+        collectionUri: 'at://did:plc:test/network.cosmik.collection/backing',
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(removeAll.disabled).toBe(false);
+    expect(document.body.querySelector('.btn-primary')?.hasAttribute('disabled')).toBe(true);
   });
 
   it('keeps the reopened article loading when the earlier lookup resolves', async () => {
@@ -55,7 +118,7 @@ describe('CollectionPicker membership requests', () => {
     await Promise.resolve();
     flushSync();
 
-    expect(document.body.textContent).toContain('Loading collections...');
+    expect(document.body.textContent).toContain('Checking existing saves…');
     expect(document.body.querySelector('.btn-primary')?.hasAttribute('disabled')).toBe(true);
   });
 

--- a/frontend/src/lib/components/CollectionPicker.component.test.ts
+++ b/frontend/src/lib/components/CollectionPicker.component.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import CollectionPickerHost from './CollectionPicker.test-host.svelte';
+
+const pending: Array<{
+  url: string;
+  resolve: (value: { items: []; memberships: []; truncated: boolean }) => void;
+}> = [];
+
+vi.mock('$lib/services/api', () => ({
+  api: {
+    getIntegrationMemberships: vi.fn(
+      (_kind: string, url: string) =>
+        new Promise((resolve) => pending.push({ url, resolve: resolve as (value: any) => void }))
+    ),
+    getSettings: vi.fn(async () => ({ backing: null })),
+  },
+}));
+
+vi.mock('$lib/stores/collections.svelte', () => ({
+  collectionsStore: {
+    collections: { semble: [], margin: [] },
+    loading: { semble: false, margin: false },
+    refreshing: { semble: false, margin: false },
+    error: { semble: null, margin: null },
+    loadAndRefresh: vi.fn(),
+  },
+}));
+
+describe('CollectionPicker membership requests', () => {
+  let component: Record<string, any> | undefined;
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    pending.length = 0;
+    document.body.innerHTML = '';
+  });
+
+  it('keeps the reopened article loading when the earlier lookup resolves', async () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    component = mount(CollectionPickerHost, { target });
+    flushSync();
+    expect(pending.map((request) => request.url)).toEqual(['https://example.test/a']);
+
+    (target.querySelector('[data-testid="reopen"]') as HTMLButtonElement).click();
+    flushSync();
+    expect(pending.map((request) => request.url)).toEqual([
+      'https://example.test/a',
+      'https://example.test/b',
+    ]);
+
+    pending[0].resolve({ items: [], memberships: [], truncated: false });
+    await Promise.resolve();
+    flushSync();
+
+    expect(document.body.textContent).toContain('Loading collections...');
+    expect(document.body.querySelector('.btn-primary')?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('warns but permits a new save after a truncated lookup', async () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    component = mount(CollectionPickerHost, { target });
+    flushSync();
+
+    pending[0].resolve({ items: [], memberships: [], truncated: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(document.body.textContent).toContain(
+      "Couldn't check all older saves. Saving may create another Semble item."
+    );
+    (document.body.querySelector('.no-collection') as HTMLButtonElement).click();
+    flushSync();
+    expect(document.body.querySelector('.btn-primary')?.hasAttribute('disabled')).toBe(false);
+  });
+});

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -39,6 +39,9 @@
   let noCollection = $state(false);
   let memberships = $state<IntegrationMemberships | null>(null);
   let membershipsLoading = $state(false);
+  // Non-reactive generation counter: changing it must not retrigger the open
+  // effect that starts membership requests.
+  let membershipRequestId = 0;
   // The lookup is advisory: if it fails we fall back to create mode rather than
   // block the save. A duplicate card is recoverable; a blocked save is annoying.
   let membershipsFailed = $state(false);
@@ -65,6 +68,10 @@
 
   // Edit mode = this URL already has a card/note in the user's repo.
   let isEdit = $derived((memberships?.items.length ?? 0) > 0);
+  // A capped item listing that found no match is not proof this is a first save.
+  // Block creation until a complete lookup can distinguish that from an older
+  // existing item; otherwise the warning still permits the duplicate it describes.
+  let lookupIncomplete = $derived(memberships?.truncated === true && !isEdit);
   /** collections the save currently belongs to (the diff baseline) */
   let initialUris = $derived(new Set((memberships?.memberships ?? []).map((m) => m.collectionUri)));
 
@@ -83,6 +90,7 @@
 
   let canSave = $derived.by(() => {
     if (membershipsLoading) return false;
+    if (lookupIncomplete) return false;
     if (isEdit) return changed;
     return noCollection || selectedUris.size > 0;
   });
@@ -101,6 +109,7 @@
       loadMemberships(integration, url);
     } else {
       // Reset picker state when modal closes.
+      membershipRequestId += 1;
       searchQuery = '';
       selectedUris = new Set();
       noCollection = false;
@@ -111,6 +120,7 @@
   });
 
   async function loadMemberships(kind: IntegrationKind, target: string | undefined) {
+    const requestId = ++membershipRequestId;
     memberships = null;
     membershipsFailed = false;
     // No URL, or offline: nothing readable, so stay in create mode.
@@ -123,15 +133,19 @@
       const res = await api.getIntegrationMemberships(kind, target);
       // The modal may have been closed (or reopened for another article) while the
       // request was in flight — only apply an answer that's still the current one.
-      if (!open || kind !== integration || target !== url) return;
+      if (requestId !== membershipRequestId || !open || kind !== integration || target !== url)
+        return;
       memberships = res;
       selectedUris = new Set(res.memberships.map((m) => m.collectionUri));
     } catch (err) {
       console.error('Failed to load existing saves:', err);
-      if (!open || kind !== integration || target !== url) return;
+      if (requestId !== membershipRequestId || !open || kind !== integration || target !== url)
+        return;
       membershipsFailed = true;
     } finally {
-      membershipsLoading = false;
+      // A request for an earlier article must not unlock the current picker while
+      // its membership lookup is still pending.
+      if (requestId === membershipRequestId) membershipsLoading = false;
     }
   }
 
@@ -226,6 +240,10 @@
           {#if memberships?.truncated}
             <span class="picker-note-soft">Some older saves may not be shown.</span>
           {/if}
+        </div>
+      {:else if lookupIncomplete}
+        <div class="picker-note">
+          Couldn't check all older saves. Refresh and try again before creating a new one.
         </div>
       {:else if membershipsFailed}
         <div class="picker-note">Couldn't check existing saves — saving will create a new one.</div>

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -1,26 +1,47 @@
 <script lang="ts">
+  // Two modes in one modal. If the article has never been saved to this
+  // integration, the picker behaves exactly as it always did: pick collections,
+  // create a card/note. If it HAS been saved, the modal opens on the live PDS
+  // answer — the collections it's already in are pre-checked, and confirming
+  // applies the difference (new links added, unchecked links deleted) instead of
+  // creating a second card. Editing never deletes the card/note itself.
+  //
+  // Membership is read per-open rather than remembered: a save can be created or
+  // moved in Semble/Margin themselves, so anything we cached would eventually lie.
+  // Offline there's no way to read it, so the picker stays in create mode (a diff
+  // computed against stale state would delete the wrong links).
   import Modal from '$lib/components/common/Modal.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { collectionsStore, type IntegrationKind } from '$lib/stores/collections.svelte';
-  import type { SembleCollection, MarginCollection } from '$lib/types';
-
-  export interface CollectionSelection {
-    uri: string;
-    cid: string;
-  }
+  import { saveBackingStore } from '$lib/stores/saveBacking.svelte';
+  import { api } from '$lib/services/api';
+  import type {
+    SembleCollection,
+    MarginCollection,
+    IntegrationMemberships,
+    CollectionSelection,
+    CollectionPickerResult,
+  } from '$lib/types';
 
   interface Props {
     open: boolean;
     integration: IntegrationKind;
-    onselect: (collections: CollectionSelection[]) => void;
+    /** the article URL being saved — membership is looked up per-URL */
+    url?: string;
+    onconfirm: (result: CollectionPickerResult) => void;
     onclose: () => void;
   }
 
-  let { open, integration, onselect, onclose }: Props = $props();
+  let { open, integration, url, onconfirm, onclose }: Props = $props();
 
   let searchQuery = $state('');
   let selectedUris = $state<Set<string>>(new Set());
   let noCollection = $state(false);
+  let memberships = $state<IntegrationMemberships | null>(null);
+  let membershipsLoading = $state(false);
+  // The lookup is advisory: if it fails we fall back to create mode rather than
+  // block the save. A duplicate card is recoverable; a blocked save is annoying.
+  let membershipsFailed = $state(false);
 
   let list = $derived<(SembleCollection | MarginCollection)[]>(
     collectionsStore.collections[integration]
@@ -41,25 +62,81 @@
   });
 
   let integrationName = $derived(integration === 'semble' ? 'Semble' : 'Margin');
-  let canSave = $derived(noCollection || selectedUris.size > 0);
-  let saveLabel = $derived(
-    selectedUris.size > 0
+
+  // Edit mode = this URL already has a card/note in the user's repo.
+  let isEdit = $derived((memberships?.items.length ?? 0) > 0);
+  /** collections the save currently belongs to (the diff baseline) */
+  let initialUris = $derived(new Set((memberships?.memberships ?? []).map((m) => m.collectionUri)));
+
+  // The one collection that must not be edited from here: when the Saved list is
+  // backed by it, its membership IS the save, and removing the link would silently
+  // unsave the article on the next poll. Unknown backing (lookup failed) locks
+  // nothing — see saveBacking.svelte.ts.
+  let lockedUri = $derived.by(() => {
+    const backing = saveBackingStore.backing;
+    return backing && backing.provider === integration ? backing.collectionUri : null;
+  });
+
+  let addedUris = $derived([...selectedUris].filter((u) => !initialUris.has(u)));
+  let removedUris = $derived([...initialUris].filter((u) => !selectedUris.has(u)));
+  let changed = $derived(addedUris.length > 0 || removedUris.length > 0);
+
+  let canSave = $derived.by(() => {
+    if (membershipsLoading) return false;
+    if (isEdit) return changed;
+    return noCollection || selectedUris.size > 0;
+  });
+
+  let saveLabel = $derived.by(() => {
+    if (isEdit) return 'Update';
+    return selectedUris.size > 0
       ? `Save to ${selectedUris.size} collection${selectedUris.size === 1 ? '' : 's'}`
-      : 'Save'
-  );
+      : 'Save';
+  });
 
   $effect(() => {
     if (open) {
       collectionsStore.loadAndRefresh(integration);
+      saveBackingStore.load();
+      loadMemberships(integration, url);
     } else {
       // Reset picker state when modal closes.
       searchQuery = '';
       selectedUris = new Set();
       noCollection = false;
+      memberships = null;
+      membershipsLoading = false;
+      membershipsFailed = false;
     }
   });
 
+  async function loadMemberships(kind: IntegrationKind, target: string | undefined) {
+    memberships = null;
+    membershipsFailed = false;
+    // No URL, or offline: nothing readable, so stay in create mode.
+    if (!target || (typeof navigator !== 'undefined' && !navigator.onLine)) {
+      membershipsLoading = false;
+      return;
+    }
+    membershipsLoading = true;
+    try {
+      const res = await api.getIntegrationMemberships(kind, target);
+      // The modal may have been closed (or reopened for another article) while the
+      // request was in flight — only apply an answer that's still the current one.
+      if (!open || kind !== integration || target !== url) return;
+      memberships = res;
+      selectedUris = new Set(res.memberships.map((m) => m.collectionUri));
+    } catch (err) {
+      console.error('Failed to load existing saves:', err);
+      if (!open || kind !== integration || target !== url) return;
+      membershipsFailed = true;
+    } finally {
+      membershipsLoading = false;
+    }
+  }
+
   function toggleCollection(uri: string) {
+    if (uri === lockedUri) return;
     const next = new Set(selectedUris);
     if (next.has(uri)) {
       next.delete(uri);
@@ -70,7 +147,12 @@
     selectedUris = next;
   }
 
+  /** Create mode: "No collection". Edit mode: "Remove from all collections". */
   function toggleNoCollection() {
+    if (isEdit) {
+      selectedUris = new Set(lockedUri && initialUris.has(lockedUri) ? [lockedUri] : []);
+      return;
+    }
     if (noCollection) {
       noCollection = false;
     } else {
@@ -81,21 +163,41 @@
 
   function handleSave() {
     if (!canSave) return;
+
+    if (isEdit) {
+      const byUri = new Map(list.map((c) => [c.uri, c]));
+      const add: CollectionSelection[] = addedUris.map((uri) => ({
+        uri,
+        cid: byUri.get(uri)?.cid ?? '',
+      }));
+      // Every link pointing at a de-selected collection, across all matched items —
+      // a URL saved twice can sit in the same collection through two links.
+      const remove = (memberships?.memberships ?? [])
+        .filter((m) => removedUris.includes(m.collectionUri))
+        .map((m) => m.linkUri);
+      onconfirm({ mode: 'edit', add, remove });
+      return;
+    }
+
     if (noCollection) {
-      onselect([]);
+      onconfirm({ mode: 'create', collections: [] });
       return;
     }
     const byUri = new Map(list.map((c) => [c.uri, c]));
-    const result: CollectionSelection[] = [];
+    const collections: CollectionSelection[] = [];
     for (const uri of selectedUris) {
       const col = byUri.get(uri);
-      if (col) result.push({ uri: col.uri, cid: col.cid });
+      if (col) collections.push({ uri: col.uri, cid: col.cid });
     }
-    onselect(result);
+    onconfirm({ mode: 'create', collections });
   }
 </script>
 
-<Modal {open} {onclose} title="Save to {integrationName}">
+<Modal
+  {open}
+  {onclose}
+  title={isEdit ? `Saved to ${integrationName}` : `Save to ${integrationName}`}
+>
   <div class="picker-body">
     {#if isOffline && list.length === 0}
       <div class="picker-offline">
@@ -104,11 +206,29 @@
       </div>
     {:else if loadError && !isOffline && list.length === 0}
       <div class="picker-error">{loadError}</div>
-    {:else if isLoading && list.length === 0}
+    {:else if (isLoading || membershipsLoading) && list.length === 0}
       <div class="picker-loading">Loading collections...</div>
     {:else}
       {#if isOffline}
         <div class="picker-offline">Offline — showing cached collections. Save will be queued.</div>
+      {/if}
+
+      {#if membershipsLoading}
+        <div class="picker-note" aria-live="polite">Checking existing saves…</div>
+      {:else if isEdit}
+        <div class="picker-note">
+          {#if initialUris.size === 0}
+            Saved without a collection. Pick where it should live.
+          {:else}
+            Already in {initialUris.size} collection{initialUris.size === 1 ? '' : 's'}. Changes
+            apply on update.
+          {/if}
+          {#if memberships?.truncated}
+            <span class="picker-note-soft">Some older saves may not be shown.</span>
+          {/if}
+        </div>
+      {:else if membershipsFailed}
+        <div class="picker-note">Couldn't check existing saves — saving will create a new one.</div>
       {/if}
 
       <div class="search-row">
@@ -127,15 +247,17 @@
 
       <button
         class="collection-row no-collection"
-        class:selected={noCollection}
+        class:selected={!isEdit && noCollection}
         onclick={toggleNoCollection}
         type="button"
       >
         <span class="checkbox" aria-hidden="true">
-          {#if noCollection}<Icon name="check" size={14} />{/if}
+          {#if !isEdit && noCollection}<Icon name="check" size={14} />{/if}
         </span>
         <div class="collection-info">
-          <span class="collection-name">No collection</span>
+          <span class="collection-name">
+            {isEdit && initialUris.size > 0 ? 'Remove from all collections' : 'No collection'}
+          </span>
         </div>
       </button>
 
@@ -149,10 +271,13 @@
         {:else}
           {#each filtered as collection (collection.uri)}
             {@const checked = selectedUris.has(collection.uri)}
+            {@const locked = collection.uri === lockedUri}
             <button
               class="collection-row"
               class:selected={checked}
+              class:locked
               onclick={() => toggleCollection(collection.uri)}
+              disabled={locked}
               type="button"
             >
               <span class="checkbox" aria-hidden="true">
@@ -160,7 +285,11 @@
               </span>
               <div class="collection-info">
                 <span class="collection-name">{collection.name || 'Untitled'}</span>
-                {#if collection.description}
+                {#if locked}
+                  <span class="collection-desc">
+                    Managed by your Saved list — {checked ? 'unsave to remove' : 'save to add'}
+                  </span>
+                {:else if collection.description}
                   <span class="collection-desc">{collection.description}</span>
                 {/if}
               </div>
@@ -209,6 +338,17 @@
   .picker-offline {
     color: var(--color-text-secondary);
     background: var(--color-bg-secondary, rgba(0, 0, 0, 0.03));
+  }
+
+  .picker-note {
+    padding: 0.5rem 0.25rem;
+    font-size: var(--text-md);
+    color: var(--color-text-secondary);
+  }
+
+  .picker-note-soft {
+    display: block;
+    font-size: var(--text-sm);
   }
 
   .search-row {
@@ -264,6 +404,18 @@
   }
 
   .collection-row.selected {
+    background: var(--color-accent-subtle, rgba(59, 130, 246, 0.08));
+  }
+
+  .collection-row.locked {
+    cursor: default;
+  }
+
+  .collection-row.locked:hover {
+    background: none;
+  }
+
+  .collection-row.locked.selected:hover {
     background: var(--color-accent-subtle, rgba(59, 130, 246, 0.08));
   }
 

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -269,6 +269,7 @@
         class="collection-row no-collection"
         class:selected={!isEdit && noCollection}
         onclick={toggleNoCollection}
+        disabled={!saveBackingStore.loaded}
         type="button"
       >
         <span class="checkbox" aria-hidden="true">

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -69,8 +69,8 @@
   // Edit mode = this URL already has a card/note in the user's repo.
   let isEdit = $derived((memberships?.items.length ?? 0) > 0);
   // A capped item listing that found no match is not proof this is a first save.
-  // Block creation until a complete lookup can distinguish that from an older
-  // existing item; otherwise the warning still permits the duplicate it describes.
+  // Keep the lookup honest, but don't permanently block established users whose
+  // repos are larger than the bounded scan: a possible duplicate is recoverable.
   let lookupIncomplete = $derived(memberships?.truncated === true && !isEdit);
   /** collections the save currently belongs to (the diff baseline) */
   let initialUris = $derived(new Set((memberships?.memberships ?? []).map((m) => m.collectionUri)));
@@ -90,7 +90,9 @@
 
   let canSave = $derived.by(() => {
     if (membershipsLoading) return false;
-    if (lookupIncomplete) return false;
+    // Until this settles, the row whose membership IS the user's Saved entry is
+    // unknown and must not be editable (or removable through "remove all").
+    if (!saveBackingStore.loaded) return false;
     if (isEdit) return changed;
     return noCollection || selectedUris.size > 0;
   });
@@ -243,7 +245,7 @@
         </div>
       {:else if lookupIncomplete}
         <div class="picker-note">
-          Couldn't check all older saves. Refresh and try again before creating a new one.
+          Couldn't check all older saves. Saving may create another {integrationName} item.
         </div>
       {:else if membershipsFailed}
         <div class="picker-note">Couldn't check existing saves — saving will create a new one.</div>
@@ -295,7 +297,7 @@
               class:selected={checked}
               class:locked
               onclick={() => toggleCollection(collection.uri)}
-              disabled={locked}
+              disabled={locked || !saveBackingStore.loaded}
               type="button"
             >
               <span class="checkbox" aria-hidden="true">

--- a/frontend/src/lib/components/CollectionPicker.test-host.svelte
+++ b/frontend/src/lib/components/CollectionPicker.test-host.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import CollectionPicker from './CollectionPicker.svelte';
+
+  let open = $state(true);
+  let url = $state('https://example.test/a');
+
+  function reopenForB() {
+    open = false;
+    url = 'https://example.test/b';
+    open = true;
+  }
+</script>
+
+<button data-testid="reopen" onclick={reopenForB}>Reopen</button>
+<CollectionPicker integration="semble" {open} {url} onconfirm={() => {}} onclose={() => {}} />

--- a/frontend/src/lib/components/feed/IntegrationSaveDialog.svelte
+++ b/frontend/src/lib/components/feed/IntegrationSaveDialog.svelte
@@ -10,6 +10,7 @@
 <CollectionPicker
   open={integrationSaveStore.open}
   integration={integrationSaveStore.integration}
-  onselect={(collections) => integrationSaveStore.select(collections)}
+  url={integrationSaveStore.url}
+  onconfirm={(result) => integrationSaveStore.confirm(result)}
   onclose={() => integrationSaveStore.close()}
 />

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -1,5 +1,7 @@
 import type {
   FeedItem,
+  IntegrationMembershipEditResult,
+  IntegrationMemberships,
   IntegrationStatus,
   ItemLabel,
   ItemLabelType,
@@ -1081,6 +1083,38 @@ class ApiClient {
 
   async listMarginCollections(): Promise<{ collections: MarginCollection[] }> {
     return this.fetch('/api/integrations/margin/collections');
+  }
+
+  /** Which collections this URL is already saved to (read live from the PDS). */
+  async getIntegrationMemberships(
+    integration: 'semble' | 'margin',
+    url: string
+  ): Promise<IntegrationMemberships> {
+    return this.fetch(
+      `/api/integrations/${integration}/memberships?url=${encodeURIComponent(url)}`
+    );
+  }
+
+  /**
+   * Apply a collection-membership diff for an already-saved URL. Removals delete
+   * only the membership records — the card/note itself always stays.
+   */
+  async editIntegrationMemberships(
+    integration: 'semble' | 'margin',
+    data: {
+      url: string;
+      add: { uri: string; cid?: string }[];
+      remove: string[];
+      title?: string;
+      description?: string;
+      author?: string;
+      publishedAt?: string;
+    }
+  ): Promise<IntegrationMembershipEditResult> {
+    return this.fetch(`/api/integrations/${integration}/memberships`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
   }
 
   async createMarginNote(data: {

--- a/frontend/src/lib/stores/integrationSave.svelte.ts
+++ b/frontend/src/lib/stores/integrationSave.svelte.ts
@@ -8,14 +8,18 @@
 // couldn't act on. The flow lives here instead, and the picker is mounted once
 // in AppShell, so any surface can open it without threading props.
 //
-// Saving is additive: a card/bookmark is created in the chosen collections. An
-// article already in a collection can be saved again into another one, which is
-// how you edit where it lives.
+// A first save is additive: a card/bookmark is created in the chosen collections.
+// Re-opening the picker on an article that's already there is an EDIT — the picker
+// reads the live membership and hands back a diff, which we apply as added links
+// and deleted links. Editing is online-only (a diff against stale state would
+// delete the wrong links), so there's no queueing on that path; the create path
+// keeps its offline queue untouched.
 import { api, ScopeUpgradeError } from '$lib/services/api';
 import { syncQueue, type IntegrationPayload } from '$lib/services/sync-queue';
 import { syncStore } from '$lib/stores/sync.svelte';
 import { toastStore } from '$lib/stores/toast.svelte';
 import type { IntegrationKind } from '$lib/stores/collections.svelte';
+import type { CollectionPickerResult, CollectionSelection } from '$lib/types';
 
 export interface IntegrationSaveTarget {
   url: string;
@@ -25,10 +29,7 @@ export interface IntegrationSaveTarget {
   publishedAt?: string;
 }
 
-export interface CollectionChoice {
-  uri: string;
-  cid: string;
-}
+export type CollectionChoice = CollectionSelection;
 
 function createIntegrationSaveStore() {
   let open = $state(false);
@@ -46,7 +47,16 @@ function createIntegrationSaveStore() {
     target = null;
   }
 
-  async function select(collections: CollectionChoice[]) {
+  /** Apply whatever the picker decided: a first save, or a membership edit. */
+  async function confirm(result: CollectionPickerResult) {
+    if (result.mode === 'edit') {
+      await applyEdit(result.add, result.remove);
+      return;
+    }
+    await save(result.collections);
+  }
+
+  async function save(collections: CollectionChoice[]) {
     open = false;
     const data = target;
     if (!data) return;
@@ -108,6 +118,49 @@ function createIntegrationSaveStore() {
     }
   }
 
+  /**
+   * Change which collections an existing save belongs to. Online-only on purpose:
+   * the removals name specific membership records read moments ago, so there's
+   * nothing safe to queue — a failure keeps the toast and invites a retry.
+   */
+  async function applyEdit(add: CollectionChoice[], remove: string[]) {
+    open = false;
+    const data = target;
+    if (!data) return;
+    target = null;
+
+    const label = integration === 'margin' ? 'Margin' : 'Semble';
+    const id = toastStore.add(`Updating ${label} save...`);
+    try {
+      const res = await api.editIntegrationMemberships(integration, {
+        url: data.url,
+        add,
+        remove,
+        title: data.title,
+        description: data.description,
+        author: data.author,
+        publishedAt: data.publishedAt,
+      });
+      const failed = [...res.added, ...res.removed].filter((r) => r.error).length;
+      if (failed > 0) {
+        toastStore.update(
+          id,
+          'error',
+          `${label} save partly updated — ${failed} change${failed === 1 ? '' : 's'} failed`
+        );
+        return;
+      }
+      toastStore.update(id, 'success', `${label} save updated`);
+    } catch (err) {
+      if (err instanceof ScopeUpgradeError) {
+        toastStore.update(id, 'error', 'Please log in again to grant integration permissions');
+        return;
+      }
+      console.error(`Failed to update ${label} save:`, err);
+      toastStore.update(id, 'error', `Couldn't update ${label} save`);
+    }
+  }
+
   return {
     get open() {
       return open;
@@ -115,10 +168,14 @@ function createIntegrationSaveStore() {
     get integration() {
       return integration;
     },
+    /** The URL the picker is open for — it looks up that URL's existing saves. */
+    get url() {
+      return target?.url;
+    },
     /** Open the collection picker for `kind`, then save `data` into the choice. */
     openPicker,
     close,
-    select,
+    confirm,
   };
 }
 

--- a/frontend/src/lib/stores/saveBacking.svelte.ts
+++ b/frontend/src/lib/stores/saveBacking.svelte.ts
@@ -13,6 +13,7 @@ import type { SaveBacking } from '$lib/types';
 
 function createSaveBackingStore() {
   let backing = $state<SaveBacking | null>(null);
+  let loaded = $state(false);
   let inFlight: Promise<void> | null = null;
 
   /** Refresh from the server, deduping concurrent callers. Never throws. */
@@ -25,6 +26,7 @@ function createSaveBackingStore() {
       } catch (err) {
         console.error('Failed to load save backing:', err);
       } finally {
+        loaded = true;
         inFlight = null;
       }
     })();
@@ -39,6 +41,9 @@ function createSaveBackingStore() {
   return {
     get backing() {
       return backing;
+    },
+    get loaded() {
+      return loaded;
     },
     load,
     set,

--- a/frontend/src/lib/stores/saveBacking.svelte.ts
+++ b/frontend/src/lib/stores/saveBacking.svelte.ts
@@ -1,0 +1,48 @@
+// Which engine backs the Saved list, cached for surfaces that only need to read it.
+//
+// The collection picker needs this to protect one row: if the user's Saved list IS
+// a Semble/Margin collection, unchecking that collection here would silently unsave
+// the article on the next membership poll. The picker locks that row instead, and to
+// do that it has to know the backing target.
+//
+// Best-effort by design: a failed lookup leaves `backing` null and the picker simply
+// renders no locked row. The settings page owns changing the backing; this store only
+// reads it, refreshing in the background whenever a caller asks.
+import { api } from '$lib/services/api';
+import type { SaveBacking } from '$lib/types';
+
+function createSaveBackingStore() {
+  let backing = $state<SaveBacking | null>(null);
+  let inFlight: Promise<void> | null = null;
+
+  /** Refresh from the server, deduping concurrent callers. Never throws. */
+  async function load(): Promise<void> {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      try {
+        const settings = await api.getSettings();
+        backing = settings.backing;
+      } catch (err) {
+        console.error('Failed to load save backing:', err);
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  }
+
+  /** Push a known-good value (the settings page just changed it). */
+  function set(next: SaveBacking) {
+    backing = next;
+  }
+
+  return {
+    get backing() {
+      return backing;
+    },
+    load,
+    set,
+  };
+}
+
+export const saveBackingStore = createSaveBackingStore();

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1122,6 +1122,51 @@ export type SaveBacking =
   | { provider: 'semble'; collectionUri: string }
   | { provider: 'margin'; collectionUri: string };
 
+// What a URL is already saved as in Semble/Margin. Read live from the PDS when the
+// collection picker opens (backend/src/services/integration-membership.ts) — a save
+// can be created or moved in Semble/Margin itself, so nothing local can be trusted.
+export interface IntegrationMembershipItem {
+  uri: string;
+  cid: string;
+  rkey: string;
+  createdAt?: string;
+}
+
+export interface IntegrationMembership {
+  collectionUri: string;
+  /** the membership record — this is what gets deleted when a box is unchecked */
+  linkUri: string;
+  itemUri: string;
+}
+
+export interface IntegrationMemberships {
+  items: IntegrationMembershipItem[];
+  memberships: IntegrationMembership[];
+  /** a listing hit its page cap: older saves may be missing from this answer */
+  truncated: boolean;
+}
+
+/** A collection the user picked, with the cid its strongRef needs (Semble). */
+export interface CollectionSelection {
+  uri: string;
+  cid: string;
+}
+
+/**
+ * What the collection picker hands back. `create` is a first save (card/note plus
+ * links); `edit` is a membership diff against an article that's already there —
+ * `remove` carries membership record uris, never item uris.
+ */
+export type CollectionPickerResult =
+  | { mode: 'create'; collections: CollectionSelection[] }
+  | { mode: 'edit'; add: CollectionSelection[]; remove: string[] };
+
+export interface IntegrationMembershipEditResult {
+  item?: { uri: string; cid: string; created: boolean };
+  added: Array<{ collectionUri: string; linkUri?: string; error?: string }>;
+  removed: Array<{ linkUri: string; error?: string }>;
+}
+
 export interface SembleCollection {
   uri: string;
   cid: string;


### PR DESCRIPTION
Re-opening the Save to Semble / Margin picker now shows current collection membership and applies changes without creating duplicate cards or notes.

This continuation closes the latest review finding:
- Remove from all collections stays disabled until Saved-list backing is known, preventing a first-open race from silently unsaving an externally backed item
- Regression coverage resolves membership before settings, attempts remove-all, and verifies the backing membership remains protected

Cumulative checks:
- backend focused membership suite: 20 passed
- backend type and formatting check: passed
- frontend suite: 405 passed
- frontend type and formatting check: passed with 19 pre-existing warnings
- full backend suite: previously blocked by unrelated Worker tests repeatedly connecting to unavailable network services

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-gpaffbfpfrmqor33d7fig3a5)