### PR TITLE
Show Margin community highlights in saved articles

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import {
   handleV2SocialContext,
   handleV2Mentions,
   handleV2MentionLane,
+  handleV2MarginHighlights,
 } from './routes/feeds-v2';
 import { handleIngest, handleCrawlSet, handleFeedHealth } from './routes/ingest';
 import { handleTimeline } from './routes/timeline';
@@ -370,6 +371,10 @@ async function route(
     case url.pathname === '/api/v2/mention-lane':
       if (!session) return unauthorizedResponse(headers);
       response = await handleV2MentionLane(request, env);
+      break;
+    case url.pathname === '/api/v2/margin-highlights':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleV2MarginHighlights(request, env);
       break;
 
     // Social routes

--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -906,6 +906,40 @@ export async function handleV2MentionLane(request: Request, env: Env): Promise<R
   }
 }
 
+export async function handleV2MarginHighlights(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'POST')
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  let body: { url?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!body.url || typeof body.url !== 'string')
+    return new Response(JSON.stringify({ error: 'Missing url in request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  try {
+    const result = await new FeedProxyClient(env).fetchMarginHighlights(body.url);
+    return new Response(JSON.stringify(result), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('V2 margin-highlights fetch error:', error);
+    return new Response(JSON.stringify({ error: 'Atmosphere unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
 export interface WarmCacheResult {
   success: boolean;
   itemCount?: number;

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -2,6 +2,7 @@ import type { Env, Session } from '../types';
 import { getSessionFromRequest } from '../services/oauth';
 import { createPDSClient } from '../services/pds-client';
 import { generateTid } from '../utils/tid';
+import { normalizeArticleUrl } from '../utils/url-normalize';
 import {
   findMemberships,
   editMemberships,
@@ -475,13 +476,14 @@ interface MarginNoteBody {
  * annotation's comment body — Margin expects a `{ value, format }` shape — so
  * the note stays portable across the Atmosphere.
  */
-function buildMarginNoteRecord(body: MarginNoteBody, createdAt: string) {
+export function buildMarginNoteRecord(body: MarginNoteBody, createdAt: string) {
   const note = body.note?.trim();
+  const source = normalizeArticleUrl(body.source) ?? body.source.trim();
   return {
     $type: 'at.margin.note',
     motivation: 'highlighting',
     target: {
-      source: body.source,
+      source,
       ...(body.title ? { title: body.title } : {}),
       selector: {
         type: 'TextQuoteSelector',

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -326,6 +326,22 @@ interface RawMentionLaneResponse {
   error?: string;
 }
 
+export interface MarginHighlightResult {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatar: string | null;
+  createdAt: string | null;
+  motivation: string | null;
+  note: string | null;
+  selector: { type: 'TextQuoteSelector'; exact: string; prefix?: string; suffix?: string };
+}
+interface RawMarginHighlightsResponse {
+  notes?: MarginHighlightResult[];
+  capped?: boolean;
+  error?: string;
+}
+
 // Raw response types from the proxy
 interface RawFeedResponse {
   feed: {
@@ -674,6 +690,17 @@ export class FeedProxyClient {
       entries: raw.entries,
       ...(raw.sembleContext ? { sembleContext: raw.sembleContext } : {}),
     };
+  }
+
+  async fetchMarginHighlights(
+    url: string
+  ): Promise<{ notes: MarginHighlightResult[]; capped: boolean }> {
+    const raw = await this.fetch<RawMarginHighlightsResponse>('/margin-highlights', {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+    if (!raw.notes) throw new FeedProxyError(raw.error || 'Invalid response from feed proxy');
+    return { notes: raw.notes, capped: raw.capped === true };
   }
 
   /**

--- a/backend/src/utils/url-normalize.ts
+++ b/backend/src/utils/url-normalize.ts
@@ -46,6 +46,13 @@ const TRACKING_PARAMS = new Set([
   'oly_enc_id',
 ]);
 
+// Short parameter names are too ambiguous to strip everywhere. Substack uses
+// `r` exclusively as a reader/referral token on post URLs, while another site
+// may use the same name to select real content.
+function isHostTrackingParam(hostname: string, key: string): boolean {
+  return key === 'r' && (hostname === 'substack.com' || hostname.endsWith('.substack.com'));
+}
+
 /**
  * Canonicalize an article URL for cross-app dedup. Returns `null` for inputs that
  * aren't http(s) URLs (skip them — e.g. a Semble `type:NOTE` card has no URL).
@@ -72,7 +79,8 @@ export function normalizeArticleUrl(input: string): string | null {
   // Strip tracking params, keep + sort the rest so equivalent URLs key the same.
   const kept: Array<[string, string]> = [];
   for (const [key, value] of url.searchParams) {
-    if (TRACKING_PARAMS.has(key.toLowerCase())) continue;
+    const lowerKey = key.toLowerCase();
+    if (TRACKING_PARAMS.has(lowerKey) || isHostTrackingParam(url.hostname, lowerKey)) continue;
     kept.push([key, value]);
   }
   kept.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));

--- a/backend/test/backing-read.spec.ts
+++ b/backend/test/backing-read.spec.ts
@@ -78,6 +78,17 @@ describe('normalizeArticleUrl — the cross-app join key', () => {
     expect(normalizeArticleUrl('http://example.com/x')).toBe('http://example.com/x');
   });
 
+  it('strips Substack referral tokens without treating every r param as tracking', () => {
+    expect(
+      normalizeArticleUrl(
+        'https://chinaunread.substack.com/p/a-post?r=clku7&utm_medium=post%20viewer'
+      )
+    ).toBe('https://chinaunread.substack.com/p/a-post');
+    expect(normalizeArticleUrl('https://example.com/article?r=chapter-2')).toBe(
+      'https://example.com/article?r=chapter-2'
+    );
+  });
+
   it('returns null for non-http(s)', () => {
     expect(normalizeArticleUrl('at://did:plc:x/y/z')).toBeNull();
     expect(normalizeArticleUrl('not a url')).toBeNull();

--- a/backend/test/margin-highlights.spec.ts
+++ b/backend/test/margin-highlights.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildMarginNoteRecord } from '../src/routes/integrations';
+
+describe('Margin highlight records', () => {
+  it('writes a canonical source so later exact backlink lookups can find it', () => {
+    const record = buildMarginNoteRecord(
+      {
+        source:
+          'https://chinaunread.substack.com/p/a-post?r=clku7&utm_campaign=post-expanded-share&utm_medium=post%20viewer',
+        exact: 'A passage',
+      },
+      '2026-08-25T00:00:00.000Z'
+    );
+
+    expect(record.target.source).toBe('https://chinaunread.substack.com/p/a-post');
+  });
+});

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -22,6 +22,7 @@ import {
   MentionLaneUnavailableError,
   type MentionLaneItemsResult,
 } from './mention-lane';
+import { getMarginHighlights } from './margin-highlights';
 import type { LaneId } from './lanes';
 import { normalizeArticleUrl } from './url-normalize';
 import { Semaphore, OverloadError } from './semaphore';
@@ -3107,6 +3108,25 @@ export function createApp(db: Database, config: AppConfig) {
       if (error instanceof MentionLaneUnavailableError) {
         return c.json({ error: 'Atmosphere unavailable' }, 503);
       }
+      throw error;
+    }
+  });
+
+  app.post('/margin-highlights', async (c) => {
+    if (proxySecret && c.req.header('X-Proxy-Secret') !== proxySecret)
+      return c.json({ error: 'Unauthorized' }, 401);
+    let body: { url?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    if (!body.url || typeof body.url !== 'string') return c.json({ error: 'Missing url' }, 400);
+    try {
+      return c.json(await getMarginHighlights(db, body.url));
+    } catch (error) {
+      if (error instanceof MentionLaneUnavailableError)
+        return c.json({ error: 'Atmosphere unavailable' }, 503);
       throw error;
     }
   });

--- a/feed-proxy/src/margin-highlights.test.ts
+++ b/feed-proxy/src/margin-highlights.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { initDatabase } from './app';
+import { getMarginHighlights, MentionLaneUnavailableError } from './margin-highlights';
+import { resetConstellationBreaker } from './constellation-client';
+
+const ARTICLE = 'https://example.com/article';
+function db() {
+  const value = new Database(':memory:');
+  initDatabase(value);
+  return value;
+}
+function seedDid(value: Database, did: string) {
+  value.run('INSERT INTO did_cache (did,pds_url,handle,cached_at) VALUES (?,?,?,?)', [
+    did,
+    'https://pds.test',
+    `${did.slice(8)}.test`,
+    Date.now(),
+  ]);
+}
+function mock(
+  records: Array<{ did: string; rkey: string }>,
+  values: Record<string, unknown>,
+  reachable = true
+) {
+  return spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+    const url = new URL(String(input));
+    if (!reachable && url.hostname.includes('constellation'))
+      return new Response('no', { status: 503 });
+    if (url.pathname === '/links/all')
+      return Response.json({
+        links: { 'at.margin.note': { '.target.source': { records: records.length } } },
+      });
+    if (url.pathname === '/links')
+      return Response.json({
+        linking_records: records.map((r) => ({ ...r, collection: 'at.margin.note' })),
+      });
+    if (url.pathname.includes('getRecord'))
+      return Response.json({ value: values[url.searchParams.get('rkey')!] ?? {} });
+    return new Response('{}', { status: 404 });
+  }) as typeof fetch);
+}
+
+describe('getMarginHighlights', () => {
+  afterEach(() => {
+    (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
+    resetConstellationBreaker();
+  });
+
+  it('preserves selector context and note metadata without author dedup', async () => {
+    const value = db();
+    seedDid(value, 'did:plc:alice');
+    mock(
+      [
+        { did: 'did:plc:alice', rkey: 'one' },
+        { did: 'did:plc:alice', rkey: 'two' },
+      ],
+      {
+        one: {
+          target: { selector: { exact: 'first', prefix: 'before', suffix: 'after' } },
+          body: 'Thoughtful note',
+          motivation: 'commenting',
+          createdAt: '2026-01-02T00:00:00Z',
+        },
+        two: { target: { selector: { exact: 'second' } }, motivation: 'highlighting' },
+      }
+    );
+    const result = await getMarginHighlights(value, ARTICLE);
+    expect(result.notes).toHaveLength(2);
+    expect(result.notes[0].selector).toEqual({
+      type: 'TextQuoteSelector',
+      exact: 'first',
+      prefix: 'before',
+      suffix: 'after',
+    });
+    expect(result.notes[0].note).toBe('Thoughtful note');
+  });
+
+  it('drops bookmarks and malformed notes without passage selectors', async () => {
+    const value = db();
+    seedDid(value, 'did:plc:alice');
+    mock(
+      [
+        { did: 'did:plc:alice', rkey: 'bookmark' },
+        { did: 'did:plc:alice', rkey: 'bad' },
+      ],
+      {
+        bookmark: { motivation: 'bookmarking', target: {} },
+        bad: { target: { selector: { exact: '   ' } } },
+      }
+    );
+    expect((await getMarginHighlights(value, ARTICLE)).notes).toEqual([]);
+  });
+
+  it('caps the record fan-out and reports the cap', async () => {
+    const value = db();
+    const records = Array.from({ length: 51 }, (_, i) => ({
+      did: `did:plc:user${i}`,
+      rkey: `r${i}`,
+    }));
+    const values = Object.fromEntries(
+      records.map((r) => [r.rkey, { target: { selector: { exact: r.rkey } } }])
+    );
+    for (const record of records) seedDid(value, record.did);
+    mock(records, values);
+    const result = await getMarginHighlights(value, ARTICLE);
+    expect(result.notes).toHaveLength(50);
+    expect(result.capped).toBe(true);
+  });
+
+  it('serves a fresh cache entry without network work', async () => {
+    const value = db();
+    value.run('INSERT INTO constellation_cache (cache_key,context_json,cached_at) VALUES (?,?,?)', [
+      `margin-highlights:${ARTICLE}`,
+      JSON.stringify({ notes: [], capped: true }),
+      Date.now(),
+    ]);
+    const fetchSpy = spyOn(globalThis, 'fetch');
+    expect(await getMarginHighlights(value, ARTICLE)).toEqual({ notes: [], capped: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes an unavailable index from an empty reachable result', async () => {
+    const unavailable = db();
+    mock([], {}, false);
+    await expect(getMarginHighlights(unavailable, ARTICLE)).rejects.toBeInstanceOf(
+      MentionLaneUnavailableError
+    );
+    (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore();
+    resetConstellationBreaker();
+    const empty = db();
+    mock([], {});
+    expect(await getMarginHighlights(empty, ARTICLE)).toEqual({ notes: [], capped: false });
+  });
+});

--- a/feed-proxy/src/margin-highlights.test.ts
+++ b/feed-proxy/src/margin-highlights.test.ts
@@ -108,6 +108,48 @@ describe('getMarginHighlights', () => {
     expect(result.capped).toBe(true);
   });
 
+  it('bounds profile PDS lookups for articles with many distinct authors', async () => {
+    const value = db();
+    const records = Array.from({ length: 20 }, (_, i) => ({
+      did: `did:plc:user${i}`,
+      rkey: `r${i}`,
+    }));
+    for (const record of records) seedDid(value, record.did);
+    let activeProfiles = 0;
+    let maxActiveProfiles = 0;
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/links/all')
+        return Response.json({
+          links: { 'at.margin.note': { '.target.source': { records: records.length } } },
+        });
+      if (url.pathname === '/links')
+        return Response.json({
+          linking_records: records.map((record) => ({
+            ...record,
+            collection: 'at.margin.note',
+          })),
+        });
+      if (url.pathname.includes('getRecord')) {
+        if (url.searchParams.get('rkey') === 'self') {
+          activeProfiles++;
+          maxActiveProfiles = Math.max(maxActiveProfiles, activeProfiles);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          activeProfiles--;
+          return Response.json({ value: {} });
+        }
+        return Response.json({
+          value: { target: { selector: { exact: url.searchParams.get('rkey') } } },
+        });
+      }
+      return new Response('{}', { status: 404 });
+    }) as typeof fetch);
+
+    expect((await getMarginHighlights(value, ARTICLE)).notes).toHaveLength(records.length);
+    expect(maxActiveProfiles).toBeGreaterThan(1);
+    expect(maxActiveProfiles).toBeLessThanOrEqual(6);
+  });
+
   it('serves a fresh cache entry without network work', async () => {
     const value = db();
     value.run('INSERT INTO constellation_cache (cache_key,context_json,cached_at) VALUES (?,?,?)', [

--- a/feed-proxy/src/margin-highlights.test.ts
+++ b/feed-proxy/src/margin-highlights.test.ts
@@ -58,7 +58,7 @@ describe('getMarginHighlights', () => {
       {
         one: {
           target: { selector: { exact: 'first', prefix: 'before', suffix: 'after' } },
-          body: 'Thoughtful note',
+          body: { value: 'Thoughtful note', format: 'text/plain' },
           motivation: 'commenting',
           createdAt: '2026-01-02T00:00:00Z',
         },
@@ -74,6 +74,72 @@ describe('getMarginHighlights', () => {
       suffix: 'after',
     });
     expect(result.notes[0].note).toBe('Thoughtful note');
+  });
+
+  it('probes the exact raw URL for notes written before source canonicalization', async () => {
+    const value = db();
+    const did = 'did:plc:alice';
+    seedDid(value, did);
+    const raw =
+      'https://chinaunread.substack.com/p/a-post?r=clku7&utm_campaign=post-expanded-share&utm_medium=post%20viewer';
+    const queried: string[] = [];
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/links/all') {
+        const target = url.searchParams.get('target') ?? '';
+        queried.push(target);
+        return Response.json({
+          links: target === raw ? { 'at.margin.note': { '.target.source': { records: 1 } } } : {},
+        });
+      }
+      if (url.pathname === '/links')
+        return Response.json({
+          linking_records: [{ did, collection: 'at.margin.note', rkey: 'one' }],
+        });
+      if (url.pathname.includes('getRecord'))
+        return Response.json({
+          value: { target: { selector: { exact: 'legacy passage' } } },
+        });
+      return new Response('{}', { status: 404 });
+    }) as typeof fetch);
+
+    expect((await getMarginHighlights(value, raw)).notes[0]?.selector.exact).toBe('legacy passage');
+    expect(queried).toContain('https://chinaunread.substack.com/p/a-post');
+    expect(queried).toContain(raw);
+  });
+
+  it('recovers tracked legacy notes through Margin using the canonical URL', async () => {
+    const value = db();
+    const source =
+      'https://chinaunread.substack.com/p/a-post?r=clku7&utm_campaign=post-expanded-share&utm_medium=post%20viewer';
+    let searchQuery = '';
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'margin.at' && url.pathname === '/api/search') {
+        searchQuery = url.searchParams.get('q') ?? '';
+        return Response.json({
+          items: [
+            {
+              motivation: 'highlighting',
+              creator: { did: 'did:plc:alice', handle: 'alice.test' },
+              body: { value: 'Underrated', format: 'text/plain' },
+              target: { source, selector: { exact: 'the recovered passage' } },
+              created: '2026-08-23T01:21:30.058Z',
+            },
+          ],
+        });
+      }
+      throw new Error(`Constellation should not be needed: ${url}`);
+    }) as typeof fetch);
+
+    const result = await getMarginHighlights(
+      value,
+      'https://chinaunread.substack.com/p/a-post?r=clku7'
+    );
+    expect(searchQuery).toBe('https://chinaunread.substack.com/p/a-post');
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0].note).toBe('Underrated');
+    expect(result.notes[0].selector.exact).toBe('the recovered passage');
   });
 
   it('drops bookmarks and malformed notes without passage selectors', async () => {

--- a/feed-proxy/src/margin-highlights.ts
+++ b/feed-proxy/src/margin-highlights.ts
@@ -129,22 +129,21 @@ async function resolveMarginHighlights(
     );
   }
   const profileEntries: Array<
-    readonly [
-      string,
-      Awaited<ReturnType<typeof resolveProfile>> & { handle: string | null },
-    ]
+    readonly [string, Awaited<ReturnType<typeof resolveProfile>> & { handle: string | null }]
   > = [];
   const dids = [...new Set(records.map((r) => r.did))];
   for (let offset = 0; offset < dids.length; offset += RECORD_CONCURRENCY) {
     profileEntries.push(
       ...(await Promise.all(
-        dids.slice(offset, offset + RECORD_CONCURRENCY).map(
-          async (did) =>
-            [
-              did,
-              { ...(await resolveProfile(db, did)), handle: await resolveHandle(db, did) },
-            ] as const
-        )
+        dids
+          .slice(offset, offset + RECORD_CONCURRENCY)
+          .map(
+            async (did) =>
+              [
+                did,
+                { ...(await resolveProfile(db, did)), handle: await resolveHandle(db, did) },
+              ] as const
+          )
       ))
     );
   }

--- a/feed-proxy/src/margin-highlights.ts
+++ b/feed-proxy/src/margin-highlights.ts
@@ -1,0 +1,146 @@
+import { Database } from 'bun:sqlite';
+import { normalizeArticleUrl, constellationTargets } from './url-normalize';
+import { constellationGetResult } from './constellation-client';
+import { getRecordValue, resolveProfile, MentionLaneUnavailableError } from './mention-lane';
+import { resolveHandle } from './did-resolver';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_NOTES = 50;
+
+export interface MarginHighlightNote {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatar: string | null;
+  createdAt: string | null;
+  motivation: string | null;
+  note: string | null;
+  selector: { type: 'TextQuoteSelector'; exact: string; prefix?: string; suffix?: string };
+}
+export interface MarginHighlightsResult {
+  notes: MarginHighlightNote[];
+  capped: boolean;
+}
+interface LinksAll {
+  links?: Record<string, Record<string, { records?: number }>>;
+}
+interface Links {
+  linking_records?: Array<{ did: string; collection: string; rkey: string }>;
+}
+interface CacheRow {
+  context_json: string;
+  cached_at: number;
+}
+
+export async function getMarginHighlights(
+  db: Database,
+  rawUrl: string
+): Promise<MarginHighlightsResult> {
+  const normUrl = normalizeArticleUrl(rawUrl);
+  if (!normUrl) return { notes: [], capped: false };
+  const key = `margin-highlights:${normUrl}`;
+  const now = Date.now();
+  const cached = db
+    .query<CacheRow, [string]>(
+      'SELECT context_json, cached_at FROM constellation_cache WHERE cache_key = ?'
+    )
+    .get(key);
+  if (cached && now - cached.cached_at < CACHE_TTL_MS) {
+    try {
+      const value = JSON.parse(cached.context_json);
+      if (Array.isArray(value?.notes)) return value;
+    } catch {
+      /* recompute */
+    }
+  }
+
+  const sources: Array<{ target: string; path: string }> = [];
+  let unreachable = false;
+  for (const target of constellationTargets(normUrl)) {
+    const all = await constellationGetResult<LinksAll>('/links/all', { target });
+    if (!all.reachable) unreachable = true;
+    for (const [collection, paths] of Object.entries(all.data?.links ?? {})) {
+      if (collection !== 'at.margin.note') continue;
+      for (const [path, stats] of Object.entries(paths))
+        if (stats?.records) sources.push({ target, path });
+    }
+  }
+  if (!sources.length && unreachable) throw new MentionLaneUnavailableError();
+
+  const records: Array<{ did: string; collection: string; rkey: string }> = [];
+  const seen = new Set<string>();
+  let capped = false;
+  for (const source of sources) {
+    const links = await constellationGetResult<Links>('/links', {
+      target: source.target,
+      collection: 'at.margin.note',
+      path: source.path,
+      limit: '100',
+    });
+    if (!links.reachable) unreachable = true;
+    for (const record of links.data?.linking_records ?? []) {
+      const id = `${record.did}/${record.collection}/${record.rkey}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      if (records.length >= MAX_NOTES) {
+        capped = true;
+        break;
+      }
+      records.push(record);
+    }
+    if (capped) break;
+  }
+  if (!records.length && unreachable) throw new MentionLaneUnavailableError();
+
+  const values = await Promise.all(
+    records.map(async (record) => ({
+      record,
+      value: await getRecordValue(db, record.did, record.collection, record.rkey),
+    }))
+  );
+  const profiles = new Map(
+    await Promise.all(
+      [...new Set(records.map((r) => r.did))].map(
+        async (did) =>
+          [
+            did,
+            { ...(await resolveProfile(db, did)), handle: await resolveHandle(db, did) },
+          ] as const
+      )
+    )
+  );
+  const notes: MarginHighlightNote[] = [];
+  for (const { record, value } of values) {
+    const target = value?.target as Record<string, unknown> | undefined;
+    const selector = target?.selector as Record<string, unknown> | undefined;
+    const exact = typeof selector?.exact === 'string' ? selector.exact.trim().slice(0, 5000) : '';
+    if (!exact) continue;
+    const profile = profiles.get(record.did);
+    const optional = (name: string, cap: number) =>
+      typeof selector?.[name] === 'string' && selector[name]
+        ? String(selector[name]).slice(0, cap)
+        : undefined;
+    notes.push({
+      did: record.did,
+      handle: profile?.handle ?? null,
+      displayName: profile?.displayName ?? null,
+      avatar: profile?.avatar ?? null,
+      createdAt: typeof value?.createdAt === 'string' ? value.createdAt : null,
+      motivation: typeof value?.motivation === 'string' ? value.motivation : null,
+      note: typeof value?.body === 'string' ? value.body.trim().slice(0, 2000) || null : null,
+      selector: {
+        type: 'TextQuoteSelector',
+        exact,
+        ...(optional('prefix', 500) ? { prefix: optional('prefix', 500) } : {}),
+        ...(optional('suffix', 500) ? { suffix: optional('suffix', 500) } : {}),
+      },
+    });
+  }
+  notes.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+  const result = { notes, capped };
+  db.run(
+    `INSERT INTO constellation_cache (cache_key, context_json, cached_at) VALUES (?, ?, ?) ON CONFLICT(cache_key) DO UPDATE SET context_json=excluded.context_json, cached_at=excluded.cached_at`,
+    [key, JSON.stringify(result), now]
+  );
+  return result;
+}

--- a/feed-proxy/src/margin-highlights.ts
+++ b/feed-proxy/src/margin-highlights.ts
@@ -6,6 +6,10 @@ import { resolveHandle } from './did-resolver';
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_NOTES = 50;
+const RECORD_CONCURRENCY = 6;
+const LINKS_PAGE_SIZE = 100;
+const inFlight = new WeakMap<Database, Map<string, Promise<MarginHighlightsResult>>>();
+export { MentionLaneUnavailableError };
 
 export interface MarginHighlightNote {
   did: string;
@@ -54,6 +58,25 @@ export async function getMarginHighlights(
     }
   }
 
+  let dbRequests = inFlight.get(db);
+  if (!dbRequests) inFlight.set(db, (dbRequests = new Map()));
+  const existing = dbRequests.get(key);
+  if (existing) return existing;
+  const request = resolveMarginHighlights(db, normUrl, key, now);
+  dbRequests.set(key, request);
+  try {
+    return await request;
+  } finally {
+    dbRequests.delete(key);
+  }
+}
+
+async function resolveMarginHighlights(
+  db: Database,
+  normUrl: string,
+  key: string,
+  now: number
+): Promise<MarginHighlightsResult> {
   const sources: Array<{ target: string; path: string }> = [];
   let unreachable = false;
   for (const target of constellationTargets(normUrl)) {
@@ -75,9 +98,10 @@ export async function getMarginHighlights(
       target: source.target,
       collection: 'at.margin.note',
       path: source.path,
-      limit: '100',
+      limit: String(LINKS_PAGE_SIZE),
     });
     if (!links.reachable) unreachable = true;
+    if ((links.data?.linking_records?.length ?? 0) >= LINKS_PAGE_SIZE) capped = true;
     for (const record of links.data?.linking_records ?? []) {
       const id = `${record.did}/${record.collection}/${record.rkey}`;
       if (seen.has(id)) continue;
@@ -92,12 +116,18 @@ export async function getMarginHighlights(
   }
   if (!records.length && unreachable) throw new MentionLaneUnavailableError();
 
-  const values = await Promise.all(
-    records.map(async (record) => ({
-      record,
-      value: await getRecordValue(db, record.did, record.collection, record.rkey),
-    }))
-  );
+  const values: Array<{ record: (typeof records)[number]; value: Record<string, unknown> | null }> =
+    [];
+  for (let offset = 0; offset < records.length; offset += RECORD_CONCURRENCY) {
+    values.push(
+      ...(await Promise.all(
+        records.slice(offset, offset + RECORD_CONCURRENCY).map(async (record) => ({
+          record,
+          value: await getRecordValue(db, record.did, record.collection, record.rkey),
+        }))
+      ))
+    );
+  }
   const profiles = new Map(
     await Promise.all(
       [...new Set(records.map((r) => r.did))].map(

--- a/feed-proxy/src/margin-highlights.ts
+++ b/feed-proxy/src/margin-highlights.ts
@@ -128,17 +128,27 @@ async function resolveMarginHighlights(
       ))
     );
   }
-  const profiles = new Map(
-    await Promise.all(
-      [...new Set(records.map((r) => r.did))].map(
-        async (did) =>
-          [
-            did,
-            { ...(await resolveProfile(db, did)), handle: await resolveHandle(db, did) },
-          ] as const
-      )
-    )
-  );
+  const profileEntries: Array<
+    readonly [
+      string,
+      Awaited<ReturnType<typeof resolveProfile>> & { handle: string | null },
+    ]
+  > = [];
+  const dids = [...new Set(records.map((r) => r.did))];
+  for (let offset = 0; offset < dids.length; offset += RECORD_CONCURRENCY) {
+    profileEntries.push(
+      ...(await Promise.all(
+        dids.slice(offset, offset + RECORD_CONCURRENCY).map(
+          async (did) =>
+            [
+              did,
+              { ...(await resolveProfile(db, did)), handle: await resolveHandle(db, did) },
+            ] as const
+        )
+      ))
+    );
+  }
+  const profiles = new Map(profileEntries);
   const notes: MarginHighlightNote[] = [];
   for (const { record, value } of values) {
     const target = value?.target as Record<string, unknown> | undefined;

--- a/feed-proxy/src/margin-highlights.ts
+++ b/feed-proxy/src/margin-highlights.ts
@@ -8,6 +8,8 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_NOTES = 50;
 const RECORD_CONCURRENCY = 6;
 const LINKS_PAGE_SIZE = 100;
+const MARGIN_API_BASE = 'https://margin.at';
+const MARGIN_API_TIMEOUT_MS = 5 * 1000;
 const inFlight = new WeakMap<Database, Map<string, Promise<MarginHighlightsResult>>>();
 export { MentionLaneUnavailableError };
 
@@ -36,13 +38,92 @@ interface CacheRow {
   cached_at: number;
 }
 
+function optionalString(value: unknown, cap: number): string | undefined {
+  return typeof value === 'string' && value ? value.slice(0, cap) : undefined;
+}
+
+function marginBodyText(body: unknown): string {
+  if (typeof body === 'string') return body;
+  if (body && typeof body === 'object') {
+    const value = (body as Record<string, unknown>).value;
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+/**
+ * Margin's public index searches target URLs as text, then returns hydrated
+ * notes. Unlike Constellation's exact-string backlink lookup, this finds legacy
+ * records whose source has extra tracking parameters; normalize + filter the
+ * results locally so similarly named pages can never bleed together.
+ */
+async function searchMarginIndex(normUrl: string): Promise<MarginHighlightsResult | null> {
+  const url = new URL('/api/search', MARGIN_API_BASE);
+  url.searchParams.set('q', normUrl);
+  url.searchParams.set('limit', String(MAX_NOTES));
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)' },
+      signal: AbortSignal.timeout(MARGIN_API_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { items?: unknown[] };
+    if (!Array.isArray(data.items)) return null;
+
+    const notes: MarginHighlightNote[] = [];
+    for (const raw of data.items) {
+      if (!raw || typeof raw !== 'object') continue;
+      const item = raw as Record<string, unknown>;
+      if (item.motivation !== 'highlighting') continue;
+      const target = item.target as Record<string, unknown> | undefined;
+      const source = typeof target?.source === 'string' ? target.source : '';
+      if (normalizeArticleUrl(source) !== normUrl) continue;
+      const selector = target?.selector as Record<string, unknown> | undefined;
+      const exact = optionalString(selector?.exact, 5000)?.trim();
+      const creator = item.creator as Record<string, unknown> | undefined;
+      const did = optionalString(creator?.did, 256);
+      if (!exact || !did) continue;
+      notes.push({
+        did,
+        handle: optionalString(creator?.handle, 256) ?? null,
+        displayName:
+          optionalString(creator?.displayName, 256) ?? optionalString(creator?.name, 256) ?? null,
+        avatar: optionalString(creator?.avatar, 2048) ?? null,
+        createdAt: optionalString(item.createdAt, 64) ?? optionalString(item.created, 64) ?? null,
+        motivation: 'highlighting',
+        note: marginBodyText(item.body).trim().slice(0, 2000) || null,
+        selector: {
+          type: 'TextQuoteSelector',
+          exact,
+          ...(optionalString(selector?.prefix, 500)
+            ? { prefix: optionalString(selector?.prefix, 500) }
+            : {}),
+          ...(optionalString(selector?.suffix, 500)
+            ? { suffix: optionalString(selector?.suffix, 500) }
+            : {}),
+        },
+      });
+    }
+    notes.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+    return { notes, capped: data.items.length >= MAX_NOTES };
+  } catch {
+    return null;
+  }
+}
+
 export async function getMarginHighlights(
   db: Database,
   rawUrl: string
 ): Promise<MarginHighlightsResult> {
   const normUrl = normalizeArticleUrl(rawUrl);
   if (!normUrl) return { notes: [], capped: false };
-  const key = `margin-highlights:${normUrl}`;
+  const targets = constellationTargets(normUrl, rawUrl);
+  // A legacy tracked spelling adds exact lookup targets, so it must not reuse a
+  // clean URL's cached zero (or vice versa).
+  const key =
+    rawUrl.trim() === normUrl
+      ? `margin-highlights:${normUrl}`
+      : `margin-highlights:${normUrl}:raw:${rawUrl.trim()}`;
   const now = Date.now();
   const cached = db
     .query<CacheRow, [string]>(
@@ -62,7 +143,7 @@ export async function getMarginHighlights(
   if (!dbRequests) inFlight.set(db, (dbRequests = new Map()));
   const existing = dbRequests.get(key);
   if (existing) return existing;
-  const request = resolveMarginHighlights(db, normUrl, key, now);
+  const request = resolveMarginHighlights(db, normUrl, targets, key, now);
   dbRequests.set(key, request);
   try {
     return await request;
@@ -74,12 +155,22 @@ export async function getMarginHighlights(
 async function resolveMarginHighlights(
   db: Database,
   normUrl: string,
+  targets: string[],
   key: string,
   now: number
 ): Promise<MarginHighlightsResult> {
+  const indexed = await searchMarginIndex(normUrl);
+  if (indexed?.notes.length) {
+    db.run(
+      `INSERT INTO constellation_cache (cache_key, context_json, cached_at) VALUES (?, ?, ?) ON CONFLICT(cache_key) DO UPDATE SET context_json=excluded.context_json, cached_at=excluded.cached_at`,
+      [key, JSON.stringify(indexed), now]
+    );
+    return indexed;
+  }
+
   const sources: Array<{ target: string; path: string }> = [];
   let unreachable = false;
-  for (const target of constellationTargets(normUrl)) {
+  for (const target of targets) {
     const all = await constellationGetResult<LinksAll>('/links/all', { target });
     if (!all.reachable) unreachable = true;
     for (const [collection, paths] of Object.entries(all.data?.links ?? {})) {
@@ -155,10 +246,6 @@ async function resolveMarginHighlights(
     const exact = typeof selector?.exact === 'string' ? selector.exact.trim().slice(0, 5000) : '';
     if (!exact) continue;
     const profile = profiles.get(record.did);
-    const optional = (name: string, cap: number) =>
-      typeof selector?.[name] === 'string' && selector[name]
-        ? String(selector[name]).slice(0, cap)
-        : undefined;
     notes.push({
       did: record.did,
       handle: profile?.handle ?? null,
@@ -166,12 +253,16 @@ async function resolveMarginHighlights(
       avatar: profile?.avatar ?? null,
       createdAt: typeof value?.createdAt === 'string' ? value.createdAt : null,
       motivation: typeof value?.motivation === 'string' ? value.motivation : null,
-      note: typeof value?.body === 'string' ? value.body.trim().slice(0, 2000) || null : null,
+      note: marginBodyText(value?.body).trim().slice(0, 2000) || null,
       selector: {
         type: 'TextQuoteSelector',
         exact,
-        ...(optional('prefix', 500) ? { prefix: optional('prefix', 500) } : {}),
-        ...(optional('suffix', 500) ? { suffix: optional('suffix', 500) } : {}),
+        ...(optionalString(selector?.prefix, 500)
+          ? { prefix: optionalString(selector?.prefix, 500) }
+          : {}),
+        ...(optionalString(selector?.suffix, 500)
+          ? { suffix: optionalString(selector?.suffix, 500) }
+          : {}),
       },
     });
   }

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -137,7 +137,7 @@ interface CacheRow {
 }
 
 // Fetch a single record value from the author's PDS (for its note/snippet).
-async function getRecordValue(
+export async function getRecordValue(
   db: Database,
   did: string,
   collection: string,
@@ -252,7 +252,7 @@ async function resolveSembleCollections(
 // their PDS (the same path every other record here takes) rather than through an
 // appview, so a person with no Bluesky presence still resolves. Cached on its own
 // long TTL because a name and face outlive the link index by a wide margin.
-async function resolveProfile(db: Database, did: string): Promise<AuthorProfile> {
+export async function resolveProfile(db: Database, did: string): Promise<AuthorProfile> {
   const key = `profile:${did}`;
   const now = Date.now();
   const cached = db

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -47,6 +47,17 @@ describe('normalizeArticleUrl', () => {
     );
   });
 
+  it('strips Substack referral tokens without treating every r param as tracking', () => {
+    expect(
+      normalizeArticleUrl(
+        'https://chinaunread.substack.com/p/a-post?r=clku7&utm_medium=post%20viewer'
+      )
+    ).toBe('https://chinaunread.substack.com/p/a-post');
+    expect(normalizeArticleUrl('https://example.com/article?r=chapter-2')).toBe(
+      'https://example.com/article?r=chapter-2'
+    );
+  });
+
   it('leaves the bare root slash intact', () => {
     expect(normalizeArticleUrl('https://example.com/')).toBe('https://example.com/');
   });
@@ -74,6 +85,18 @@ describe('constellationTargets', () => {
 
   it('does not vary the bare root', () => {
     expect(constellationTargets('https://example.com/')).toEqual(['https://example.com/']);
+  });
+
+  it('also probes an exact legacy tracked spelling when supplied', () => {
+    const normalized = 'https://chinaunread.substack.com/p/a-post';
+    const raw =
+      'https://chinaunread.substack.com/p/a-post?r=clku7&utm_campaign=post-expanded-share&utm_medium=post%20viewer';
+    expect(constellationTargets(normalized, raw)).toEqual([
+      normalized,
+      `${normalized}/`,
+      raw,
+      'https://chinaunread.substack.com/p/a-post/?r=clku7&utm_campaign=post-expanded-share&utm_medium=post%20viewer',
+    ]);
   });
 });
 

--- a/feed-proxy/src/url-normalize.ts
+++ b/feed-proxy/src/url-normalize.ts
@@ -52,6 +52,13 @@ const TRACKING_PARAMS = new Set([
   'oly_enc_id',
 ]);
 
+// Short parameter names are too ambiguous to strip everywhere. Substack uses
+// `r` exclusively as a reader/referral token on post URLs, while another site
+// may use the same name to select real content.
+function isHostTrackingParam(hostname: string, key: string): boolean {
+  return key === 'r' && (hostname === 'substack.com' || hostname.endsWith('.substack.com'));
+}
+
 /**
  * Canonicalize an article URL for mention matching. Returns `null` for inputs
  * that aren't http(s) URLs (skip them — no mentions to look up).
@@ -78,7 +85,8 @@ export function normalizeArticleUrl(input: string): string | null {
   // Strip tracking params, keep + sort the rest so equivalent URLs key the same.
   const kept: Array<[string, string]> = [];
   for (const [key, value] of url.searchParams) {
-    if (TRACKING_PARAMS.has(key.toLowerCase())) continue;
+    const lowerKey = key.toLowerCase();
+    if (TRACKING_PARAMS.has(lowerKey) || isHostTrackingParam(url.hostname, lowerKey)) continue;
     kept.push([key, value]);
   }
   kept.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
@@ -105,18 +113,35 @@ export function normalizeArticleUrl(input: string): string | null {
  * (a person who linked both forms is still one person), keeping the no-slash form
  * as the canonical cache key.
  *
- * Returns 1 target for the bare root (already its only sensible form), else 2.
+ * Returns the normalized slash variants plus, when supplied, the exact raw
+ * spelling and its slash variant for legacy records written before callers
+ * canonicalized their targets.
  */
-export function constellationTargets(normUrl: string): string[] {
-  let url: URL;
-  try {
-    url = new URL(normUrl);
-  } catch {
-    return [normUrl];
+export function constellationTargets(normUrl: string, rawUrl?: string): string[] {
+  const targets = new Set<string>();
+
+  const addSlashVariants = (input: string) => {
+    targets.add(input);
+    let url: URL;
+    try {
+      url = new URL(input);
+    } catch {
+      return;
+    }
+    if (url.pathname === '/') return;
+    url.pathname = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : `${url.pathname}/`;
+    targets.add(url.toString());
+  };
+
+  addSlashVariants(normUrl);
+
+  // Records written before callers canonicalized their target may still carry
+  // the exact tracked URL. Probe that spelling too when the request has it; the
+  // normalized forms remain first so current records take the cheap path.
+  const raw = rawUrl?.trim();
+  if (raw && raw !== normUrl && normalizeArticleUrl(raw) === normUrl) {
+    addSlashVariants(raw);
   }
-  if (url.pathname === '/') return [normUrl];
-  // normUrl is already slash-trimmed, so appending one always yields a distinct
-  // variant (the query string, if any, stays after the path).
-  url.pathname = `${url.pathname}/`;
-  return [normUrl, url.toString()];
+
+  return [...targets];
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -375,10 +375,12 @@ section.footnotes {
 /* Inline note marker — a small comment glyph appended after a highlight that
    carries a note. Injected as raw DOM into the reader body (in both the saved
    reader and the article card), so it's styled globally here rather than in a
-   single component's scope. Tinted into the highlight gold (a darker, legible
-   shade of the same hue) so it reads as part of the highlight; sized in `em` so
-   it scales with the reader's chosen article size. */
-.highlight-note-marker {
+   single component's scope. Sized in `em` so it scales with the reader's chosen
+   article size. Your own notes are tinted into the highlight gold; a community
+   note takes the same slate as its dotted underline, so the two read as the
+   same affordance without claiming to be yours. */
+.highlight-note-marker,
+.community-note-marker {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -392,7 +394,6 @@ section.footnotes {
   border: none;
   background: none;
   border-radius: 50%;
-  color: #9a7700;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition:
@@ -401,9 +402,18 @@ section.footnotes {
     transform 0.1s ease;
 }
 
-.highlight-note-marker svg {
+.highlight-note-marker svg,
+.community-note-marker svg {
   width: 100%;
   height: 100%;
+}
+
+.highlight-note-marker {
+  color: #9a7700;
+}
+
+.community-note-marker {
+  color: #7a8694;
 }
 
 .highlight-note-marker:hover {
@@ -411,25 +421,33 @@ section.footnotes {
   color: #6e5500;
 }
 
-.highlight-note-marker:active {
+.community-note-marker:hover {
+  background-color: color-mix(in srgb, #7a8694 18%, transparent);
+  color: #55606d;
+}
+
+.highlight-note-marker:active,
+.community-note-marker:active {
   transform: scale(0.9);
 }
 
-.highlight-note-marker:focus-visible {
+.highlight-note-marker:focus-visible,
+.community-note-marker:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--color-primary);
 }
 
 /* Grow the tap area on touch (no hover peek there). */
 @media (pointer: coarse) {
-  .highlight-note-marker {
+  .highlight-note-marker,
+  .community-note-marker {
     width: 1.2em;
     height: 1.2em;
     top: 0.12em;
   }
 }
 
-/* Lift the marker into a lighter gold so the stroke reads on the dark body. */
+/* Lift the markers so their strokes read on the dark body. */
 @media (prefers-color-scheme: dark) {
   .highlight-note-marker {
     color: #e3b94a;
@@ -438,14 +456,24 @@ section.footnotes {
   .highlight-note-marker:hover {
     color: #f0cf6b;
   }
+
+  .community-note-marker {
+    color: #9aa6b4;
+  }
+
+  .community-note-marker:hover {
+    color: #b7c2ce;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .highlight-note-marker {
+  .highlight-note-marker,
+  .community-note-marker {
     transition: none;
   }
 
-  .highlight-note-marker:active {
+  .highlight-note-marker:active,
+  .community-note-marker:active {
     transform: none;
   }
 }

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -1011,6 +1011,7 @@
     <HighlightPopover
       mode={highlights.popoverState.mode}
       anchorRect={highlights.popoverState.anchorRect}
+      getAnchorRect={highlights.popoverAnchorRect}
       onHighlight={highlights.createHighlightFromPopover}
       onHighlightToMargin={highlights.createHighlightFromPopoverToMargin}
       onRemove={highlights.removeHighlightFromPopover}

--- a/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
+++ b/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
@@ -6,14 +6,17 @@
   let {
     group,
     anchorRect,
+    itemUrl,
     capped = false,
     onClose,
   }: {
     group: CommunityHighlightGroup;
     anchorRect: DOMRect;
+    itemUrl: string;
     capped?: boolean;
     onClose: () => void;
   } = $props();
+  let marginUrl = $derived(`https://margin.at/url/${encodeURIComponent(itemUrl)}`);
   let el: HTMLDivElement;
   function outside(event: Event) {
     if (!el?.contains(event.target as Node)) onClose();
@@ -34,10 +37,12 @@
   });
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
 <div
   class="community-popover"
   bind:this={el}
   role="dialog"
+  tabindex="-1"
   aria-label="Community highlight"
   onclick={(e) => e.stopPropagation()}
 >
@@ -55,8 +60,14 @@
       </div>
     </div>
   {/each}
-  <div class="source">On margin.at</div>
-  {#if capped}<div class="source">More highlights may be available.</div>{/if}
+  <a
+    class="source"
+    href={marginUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="View highlights for this article on margin.at">View on margin.at ↗</a
+  >
+  {#if capped}<div class="source-note">More highlights may be available.</div>{/if}
 </div>
 
 <style>
@@ -104,7 +115,17 @@
     overflow-wrap: anywhere;
   }
   .source {
+    display: inline-block;
     margin-top: 0.65rem;
+    color: var(--color-primary, #0066cc);
+    font-size: 0.75rem;
+    text-decoration: none;
+  }
+  .source:hover {
+    text-decoration: underline;
+  }
+  .source-note {
+    margin-top: 0.35rem;
     color: var(--text-muted, #717171);
     font-size: 0.75rem;
   }

--- a/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
+++ b/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { positionFloating } from '$lib/utils/floating';
+  import type { CommunityHighlightGroup } from '$lib/stores/communityHighlights.svelte';
+
+  let {
+    group,
+    anchorRect,
+    capped = false,
+    onClose,
+  }: {
+    group: CommunityHighlightGroup;
+    anchorRect: DOMRect;
+    capped?: boolean;
+    onClose: () => void;
+  } = $props();
+  let el: HTMLDivElement;
+  function outside(event: Event) {
+    if (!el?.contains(event.target as Node)) onClose();
+  }
+  function keydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') onClose();
+  }
+  onMount(() => {
+    document.addEventListener('mousedown', outside, true);
+    document.addEventListener('touchstart', outside, true);
+    document.addEventListener('keydown', keydown, true);
+    requestAnimationFrame(() => positionFloating(anchorRect, el, { gap: 6, align: 'center' }));
+  });
+  onDestroy(() => {
+    document.removeEventListener('mousedown', outside, true);
+    document.removeEventListener('touchstart', outside, true);
+    document.removeEventListener('keydown', keydown, true);
+  });
+</script>
+
+<div
+  class="community-popover"
+  bind:this={el}
+  role="dialog"
+  aria-label="Community highlight"
+  onclick={(e) => e.stopPropagation()}
+>
+  {#each group.people as person}
+    <div class="person">
+      {#if person.avatar}<img src={person.avatar} alt="" />{/if}
+      <div>
+        <strong>{person.displayName || person.handle || 'A reader'}</strong>
+        <span class="meta">
+          {person.motivation === 'commenting' ? ' commented' : ' highlighted'}{person.createdAt
+            ? ` · ${new Date(person.createdAt).toLocaleDateString()}`
+            : ''}
+        </span>
+        {#if person.note}<p>{person.note}</p>{/if}
+      </div>
+    </div>
+  {/each}
+  <div class="source">On margin.at</div>
+  {#if capped}<div class="source">More highlights may be available.</div>{/if}
+</div>
+
+<style>
+  .community-popover {
+    position: fixed;
+    z-index: 210;
+    width: min(19rem, calc(100vw - 2rem));
+    max-height: min(22rem, 60vh);
+    overflow: auto;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color, #d7d7d7);
+    border-radius: 0.5rem;
+    background: var(--surface-color, #fff);
+    color: var(--text-color, #222);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.14);
+  }
+  .person {
+    display: flex;
+    gap: 0.55rem;
+  }
+  .person + .person {
+    margin-top: 0.7rem;
+    padding-top: 0.7rem;
+    border-top: 1px solid var(--border-color, #e5e5e5);
+  }
+  img {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+  strong {
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+  .meta {
+    color: var(--text-muted, #717171);
+    font-size: 0.72rem;
+  }
+  p {
+    margin: 0.2rem 0 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  .source {
+    margin-top: 0.65rem;
+    color: var(--text-muted, #717171);
+    font-size: 0.75rem;
+  }
+</style>

--- a/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
+++ b/frontend/src/lib/components/feed/CommunityHighlightPopover.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { positionFloating } from '$lib/utils/floating';
+  import { followAnchor, positionFloating } from '$lib/utils/floating';
   import type { CommunityHighlightGroup } from '$lib/stores/communityHighlights.svelte';
 
   let {
     group,
     anchorRect,
+    getAnchorRect,
     itemUrl,
     capped = false,
     onClose,
   }: {
     group: CommunityHighlightGroup;
     anchorRect: DOMRect;
+    /**
+     * Live position of the highlight this popover belongs to. Supplied so the
+     * popover tracks the passage as the reader scrolls instead of hanging at the
+     * viewport spot it opened in; it closes once the passage scrolls away.
+     */
+    getAnchorRect?: () => DOMRect | null;
     itemUrl: string;
     capped?: boolean;
     onClose: () => void;
@@ -24,13 +31,21 @@
   function keydown(event: KeyboardEvent) {
     if (event.key === 'Escape') onClose();
   }
+  let stopFollowing: (() => void) | undefined;
   onMount(() => {
     document.addEventListener('mousedown', outside, true);
     document.addEventListener('touchstart', outside, true);
     document.addEventListener('keydown', keydown, true);
     requestAnimationFrame(() => positionFloating(anchorRect, el, { gap: 6, align: 'center' }));
+    if (getAnchorRect)
+      stopFollowing = followAnchor(() => el, getAnchorRect, {
+        gap: 6,
+        align: 'center',
+        onLost: onClose,
+      });
   });
   onDestroy(() => {
+    stopFollowing?.();
     document.removeEventListener('mousedown', outside, true);
     document.removeEventListener('touchstart', outside, true);
     document.removeEventListener('keydown', keydown, true);

--- a/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
+++ b/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
@@ -252,6 +252,7 @@
   <HighlightPopover
     mode={highlightsHook.popoverState.mode}
     anchorRect={highlightsHook.popoverState.anchorRect}
+    getAnchorRect={highlightsHook.popoverAnchorRect}
     onHighlight={highlightsHook.createHighlightFromPopover}
     onHighlightToMargin={highlightsHook.createHighlightFromPopoverToMargin}
     onRemove={highlightsHook.removeHighlightFromPopover}

--- a/frontend/src/lib/components/feed/HighlightPopover.svelte
+++ b/frontend/src/lib/components/feed/HighlightPopover.svelte
@@ -2,11 +2,19 @@
   import { onMount, onDestroy, tick, untrack } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { tooltip } from '$lib/actions/tooltip';
-  import { positionFloating } from '$lib/utils/floating';
+  import { followAnchor, positionFloating } from '$lib/utils/floating';
 
   interface Props {
     mode: 'create' | 'remove' | 'view';
     anchorRect: DOMRect;
+    /**
+     * Live position of the passage this popover belongs to. Supplied by callers
+     * whose anchor stays on screen (the reader body), so the popover tracks the
+     * text as it scrolls instead of hanging at the viewport spot it opened in.
+     * Without it the popover keeps the older behavior: closes once the reader
+     * scrolls.
+     */
+    getAnchorRect?: () => DOMRect | null;
     onHighlight?: (note?: string) => void;
     onHighlightToMargin?: (note?: string) => void;
     onRemove?: () => void;
@@ -27,6 +35,7 @@
   let {
     mode,
     anchorRect,
+    getAnchorRect,
     onHighlight,
     onHighlightToMargin,
     onRemove,
@@ -48,15 +57,21 @@
   let noteText = $state(untrack(() => (initialView === 'note' ? (existingNote ?? '') : '')));
   let scrollArmed = false;
   let scrollArmTimer: ReturnType<typeof setTimeout> | undefined;
+  let stopFollowing: (() => void) | undefined;
 
   function handleScroll() {
     // Don't dismiss while the user is editing a note (e.g. mobile keyboard scroll).
     if (scrollArmed && view === 'toolbar') onClose();
   }
 
+  /** The passage's current position, falling back to where it was at open. */
+  function currentAnchorRect(): DOMRect {
+    return getAnchorRect?.() ?? anchorRect;
+  }
+
   function positionMenu() {
     if (!menuEl) return;
-    positionFloating(anchorRect, menuEl, { gap: 4, align: 'center' });
+    positionFloating(currentAnchorRect(), menuEl, { gap: 4, align: 'center' });
   }
 
   // The on-screen keyboard (raised by focusing the note editor) shrinks the
@@ -95,7 +110,19 @@
     document.addEventListener('keydown', handleKeydown, true);
     document.addEventListener('mousedown', handleClickOutside, true);
     document.addEventListener('touchstart', handleClickOutside, true);
-    document.addEventListener('scroll', handleScroll, true);
+    // Tracking the anchor replaces scroll-to-close: the popover stays on its
+    // passage, and only leaves when the passage itself scrolls out of view.
+    if (getAnchorRect) {
+      stopFollowing = followAnchor(() => menuEl, getAnchorRect, {
+        gap: 4,
+        align: 'center',
+        onLost: () => {
+          if (view === 'toolbar') onClose();
+        },
+      });
+    } else {
+      document.addEventListener('scroll', handleScroll, true);
+    }
     window.visualViewport?.addEventListener('resize', handleViewportChange);
     window.visualViewport?.addEventListener('scroll', handleViewportChange);
     requestAnimationFrame(positionMenu);
@@ -117,6 +144,7 @@
 
   onDestroy(() => {
     clearTimeout(scrollArmTimer);
+    stopFollowing?.();
     document.removeEventListener('keydown', handleKeydown, true);
     document.removeEventListener('mousedown', handleClickOutside, true);
     document.removeEventListener('touchstart', handleClickOutside, true);

--- a/frontend/src/lib/components/feed/ReaderBottomBar.svelte
+++ b/frontend/src/lib/components/feed/ReaderBottomBar.svelte
@@ -34,6 +34,11 @@
     isSaved = false,
     onShare,
     shareActive = false,
+    onCommunity,
+    communityCount,
+    communityCapped = false,
+    communityActive = false,
+    communityButtonEl = $bindable(null),
     onTag,
     tagCount = 0,
     tagActive = false,
@@ -56,6 +61,13 @@
     onShare?: () => void;
     /** The item is already shared to the linkblog. */
     shareActive?: boolean;
+    /** Toggle passages highlighted by other readers on Margin. */
+    onCommunity?: () => void;
+    /** Number of fetched community highlights; undefined while loading. */
+    communityCount?: number;
+    communityCapped?: boolean;
+    communityActive?: boolean;
+    communityButtonEl?: HTMLButtonElement | null;
     onTag?: () => void;
     tagCount?: number;
     tagActive?: boolean;
@@ -131,6 +143,25 @@
         title={shareActive ? 'Shared — edit your note' : 'Share to your linkblog'}
       >
         <Icon name="share" size={20} />
+      </button>
+    {/if}
+
+    {#if onCommunity}
+      <button
+        class="bar-btn"
+        class:active={communityActive}
+        bind:this={communityButtonEl}
+        onclick={onCommunity}
+        aria-pressed={communityActive}
+        aria-label={communityCount === undefined
+          ? 'Community highlights'
+          : `${communityCount}${communityCapped ? ' or more' : ''} community highlight${communityCount === 1 ? '' : 's'}`}
+        title="Passages highlighted by readers on margin.at"
+      >
+        <Icon name="users" size={20} />
+        {#if communityCount !== undefined}
+          <span class="bar-btn-count">{communityCount}{communityCapped ? '+' : ''}</span>
+        {/if}
       </button>
     {/if}
 

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -1219,6 +1219,7 @@
   <HighlightPopover
     mode={highlightsHook.popoverState.mode}
     anchorRect={highlightsHook.popoverState.anchorRect}
+    getAnchorRect={highlightsHook.popoverAnchorRect}
     onHighlight={highlightsHook.createHighlightFromPopover}
     onHighlightToMargin={highlightsHook.createHighlightFromPopoverToMargin}
     onRemove={highlightsHook.removeHighlightFromPopover}
@@ -1235,6 +1236,7 @@
   <CommunityHighlightPopover
     group={communityHighlightsHook.popoverState.group}
     anchorRect={communityHighlightsHook.popoverState.anchorRect}
+    getAnchorRect={communityHighlightsHook.popoverAnchorRect}
     {itemUrl}
     capped={communityHighlightsHook.capped}
     onClose={communityHighlightsHook.closePopover}

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -39,6 +39,7 @@
   import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
   import { shareTargetForDisplayItem } from '$lib/utils/shareTarget';
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
+  import CommunityHighlightPopover from '$lib/components/feed/CommunityHighlightPopover.svelte';
   import NotePeek from '$lib/components/feed/NotePeek.svelte';
   import CollectionMagazine from '$lib/components/feed/CollectionMagazine.svelte';
   import PagedView, { type PagedController } from '$lib/components/feed/PagedView.svelte';
@@ -877,7 +878,11 @@
           <button
             class="action-btn"
             class:active={preferences.communityHighlights}
-            onclick={() => preferences.setCommunityHighlights(!preferences.communityHighlights)}
+            aria-pressed={preferences.communityHighlights}
+            onclick={() => {
+              if (!preferences.communityHighlights) communityHighlightsHook.retry();
+              preferences.setCommunityHighlights(!preferences.communityHighlights);
+            }}
             title="Passages highlighted by readers on margin.at"
           >
             <Icon name="users" size={16} />
@@ -1203,6 +1208,15 @@
     existingNote={highlightsHook.popoverHighlightNote}
     marginSaved={highlightsHook.popoverHighlightSavedToMargin}
     onClose={highlightsHook.closePopover}
+  />
+{/if}
+
+{#if communityHighlightsHook.popoverState}
+  <CommunityHighlightPopover
+    group={communityHighlightsHook.popoverState.group}
+    anchorRect={communityHighlightsHook.popoverState.anchorRect}
+    capped={communityHighlightsHook.capped}
+    onClose={communityHighlightsHook.closePopover}
   />
 {/if}
 

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -80,11 +80,15 @@
   let tagMenuOpen = $state(false);
   let overflowMenuOpen = $state(false);
   let overflowRef = $state<HTMLDivElement | null>(null);
-  // Two anchors, one per breakpoint: the desktop header button and the mobile
-  // bar's. Both exist in the DOM at once (the breakpoint hides one with CSS), so
-  // sharing a single ref would anchor the tag menu to a zero-size element.
+  // The mobile Tag popover normally anchors to its bottom-bar button. Saved
+  // articles use that slot for Community instead, so Tag (reached from the
+  // actions sheet) anchors to that stable slot after the sheet closes.
   let tagBtnRef = $state<HTMLButtonElement | null>(null);
   let mobileTagBtnRef = $state<HTMLButtonElement | null>(null);
+  let mobileCommunityBtnRef = $state<HTMLButtonElement | null>(null);
+  let mobileTagAnchorRef = $derived(
+    readerItem.type === 'saved' ? mobileCommunityBtnRef : mobileTagBtnRef
+  );
   let controlsVisible = $state(true);
   // Desktop header hides on scroll-down, but stays put while a header-anchored
   // menu (Style/Tag/overflow ⋯) is open so its popover doesn't slide off-screen.
@@ -729,7 +733,13 @@
     contentEl: () => readerBodyEl,
     itemUrl: () => itemUrl,
     enabled: () => readerItem.type === 'saved' && preferences.communityHighlights,
+    load: () => readerItem.type === 'saved',
   });
+
+  function toggleCommunityHighlights() {
+    if (!preferences.communityHighlights) communityHighlightsHook.retry();
+    preferences.setCommunityHighlights(!preferences.communityHighlights);
+  }
 
   // Set up observer when the reader body is mounted — and re-run it whenever the
   // rendered content changes. Saved/article bodies load lazily (see the lazy*
@@ -879,14 +889,19 @@
             class="action-btn"
             class:active={preferences.communityHighlights}
             aria-pressed={preferences.communityHighlights}
-            onclick={() => {
-              if (!preferences.communityHighlights) communityHighlightsHook.retry();
-              preferences.setCommunityHighlights(!preferences.communityHighlights);
-            }}
+            aria-label={communityHighlightsHook.count === undefined
+              ? 'Community highlights'
+              : `${communityHighlightsHook.count}${communityHighlightsHook.capped ? ' or more' : ''} community highlight${communityHighlightsHook.count === 1 ? '' : 's'}`}
+            onclick={toggleCommunityHighlights}
             title="Passages highlighted by readers on margin.at"
           >
             <Icon name="users" size={16} />
             <span class="action-label">Community</span>
+            {#if communityHighlightsHook.count !== undefined}
+              <span class="action-count">
+                ({communityHighlightsHook.count}{communityHighlightsHook.capped ? '+' : ''})
+              </span>
+            {/if}
           </button>
         {/if}
 
@@ -991,7 +1006,12 @@
     {isSaved}
     onShare={canShareLinkblog ? openShareComposer : undefined}
     shareActive={sharedNow}
-    onTag={() => (tagMenuOpen = !tagMenuOpen)}
+    onCommunity={readerItem.type === 'saved' ? toggleCommunityHighlights : undefined}
+    communityCount={communityHighlightsHook.count}
+    communityCapped={communityHighlightsHook.capped}
+    communityActive={preferences.communityHighlights}
+    bind:communityButtonEl={mobileCommunityBtnRef}
+    onTag={readerItem.type !== 'saved' ? () => (tagMenuOpen = !tagMenuOpen) : undefined}
     tagCount={itemTags.length}
     tagActive={tagMenuOpen}
     bind:tagButtonEl={mobileTagBtnRef}
@@ -1101,7 +1121,7 @@
         <TagMenu
           {itemKey}
           itemType={labelItemType}
-          anchorEl={mobileTagBtnRef}
+          anchorEl={mobileTagAnchorRef}
           onClose={() => (tagMenuOpen = false)}
         />
       {/if}
@@ -1215,6 +1235,7 @@
   <CommunityHighlightPopover
     group={communityHighlightsHook.popoverState.group}
     anchorRect={communityHighlightsHook.popoverState.anchorRect}
+    {itemUrl}
     capped={communityHighlightsHook.capped}
     onClose={communityHighlightsHook.closePopover}
   />
@@ -1522,6 +1543,11 @@
     font-weight: var(--weight-medium);
   }
 
+  .action-count {
+    font-size: var(--text-sm);
+    font-variant-numeric: tabular-nums;
+  }
+
   .action-btn:hover:not(.active) {
     color: var(--color-text);
   }
@@ -1775,7 +1801,7 @@
     background: transparent;
     text-decoration: underline dotted #7a8694 1.5px;
     text-underline-offset: 0.18em;
-    cursor: help;
+    cursor: pointer;
   }
 
   :global([data-theme='dark']) .reader-body :global(mark.community-highlight) {

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -32,6 +32,7 @@
   import { useParagraphTracking } from '$lib/hooks/useParagraphTracking.svelte';
   import { useLinkInterception } from '$lib/hooks/useLinkInterception.svelte';
   import { useHighlights } from '$lib/hooks/useHighlights.svelte';
+  import { useCommunityHighlights } from '$lib/hooks/useCommunityHighlights.svelte';
   import { auth } from '$lib/stores/auth.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { shareComposerStore } from '$lib/stores/shareComposer.svelte';
@@ -723,6 +724,11 @@
     itemUrl: () => itemUrl,
     itemTitle: () => title,
   });
+  const communityHighlightsHook = useCommunityHighlights({
+    contentEl: () => readerBodyEl,
+    itemUrl: () => itemUrl,
+    enabled: () => readerItem.type === 'saved' && preferences.communityHighlights,
+  });
 
   // Set up observer when the reader body is mounted — and re-run it whenever the
   // rendered content changes. Saved/article bodies load lazily (see the lazy*
@@ -740,6 +746,7 @@
         paragraphTracking.setupObserver();
         linkInterception.attach();
         highlightsHook.attach();
+        communityHighlightsHook.attach();
         // The scroll-driven progress bar + paragraph position restore only apply
         // to scroll mode; paged mode handles its own page restore (see above).
         if (paged) return;
@@ -771,6 +778,7 @@
       paragraphTracking.cleanup();
       linkInterception.detach();
       highlightsHook.detach();
+      communityHighlightsHook.detach();
     };
   });
 
@@ -864,6 +872,18 @@
         </button>
 
         <span class="action-separator"></span>
+
+        {#if readerItem.type === 'saved'}
+          <button
+            class="action-btn"
+            class:active={preferences.communityHighlights}
+            onclick={() => preferences.setCommunityHighlights(!preferences.communityHighlights)}
+            title="Passages highlighted by readers on margin.at"
+          >
+            <Icon name="users" size={16} />
+            <span class="action-label">Community</span>
+          </button>
+        {/if}
 
         {#if canShareLinkblog}
           <button
@@ -1734,6 +1754,18 @@
 
   .reader-body :global(mark.highlight:hover) {
     background-color: color-mix(in srgb, #f5c518 40%, transparent);
+  }
+
+  .reader-body :global(mark.community-highlight) {
+    color: inherit;
+    background: transparent;
+    text-decoration: underline dotted #7a8694 1.5px;
+    text-underline-offset: 0.18em;
+    cursor: help;
+  }
+
+  :global([data-theme='dark']) .reader-body :global(mark.community-highlight) {
+    text-decoration-color: #9aa6b2;
   }
 
   /* Leaflet footnote styling is shared by every surface that renders leaflet

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -1,0 +1,63 @@
+import { communityHighlightsStore } from '$lib/stores/communityHighlights.svelte';
+import { findAllInDOM } from '$lib/utils/textSelector';
+
+export function useCommunityHighlights(params: {
+  contentEl: () => HTMLElement | undefined;
+  itemUrl: () => string;
+  enabled: () => boolean;
+}) {
+  let marks: HTMLElement[] = [];
+  $effect(() => {
+    const url = params.itemUrl();
+    const enabled = params.enabled();
+    const state = communityHighlightsStore.get(url);
+    if (enabled && url && !state) communityHighlightsStore.load(url);
+    // Reading groups here makes the decoration react when the lazy request
+    // settles. Defer until Svelte has committed the current article body.
+    void state?.groups;
+    queueMicrotask(apply);
+  });
+  function clear() {
+    for (const mark of marks) mark.replaceWith(...Array.from(mark.childNodes));
+    marks = [];
+    params.contentEl()?.normalize();
+  }
+  function apply() {
+    clear();
+    const el = params.contentEl();
+    const url = params.itemUrl();
+    if (!el || !url || !params.enabled()) return;
+    communityHighlightsStore.load(url);
+    const groups = communityHighlightsStore.get(url)?.groups ?? [];
+    const ranges = findAllInDOM(
+      groups.map((g) => g.selector),
+      el
+    );
+    for (let i = ranges.length - 1; i >= 0; i--) {
+      const range = ranges[i];
+      if (!range) continue;
+      const mark = document.createElement('mark');
+      mark.className = 'community-highlight';
+      mark.dataset.communityId = groups[i].id;
+      const names = groups[i].people.map((p) => p.displayName || p.handle || 'A reader');
+      mark.title = `${names.join(', ')} on margin.at`;
+      try {
+        if (range.startContainer === range.endContainer) range.surroundContents(mark);
+        else {
+          mark.appendChild(range.extractContents());
+          range.insertNode(mark);
+        }
+        marks.push(mark);
+      } catch {
+        /* adornment only */
+      }
+    }
+  }
+  function attach() {
+    apply();
+  }
+  function detach() {
+    clear();
+  }
+  return { attach, detach, apply };
+}

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -6,19 +6,27 @@ import type { CommunityHighlightGroup } from '$lib/stores/communityHighlights.sv
 export function useCommunityHighlights(params: {
   contentEl: () => HTMLElement | undefined;
   itemUrl: () => string;
+  /** Whether community marks should be drawn in the article. */
   enabled: () => boolean;
+  /**
+   * Whether to fetch the Margin highlights. This can stay true while drawing is
+   * off so the toolbar can show how many highlights are available before the
+   * reader turns them on.
+   */
+  load?: () => boolean;
 }) {
   let marks: HTMLElement[] = [];
   let popoverState = $state<{ group: CommunityHighlightGroup; anchorRect: DOMRect } | null>(null);
-  let wasEnabled = false;
+  let wasLoadEnabled = false;
   $effect(() => {
     const url = params.itemUrl();
     const enabled = params.enabled();
+    const shouldLoad = params.load?.() ?? enabled;
     const state = communityHighlightsStore.get(url);
-    if (enabled && url && (!state || (!wasEnabled && state.failed))) {
+    if (shouldLoad && url && (!state || (!wasLoadEnabled && state.failed))) {
       communityHighlightsStore.load(url, { force: state?.failed });
     }
-    wasEnabled = enabled;
+    wasLoadEnabled = shouldLoad;
     // Reading groups here makes the decoration react when the lazy request
     // settles. Defer until Svelte has committed the current article body.
     void state?.groups;
@@ -94,6 +102,11 @@ export function useCommunityHighlights(params: {
     },
     get capped() {
       return communityHighlightsStore.get(params.itemUrl())?.capped ?? false;
+    },
+    get count(): number | undefined {
+      const state = communityHighlightsStore.get(params.itemUrl());
+      if (!state?.loaded) return undefined;
+      return state.groups.reduce((total, group) => total + group.people.length, 0);
     },
     closePopover: () => (popoverState = null),
     retry: () => communityHighlightsStore.load(params.itemUrl(), { force: true }),

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -3,6 +3,12 @@ import { findAllInDOM } from '$lib/utils/textSelector';
 import { wrapTextRange } from '$lib/utils/wrapTextRange';
 import type { CommunityHighlightGroup } from '$lib/stores/communityHighlights.svelte';
 
+// The same comment glyph the private highlights use (Lucide message-circle), so
+// a passage someone wrote a note on reads the same way whoever made it. The
+// tint that tells the two apart lives in `.community-note-marker` (app.css).
+const NOTE_MARKER_SVG =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>';
+
 export function useCommunityHighlights(params: {
   contentEl: () => HTMLElement | undefined;
   itemUrl: () => string;
@@ -16,7 +22,12 @@ export function useCommunityHighlights(params: {
   load?: () => boolean;
 }) {
   let marks: HTMLElement[] = [];
-  let popoverState = $state<{ group: CommunityHighlightGroup; anchorRect: DOMRect } | null>(null);
+  let noteMarkers: HTMLElement[] = [];
+  let popoverState = $state<{
+    group: CommunityHighlightGroup;
+    anchorRect: DOMRect;
+    anchorEl: HTMLElement;
+  } | null>(null);
   let wasLoadEnabled = false;
   $effect(() => {
     const url = params.itemUrl();
@@ -33,24 +44,35 @@ export function useCommunityHighlights(params: {
     queueMicrotask(apply);
   });
   function clear() {
+    // Note markers first, so the normalize() below can merge the text nodes they
+    // were sitting between.
+    for (const marker of noteMarkers) marker.remove();
+    noteMarkers = [];
     for (const mark of marks) mark.replaceWith(...Array.from(mark.childNodes));
     marks = [];
     params.contentEl()?.normalize();
   }
   function handleClick(event: MouseEvent) {
     if (window.getSelection()?.toString()) return;
-    const mark = (event.target as HTMLElement).closest<HTMLElement>('mark.community-highlight');
-    if (!mark) return;
+    // The note marker sits beside its mark rather than inside it, so it carries
+    // the same group id and opens the same popover.
+    const anchor = (event.target as HTMLElement).closest<HTMLElement>(
+      'mark.community-highlight, .community-note-marker'
+    );
+    if (!anchor) return;
     const group = communityHighlightsStore
       .get(params.itemUrl())
-      ?.groups.find((item) => item.id === mark.dataset.communityId);
+      ?.groups.find((item) => item.id === anchor.dataset.communityId);
     if (!group) return;
     event.preventDefault();
     event.stopPropagation();
-    popoverState = { group, anchorRect: mark.getBoundingClientRect() };
+    popoverState = { group, anchorRect: anchor.getBoundingClientRect(), anchorEl: anchor };
   }
   function handleKeydown(event: KeyboardEvent) {
     if (event.key !== 'Enter' && event.key !== ' ') return;
+    // The marker is a real <button>: let it fire its own click rather than
+    // opening the popover twice.
+    if ((event.target as HTMLElement).closest('.community-note-marker')) return;
     handleClick(event as unknown as MouseEvent);
   }
   function apply() {
@@ -68,19 +90,39 @@ export function useCommunityHighlights(params: {
       const range = ranges[i];
       if (!range) continue;
       const names = groups[i].people.map((p) => p.displayName || p.handle || 'A reader');
-      marks.push(
-        ...wrapTextRange(range, el, () => {
-          const mark = document.createElement('mark');
-          mark.className = 'community-highlight';
-          mark.dataset.communityId = groups[i].id;
-          mark.title = `${names.join(', ')} on margin.at`;
-          mark.tabIndex = 0;
-          mark.setAttribute('role', 'button');
-          mark.setAttribute('aria-label', `Community highlight by ${names.join(', ')}`);
-          return mark;
-        })
-      );
+      const created = wrapTextRange(range, el, () => {
+        const mark = document.createElement('mark');
+        mark.className = 'community-highlight';
+        mark.dataset.communityId = groups[i].id;
+        mark.title = `${names.join(', ')} on margin.at`;
+        mark.tabIndex = 0;
+        mark.setAttribute('role', 'button');
+        mark.setAttribute('aria-label', `Community highlight by ${names.join(', ')}`);
+        return mark;
+      });
+      marks.push(...created);
+      // A passage someone wrote a note on gets the inline comment glyph, so it's
+      // legible as a note without opening the popover to find out.
+      const lastMark = created[created.length - 1];
+      if (lastMark && groups[i].people.some((person) => person.note))
+        insertNoteMarker(lastMark, groups[i], names);
     }
+  }
+  /** Append the comment glyph immediately after a group's final mark. */
+  function insertNoteMarker(
+    afterMark: HTMLElement,
+    group: CommunityHighlightGroup,
+    names: string[]
+  ) {
+    const marker = document.createElement('button');
+    marker.type = 'button';
+    marker.className = 'community-note-marker';
+    marker.dataset.communityId = group.id;
+    marker.title = `${names.join(', ')} on margin.at`;
+    marker.setAttribute('aria-label', `Show note by ${names.join(', ')}`);
+    marker.innerHTML = NOTE_MARKER_SVG;
+    afterMark.after(marker);
+    noteMarkers.push(marker);
   }
   function attach() {
     params.contentEl()?.addEventListener('click', handleClick);
@@ -99,6 +141,24 @@ export function useCommunityHighlights(params: {
     apply,
     get popoverState() {
       return popoverState;
+    },
+    /**
+     * Where the open popover's mark sits *now*. Re-applying the decorations
+     * replaces the element the popover opened against, so fall back to the
+     * group's first surviving mark; `null` means the passage is gone and the
+     * popover has nothing left to point at.
+     */
+    popoverAnchorRect(): DOMRect | null {
+      const state = popoverState;
+      if (!state) return null;
+      const el = state.anchorEl.isConnected
+        ? state.anchorEl
+        : (params
+            .contentEl()
+            ?.querySelector<HTMLElement>(
+              `mark.community-highlight[data-community-id="${CSS.escape(state.group.id)}"]`
+            ) ?? null);
+      return el?.getBoundingClientRect() ?? null;
     },
     get capped() {
       return communityHighlightsStore.get(params.itemUrl())?.capped ?? false;

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -1,5 +1,7 @@
 import { communityHighlightsStore } from '$lib/stores/communityHighlights.svelte';
 import { findAllInDOM } from '$lib/utils/textSelector';
+import { wrapTextRange } from '$lib/utils/wrapTextRange';
+import type { CommunityHighlightGroup } from '$lib/stores/communityHighlights.svelte';
 
 export function useCommunityHighlights(params: {
   contentEl: () => HTMLElement | undefined;
@@ -7,11 +9,16 @@ export function useCommunityHighlights(params: {
   enabled: () => boolean;
 }) {
   let marks: HTMLElement[] = [];
+  let popoverState = $state<{ group: CommunityHighlightGroup; anchorRect: DOMRect } | null>(null);
+  let wasEnabled = false;
   $effect(() => {
     const url = params.itemUrl();
     const enabled = params.enabled();
     const state = communityHighlightsStore.get(url);
-    if (enabled && url && !state) communityHighlightsStore.load(url);
+    if (enabled && url && (!state || (!wasEnabled && state.failed))) {
+      communityHighlightsStore.load(url, { force: state?.failed });
+    }
+    wasEnabled = enabled;
     // Reading groups here makes the decoration react when the lazy request
     // settles. Defer until Svelte has committed the current article body.
     void state?.groups;
@@ -21,6 +28,22 @@ export function useCommunityHighlights(params: {
     for (const mark of marks) mark.replaceWith(...Array.from(mark.childNodes));
     marks = [];
     params.contentEl()?.normalize();
+  }
+  function handleClick(event: MouseEvent) {
+    if (window.getSelection()?.toString()) return;
+    const mark = (event.target as HTMLElement).closest<HTMLElement>('mark.community-highlight');
+    if (!mark) return;
+    const group = communityHighlightsStore
+      .get(params.itemUrl())
+      ?.groups.find((item) => item.id === mark.dataset.communityId);
+    if (!group) return;
+    event.preventDefault();
+    event.stopPropagation();
+    popoverState = { group, anchorRect: mark.getBoundingClientRect() };
+  }
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    handleClick(event as unknown as MouseEvent);
   }
   function apply() {
     clear();
@@ -36,28 +59,43 @@ export function useCommunityHighlights(params: {
     for (let i = ranges.length - 1; i >= 0; i--) {
       const range = ranges[i];
       if (!range) continue;
-      const mark = document.createElement('mark');
-      mark.className = 'community-highlight';
-      mark.dataset.communityId = groups[i].id;
       const names = groups[i].people.map((p) => p.displayName || p.handle || 'A reader');
-      mark.title = `${names.join(', ')} on margin.at`;
-      try {
-        if (range.startContainer === range.endContainer) range.surroundContents(mark);
-        else {
-          mark.appendChild(range.extractContents());
-          range.insertNode(mark);
-        }
-        marks.push(mark);
-      } catch {
-        /* adornment only */
-      }
+      marks.push(
+        ...wrapTextRange(range, el, () => {
+          const mark = document.createElement('mark');
+          mark.className = 'community-highlight';
+          mark.dataset.communityId = groups[i].id;
+          mark.title = `${names.join(', ')} on margin.at`;
+          mark.tabIndex = 0;
+          mark.setAttribute('role', 'button');
+          mark.setAttribute('aria-label', `Community highlight by ${names.join(', ')}`);
+          return mark;
+        })
+      );
     }
   }
   function attach() {
+    params.contentEl()?.addEventListener('click', handleClick);
+    params.contentEl()?.addEventListener('keydown', handleKeydown);
     apply();
   }
   function detach() {
+    params.contentEl()?.removeEventListener('click', handleClick);
+    params.contentEl()?.removeEventListener('keydown', handleKeydown);
+    popoverState = null;
     clear();
   }
-  return { attach, detach, apply };
+  return {
+    attach,
+    detach,
+    apply,
+    get popoverState() {
+      return popoverState;
+    },
+    get capped() {
+      return communityHighlightsStore.get(params.itemUrl())?.capped ?? false;
+    },
+    closePopover: () => (popoverState = null),
+    retry: () => communityHighlightsStore.load(params.itemUrl(), { force: true }),
+  };
 }

--- a/frontend/src/lib/hooks/useHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useHighlights.svelte.ts
@@ -7,6 +7,7 @@ import {
   updateHighlightNoteOnMargin,
 } from '$lib/services/marginHighlights';
 import type { ItemLabelType, Highlight, TextQuoteSelector } from '$lib/types';
+import { wrapTextRange } from '$lib/utils/wrapTextRange';
 
 const BLOCK_SELECTORS = 'p, h1, h2, h3, h4, h5, h6, blockquote, pre, figure, li';
 const INTERACTIVE_MEDIA_SELECTOR = 'video, audio, iframe, embed, object';
@@ -139,47 +140,16 @@ export function useHighlights(params: HighlightParams) {
   }
 
   function wrapRangeMultiNode(range: Range, highlightId: string) {
-    // Walk text nodes within the range and wrap each one
     const container = params.contentEl();
     if (!container) return;
-
-    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-    const textNodes: Text[] = [];
-    let node = walker.nextNode();
-    while (node) {
-      if (range.intersectsNode(node)) {
-        textNodes.push(node as Text);
-      }
-      node = walker.nextNode();
-    }
-
-    for (const textNode of textNodes) {
-      const nodeRange = document.createRange();
-
-      if (textNode === range.startContainer) {
-        nodeRange.setStart(textNode, range.startOffset);
-      } else {
-        nodeRange.setStart(textNode, 0);
-      }
-
-      if (textNode === range.endContainer) {
-        nodeRange.setEnd(textNode, range.endOffset);
-      } else {
-        nodeRange.setEnd(textNode, textNode.textContent?.length ?? 0);
-      }
-
-      if (nodeRange.toString().length === 0) continue;
-
-      const mark = document.createElement('mark');
-      mark.className = 'highlight';
-      mark.dataset.highlightId = highlightId;
-      try {
-        nodeRange.surroundContents(mark);
-        appliedMarks.push(mark);
-      } catch {
-        // Skip if we can't wrap this node
-      }
-    }
+    appliedMarks.push(
+      ...wrapTextRange(range, container, () => {
+        const mark = document.createElement('mark');
+        mark.className = 'highlight';
+        mark.dataset.highlightId = highlightId;
+        return mark;
+      })
+    );
   }
 
   function clearMarks() {

--- a/frontend/src/lib/hooks/useHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useHighlights.svelte.ts
@@ -58,6 +58,11 @@ export function useHighlights(params: HighlightParams) {
     anchorRect: DOMRect;
     pendingSelector?: TextQuoteSelector;
     highlightId?: string;
+    // Live anchors, so the popover can track what it points at while the reader
+    // scrolls: the mark/marker element for an existing highlight, or a cloned
+    // range for a selection (which outlives the selection being cleared).
+    anchorEl?: HTMLElement;
+    anchorRange?: Range;
   } | null>(null);
 
   // Desktop-only hover peek: a read-only preview of a note when the pointer
@@ -300,6 +305,7 @@ export function useHighlights(params: HighlightParams) {
         mode: 'create',
         anchorRect: rect,
         pendingSelector: selector,
+        anchorRange: range.cloneRange(),
       };
     }, 10);
   }
@@ -320,6 +326,7 @@ export function useHighlights(params: HighlightParams) {
         mode: 'view',
         anchorRect: marker.getBoundingClientRect(),
         highlightId,
+        anchorEl: marker,
       };
       return;
     }
@@ -338,6 +345,7 @@ export function useHighlights(params: HighlightParams) {
       mode: 'remove',
       anchorRect: rect,
       highlightId,
+      anchorEl: mark,
     };
   }
 
@@ -458,6 +466,33 @@ export function useHighlights(params: HighlightParams) {
     return !!hl?.marginUri;
   }
 
+  /**
+   * Where the open popover's anchor sits *now*. Re-applying the marks replaces
+   * the element the popover opened against, so fall back to whichever mark
+   * currently carries the highlight; `null` means the passage is gone from the
+   * body and the popover has nothing left to point at.
+   */
+  function popoverAnchorRect(): DOMRect | null {
+    const state = popoverState;
+    if (!state) return null;
+    if (state.anchorRange) {
+      const rect = state.anchorRange.getBoundingClientRect();
+      // A range whose nodes have been replaced measures as an empty rect.
+      return rect.width || rect.height ? rect : null;
+    }
+    const live =
+      state.anchorEl?.isConnected === true
+        ? state.anchorEl
+        : state.highlightId
+          ? (params
+              .contentEl()
+              ?.querySelector<HTMLElement>(
+                `mark.highlight[data-highlight-id="${CSS.escape(state.highlightId)}"]`
+              ) ?? null)
+          : null;
+    return live?.getBoundingClientRect() ?? null;
+  }
+
   /** The current note on the highlight targeted by the popover (for prefill). */
   function popoverHighlightNote(): string {
     if (!popoverState?.highlightId) return '';
@@ -573,6 +608,7 @@ export function useHighlights(params: HighlightParams) {
     attach,
     detach,
     applyHighlights,
+    popoverAnchorRect,
     createHighlightFromPopover,
     createHighlightFromPopoverToMargin,
     saveNoteFromPopover,

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -18,6 +18,7 @@ import type {
   SocialContextResult,
   ArticleMentions,
   MentionLaneEntry,
+  CommunityHighlightNote,
   SembleContext,
   SocialDocument,
   User,
@@ -670,6 +671,15 @@ class ApiClient {
     return this.fetch('/api/v2/mention-lane', {
       method: 'POST',
       body: JSON.stringify({ url, lane }),
+    });
+  }
+
+  async fetchCommunityHighlights(
+    url: string
+  ): Promise<{ notes: CommunityHighlightNote[]; capped: boolean }> {
+    return this.fetch('/api/v2/margin-highlights', {
+      method: 'POST',
+      body: JSON.stringify({ url }),
     });
   }
 

--- a/frontend/src/lib/stores/communityHighlights.svelte.ts
+++ b/frontend/src/lib/stores/communityHighlights.svelte.ts
@@ -1,0 +1,68 @@
+import { api } from '$lib/services/api';
+import { auth } from '$lib/stores/auth.svelte';
+import type { CommunityHighlightNote, TextQuoteSelector } from '$lib/types';
+
+export interface CommunityHighlightGroup {
+  id: string;
+  selector: TextQuoteSelector;
+  people: CommunityHighlightNote[];
+}
+export interface CommunityHighlightsState {
+  loading: boolean;
+  loaded: boolean;
+  failed: boolean;
+  capped: boolean;
+  groups: CommunityHighlightGroup[];
+}
+
+function createStore() {
+  let cache = $state(new Map<string, CommunityHighlightsState>());
+  const inFlight = new Map<string, Promise<void>>();
+  const keyFor = (url: string) => {
+    try {
+      return new URL(url).href;
+    } catch {
+      return url;
+    }
+  };
+  const set = (key: string, value: CommunityHighlightsState) => {
+    cache = new Map(cache).set(key, value);
+  };
+  function load(url: string, options?: { force?: boolean }) {
+    if (!url || (typeof navigator !== 'undefined' && !navigator.onLine)) return;
+    const key = keyFor(url);
+    const old = cache.get(key);
+    if (old?.loaded || inFlight.has(key) || (old?.failed && !options?.force)) return;
+    set(key, { loading: true, loaded: false, failed: false, capped: false, groups: [] });
+    const promise = api
+      .fetchCommunityHighlights(url)
+      .then((res) => {
+        const ownDid = auth.user?.did;
+        const merged = new Map<string, CommunityHighlightGroup>();
+        for (const note of res.notes.filter((n) => n.did !== ownDid)) {
+          const group = merged.get(note.selector.exact);
+          if (group) group.people.push(note);
+          else
+            merged.set(note.selector.exact, {
+              id: `community-${merged.size}`,
+              selector: note.selector,
+              people: [note],
+            });
+        }
+        set(key, {
+          loading: false,
+          loaded: true,
+          failed: false,
+          capped: res.capped,
+          groups: [...merged.values()],
+        });
+      })
+      .catch(() =>
+        set(key, { loading: false, loaded: false, failed: true, capped: false, groups: [] })
+      )
+      .finally(() => inFlight.delete(key));
+    inFlight.set(key, promise);
+  }
+  return { load, get: (url: string) => cache.get(keyFor(url)) };
+}
+export const communityHighlightsStore = createStore();

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -74,6 +74,7 @@ interface PreferencesState {
   cardDensity: CardDensity;
   dailyMagazineMinutes: DailyMagazineMinutes;
   dailyMagazineOrder: DailyMagazineOrder;
+  communityHighlights: boolean;
 }
 
 const STORAGE_KEY = 'skyreader-preferences';
@@ -98,6 +99,7 @@ function createPreferencesStore() {
     cardDensity: 'cozy',
     dailyMagazineMinutes: 20,
     dailyMagazineOrder: 'shuffle',
+    communityHighlights: false,
   });
 
   // Restore from localStorage on init
@@ -152,6 +154,8 @@ function createPreferencesStore() {
         if (DAILY_MAGAZINE_ORDER_OPTIONS.some((o) => o.value === parsed.dailyMagazineOrder)) {
           state.dailyMagazineOrder = parsed.dailyMagazineOrder;
         }
+        if (typeof parsed.communityHighlights === 'boolean')
+          state.communityHighlights = parsed.communityHighlights;
       } catch {
         localStorage.removeItem(STORAGE_KEY);
       }
@@ -262,6 +266,10 @@ function createPreferencesStore() {
     state.dailyMagazineOrder = order;
     save();
   }
+  function setCommunityHighlights(enabled: boolean) {
+    state.communityHighlights = enabled;
+    save();
+  }
 
   return {
     get articleFont() {
@@ -304,12 +312,16 @@ function createPreferencesStore() {
     get dailyMagazineOrder() {
       return state.dailyMagazineOrder;
     },
+    get communityHighlights() {
+      return state.communityHighlights;
+    },
     confirmLinkblogShare,
     setLinkblogDisabled,
     setDefaultView,
     setCardDensity,
     setDailyMagazineMinutes,
     setDailyMagazineOrder,
+    setCommunityHighlights,
     setArticleFont,
     setArticleFontSize,
     increaseFontSize,

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -795,6 +795,17 @@ export interface MentionLaneEntry {
   quote: string | null;
 }
 
+export interface CommunityHighlightNote {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatar: string | null;
+  createdAt: string | null;
+  motivation: string | null;
+  note: string | null;
+  selector: TextQuoteSelector;
+}
+
 // One named Semble collection a card was filed into (see MentionLaneEntry).
 export interface SembleCollectionRef {
   name: string;

--- a/frontend/src/lib/utils/floating.ts
+++ b/frontend/src/lib/utils/floating.ts
@@ -105,3 +105,60 @@ export function positionFloating(
   el.style.top = `${top}px`;
   el.style.left = `${left}px`;
 }
+
+/**
+ * Keep a floating element pinned to a live anchor while the page scrolls.
+ *
+ * `positionFloating` places the element once, against the rect its anchor had
+ * when it opened. The reader body scrolls inside its own overlay while the
+ * popover is `position: fixed`, so the text a popover belongs to slides out from
+ * under it. Re-measuring each scroll frame keeps the two together, and `onLost`
+ * fires once the anchor is gone or has left the viewport entirely — at which
+ * point there is nothing left to pin to.
+ *
+ * Returns a cleanup function; call it when the floating element unmounts.
+ */
+export function followAnchor(
+  getEl: () => HTMLElement | null,
+  getAnchorRect: () => DOMRect | null,
+  opts: FloatingOptions & { onLost?: () => void } = {}
+): () => void {
+  let frame: number | null = null;
+
+  const update = () => {
+    frame = null;
+    const el = getEl();
+    if (!el) return;
+    const rect = getAnchorRect();
+    const vv = window.visualViewport;
+    const viewTop = vv?.offsetTop ?? 0;
+    const viewBottom = viewTop + (vv?.height ?? window.innerHeight);
+    // A detached anchor measures as an all-zero rect, which would pin the
+    // element to the top-left corner — treat that as lost too (the callers'
+    // rect getters return null for it).
+    if (!rect || rect.bottom < viewTop || rect.top > viewBottom) {
+      opts.onLost?.();
+      return;
+    }
+    positionFloating(rect, el, opts);
+  };
+
+  const schedule = () => {
+    if (frame == null) frame = requestAnimationFrame(update);
+  };
+
+  // Capture phase: the reader body scrolls in its own overlay, and scroll events
+  // from a nested scroller never reach window.
+  document.addEventListener('scroll', schedule, true);
+  window.addEventListener('resize', schedule);
+  window.visualViewport?.addEventListener('resize', schedule);
+  window.visualViewport?.addEventListener('scroll', schedule);
+
+  return () => {
+    if (frame != null) cancelAnimationFrame(frame);
+    document.removeEventListener('scroll', schedule, true);
+    window.removeEventListener('resize', schedule);
+    window.visualViewport?.removeEventListener('resize', schedule);
+    window.visualViewport?.removeEventListener('scroll', schedule);
+  };
+}

--- a/frontend/src/lib/utils/textSelector.ts
+++ b/frontend/src/lib/utils/textSelector.ts
@@ -118,6 +118,22 @@ export function createSelectorForElement(
  */
 export function findTextInDOM(selector: TextQuoteSelector, container: HTMLElement): Range | null {
   const { text, nodes } = buildTextMap(container);
+  return findInTextMap(selector, text, nodes);
+}
+
+export function findAllInDOM(
+  selectors: TextQuoteSelector[],
+  container: HTMLElement
+): Array<Range | null> {
+  const { text, nodes } = buildTextMap(container);
+  return selectors.map((selector) => findInTextMap(selector, text, nodes));
+}
+
+function findInTextMap(
+  selector: TextQuoteSelector,
+  text: string,
+  nodes: Array<{ node: Text; start: number; end: number }>
+): Range | null {
   if (nodes.length === 0 || !selector.exact) return null;
 
   // Find all matches of the exact text

--- a/frontend/src/lib/utils/urlKey.test.ts
+++ b/frontend/src/lib/utils/urlKey.test.ts
@@ -22,6 +22,15 @@ describe('urlKey', () => {
     expect(urlKey('https://example.com/a')).not.toBe(urlKey('https://example.com/b'));
   });
 
+  it('strips Substack referral tokens without treating every r param as tracking', () => {
+    expect(
+      urlKey('https://chinaunread.substack.com/p/a-post?r=clku7&utm_medium=post%20viewer')
+    ).toBe('https://chinaunread.substack.com/p/a-post');
+    expect(urlKey('https://example.com/article?r=chapter-2')).toBe(
+      'https://example.com/article?r=chapter-2'
+    );
+  });
+
   it('leaves the bare root alone', () => {
     expect(urlKey('https://example.com/')).toBe('https://example.com/');
   });

--- a/frontend/src/lib/utils/urlKey.ts
+++ b/frontend/src/lib/utils/urlKey.ts
@@ -46,6 +46,13 @@ const TRACKING_PARAMS = new Set([
   'oly_enc_id',
 ]);
 
+// Short parameter names are too ambiguous to strip everywhere. Substack uses
+// `r` exclusively as a reader/referral token on post URLs, while another site
+// may use the same name to select real content.
+function isHostTrackingParam(hostname: string, key: string): boolean {
+  return key === 'r' && (hostname === 'substack.com' || hostname.endsWith('.substack.com'));
+}
+
 /**
  * Canonicalize a URL for same-page matching. Returns `null` for anything that
  * isn't an http(s) URL — a guid, an at:// uri, a bare id — so callers that
@@ -71,7 +78,8 @@ export function urlKey(input: string): string | null {
 
   const kept: Array<[string, string]> = [];
   for (const [key, value] of url.searchParams) {
-    if (TRACKING_PARAMS.has(key.toLowerCase())) continue;
+    const lowerKey = key.toLowerCase();
+    if (TRACKING_PARAMS.has(lowerKey) || isHostTrackingParam(url.hostname, lowerKey)) continue;
     kept.push([key, value]);
   }
   kept.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));

--- a/frontend/src/lib/utils/wrapTextRange.component.test.ts
+++ b/frontend/src/lib/utils/wrapTextRange.component.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { wrapTextRange } from './wrapTextRange';
+
+describe('wrapTextRange', () => {
+  it('wraps cross-node text without cloning or moving article elements', () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<p>foo <strong>bar</strong></p><p> baz</p>';
+    const paragraphs = [...container.querySelectorAll('p')];
+    const strong = container.querySelector('strong')!;
+    const range = document.createRange();
+    range.setStart(strong.firstChild!, 0);
+    range.setEnd(paragraphs[1].firstChild!, 4);
+
+    const marks = wrapTextRange(range, container, () => {
+      const mark = document.createElement('mark');
+      mark.className = 'community-highlight';
+      return mark;
+    });
+
+    expect(marks).toHaveLength(2);
+    expect(container.querySelectorAll('p')).toHaveLength(2);
+    expect(container.querySelectorAll('strong')).toHaveLength(1);
+    expect(strong.parentElement).toBe(paragraphs[0]);
+
+    for (const mark of marks) mark.replaceWith(...mark.childNodes);
+    container.normalize();
+    expect(container.innerHTML).toBe('<p>foo <strong>bar</strong></p><p> baz</p>');
+  });
+});

--- a/frontend/src/lib/utils/wrapTextRange.ts
+++ b/frontend/src/lib/utils/wrapTextRange.ts
@@ -1,0 +1,33 @@
+/** Wrap only the text nodes intersecting a range, preserving the article's element tree. */
+export function wrapTextRange(
+  range: Range,
+  container: HTMLElement,
+  createMark: () => HTMLElement
+): HTMLElement[] {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    if (range.intersectsNode(node)) nodes.push(node as Text);
+    node = walker.nextNode();
+  }
+
+  const marks: HTMLElement[] = [];
+  for (const textNode of nodes) {
+    const part = document.createRange();
+    part.setStart(textNode, textNode === range.startContainer ? range.startOffset : 0);
+    part.setEnd(
+      textNode,
+      textNode === range.endContainer ? range.endOffset : (textNode.textContent?.length ?? 0)
+    );
+    if (!part.toString()) continue;
+    const mark = createMark();
+    try {
+      part.surroundContents(mark);
+      marks.push(mark);
+    } catch {
+      // Decorations are best-effort; never mutate broader article structure.
+    }
+  }
+  return marks;
+}


### PR DESCRIPTION
Adds an opt-in community highlight layer to saved articles, sourced read-only from public Margin annotations. Includes the cached proxy resolver, authenticated backend pass-through, lazy client merging and self-filtering, batch text anchoring, persistent preference, and quiet dotted-underlined attribution.

Review follow-up adds non-destructive shared text-node wrapping, coalesced requests, bounded note and profile/handle PDS resolution, resolver concurrency coverage, explicit retry after transient failure, and an accessible attribution popover with comments and cap disclosure.

Latest commit formats `feed-proxy/src/margin-highlights.ts` to Prettier style, which is what the required feed-proxy `Type Check` job was failing on. No behavior change.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-fywmig4ecvmw4ai3xayvjl3p)
[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-sqplatwci7ctjuldzbeddeb6)

Checks (run locally against this commit with Bun 1.4.0): `bun run check` (tsc + `prettier --check .`) passes, and `bun test` passes — 368 tests across 22 files, including `src/margin-highlights.test.ts`.
