### PR TITLE
Add search for saved articles

### DIFF
--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -70,6 +70,12 @@ test.describe('Saved search', () => {
     await expect(authedPage.locator('mark', { hasText: BODY_WORD })).toBeVisible();
     await expect(authedPage.getByText('sits the word')).toBeVisible();
 
+    // AND terms can be split across metadata and full text: "ownership" is
+    // only in the title, while BODY_WORD is only in the cached article body.
+    await input.fill(`ownership ${BODY_WORD}`);
+    await expect(authedPage.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
+    await expect(authedPage.getByText('Gardening Basics')).not.toBeVisible();
+
     // Diacritic-folded metadata match.
     await input.fill('cafe');
     await expect(authedPage.getByText('An Afternoon at the Café')).toBeVisible();

--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from './fixtures';
+import { seedItemLabel, seedSavedArticle, type TestUser } from './seed';
+
+// A word that exists ONLY inside an article body, so a hit proves full-text
+// search reached the cached body rather than the metadata.
+const BODY_WORD = 'quokkatelemetry';
+
+async function seedLibrary(testUser: TestUser) {
+  await seedSavedArticle(testUser, {
+    url: 'https://example.com/gardening',
+    title: 'Gardening Basics',
+    domain: 'example.com',
+    description: 'Starting a first vegetable bed',
+    content: '<p>Tomatoes want sun and patience.</p>',
+  });
+
+  await seedSavedArticle(testUser, {
+    url: 'https://example.com/ownership',
+    title: 'Ownership Explained',
+    domain: 'example.com',
+    description: 'Borrowing, moves, and lifetimes',
+    content: `<p>Somewhere deep in the piece sits the word ${BODY_WORD}, which never appears in the title.</p>`,
+  });
+
+  await seedSavedArticle(testUser, {
+    url: 'https://example.com/cafe',
+    title: 'An Afternoon at the Café',
+    domain: 'example.com',
+    content: '<p>Espresso, a notebook, and two hours.</p>',
+  });
+
+  // Archived, and the only item whose title carries "sourdough" — the cross-view
+  // hint has to be what surfaces it while the inbox is showing.
+  const archivedRkey = await seedSavedArticle(testUser, {
+    url: 'https://example.com/sourdough',
+    title: 'Sourdough Notes',
+    domain: 'example.com',
+    content: '<p>Feed the starter twice a day.</p>',
+  });
+  await seedItemLabel(testUser, {
+    itemKey: `at://${testUser.did}/app.skyreader.feed.saved/${archivedRkey}`,
+    itemType: 'saved',
+    label: 'archived',
+  });
+}
+
+test.describe('Saved search', () => {
+  test('filters the saved list by title, body text, and clears back', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedLibrary(testUser);
+    await authedPage.goto('/saved');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible({ timeout: 15_000 });
+
+    await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+    const input = authedPage.getByTestId('saved-search-input');
+    await expect(input).toBeFocused();
+
+    // Metadata (title) search.
+    await input.fill('gardening');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible();
+    await expect(authedPage.getByText('An Afternoon at the Café')).not.toBeVisible();
+
+    // Full-text search: the phrase only exists inside the stored body, and the
+    // card swaps its preview line for a snippet around the hit.
+    await input.fill(BODY_WORD);
+    await expect(authedPage.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
+    await expect(authedPage.getByText('Gardening Basics')).not.toBeVisible();
+    await expect(authedPage.locator('mark', { hasText: BODY_WORD })).toBeVisible();
+    await expect(authedPage.getByText('sits the word')).toBeVisible();
+
+    // Diacritic-folded metadata match.
+    await input.fill('cafe');
+    await expect(authedPage.getByText('An Afternoon at the Café')).toBeVisible();
+
+    // Clearing restores the full list.
+    await input.fill('');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible();
+    await expect(authedPage.getByText('Ownership Explained')).toBeVisible();
+  });
+
+  test('offers the archive match count and flips to it', async ({ authedPage, testUser }) => {
+    await seedLibrary(testUser);
+    await authedPage.goto('/saved');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible({ timeout: 15_000 });
+
+    await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+    await authedPage.getByTestId('saved-search-input').fill('sourdough');
+
+    // Nothing in the inbox matches, but the archive has exactly one.
+    await expect(authedPage.getByText('No matches for')).toBeVisible({ timeout: 10_000 });
+    const hint = authedPage.getByRole('button', { name: '1 match in Archive' });
+    await expect(hint).toBeVisible();
+
+    await hint.click();
+    await expect(authedPage.getByText('Sourdough Notes')).toBeVisible();
+  });
+
+  test.describe('on a mobile viewport', () => {
+    // Below 1000px the desktop header is hidden and the bottom bar takes over,
+    // so the bar is the only way into search there.
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('the bottom bar opens search', async ({ authedPage, testUser }) => {
+      await seedLibrary(testUser);
+      await authedPage.goto('/saved');
+      await expect(authedPage.getByText('Gardening Basics')).toBeVisible({ timeout: 15_000 });
+
+      await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+      const input = authedPage.getByTestId('saved-search-input');
+      await expect(input).toBeVisible();
+
+      await input.fill('gardening');
+      await expect(authedPage.getByText('Gardening Basics')).toBeVisible();
+      await expect(authedPage.getByText('An Afternoon at the Café')).not.toBeVisible();
+    });
+  });
+
+  test('"/" opens search and Escape clears it', async ({ authedPage, testUser }) => {
+    await seedLibrary(testUser);
+    await authedPage.goto('/saved');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible({ timeout: 15_000 });
+
+    await authedPage.locator('body').press('/');
+    const input = authedPage.getByTestId('saved-search-input');
+    await expect(input).toBeFocused();
+
+    await input.fill('gardening');
+    await expect(authedPage.getByText('An Afternoon at the Café')).not.toBeVisible();
+
+    await input.press('Escape');
+    await expect(input).not.toBeVisible();
+    await expect(authedPage.getByText('An Afternoon at the Café')).toBeVisible();
+  });
+});

--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -72,6 +72,12 @@ test.describe('Saved search', () => {
 
     // AND terms can be split across metadata and full text: "ownership" is
     // only in the title, while BODY_WORD is only in the cached article body.
+    // Entered from a query that hides the item, so the assertion below is a
+    // hidden → visible transition and not the state the list already sat in —
+    // matching each source as a whole (the bug this covers) leaves it hidden.
+    await input.fill('gardening');
+    await expect(authedPage.getByText('Ownership Explained')).not.toBeVisible();
+
     await input.fill(`ownership ${BODY_WORD}`);
     await expect(authedPage.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
     await expect(authedPage.getByText('Gardening Basics')).not.toBeVisible();
@@ -101,6 +107,44 @@ test.describe('Saved search', () => {
 
     await hint.click();
     await expect(authedPage.getByText('Sourdough Notes')).toBeVisible();
+  });
+
+  test('leaving Saved hands "/" back to the navigation switcher', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedLibrary(testUser);
+    await authedPage.goto('/saved');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible({ timeout: 15_000 });
+
+    // Search on Saved, then leave the surface with the query still applied.
+    await authedPage.locator('body').press('/');
+    const input = authedPage.getByTestId('saved-search-input');
+    await expect(input).toBeFocused();
+    await input.fill('gardening');
+    await expect(authedPage.getByText('An Afternoon at the Café')).not.toBeVisible();
+
+    // Client-side navigation, deliberately: a full reload would rebuild every
+    // store and hide the residual-state bug this covers.
+    await authedPage.getByRole('link', { name: 'Home' }).click();
+    await expect(authedPage).toHaveURL(/\/home$/);
+    await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
+
+    // Off the saved surface, "/" is the switcher again.
+    await authedPage.locator('body').press('/');
+    await expect(authedPage.getByRole('listbox')).toBeVisible();
+    await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
+    await authedPage.keyboard.press('Escape');
+    await expect(authedPage.getByRole('listbox')).toHaveCount(0);
+
+    // And coming back is a clean list, not the query from last time.
+    await authedPage.getByRole('button', { name: 'Saved' }).first().click();
+    await expect(
+      authedPage
+        .getByLabel('Recently saved', { exact: true })
+        .getByRole('button', { name: 'An Afternoon at the Café' })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
   });
 
   test.describe('on a mobile viewport', () => {

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -14,7 +14,6 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { keyboardStore } from '$lib/stores/keyboard.svelte';
-  import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { feedPath, FEEDS_PATH, SAVED_PATH } from '$lib/utils/viewNav';
@@ -171,12 +170,15 @@
     // otherwise. Registered once here rather than re-registered per page,
     // because the store keys shortcuts by key: a second '/' registration would
     // clobber this one and take the switcher with it when it unregistered.
+    // Gated on `available` (the saved page is mounted *now*) rather than on the
+    // view filters, which keep their last value after that page unmounts and
+    // would leave the switcher dead on every route after one Saved visit.
     keyboardStore.register({
       key: '/',
       description: 'Search saved / open switcher',
       category: 'Navigation',
       action: () => {
-        if (feedViewStore.isSavedView) savedSearchStore.openSearch();
+        if (savedSearchStore.available) savedSearchStore.openSearch();
         else sidebarStore.toggleNavigationDropdown();
       },
       condition: () => auth.isAuthenticated,

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -14,6 +14,8 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { keyboardStore } from '$lib/stores/keyboard.svelte';
+  import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { feedPath, FEEDS_PATH, SAVED_PATH } from '$lib/utils/viewNav';
   import Sidebar from '$lib/components/Sidebar.svelte';
@@ -164,12 +166,19 @@
       condition: () => auth.isAuthenticated,
     });
 
-    // Navigation switcher shortcut
+    // Navigation switcher shortcut. In a saved view "/" means what it means
+    // everywhere else — search this list — and falls back to the switcher
+    // otherwise. Registered once here rather than re-registered per page,
+    // because the store keys shortcuts by key: a second '/' registration would
+    // clobber this one and take the switcher with it when it unregistered.
     keyboardStore.register({
       key: '/',
-      description: 'Open switcher',
+      description: 'Search saved / open switcher',
       category: 'Navigation',
-      action: () => sidebarStore.toggleNavigationDropdown(),
+      action: () => {
+        if (feedViewStore.isSavedView) savedSearchStore.openSearch();
+        else sidebarStore.toggleNavigationDropdown();
+      },
       condition: () => auth.isAuthenticated,
     });
 

--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -477,10 +477,20 @@
     feedViewStore.resetSelection();
   });
 
+  // This page owns the saved search row, so it owns the window in which search
+  // exists at all: the global `/` shortcut asks the store whether there is a
+  // row to open. The view filters can't answer that — they survive unmount.
+  $effect(() => {
+    savedSearchStore.setSurfaceActive(isSavedView);
+  });
+
   onDestroy(() => {
     if (mode === 'linkblog') {
       feedViewStore.setMyLinkblogMode(false);
     }
+    // Leaving the surface ends the search; a stale query must not come back
+    // pre-applied (and silently emptying the list) on the next visit.
+    savedSearchStore.setSurfaceActive(false);
     document.removeEventListener('visibilitychange', handleVisibilityChange);
   });
 </script>

--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -8,6 +8,7 @@
   import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { unreadCounts } from '$lib/stores/unreadCounts.svelte';
   import { filteredViewsStore } from '$lib/stores/filteredViews.svelte';
   import { appManager } from '$lib/stores/app.svelte';
@@ -21,6 +22,7 @@
   import FeedPageHeader from '$lib/components/feed/FeedPageHeader.svelte';
   import FeedListView from '$lib/components/feed/FeedListView.svelte';
   import SavedListView from '$lib/components/feed/SavedListView.svelte';
+  import SavedSearchBar from '$lib/components/feed/SavedSearchBar.svelte';
   import EditFeedModal from '$lib/components/EditFeedModal.svelte';
   import MobileBottomBar from '$lib/components/feed/MobileBottomBar.svelte';
   import MobileFeedSwitcher from '$lib/components/feed/MobileFeedSwitcher.svelte';
@@ -531,6 +533,13 @@
         <LinkblogIntro />
       {/if}
 
+      <!-- Sits here rather than inside the header because the header is hidden
+           below 1000px (the mobile bottom bar takes over) — this way the same
+           row serves desktop and mobile, directly beneath the header on both. -->
+      {#if isSavedView && savedSearchStore.open && !readerOpen}
+        <SavedSearchBar />
+      {/if}
+
       <PullToRefresh
         onRefresh={handleRefreshWithToast}
         disabled={!syncStore.isOnline || appManager.isRefreshing}
@@ -642,6 +651,8 @@
           filterSheetOpen = true;
         }}
         {hasActiveFilters}
+        onOpenSearch={isSavedView ? () => savedSearchStore.openSearch() : undefined}
+        searchActive={savedSearchStore.active}
       />
 
       <BottomSheet

--- a/frontend/src/lib/components/feed/FeedPageHeader.svelte
+++ b/frontend/src/lib/components/feed/FeedPageHeader.svelte
@@ -9,6 +9,7 @@
   import { syncStore } from '$lib/stores/sync.svelte';
   import { formatRelativeTime } from '$lib/utils/date';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
 
   interface Props {
     title: string;
@@ -212,6 +213,17 @@
                 >
               </button>
             {/if}
+            <span class="toggle-divider"></span>
+            <button
+              class:active={savedSearchStore.open || savedSearchStore.active}
+              onclick={() => savedSearchStore.toggle()}
+              aria-label="Search saved items"
+              aria-pressed={savedSearchStore.open}
+              title="Search saved (/)"
+            >
+              <Icon name="search" size={16} />
+              <span class="btn-label">Search</span>
+            </button>
             <span class="toggle-divider"></span>
             <button
               onclick={() => sidebarStore.openSaveArticleModal()}

--- a/frontend/src/lib/components/feed/MobileBottomBar.svelte
+++ b/frontend/src/lib/components/feed/MobileBottomBar.svelte
@@ -16,6 +16,9 @@
     onOpenNotifications: () => void;
     hasActiveFilters: boolean;
     hideFilterButton?: boolean;
+    /** Saved views only: the header's search button isn't reachable down here. */
+    onOpenSearch?: () => void;
+    searchActive?: boolean;
   }
 
   let {
@@ -27,6 +30,8 @@
     onOpenNotifications,
     hasActiveFilters,
     hideFilterButton = false,
+    onOpenSearch,
+    searchActive = false,
   }: Props = $props();
 
   let addMenuOpen = $state(false);
@@ -178,6 +183,20 @@
           >
         {/if}
       </button>
+      {#if onOpenSearch}
+        <button
+          class="bar-btn"
+          class:has-filters={searchActive}
+          onclick={onOpenSearch}
+          aria-label="Search saved items"
+          title="Search saved"
+        >
+          <Icon name="search" size={20} />
+          {#if searchActive}
+            <span class="filter-dot"></span>
+          {/if}
+        </button>
+      {/if}
       {#if !hideFilterButton}
         <button
           class="bar-btn"

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -6,6 +6,14 @@
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { feedViewStore } from '$lib/stores/feedView.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
+  import {
+    makeSnippet,
+    matchesTerms,
+    normalize,
+    splitHighlights,
+    type Snippet,
+  } from '$lib/services/savedSearch';
   import { integrationSaveStore } from '$lib/stores/integrationSave.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { auth } from '$lib/stores/auth.svelte';
@@ -258,6 +266,79 @@
     return text.length > 200 ? text.slice(0, 200) + '...' : text;
   });
 
+  // --- Search presentation ---------------------------------------------------
+  // Why an item matched decides what the card shows: a metadata hit highlights
+  // the title in place, a body-only hit swaps the preview line for a snippet
+  // around the hit. Every `<mark>` below comes from this template, never from
+  // the data — extracted bodies are untrusted, so nothing here is `{@html}`.
+  let searchTerms = $derived(savedSearchStore.terms);
+
+  let titleParts = $derived(
+    searchTerms.length > 0 ? splitHighlights(title, searchTerms) : [{ text: title, mark: false }]
+  );
+
+  // Same haystack the saved-items pipeline filters on, so "matched by metadata"
+  // means the same thing on both sides.
+  let metadataMatched = $derived.by(() => {
+    if (searchTerms.length === 0) return true;
+    const parts: (string | null | undefined)[] = [title, url, metaSummary];
+    if (displayItem.type === 'article') parts.push(displayItem.item.author, feedTitle);
+    else if (displayItem.type === 'saved')
+      parts.push(displayItem.item.author, displayItem.item.domain);
+    return matchesTerms(normalize(parts.filter(Boolean).join(' ')), searchTerms);
+  });
+
+  // A body-only hit: pull the stored full text back (same sources the excerpt
+  // fallback uses) and cut a window around the first term.
+  let searchSnippet = $state<Snippet | null>(null);
+  let bodyMatchOnly = $derived(searchTerms.length > 0 && !metadataMatched);
+
+  $effect(() => {
+    const terms = searchTerms;
+    if (!bodyMatchOnly) {
+      searchSnippet = null;
+      return;
+    }
+
+    let savedRkey: string | undefined;
+    let articleRef: { id?: number; guid: string; subscriptionId: number } | undefined;
+    if (displayItem.type === 'saved') {
+      savedRkey = displayItem.item.rkey;
+    } else if (displayItem.type === 'article') {
+      const a = displayItem.item;
+      savedRkey = a.guid ? savesStore.getByGuid(a.guid)?.rkey : undefined;
+      articleRef = { id: a.id, guid: a.guid, subscriptionId: a.subscriptionId };
+    } else {
+      savedRkey = savesStore.getByGuid(displayItem.item.recordUri)?.rkey;
+    }
+
+    let cancelled = false;
+    (async () => {
+      let body = '';
+      try {
+        if (savedRkey) body = (await savesStore.getContent(savedRkey)) || '';
+        if (!body && articleRef) {
+          let row = articleRef.id != null ? await db.articles.get(articleRef.id) : undefined;
+          if (!row && articleRef.guid) {
+            row = await db.articles
+              .where('guid')
+              .equals(articleRef.guid)
+              .filter((a) => a.subscriptionId === articleRef!.subscriptionId)
+              .first();
+          }
+          body = row?.content || '';
+        }
+      } catch {
+        // Best effort — fall back to the plain "matches article text" caption.
+      }
+      if (cancelled) return;
+      searchSnippet = body ? makeSnippet(htmlToText(body), terms) : null;
+    })();
+    return () => {
+      cancelled = true;
+    };
+  });
+
   // Type badge
   let typeBadge = $derived.by(() => {
     if (displayItem.type === 'saved') return displayItem.item.domain || 'Saved';
@@ -503,8 +584,19 @@
           onOpen?.();
         }}
       >
-        <h3 class="bookmark-title">{title}</h3>
-        {#if summaryText}
+        <h3 class="bookmark-title">
+          {#each titleParts as part}{#if part.mark}<mark>{part.text}</mark
+              >{:else}{part.text}{/if}{/each}
+        </h3>
+        {#if bodyMatchOnly && searchSnippet}
+          <p class="bookmark-summary">
+            {searchSnippet.truncatedStart ? '…' : ''}{searchSnippet.before}<mark
+              >{searchSnippet.match}</mark
+            >{searchSnippet.after}{searchSnippet.truncatedEnd ? '…' : ''}
+          </p>
+        {:else if bodyMatchOnly}
+          <p class="bookmark-summary match-caption">Matches article text</p>
+        {:else if summaryText}
           <p class="bookmark-summary">{summaryText}</p>
         {/if}
         <div class="bookmark-meta">
@@ -663,6 +755,20 @@
     -webkit-line-clamp: 2;
     line-clamp: 2;
     -webkit-box-orient: vertical;
+  }
+
+  /* Search hits: a quiet tint, not a highlighter — the text stays the product. */
+  .bookmark-title mark,
+  .bookmark-summary mark {
+    background: rgba(0, 102, 204, 0.12);
+    color: inherit;
+    border-radius: 3px;
+    padding: 0 0.1em;
+  }
+
+  .match-caption {
+    font-style: italic;
+    opacity: 0.8;
   }
 
   .bookmark-meta {

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -4,13 +4,12 @@
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
-  import { feedViewStore } from '$lib/stores/feedView.svelte';
+  import { feedViewStore, searchHaystack } from '$lib/stores/feedView.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import {
     makeSnippet,
     matchesTerms,
-    normalize,
     splitHighlights,
     type Snippet,
   } from '$lib/services/savedSearch';
@@ -277,15 +276,12 @@
     searchTerms.length > 0 ? splitHighlights(title, searchTerms) : [{ text: title, mark: false }]
   );
 
-  // Same haystack the saved-items pipeline filters on, so "matched by metadata"
-  // means the same thing on both sides.
+  // Literally the haystack the saved-items pipeline filters on — shared rather
+  // than rebuilt, so "matched by metadata" can't mean one thing to the filter
+  // and another to the caption explaining the match.
   let metadataMatched = $derived.by(() => {
     if (searchTerms.length === 0) return true;
-    const parts: (string | null | undefined)[] = [title, url, metaSummary];
-    if (displayItem.type === 'article') parts.push(displayItem.item.author, feedTitle);
-    else if (displayItem.type === 'saved')
-      parts.push(displayItem.item.author, displayItem.item.domain);
-    return matchesTerms(normalize(parts.filter(Boolean).join(' ')), searchTerms);
+    return matchesTerms(searchHaystack(displayItem), searchTerms);
   });
 
   // A body-only hit: pull the stored full text back (same sources the excerpt
@@ -845,6 +841,14 @@
   @media (prefers-color-scheme: dark) {
     .bookmark-card:hover {
       background-color: var(--color-bg-hover, rgba(255, 255, 255, 0.05));
+    }
+
+    /* The light tint composites to near-black over the dark background, which
+       hides the one thing explaining why a result is in the list. Re-tint with
+       the dark-scheme blue, the same way --color-sidebar-active flips. */
+    .bookmark-title mark,
+    .bookmark-summary mark {
+      background: rgba(77, 166, 255, 0.22);
     }
   }
 </style>

--- a/frontend/src/lib/components/feed/SavedListView.svelte
+++ b/frontend/src/lib/components/feed/SavedListView.svelte
@@ -7,6 +7,7 @@
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
   import type { ItemLabelType } from '$lib/types';
 
@@ -49,6 +50,10 @@
       if (readerItem?.key !== key) openReader(item);
     }
   });
+
+  // Cross-view search hint: matches sitting in the tab the user isn't looking at.
+  let otherViewCount = $derived(feedViewStore.savedSearchOtherViewCount);
+  let otherViewLabel = $derived(feedViewStore.savedView === 'inbox' ? 'Archive' : 'Inbox');
 
   function getItemType(item: FeedDisplayItem): ItemLabelType {
     return item.type;
@@ -140,7 +145,23 @@
   {/each}
 
   {#if feedViewStore.currentItems.length === 0}
-    {#if feedViewStore.savedView === 'inbox'}
+    {#if savedSearchStore.active}
+      <!-- Search is scoped to the current sub-view like every other filter, so
+           point at the other one when that's where the match actually is. -->
+      <EmptyState
+        title={`No matches for “${savedSearchStore.appliedQuery}”`}
+        description={otherViewCount > 0
+          ? `Nothing here matches. ${otherViewLabel} has ${otherViewCount} match${otherViewCount === 1 ? '' : 'es'}.`
+          : 'Try fewer or different words.'}
+        actionText={otherViewCount > 0
+          ? `${otherViewCount} match${otherViewCount === 1 ? '' : 'es'} in ${otherViewLabel}`
+          : undefined}
+        onAction={otherViewCount > 0
+          ? () =>
+              feedViewStore.setSavedView(feedViewStore.savedView === 'inbox' ? 'archive' : 'inbox')
+          : undefined}
+      />
+    {:else if feedViewStore.savedView === 'inbox'}
       <EmptyState
         title="No saved items"
         description="Save articles, shares, or documents to save them for later"

--- a/frontend/src/lib/components/feed/SavedSearchBar.svelte
+++ b/frontend/src/lib/components/feed/SavedSearchBar.svelte
@@ -71,6 +71,13 @@
     color: var(--color-text-secondary);
   }
 
+  /* The input's own outline would ring a borderless field inside the pill; the
+     pill carries the focus treatment instead, so tabbing back in is still
+     visible (auto-focus on open only covers the mouse/`/` path). */
+  .search-wrapper:focus-within {
+    box-shadow: 0 0 0 2px var(--color-primary);
+  }
+
   .search-input {
     flex: 1;
     min-width: 0;
@@ -80,6 +87,13 @@
     font-size: var(--text-md);
     color: var(--color-text);
     outline: none;
+  }
+
+  /* iOS Safari zooms the viewport when a focused input is smaller than 16px. */
+  @media (hover: none) and (pointer: coarse) {
+    .search-input {
+      font-size: 1rem;
+    }
   }
 
   .search-input::placeholder {

--- a/frontend/src/lib/components/feed/SavedSearchBar.svelte
+++ b/frontend/src/lib/components/feed/SavedSearchBar.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
+
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  // The store bumps `focusRequest` when the toolbar button or `/` opens search;
+  // take focus on each bump so re-triggering `/` refocuses an already-open row.
+  $effect(() => {
+    const _ = savedSearchStore.focusRequest;
+    inputEl?.focus();
+    inputEl?.select();
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      savedSearchStore.close();
+    }
+  }
+</script>
+
+<div class="search-row">
+  <div class="search-wrapper">
+    <Icon name="search" size={16} />
+    <input
+      bind:this={inputEl}
+      type="search"
+      class="search-input"
+      value={savedSearchStore.query}
+      oninput={(e) => savedSearchStore.setQuery(e.currentTarget.value)}
+      onkeydown={handleKeydown}
+      placeholder="Search saved…"
+      aria-label="Search saved items"
+      data-testid="saved-search-input"
+    />
+    {#if savedSearchStore.query}
+      <button
+        class="clear-btn"
+        onclick={() => {
+          savedSearchStore.clear();
+          inputEl?.focus();
+        }}
+        aria-label="Clear search"
+        title="Clear search"
+      >
+        <Icon name="x" size={14} />
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  /* Sits directly under the header (desktop) or at the top of the list
+     (mobile, where the header is replaced by the bottom bar). Flat, one row,
+     no shadow — it's part of the page, not floating over it. */
+  .search-row {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 1rem 0.625rem;
+  }
+
+  .search-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    font-size: var(--text-md);
+    color: var(--color-text);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  /* The browser's own clear affordance duplicates the button below. */
+  .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  .clear-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: none;
+    padding: 0.125rem;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+  }
+
+  .clear-btn:hover {
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/src/lib/services/savedSearch.test.ts
+++ b/frontend/src/lib/services/savedSearch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   htmlToText,
   makeSnippet,
+  matchesSearch,
   matchesTerms,
   normalize,
   parseQuery,
@@ -82,6 +83,58 @@ describe('matchesTerms', () => {
 
   it('never matches an empty haystack against real terms', () => {
     expect(matchesTerms('', ['a'])).toBe(false);
+  });
+});
+
+describe('matchesSearch', () => {
+  // "Ownership Explained": the title carries one term, the cached body another.
+  const metadata = normalize('Ownership Explained example.com');
+  const bodyTerms = new Map([['rkey1', new Set(['quokkatelemetry'])]]);
+  const keys = () => ['rkey1'];
+
+  it('lets each term of an AND query pick its own source', () => {
+    expect(matchesSearch(metadata, ['ownership', 'quokkatelemetry'], bodyTerms, keys)).toBe(true);
+  });
+
+  it('still requires every term to hit somewhere', () => {
+    expect(matchesSearch(metadata, ['ownership', 'sourdough'], bodyTerms, keys)).toBe(false);
+    expect(matchesSearch(metadata, ['gardening', 'quokkatelemetry'], bodyTerms, keys)).toBe(false);
+  });
+
+  it('matches on a single source alone', () => {
+    expect(matchesSearch(metadata, ['ownership'], bodyTerms, keys)).toBe(true);
+    expect(matchesSearch(metadata, ['quokkatelemetry'], bodyTerms, keys)).toBe(true);
+  });
+
+  it('checks every key an item can be indexed under', () => {
+    const byGuid = new Map([['guid-1', new Set(['quokkatelemetry'])]]);
+    expect(
+      matchesSearch(metadata, ['ownership', 'quokkatelemetry'], byGuid, () => ['rkey1', 'guid-1'])
+    ).toBe(true);
+    expect(matchesSearch(metadata, ['quokkatelemetry'], byGuid, () => ['rkey1'])).toBe(false);
+  });
+
+  it('degrades to metadata-only while the corpus is still building', () => {
+    expect(matchesSearch(metadata, ['ownership'], null, keys)).toBe(true);
+    expect(matchesSearch(metadata, ['ownership', 'quokkatelemetry'], null, keys)).toBe(false);
+  });
+
+  it('does not build the key list when metadata alone answers the query', () => {
+    let built = 0;
+    const counted = () => {
+      built++;
+      return ['rkey1'];
+    };
+    expect(matchesSearch(metadata, ['ownership'], bodyTerms, counted)).toBe(true);
+    expect(built).toBe(0);
+    expect(matchesSearch(metadata, ['ownership', 'quokkatelemetry'], bodyTerms, counted)).toBe(
+      true
+    );
+    expect(built).toBe(1);
+  });
+
+  it('treats an empty query as no filter', () => {
+    expect(matchesSearch(metadata, [], null, keys)).toBe(true);
   });
 });
 

--- a/frontend/src/lib/services/savedSearch.test.ts
+++ b/frontend/src/lib/services/savedSearch.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  htmlToText,
+  makeSnippet,
+  matchesTerms,
+  normalize,
+  parseQuery,
+  splitHighlights,
+  toIndexText,
+  MAX_INDEX_CHARS,
+} from './savedSearch';
+
+describe('htmlToText', () => {
+  it('strips tags and collapses whitespace', () => {
+    expect(htmlToText('<p>Hello</p>\n<p>world</p>')).toBe('Hello world');
+  });
+
+  it('drops script and style bodies so they cannot produce phantom hits', () => {
+    const html =
+      '<div>Visible<script>var secretword = 1;</script><style>.a{color:red}</style></div>';
+    const text = htmlToText(html);
+    expect(text).toBe('Visible');
+    expect(text).not.toContain('secretword');
+  });
+
+  it('decodes named and numeric entities', () => {
+    expect(htmlToText('<p>Tom &amp; Jerry &#8220;quoted&#8221; &#x2014; done</p>')).toBe(
+      'Tom & Jerry “quoted” — done'
+    );
+  });
+
+  it('strips comments and never emits markup', () => {
+    expect(htmlToText('<!-- hidden --><b>shown</b>')).toBe('shown');
+  });
+
+  it('handles empty input', () => {
+    expect(htmlToText('')).toBe('');
+  });
+});
+
+describe('normalize', () => {
+  it('lowercases', () => {
+    expect(normalize('MiXeD')).toBe('mixed');
+  });
+
+  it('folds diacritics so "café" matches "cafe"', () => {
+    expect(normalize('Café')).toBe('cafe');
+    expect(normalize('naïve résumé')).toBe('naive resume');
+  });
+});
+
+describe('parseQuery', () => {
+  it('splits on whitespace and normalizes', () => {
+    expect(parseQuery('  Deep   Café ')).toEqual(['deep', 'cafe']);
+  });
+
+  it('dedupes repeated terms', () => {
+    expect(parseQuery('rust rust')).toEqual(['rust']);
+  });
+
+  it('returns no terms for blank input', () => {
+    expect(parseQuery('   ')).toEqual([]);
+  });
+});
+
+describe('matchesTerms', () => {
+  const hay = normalize('The quick brown fox jumps');
+
+  it('requires every term (AND semantics)', () => {
+    expect(matchesTerms(hay, ['quick', 'fox'])).toBe(true);
+    expect(matchesTerms(hay, ['quick', 'cat'])).toBe(false);
+  });
+
+  it('matches substrings, not just whole words', () => {
+    expect(matchesTerms(hay, ['ump'])).toBe(true);
+  });
+
+  it('treats an empty term list as "no filter"', () => {
+    expect(matchesTerms(hay, [])).toBe(true);
+    expect(matchesTerms('', [])).toBe(true);
+  });
+
+  it('never matches an empty haystack against real terms', () => {
+    expect(matchesTerms('', ['a'])).toBe(false);
+  });
+});
+
+describe('toIndexText', () => {
+  it('strips, normalizes, and tolerates a null body', () => {
+    expect(toIndexText('<p>Café <b>MOCHA</b></p>')).toBe('cafe mocha');
+    expect(toIndexText(null)).toBe('');
+  });
+
+  it('caps a pathological body', () => {
+    const long = 'a'.repeat(MAX_INDEX_CHARS + 5000);
+    expect(toIndexText(long).length).toBe(MAX_INDEX_CHARS);
+  });
+});
+
+describe('makeSnippet', () => {
+  const text =
+    'Paragraph one is about gardening. The particular phrase we want lives here in the middle. ' +
+    'And the tail continues on for a while afterwards so both edges are truncated.';
+
+  it('returns a window around the hit with the original casing', () => {
+    const snip = makeSnippet(text, ['particular phrase'], 30);
+    expect(snip).not.toBeNull();
+    expect(snip!.match).toBe('particular phrase');
+    expect(snip!.before + snip!.match + snip!.after).toBe(
+      text.slice(
+        text.indexOf(snip!.before),
+        text.indexOf(snip!.before) + snip!.before.length + snip!.match.length + snip!.after.length
+      )
+    );
+    expect(snip!.truncatedStart).toBe(true);
+    expect(snip!.truncatedEnd).toBe(true);
+  });
+
+  it('finds a diacritic-folded hit and slices the accented original', () => {
+    const snip = makeSnippet('We met at the Café Rouge today', ['cafe']);
+    expect(snip!.match).toBe('Café');
+  });
+
+  it('reports untruncated edges at the string boundaries', () => {
+    const snip = makeSnippet('alpha beta', ['alpha'], 100);
+    expect(snip!.before).toBe('');
+    expect(snip!.truncatedStart).toBe(false);
+    expect(snip!.truncatedEnd).toBe(false);
+    expect(snip!.after).toBe(' beta');
+  });
+
+  it('uses the earliest hit among terms', () => {
+    const snip = makeSnippet('zebra then apple', ['apple', 'zebra']);
+    expect(snip!.match).toBe('zebra');
+  });
+
+  it('returns null when nothing hits', () => {
+    expect(makeSnippet(text, ['nonexistent'])).toBeNull();
+    expect(makeSnippet('', ['a'])).toBeNull();
+    expect(makeSnippet(text, [])).toBeNull();
+  });
+});
+
+describe('splitHighlights', () => {
+  it('marks each hit and leaves the rest alone', () => {
+    const parts = splitHighlights('Rust and more Rust', ['rust']);
+    expect(parts).toEqual([
+      { text: 'Rust', mark: true },
+      { text: ' and more ', mark: false },
+      { text: 'Rust', mark: true },
+    ]);
+  });
+
+  it('reassembles into the original text', () => {
+    const title = 'Understanding Café Culture in Rust';
+    const parts = splitHighlights(title, ['cafe', 'rust']);
+    expect(parts.map((p) => p.text).join('')).toBe(title);
+    expect(parts.filter((p) => p.mark).map((p) => p.text)).toEqual(['Café', 'Rust']);
+  });
+
+  it('merges overlapping terms into one run', () => {
+    const parts = splitHighlights('reading', ['read', 'reading']);
+    expect(parts).toEqual([{ text: 'reading', mark: true }]);
+  });
+
+  it('returns the whole string unmarked when there are no terms or no hits', () => {
+    expect(splitHighlights('title', [])).toEqual([{ text: 'title', mark: false }]);
+    expect(splitHighlights('title', ['zzz'])).toEqual([{ text: 'title', mark: false }]);
+  });
+});

--- a/frontend/src/lib/services/savedSearch.ts
+++ b/frontend/src/lib/services/savedSearch.ts
@@ -1,0 +1,235 @@
+// Pure helpers behind saved-article search. Deliberately dependency-free (no
+// DOM, no stores) so they can be unit-tested in node and run over hundreds of
+// article bodies without touching the document.
+//
+// Everything here works on *plain text*. Extracted article HTML is stripped to
+// text once, when the body corpus is built, and the result is only ever
+// compared against or rendered through Svelte text interpolation — never as
+// HTML. See `savedSearch.svelte.ts` for the corpus itself.
+
+/** Cap on how much of one article's text is indexed (characters, post-strip). */
+export const MAX_INDEX_CHARS = 200_000;
+
+/** Cap on the raw HTML we bother stripping for a single item. */
+const MAX_HTML_CHARS = 1_000_000;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  ndash: '–',
+  mdash: '—',
+  hellip: '…',
+  lsquo: '‘',
+  rsquo: '’',
+  ldquo: '“',
+  rdquo: '”',
+};
+
+function decodeEntity(entity: string): string {
+  if (entity.startsWith('#')) {
+    const code =
+      entity.startsWith('#x') || entity.startsWith('#X')
+        ? parseInt(entity.slice(2), 16)
+        : parseInt(entity.slice(1), 10);
+    if (Number.isFinite(code) && code > 0 && code <= 0x10ffff) {
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return ' ';
+      }
+    }
+    return ' ';
+  }
+  return NAMED_ENTITIES[entity.toLowerCase()] ?? ' ';
+}
+
+/**
+ * Strip HTML to plain text for indexing. Regex-based rather than DOMParser:
+ * this runs over every cached article body, and the output is only ever matched
+ * against or rendered as text. Script/style bodies are dropped wholesale so
+ * their contents can't produce phantom hits.
+ */
+export function htmlToText(html: string): string {
+  if (!html) return '';
+  const capped = html.length > MAX_HTML_CHARS ? html.slice(0, MAX_HTML_CHARS) : html;
+  return capped
+    .replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&(#[0-9]+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (_m, e: string) => decodeEntity(e))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+/**
+ * Case- and diacritic-insensitive fold, so "Café" matches a query of "cafe".
+ * NFKD splits accented letters into base + combining mark; dropping the marks
+ * leaves the base letter.
+ */
+export function normalize(s: string): string {
+  if (!s) return '';
+  return s.normalize('NFKD').replace(COMBINING_MARKS, '').toLowerCase();
+}
+
+/** Normalize an article body into the text stored in the search corpus. */
+export function toIndexText(html: string | null | undefined): string {
+  if (!html) return '';
+  const text = normalize(htmlToText(html));
+  return text.length > MAX_INDEX_CHARS ? text.slice(0, MAX_INDEX_CHARS) : text;
+}
+
+/**
+ * Split a raw query into normalized terms. All terms must match (AND), each as
+ * a substring — the same idiom the rest of the app's filter inputs use.
+ */
+export function parseQuery(q: string): string[] {
+  const normalized = normalize(q).trim();
+  if (!normalized) return [];
+  return [...new Set(normalized.split(/\s+/).filter(Boolean))];
+}
+
+/** True when every term appears in an already-normalized haystack. */
+export function matchesTerms(haystack: string, terms: string[]): boolean {
+  if (terms.length === 0) return true;
+  if (!haystack) return false;
+  for (const term of terms) {
+    if (!haystack.includes(term)) return false;
+  }
+  return true;
+}
+
+/**
+ * Fold `text` the way `normalize` does while keeping a per-character map back
+ * to the original string, so a hit found in folded space can be sliced out of
+ * the original (right case, right accents). ASCII takes a fast path — the
+ * per-character `normalize()` call is what makes this expensive, and article
+ * bodies are overwhelmingly ASCII.
+ */
+function foldWithMap(text: string): { folded: string; map: number[] } {
+  let folded = '';
+  const map: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code < 128) {
+      folded += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : text[i];
+      map.push(i);
+      continue;
+    }
+    const piece = normalize(text[i]);
+    for (let j = 0; j < piece.length; j++) {
+      folded += piece[j];
+      map.push(i);
+    }
+  }
+  return { folded, map };
+}
+
+/** Earliest hit of any term, in folded space. */
+function firstHit(folded: string, terms: string[]): { start: number; end: number } | null {
+  let best: { start: number; end: number } | null = null;
+  for (const term of terms) {
+    if (!term) continue;
+    const idx = folded.indexOf(term);
+    if (idx === -1) continue;
+    if (!best || idx < best.start) best = { start: idx, end: idx + term.length };
+  }
+  return best;
+}
+
+export interface Snippet {
+  before: string;
+  match: string;
+  after: string;
+  /** True when text was elided at that edge (render as a leading/trailing ellipsis). */
+  truncatedStart: boolean;
+  truncatedEnd: boolean;
+}
+
+/**
+ * A window of `text` around the first term hit, split so the caller can wrap
+ * `match` in a `<mark>` from its own template. Returns null when no term hits.
+ */
+export function makeSnippet(text: string, terms: string[], radius = 90): Snippet | null {
+  if (!text || terms.length === 0) return null;
+  const { folded, map } = foldWithMap(text);
+  const hit = firstHit(folded, terms);
+  if (!hit) return null;
+
+  const start = map[hit.start] ?? 0;
+  const end = (map[hit.end - 1] ?? start) + 1;
+
+  let from = Math.max(0, start - radius);
+  let to = Math.min(text.length, end + radius);
+  // Don't start or end mid-word when we're cutting into the text.
+  if (from > 0) {
+    const space = text.indexOf(' ', from);
+    if (space !== -1 && space < start) from = space + 1;
+  }
+  if (to < text.length) {
+    const space = text.lastIndexOf(' ', to);
+    if (space !== -1 && space > end) to = space;
+  }
+
+  return {
+    before: text.slice(from, start),
+    match: text.slice(start, end),
+    after: text.slice(end, to),
+    truncatedStart: from > 0,
+    truncatedEnd: to < text.length,
+  };
+}
+
+export interface HighlightPart {
+  text: string;
+  mark: boolean;
+}
+
+/**
+ * Split short text (a title) into marked/unmarked runs for the same
+ * template-side `<mark>` treatment. Non-overlapping, left to right.
+ */
+export function splitHighlights(text: string, terms: string[]): HighlightPart[] {
+  if (!text || terms.length === 0) return [{ text, mark: false }];
+  const { folded, map } = foldWithMap(text);
+
+  // Collect every hit of every term, then merge overlaps.
+  const hits: Array<{ start: number; end: number }> = [];
+  for (const term of terms) {
+    if (!term) continue;
+    let idx = folded.indexOf(term);
+    while (idx !== -1) {
+      hits.push({ start: idx, end: idx + term.length });
+      idx = folded.indexOf(term, idx + term.length);
+    }
+  }
+  if (hits.length === 0) return [{ text, mark: false }];
+  hits.sort((a, b) => a.start - b.start);
+
+  // Merge overlapping/adjacent hits in folded space first, so two terms that
+  // overlap ("read" and "reading") produce one run rather than a nested one.
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const hit of hits) {
+    const last = merged[merged.length - 1];
+    if (last && hit.start <= last.end) last.end = Math.max(last.end, hit.end);
+    else merged.push({ ...hit });
+  }
+
+  const parts: HighlightPart[] = [];
+  let cursor = 0; // index into the original string
+  for (const hit of merged) {
+    const start = map[hit.start] ?? 0;
+    const end = (map[hit.end - 1] ?? start) + 1;
+    if (end <= cursor) continue;
+    if (start > cursor) parts.push({ text: text.slice(cursor, start), mark: false });
+    parts.push({ text: text.slice(Math.max(cursor, start), end), mark: true });
+    cursor = end;
+  }
+  if (cursor < text.length) parts.push({ text: text.slice(cursor), mark: false });
+  return parts;
+}

--- a/frontend/src/lib/services/savedSearch.ts
+++ b/frontend/src/lib/services/savedSearch.ts
@@ -105,6 +105,36 @@ export function matchesTerms(haystack: string, terms: string[]): boolean {
 }
 
 /**
+ * Does one item satisfy the query, given its normalized metadata haystack and
+ * the per-key term sets the body corpus matched?
+ *
+ * Every term must hit (AND), but each term picks its own source: one may come
+ * from the title while another only appears in the article text. Checking the
+ * two sources term-by-term rather than side-by-side is what makes
+ * "ownership <word-only-in-the-body>" find the piece.
+ *
+ * `bodyKeys` is a thunk because most items match entirely on metadata: the keys
+ * a save is indexed under are only built when a term misses the metadata.
+ * A `null` `bodyMatchTerms` means no corpus yet (the first search runs before
+ * it resolves) — the query then degrades to metadata-only AND.
+ */
+export function matchesSearch(
+  metadata: string,
+  terms: string[],
+  bodyMatchTerms: Map<string, Set<string>> | null,
+  bodyKeys: () => string[]
+): boolean {
+  if (terms.length === 0) return true;
+  let keys: string[] | null = null;
+  return terms.every((term) => {
+    if (matchesTerms(metadata, [term])) return true;
+    if (bodyMatchTerms === null) return false;
+    keys ??= bodyKeys();
+    return keys.some((key) => bodyMatchTerms.get(key)?.has(term) === true);
+  });
+}
+
+/**
  * Fold `text` the way `normalize` does while keeping a per-character map back
  * to the original string, so a hit found in folded space can be sliced out of
  * the original (right case, right accents). ASCII takes a fast path — the

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -4,6 +4,7 @@ import { itemLabelsStore } from './itemLabels.svelte';
 import { socialStore } from './social.svelte';
 import { myLinkblogStore } from './myLinkblog.svelte';
 import { savesStore } from './saves.svelte';
+import { savedSearchStore } from './savedSearch.svelte';
 import { preferences } from './preferences.svelte';
 import { filteredViewsStore } from './filteredViews.svelte';
 import { liveDb } from '$lib/services/liveDb.svelte';
@@ -18,6 +19,7 @@ import type {
   ReadingLengthFilter,
   SortOrder,
 } from '$lib/types';
+import { matchesTerms, normalize } from '$lib/services/savedSearch';
 import {
   isRssSource,
   isDocumentsSource,
@@ -168,6 +170,62 @@ export function matchesReadingLength(wc: number | null, bucket: ReadingLengthFil
   }
 }
 
+/**
+ * Every key a saved display-item can be indexed under in the body-search
+ * corpus. The list can present one save as a bookmark (keyed by uri/rkey) or as
+ * the feed article it came from (keyed by guid), depending on which
+ * representation survives dedup — so a body hit has to be checked under all of
+ * them, or the match would vanish for the surviving representation.
+ */
+function searchKeysForItem(item: FeedDisplayItem): string[] {
+  const keys = [item.key];
+  if (item.type === 'saved') {
+    keys.push(item.item.rkey);
+    if (item.item.itemGuid) keys.push(item.item.itemGuid);
+  } else if (item.type === 'article') {
+    keys.push(item.item.guid);
+  } else if (item.type === 'document') {
+    keys.push(item.item.recordUri);
+  }
+  return keys;
+}
+
+/** Normalized metadata haystack for search: title, author, description, domain, url. */
+function searchHaystack(item: FeedDisplayItem): string {
+  const parts: (string | null | undefined)[] = [];
+  if (item.type === 'article') {
+    parts.push(item.item.title, item.item.author, item.item.summary, item.item.url);
+  } else if (item.type === 'saved') {
+    parts.push(
+      item.item.title,
+      item.item.author,
+      item.item.description,
+      item.item.domain,
+      item.item.url
+    );
+  } else {
+    parts.push(item.item.title, item.item.description, item.item.canonicalUrl || item.item.path);
+  }
+  const domain = getItemDomain(item);
+  if (domain) parts.push(domain);
+  return normalize(parts.filter(Boolean).join(' '));
+}
+
+/**
+ * A saved item matches a search when its own metadata matches, or when the
+ * save's full article text does (the corpus is built asynchronously, so body
+ * hits land a beat after metadata hits on the very first search).
+ */
+function matchesSavedSearch(
+  item: FeedDisplayItem,
+  terms: string[],
+  bodyMatchKeys: Set<string> | null
+): boolean {
+  if (matchesTerms(searchHaystack(item), terms)) return true;
+  if (!bodyMatchKeys) return false;
+  return searchKeysForItem(item).some((key) => bodyMatchKeys.has(key));
+}
+
 function createFeedViewStore() {
   // UI state
   let showOnlyUnread = $state(true);
@@ -203,6 +261,10 @@ function createFeedViewStore() {
 
   // Bookmarks view sub-filter (inbox vs archive)
   let savedView = $state<'inbox' | 'archive'>('inbox');
+
+  // Identity of the saved surface the current search belongs to (`saved` param
+  // + channel id). Non-reactive — it only gates the reset in setFilters.
+  let currentSavedKey = '';
 
   // URL filters (set by component from $page store)
   let feedFilter = $state<string | null>(null);
@@ -610,15 +672,11 @@ function createFeedViewStore() {
   // loadedArticleCount, revealing older items of either type.
   let displayedCombined = $derived(combinedAll.slice(0, loadedArticleCount));
 
-  // Derived: full merged-and-filtered saved-items list (pre-pagination).
-  // Exposed separately from currentItems so the saved-view rendering path can
-  // slice into it for infinite scroll while hasMore/loadMore still see the
-  // total count.
-  let savedItemsAll = $derived.by((): FeedDisplayItem[] => {
-    if (!isSavedView) return [];
-
+  // The merged-and-filtered saved-items list for one sub-view. Parameterized on
+  // inbox-vs-archive so the search empty state can ask "how many matches are in
+  // the *other* tab?" without duplicating this pipeline.
+  function computeSavedItems(isArchiveView: boolean): FeedDisplayItem[] {
     const sortOrder = effectiveFilters.sortOrder;
-    const isArchiveView = savedView === 'archive';
 
     // Per-item predicate for saved-channel filters. Used both for the final
     // item list *and* for deciding whether an article should dedup a bookmark
@@ -654,10 +712,27 @@ function createFeedViewStore() {
     // filters (reading length, date, domain) are applied at the end of this
     // block, and pagination-before-filter would hide matches that fall outside
     // the current page window.
+    //
+    // filteredArticles is pinned to the *displayed* sub-view, so when this runs
+    // for the other one (the cross-view search count) the same filter has to be
+    // rebuilt here against the flipped archive test.
+    const savedArticles = (() => {
+      if (isArchiveView === (savedView === 'archive')) return filteredArticles;
+      if (!showArticles) return [];
+      const seen = new Set<string>();
+      return articlesStore.allArticles.filter((a) => {
+        if (!itemLabelsStore.isSaved(a.guid)) return false;
+        if (itemLabelsStore.isArchived(a.guid) !== isArchiveView) return false;
+        if (seen.has(a.guid)) return false;
+        seen.add(a.guid);
+        return true;
+      });
+    })();
+
     const articleItems: FeedDisplayItem[] =
       sourceFilter && !sourceFilter.has('feed')
         ? []
-        : filteredArticles.map((item) => ({
+        : savedArticles.map((item) => ({
             type: 'article' as const,
             item,
             key: item.guid,
@@ -794,7 +869,33 @@ function createFeedViewStore() {
       });
     }
 
+    // Search, last: it runs after the merge/dedup above so it can't perturb the
+    // bookmark-vs-article dedup, and it composes with every channel filter.
+    const searchTerms = savedSearchStore.terms;
+    if (searchTerms.length > 0) {
+      const bodyMatchKeys = savedSearchStore.bodyMatchKeys;
+      items = items.filter((item) => matchesSavedSearch(item, searchTerms, bodyMatchKeys));
+    }
+
     return items;
+  }
+
+  // Derived: full merged-and-filtered saved-items list (pre-pagination).
+  // Exposed separately from currentItems so the saved-view rendering path can
+  // slice into it for infinite scroll while hasMore/loadMore still see the
+  // total count.
+  let savedItemsAll = $derived.by((): FeedDisplayItem[] => {
+    if (!isSavedView) return [];
+    return computeSavedItems(savedView === 'archive');
+  });
+
+  // Derived: how many items the current search would match in the *other*
+  // sub-view (inbox ↔ archive). Powers the "N matches in Archive" hint on the
+  // search empty state — the thing that keeps "I know I saved it" findable once
+  // it's been archived. Only computed while a search is active.
+  let savedSearchOtherViewCount = $derived.by((): number => {
+    if (!isSavedView || !savedSearchStore.active) return 0;
+    return computeSavedItems(savedView !== 'archive').length;
   });
 
   // Derived: unified current items for the active view mode
@@ -1274,6 +1375,9 @@ function createFeedViewStore() {
     get isSavedChannel() {
       return isSavedChannel;
     },
+    get savedSearchOtherViewCount() {
+      return savedSearchOtherViewCount;
+    },
     get toolbarSavedSourceFilter() {
       return toolbarSavedSourceFilter;
     },
@@ -1412,6 +1516,16 @@ function createFeedViewStore() {
     }) {
       // Any URL-driven filter change exits the "Your Linkblog" view.
       myLinkblogFilter = false;
+      // Search is ephemeral session state, scoped to one saved surface: leaving
+      // it (or switching to another saved channel) drops the query, so a stale
+      // search never silently empties a later visit. Compared rather than reset
+      // unconditionally because this runs on every URL change, including ones
+      // that don't move the view.
+      const nextSavedKey = `${filters.saved ?? ''}|${filters.view ?? ''}`;
+      if (nextSavedKey !== currentSavedKey) {
+        currentSavedKey = nextSavedKey;
+        savedSearchStore.reset();
+      }
       feedFilter = filters.feed;
       savedFilter = filters.saved;
       sharerFilter = filters.sharer;

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -219,11 +219,15 @@ function searchHaystack(item: FeedDisplayItem): string {
 function matchesSavedSearch(
   item: FeedDisplayItem,
   terms: string[],
-  bodyMatchKeys: Set<string> | null
+  bodyMatchTerms: Map<string, Set<string>> | null
 ): boolean {
-  if (matchesTerms(searchHaystack(item), terms)) return true;
-  if (!bodyMatchKeys) return false;
-  return searchKeysForItem(item).some((key) => bodyMatchKeys.has(key));
+  const metadata = searchHaystack(item);
+  const keys = searchKeysForItem(item);
+  return terms.every(
+    (term) =>
+      matchesTerms(metadata, [term]) ||
+      (bodyMatchTerms !== null && keys.some((key) => bodyMatchTerms.get(key)?.has(term) === true))
+  );
 }
 
 function createFeedViewStore() {
@@ -873,8 +877,8 @@ function createFeedViewStore() {
     // bookmark-vs-article dedup, and it composes with every channel filter.
     const searchTerms = savedSearchStore.terms;
     if (searchTerms.length > 0) {
-      const bodyMatchKeys = savedSearchStore.bodyMatchKeys;
-      items = items.filter((item) => matchesSavedSearch(item, searchTerms, bodyMatchKeys));
+      const bodyMatchTerms = savedSearchStore.bodyMatchTerms;
+      items = items.filter((item) => matchesSavedSearch(item, searchTerms, bodyMatchTerms));
     }
 
     return items;

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -19,7 +19,7 @@ import type {
   ReadingLengthFilter,
   SortOrder,
 } from '$lib/types';
-import { matchesTerms, normalize } from '$lib/services/savedSearch';
+import { htmlToText, matchesSearch, normalize } from '$lib/services/savedSearch';
 import {
   isRssSource,
   isDocumentsSource,
@@ -190,21 +190,39 @@ function searchKeysForItem(item: FeedDisplayItem): string[] {
   return keys;
 }
 
-/** Normalized metadata haystack for search: title, author, description, domain, url. */
-function searchHaystack(item: FeedDisplayItem): string {
+/**
+ * Normalized metadata haystack for search: title, author, summary, domain, url.
+ *
+ * Description/summary fields carry raw feed HTML, so they're stripped to
+ * visible text first — otherwise a query could hit a tag name or a URL inside
+ * an `img src` ("substack" matching a `substackcdn.com` image), which reads as
+ * a mystery match. Exported because `SavedCard` classifies a hit as
+ * metadata-vs-body against this exact document; two haystacks would let the
+ * filter and the card's explanation of it drift apart.
+ */
+export function searchHaystack(item: FeedDisplayItem): string {
   const parts: (string | null | undefined)[] = [];
   if (item.type === 'article') {
-    parts.push(item.item.title, item.item.author, item.item.summary, item.item.url);
+    parts.push(
+      item.item.title,
+      item.item.author,
+      htmlToText(item.item.summary ?? ''),
+      item.item.url
+    );
   } else if (item.type === 'saved') {
     parts.push(
       item.item.title,
       item.item.author,
-      item.item.description,
+      htmlToText(item.item.description ?? ''),
       item.item.domain,
       item.item.url
     );
   } else {
-    parts.push(item.item.title, item.item.description, item.item.canonicalUrl || item.item.path);
+    parts.push(
+      item.item.title,
+      htmlToText(item.item.description ?? ''),
+      item.item.canonicalUrl || item.item.path
+    );
   }
   const domain = getItemDomain(item);
   if (domain) parts.push(domain);
@@ -212,22 +230,17 @@ function searchHaystack(item: FeedDisplayItem): string {
 }
 
 /**
- * A saved item matches a search when its own metadata matches, or when the
- * save's full article text does (the corpus is built asynchronously, so body
- * hits land a beat after metadata hits on the very first search).
+ * A saved item matches a search when every term hits its metadata or the save's
+ * full article text — each term free to hit in either (the corpus is built
+ * asynchronously, so body hits land a beat after metadata hits on the very
+ * first search).
  */
 function matchesSavedSearch(
   item: FeedDisplayItem,
   terms: string[],
   bodyMatchTerms: Map<string, Set<string>> | null
 ): boolean {
-  const metadata = searchHaystack(item);
-  const keys = searchKeysForItem(item);
-  return terms.every(
-    (term) =>
-      matchesTerms(metadata, [term]) ||
-      (bodyMatchTerms !== null && keys.some((key) => bodyMatchTerms.get(key)?.has(term) === true))
-  );
+  return matchesSearch(searchHaystack(item), terms, bodyMatchTerms, () => searchKeysForItem(item));
 }
 
 function createFeedViewStore() {
@@ -1520,11 +1533,13 @@ function createFeedViewStore() {
     }) {
       // Any URL-driven filter change exits the "Your Linkblog" view.
       myLinkblogFilter = false;
-      // Search is ephemeral session state, scoped to one saved surface: leaving
-      // it (or switching to another saved channel) drops the query, so a stale
-      // search never silently empties a later visit. Compared rather than reset
-      // unconditionally because this runs on every URL change, including ones
-      // that don't move the view.
+      // Search is ephemeral session state, scoped to one saved surface, so
+      // switching to another saved channel drops the query — a stale search
+      // must never silently empty the list you land on. Compared rather than
+      // reset unconditionally because this runs on every URL change, including
+      // ones that don't move the view. Leaving the surface entirely is the page's
+      // job (`savedSearchStore.setSurfaceActive(false)` on unmount): this only
+      // runs while `FeedPage` is mounted, so it can't see that transition.
       const nextSavedKey = `${filters.saved ?? ''}|${filters.view ?? ''}`;
       if (nextSavedKey !== currentSavedKey) {
         currentSavedKey = nextSavedKey;

--- a/frontend/src/lib/stores/savedSearch.svelte.ts
+++ b/frontend/src/lib/stores/savedSearch.svelte.ts
@@ -1,0 +1,234 @@
+import { db } from '$lib/services/db';
+import { safePut } from '$lib/services/safeDb.svelte';
+import { api } from '$lib/services/api';
+import { syncStore } from './sync.svelte';
+import { matchesTerms, parseQuery, toIndexText } from '$lib/services/savedSearch';
+import type { SavedItem } from '$lib/types';
+
+// Search over the saved library. Metadata (title/author/description/domain/url)
+// is matched synchronously inside the saved-items pipeline; full article text is
+// matched here, against a corpus built lazily from the bodies already cached in
+// IndexedDB. Nothing goes to the server: the saved library — bodies included —
+// is fully local by design, so search works offline like every other saved-view
+// feature.
+
+const DEBOUNCE_MS = 150;
+const BUILD_CHUNK = 100;
+const BODY_BATCH = 200;
+
+function createSavedSearchStore() {
+  // Raw input, and the debounced value the pipeline actually filters on.
+  let query = $state('');
+  let appliedQuery = $state('');
+  // Whether the search row is showing. Cleared with the query.
+  let open = $state(false);
+  // Bumped to ask the input to take focus (opening via `/` or the toolbar button).
+  let focusRequest = $state(0);
+
+  // The corpus is deliberately NOT reactive: it can hold megabytes of text and
+  // nothing should re-diff it on every keystroke. Keyed by BOTH rkey and
+  // itemGuid, because the saved list can present the same save as a bookmark
+  // (keyed by uri/rkey) or as a feed article (keyed by guid) depending on
+  // dedup — either representation must be able to hit on the save's body.
+  let corpus: Map<string, string> | null = null;
+  let building: Promise<void> | null = null;
+
+  // Keys (rkey/itemGuid) whose body matches the applied query. `null` means no
+  // active search. Always reassigned, never mutated, so the pipeline re-derives.
+  let bodyMatchKeys = $state<Set<string> | null>(null);
+
+  let terms = $derived(parseQuery(appliedQuery));
+  let active = $derived(terms.length > 0);
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function indexItem(target: Map<string, string>, item: SavedItem) {
+    const text = toIndexText(item.content);
+    if (!text) {
+      target.delete(item.rkey);
+      if (item.itemGuid) target.delete(item.itemGuid);
+      return;
+    }
+    target.set(item.rkey, text);
+    if (item.itemGuid) target.set(item.itemGuid, text);
+  }
+
+  async function buildCorpus(): Promise<void> {
+    const next = new Map<string, string>();
+    const missingBodies: SavedItem[] = [];
+    let rows: SavedItem[] = [];
+    try {
+      rows = await db.saved.toArray();
+    } catch (err) {
+      console.warn('Saved search: failed to read cached bodies:', err);
+    }
+
+    for (let i = 0; i < rows.length; i += BUILD_CHUNK) {
+      for (const row of rows.slice(i, i + BUILD_CHUNK)) {
+        if (row.content == null) {
+          missingBodies.push(row);
+          continue;
+        }
+        indexItem(next, row);
+      }
+      // Yield between chunks so a large library doesn't jank the main thread.
+      if (i + BUILD_CHUNK < rows.length) await new Promise((r) => setTimeout(r, 0));
+    }
+
+    corpus = next;
+    // Self-heal rows whose body never landed (failed hydration, an offline
+    // save, a backed stub awaiting extraction) — same pattern savesStore's
+    // getContent uses on demand.
+    void repairMissingBodies(missingBodies);
+  }
+
+  function ensureCorpus(): Promise<void> {
+    if (corpus) return Promise.resolve();
+    if (!building) {
+      building = buildCorpus().finally(() => {
+        building = null;
+      });
+    }
+    return building;
+  }
+
+  async function repairMissingBodies(rows: SavedItem[]) {
+    if (rows.length === 0 || !syncStore.isOnline) return;
+    let repaired = false;
+    for (let i = 0; i < rows.length; i += BODY_BATCH) {
+      const chunk = rows.slice(i, i + BODY_BATCH);
+      try {
+        const { bodies } = await api.getSavedBodies(chunk.map((r) => r.rkey));
+        for (const row of chunk) {
+          const body = bodies[row.rkey];
+          if (body == null) continue;
+          const filled = { ...row, content: body };
+          await safePut(db.saved, filled);
+          if (corpus) {
+            indexItem(corpus, filled);
+            repaired = true;
+          }
+        }
+      } catch (err) {
+        console.warn('Saved search: failed to backfill missing bodies:', err);
+        return;
+      }
+    }
+    if (repaired && active) void recomputeMatches();
+  }
+
+  async function recomputeMatches(): Promise<void> {
+    const forQuery = appliedQuery;
+    const forTerms = parseQuery(forQuery);
+    if (forTerms.length === 0) {
+      bodyMatchKeys = null;
+      return;
+    }
+    await ensureCorpus();
+    // A later keystroke already superseded this pass.
+    if (appliedQuery !== forQuery) return;
+    const keys = new Set<string>();
+    if (corpus) {
+      for (const [key, text] of corpus) {
+        if (matchesTerms(text, forTerms)) keys.add(key);
+      }
+    }
+    bodyMatchKeys = keys;
+  }
+
+  function apply(value: string) {
+    appliedQuery = value;
+    void recomputeMatches();
+  }
+
+  function setQuery(value: string) {
+    query = value;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    // Clearing is instant — waiting 150ms to restore the full list reads as lag.
+    if (value.trim() === '') {
+      apply('');
+      return;
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      apply(value);
+    }, DEBOUNCE_MS);
+  }
+
+  function clear() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    query = '';
+    apply('');
+  }
+
+  /** Show the search row and ask the input for focus (toolbar button, `/`). */
+  function openSearch() {
+    open = true;
+    focusRequest++;
+    // Warm the corpus while the user is still typing the first character.
+    void ensureCorpus();
+  }
+
+  /** Hide the search row and drop the query — closing means "stop filtering". */
+  function closeSearch() {
+    open = false;
+    clear();
+  }
+
+  return {
+    get query() {
+      return query;
+    },
+    get appliedQuery() {
+      return appliedQuery;
+    },
+    get terms() {
+      return terms;
+    },
+    get active() {
+      return active;
+    },
+    get bodyMatchKeys() {
+      return bodyMatchKeys;
+    },
+    get open() {
+      return open;
+    },
+    get focusRequest() {
+      return focusRequest;
+    },
+    setQuery,
+    clear,
+    openSearch,
+    close: closeSearch,
+    toggle() {
+      if (open) closeSearch();
+      else openSearch();
+    },
+    /** Full reset, used when leaving the saved view. */
+    reset: closeSearch,
+    /**
+     * Incremental cache maintenance, called from savesStore's write points. A
+     * no-op until the corpus exists — the first search builds it from scratch.
+     */
+    upsert(item: SavedItem) {
+      if (!corpus) return;
+      indexItem(corpus, item);
+      if (active) void recomputeMatches();
+    },
+    remove(rkey: string, itemGuid?: string | null) {
+      if (!corpus) return;
+      corpus.delete(rkey);
+      if (itemGuid) corpus.delete(itemGuid);
+      if (active) void recomputeMatches();
+    },
+    /** Drop the corpus wholesale; the next search rebuilds it. */
+    invalidate() {
+      corpus = null;
+      if (active) void recomputeMatches();
+    },
+  };
+}
+
+export const savedSearchStore = createSavedSearchStore();

--- a/frontend/src/lib/stores/savedSearch.svelte.ts
+++ b/frontend/src/lib/stores/savedSearch.svelte.ts
@@ -33,9 +33,11 @@ function createSavedSearchStore() {
   let corpus: Map<string, string> | null = null;
   let building: Promise<void> | null = null;
 
-  // Keys (rkey/itemGuid) whose body matches the applied query. `null` means no
-  // active search. Always reassigned, never mutated, so the pipeline re-derives.
-  let bodyMatchKeys = $state<Set<string> | null>(null);
+  // Terms matched by each body, keyed by rkey/itemGuid. Keeping the individual
+  // terms lets the list satisfy an AND query across metadata and body text
+  // (for example, one term in the title and another in the article). `null`
+  // means no active search. Always reassigned so the pipeline re-derives.
+  let bodyMatchTerms = $state<Map<string, Set<string>> | null>(null);
 
   let terms = $derived(parseQuery(appliedQuery));
   let active = $derived(terms.length > 0);
@@ -121,19 +123,20 @@ function createSavedSearchStore() {
     const forQuery = appliedQuery;
     const forTerms = parseQuery(forQuery);
     if (forTerms.length === 0) {
-      bodyMatchKeys = null;
+      bodyMatchTerms = null;
       return;
     }
     await ensureCorpus();
     // A later keystroke already superseded this pass.
     if (appliedQuery !== forQuery) return;
-    const keys = new Set<string>();
+    const matches = new Map<string, Set<string>>();
     if (corpus) {
       for (const [key, text] of corpus) {
-        if (matchesTerms(text, forTerms)) keys.add(key);
+        const matchedTerms = forTerms.filter((term) => matchesTerms(text, [term]));
+        if (matchedTerms.length > 0) matches.set(key, new Set(matchedTerms));
       }
     }
-    bodyMatchKeys = keys;
+    bodyMatchTerms = matches;
   }
 
   function apply(value: string) {
@@ -189,8 +192,8 @@ function createSavedSearchStore() {
     get active() {
       return active;
     },
-    get bodyMatchKeys() {
-      return bodyMatchKeys;
+    get bodyMatchTerms() {
+      return bodyMatchTerms;
     },
     get open() {
       return open;

--- a/frontend/src/lib/stores/savedSearch.svelte.ts
+++ b/frontend/src/lib/stores/savedSearch.svelte.ts
@@ -22,6 +22,14 @@ function createSavedSearchStore() {
   let appliedQuery = $state('');
   // Whether the search row is showing. Cleared with the query.
   let open = $state(false);
+  // Whether a saved surface is mounted right now, i.e. whether there is a
+  // search row for a global entry point like `/` to open. The view filters
+  // can't answer that — they keep their last value after the page unmounts, so
+  // one visit to /saved would leave `/` hijacked on every other route. The
+  // saved page owns this flag; leaving the surface also drops the query, which
+  // is ephemeral session state and would otherwise silently filter the list on
+  // the next visit.
+  let surfaceActive = $state(false);
   // Bumped to ask the input to take focus (opening via `/` or the toolbar button).
   let focusRequest = $state(0);
 
@@ -32,6 +40,12 @@ function createSavedSearchStore() {
   // dedup — either representation must be able to hit on the save's body.
   let corpus: Map<string, string> | null = null;
   let building: Promise<void> | null = null;
+  // Bumped by every invalidation. A build that started under an older
+  // generation read a now-stale snapshot of `db.saved`, so it must not install
+  // its map — otherwise a sync that lands mid-build (savesStore.load() merges,
+  // writes, then invalidates) is quietly undone by the very build it discarded,
+  // and the freshly synced saves stay unsearchable by body text.
+  let generation = 0;
 
   // Terms matched by each body, keyed by rkey/itemGuid. Keeping the individual
   // terms lets the list satisfy an AND query across metadata and body text
@@ -56,6 +70,7 @@ function createSavedSearchStore() {
   }
 
   async function buildCorpus(): Promise<void> {
+    const forGeneration = generation;
     const next = new Map<string, string>();
     const missingBodies: SavedItem[] = [];
     let rows: SavedItem[] = [];
@@ -77,6 +92,13 @@ function createSavedSearchStore() {
       if (i + BUILD_CHUNK < rows.length) await new Promise((r) => setTimeout(r, 0));
     }
 
+    // Superseded mid-flight: drop this pass and let `ensureCorpus` start a fresh
+    // one. The rows we did fetch may still be missing bodies worth repairing.
+    if (forGeneration !== generation) {
+      void repairMissingBodies(missingBodies);
+      return;
+    }
+
     corpus = next;
     // Self-heal rows whose body never landed (failed hydration, an offline
     // save, a backed stub awaiting extraction) — same pattern savesStore's
@@ -84,14 +106,21 @@ function createSavedSearchStore() {
     void repairMissingBodies(missingBodies);
   }
 
-  function ensureCorpus(): Promise<void> {
-    if (corpus) return Promise.resolve();
-    if (!building) {
-      building = buildCorpus().finally(() => {
-        building = null;
-      });
+  // A build that an invalidation superseded resolves without installing a
+  // corpus, so awaiting the in-flight pass isn't enough — retry until one
+  // actually lands. Bounded, because a storm of writes could otherwise keep
+  // invalidating forever; a null corpus just degrades search to metadata-only.
+  const MAX_BUILD_ATTEMPTS = 5;
+
+  async function ensureCorpus(): Promise<void> {
+    for (let attempt = 0; !corpus && attempt < MAX_BUILD_ATTEMPTS; attempt++) {
+      if (!building) {
+        building = buildCorpus().finally(() => {
+          building = null;
+        });
+      }
+      await building;
     }
-    return building;
   }
 
   async function repairMissingBodies(rows: SavedItem[]) {
@@ -179,6 +208,12 @@ function createSavedSearchStore() {
     clear();
   }
 
+  function setSurfaceActive(on: boolean) {
+    if (surfaceActive === on) return;
+    surfaceActive = on;
+    if (!on) closeSearch();
+  }
+
   return {
     get query() {
       return query;
@@ -198,6 +233,12 @@ function createSavedSearchStore() {
     get open() {
       return open;
     },
+    /** True while a saved surface is mounted and can show the search row. */
+    get available() {
+      return surfaceActive;
+    },
+    /** Saved-surface lifecycle, owned by `FeedPage`. Leaving resets the search. */
+    setSurfaceActive,
     get focusRequest() {
       return focusRequest;
     },
@@ -229,6 +270,7 @@ function createSavedSearchStore() {
     /** Drop the corpus wholesale; the next search rebuilds it. */
     invalidate() {
       corpus = null;
+      generation++;
       if (active) void recomputeMatches();
     },
   };

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -7,6 +7,7 @@ import { syncQueue, type SavedPayload } from '$lib/services/sync-queue';
 import { syncStore } from './sync.svelte';
 import { extractArticle } from '$lib/services/extract';
 import { computeContentStats } from '$lib/services/articleMerge';
+import { savedSearchStore } from './savedSearch.svelte';
 import type { SavedItem } from '$lib/types';
 
 // Derive a word count from the best available body text, returning null when
@@ -164,6 +165,9 @@ function createSavesStore() {
         if (snapshot.length > 0) {
           await safeBulkPut(db.saved, snapshot);
         }
+        // A batch landed: rebuild the search corpus on the next search rather
+        // than patching it row by row.
+        savedSearchStore.invalidate();
         pushWordCountBackfills(backfilled);
         return;
       }
@@ -205,6 +209,7 @@ function createSavesStore() {
       // the cache is left untouched.
       if (fresh.length > 0) {
         await safeBulkPut(db.saved, fresh);
+        savedSearchStore.invalidate();
       }
 
       pushWordCountBackfills(backfilled);
@@ -263,6 +268,7 @@ function createSavesStore() {
       articles = [toLightSaved(savedItem), ...articles];
       rebuildMaps();
       await safePut(db.saved, savedItem);
+      savedSearchStore.upsert(savedItem);
 
       return savedItem;
     } catch (err) {
@@ -337,6 +343,7 @@ function createSavesStore() {
       articles = [toLightSaved(savedItem), ...articles];
       rebuildMaps();
       await safePut(db.saved, savedItem);
+      savedSearchStore.upsert(savedItem);
 
       if (syncStore.isOnline) {
         try {
@@ -387,6 +394,10 @@ function createSavesStore() {
           articles = articles.map((a) => (a.rkey === rkey ? toLightSaved(updated) : a));
           rebuildMaps();
           await safePut(db.saved, updated);
+          // The backend can hand back a different rkey; drop the optimistic key
+          // so the corpus doesn't keep a stale copy of the same save.
+          if (updated.rkey !== rkey) savedSearchStore.remove(rkey);
+          savedSearchStore.upsert(updated);
 
           return updated;
         } catch (err) {
@@ -474,6 +485,7 @@ function createSavesStore() {
       articles = [savedItem, ...articles];
       rebuildMaps();
       await safePut(db.saved, savedItem);
+      savedSearchStore.upsert(savedItem);
 
       if (syncStore.isOnline) {
         try {
@@ -499,6 +511,8 @@ function createSavesStore() {
           articles = articles.map((a) => (a.rkey === rkey ? updated : a));
           rebuildMaps();
           await safePut(db.saved, updated);
+          if (updated.rkey !== rkey) savedSearchStore.remove(rkey);
+          savedSearchStore.upsert(updated);
           return updated;
         } catch (err) {
           console.error('Failed to save document to backend, queueing:', err);
@@ -545,6 +559,7 @@ function createSavesStore() {
     // Optimistically remove from local state
     articles = articles.filter((a) => a.itemGuid !== guid);
     rebuildMaps();
+    savedSearchStore.remove(item.rkey, guid);
     await db.saved.where('itemGuid').equals(guid).delete();
 
     if (syncStore.isOnline) {
@@ -574,6 +589,7 @@ function createSavesStore() {
     articles = articles.filter((a) => a.rkey !== rkey);
     rebuildMaps();
     contentCache.delete(rkey);
+    savedSearchStore.remove(rkey, item?.itemGuid);
     await db.saved.delete(rkey);
 
     if (syncStore.isOnline) {
@@ -655,7 +671,9 @@ function createSavesStore() {
       const { bodies } = await api.getSavedBodies([rkey]);
       const body = bodies[rkey] ?? null;
       if (body != null && row) {
-        await safePut(db.saved, { ...row, content: body });
+        const filled = { ...row, content: body };
+        await safePut(db.saved, filled);
+        savedSearchStore.upsert(filled);
       }
       if (body != null) contentCache.set(rkey, body);
       return body;


### PR DESCRIPTION
Adds client-side search to saved views across metadata and cached full article text, including offline use, inbox/archive filtering, keyboard controls, result highlighting, and cross-view match hints.

**Latest revision — outstanding review findings.**

- **`/` is scoped to the mounted surface.** The shortcut branched on `feedViewStore.isSavedView`, a filter that keeps its last value after `FeedPage` unmounts, so one visit to `/saved` left the navigation switcher dead on Home. The saved page now owns an explicit surface flag on the search store; leaving the surface also drops the query, so a stale search can't come back pre-applied on the next visit.
- **Mid-build invalidation no longer loses saves.** A build that a `savesStore` sync superseded still installed its stale map, leaving the newly merged saves unsearchable by body text. Builds carry a generation, stale passes are discarded, and `ensureCorpus` retries until one lands.
- **One haystack for filter and card.** `searchHaystack` matched raw feed HTML, so a query could hit a tag name or a CDN hostname inside an `img src` — and `SavedCard`, classifying against stripped text, would then caption it "Matches article text". Summary/description are stripped to visible text, and the card now classifies against the same exported haystack.
- **The cross-source AND predicate is tested.** It moved into the pure service (`matchesSearch`) with direct unit coverage, and it defers building an item's corpus keys until a term misses metadata. The E2E split-term case now enters from a query that *hides* the item, so it asserts a hidden → visible transition rather than the state the list already sat in; a new case covers `/` after leaving Saved.
- **Dark mode and focus.** Search `<mark>`s used a fixed light tint that composited to near-invisible over `#1a1a1a`; the search input dropped its outline with nothing in its place. Both re-tint per scheme.

Checks:

- Frontend unit suite: 437/437 passed (7 new)
- `npm run check`: 0 errors, 19 pre-existing warnings
- Playwright: not runnable in this environment (the sandbox mounts `$HOME` and `/tmp` `noexec`, and chromium's system libs are absent) — the E2E specs run in CI

No backend, migration, or Dexie schema changes.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-kj437bq3upybk6regw3tqg4z)
