### PR TITLE
Add Connect on Semble with complete card search

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -74,11 +74,19 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/routes/reading.ts`       | Article + document read positions (forward delta)      |
 | `src/routes/labels.ts`        | Unified item labels (read/starred/archived/tags)       |
 | `src/routes/saved.ts`         | Saved articles CRUD                                    |
+| `src/routes/integrations.ts`  | Semble/Margin writes to the user's PDS                 |
 | `src/routes/settings.ts`      | User settings                                          |
 | `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status          |
 | `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons         |
 | `src/routes/health.ts`        | `/api/health` (shallow) + `/api/health/deep` (gated)   |
 | `src/routes/telemetry.ts`     | `/api/telemetry/error` — sampled client error reports  |
+
+Integration writes are gated per-capability, not per-app: `POST /api/integrations/semble/connections`
+(a `network.cosmik.connection` edge between two URLs) checks `SEMBLE_CONNECTION_SCOPES`, which is
+deliberately **not** part of `SEMBLE_SCOPES` — folding it in would 403 every existing user's card
+saves until they re-authed. `GET /api/integrations/status` reports the two separately
+(`scopeStatus.semble` vs `scopeStatus.sembleConnections`). Same pattern as `PCKT_SCOPES` /
+`ATMOSPHERE_SCOPES`; see `src/config/scopes.ts`.
 
 ### Services
 

--- a/backend/src/config/scopes.ts
+++ b/backend/src/config/scopes.ts
@@ -20,6 +20,14 @@ export const SEMBLE_SCOPES = [
   'repo:network.cosmik.collection',
   'repo:network.cosmik.collectionLink',
 ];
+// Writing a Semble *connection* (a typed edge between two URLs) needs its own
+// repo scope. Deliberately NOT folded into SEMBLE_SCOPES: that set is the gate on
+// every existing Semble action (card saves, the collection picker, backed saves),
+// so adding a scope no current session holds would 403 all of them until every
+// user re-authed. Same reasoning as PCKT_SCOPES / ATMOSPHERE_SCOPES below — it
+// only joins ALL_POSSIBLE_SCOPES (what login actually requests) and is checked
+// solely on the connection endpoint.
+export const SEMBLE_CONNECTION_SCOPES = ['repo:network.cosmik.connection'];
 export const MARGIN_SCOPES = [
   // Bookmarks are no longer a distinct collection — Margin folded them into
   // at.margin.note (motivation: 'bookmarking'), so we only need the note +
@@ -60,6 +68,7 @@ export const AT_INTENT_SCOPES = ['repo:dev.at-intent.usage'];
 export const ALL_POSSIBLE_SCOPES = [
   GRANULAR_SCOPES,
   ...SEMBLE_SCOPES,
+  ...SEMBLE_CONNECTION_SCOPES,
   ...MARGIN_SCOPES,
   ...LINKBLOG_SCOPES,
   ...PCKT_SCOPES,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -83,6 +83,7 @@ import {
 import {
   handleIntegrationStatus,
   handleCreateSembleCard,
+  handleCreateSembleConnection,
   handleListSembleCollections,
   handleCreateMarginBookmark,
   handleListMarginCollections,
@@ -623,6 +624,17 @@ async function route(
         });
       } else {
         response = await handleCreateSembleCard(request, env);
+      }
+      break;
+    case url.pathname === '/api/integrations/semble/connections':
+      if (!session) return unauthorizedResponse(headers);
+      if (request.method !== 'POST') {
+        response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } else {
+        response = await handleCreateSembleConnection(request, env);
       }
       break;
     case url.pathname === '/api/integrations/semble/collections':

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -83,6 +83,7 @@ import {
 import {
   handleIntegrationStatus,
   handleCreateSembleCard,
+  handleListSembleCards,
   handleCreateSembleConnection,
   handleListSembleCollections,
   handleCreateMarginBookmark,
@@ -617,13 +618,15 @@ async function route(
       break;
     case url.pathname === '/api/integrations/semble/cards':
       if (!session) return unauthorizedResponse(headers);
-      if (request.method !== 'POST') {
+      if (request.method === 'GET') {
+        response = await handleListSembleCards(request, env);
+      } else if (request.method === 'POST') {
+        response = await handleCreateSembleCard(request, env);
+      } else {
         response = new Response(JSON.stringify({ error: 'Method not allowed' }), {
           status: 405,
           headers: { 'Content-Type': 'application/json' },
         });
-      } else {
-        response = await handleCreateSembleCard(request, env);
       }
       break;
     case url.pathname === '/api/integrations/semble/connections':

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -10,15 +10,29 @@ import {
   type IntegrationProvider,
 } from '../services/integration-membership';
 import { SEMBLE_SCOPES, MARGIN_SCOPES } from './auth';
+import { SEMBLE_CONNECTION_SCOPES } from '../config/scopes';
+
+/**
+ * The scope sets a request can be gated on. `semble-connections` is a *separate*
+ * capability from `semble`, not a superset: the connection scope is newer than
+ * every live session, so folding it into the Semble set would break card saves
+ * for everyone until they re-authed (see config/scopes.ts).
+ */
+export type ScopeGate = 'semble' | 'margin' | 'semble-connections';
+
+const SCOPE_SETS: Record<ScopeGate, string[]> = {
+  semble: SEMBLE_SCOPES,
+  margin: MARGIN_SCOPES,
+  'semble-connections': SEMBLE_CONNECTION_SCOPES,
+};
 
 /**
  * Check if the session has the required scopes for a specific integration
  */
-export function hasIntegrationScopes(session: Session, integration: 'semble' | 'margin'): boolean {
+export function hasIntegrationScopes(session: Session, integration: ScopeGate): boolean {
   if (!session.grantedScopes) return false;
   const granted = new Set(session.grantedScopes.split(' '));
-  const required = integration === 'semble' ? SEMBLE_SCOPES : MARGIN_SCOPES;
-  return required.every((scope) => granted.has(scope));
+  return SCOPE_SETS[integration].every((scope) => granted.has(scope));
 }
 
 /**
@@ -38,6 +52,9 @@ export async function handleIntegrationStatus(request: Request, env: Env): Promi
       scopeStatus: {
         semble: hasIntegrationScopes(session, 'semble'),
         margin: hasIntegrationScopes(session, 'margin'),
+        // Reported separately so a surface can tell "offer the control" from
+        // "the control will trip the re-login banner" and say so up front.
+        sembleConnections: hasIntegrationScopes(session, 'semble-connections'),
       },
     }),
     { headers: { 'Content-Type': 'application/json' } }
@@ -47,16 +64,16 @@ export async function handleIntegrationStatus(request: Request, env: Env): Promi
 /**
  * Check session has required scopes for an integration
  */
-function checkIntegrationScopes(
-  session: Session,
-  integration: 'semble' | 'margin'
-): Response | null {
+function checkIntegrationScopes(session: Session, integration: ScopeGate): Response | null {
   if (!hasIntegrationScopes(session, integration)) {
+    // The body still names the *integration* the reader recognizes, not the
+    // internal gate — the frontend keys its re-login banner off this shape.
+    const name = integration === 'semble-connections' ? 'semble' : integration;
     return new Response(
       JSON.stringify({
         error: 'scope_upgrade_required',
-        message: `Additional permissions are needed for ${integration}. Please log in again.`,
-        integration,
+        message: `Additional permissions are needed for ${name}. Please log in again.`,
+        integration: name,
       }),
       { status: 403, headers: { 'Content-Type': 'application/json' } }
     );
@@ -214,6 +231,140 @@ export async function handleListSembleCollections(request: Request, env: Env): P
   }));
 
   return new Response(JSON.stringify({ collections }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * Semble's connection types, exact casing. `RELATED` and `HELPFUL` are
+ * non-directional; the rest read source → target.
+ */
+export const SEMBLE_CONNECTION_TYPES = [
+  'SUPPORTS',
+  'OPPOSES',
+  'ADDRESSES',
+  'HELPFUL',
+  'LEADS_TO',
+  'RELATED',
+  'SUPPLEMENT',
+  'EXPLAINER',
+] as const;
+
+/** Semble's lexicon caps the note at 1000 (atproto string maxLength = UTF-8 bytes). */
+const MAX_NOTE_BYTES = 1000;
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build a `network.cosmik.connection` record. Kept as one function with the
+ * foreign lexicon quoted below, because `network.cosmik.*` is Semble's namespace
+ * — nothing here is validated by a schema we own, so the shape lives in one
+ * place that can be diffed against theirs.
+ *
+ * From cosmik-network/semble, `.../lexicons/connection.json` (key: tid):
+ *   source        required string  — URL or AT URI
+ *   target        required string  — URL or AT URI
+ *   connectionType         string  — one of SEMBLE_CONNECTION_TYPES
+ *   note                   string  — maxLength 1000
+ *   createdAt / updatedAt  datetime
+ */
+export function buildSembleConnectionRecord(
+  input: { source: string; target: string; connectionType?: string; note?: string },
+  now: string
+) {
+  return {
+    $type: 'network.cosmik.connection',
+    source: input.source,
+    target: input.target,
+    ...(input.connectionType ? { connectionType: input.connectionType } : {}),
+    ...(input.note ? { note: input.note } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * POST /api/integrations/semble/connections — create a network.cosmik.connection
+ * on the user's PDS: a typed, directional edge from one URL to another.
+ *
+ * Online-only by design (no offline queue): a connection is a deliberate act on
+ * live context, and unlike a card save there is nothing to reconcile later.
+ */
+export async function handleCreateSembleConnection(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const checkResult = checkIntegrationScopes(session, 'semble-connections');
+  if (checkResult) return checkResult;
+
+  let body: {
+    source?: string;
+    target?: string;
+    connectionType?: string;
+    note?: string;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const bad = (error: string) =>
+    new Response(JSON.stringify({ error }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  const source = typeof body.source === 'string' ? body.source.trim() : '';
+  const target = typeof body.target === 'string' ? body.target.trim() : '';
+  if (!source || !target) return bad('source and target are required');
+  if (!isHttpUrl(source) || !isHttpUrl(target))
+    return bad('source and target must be http(s) URLs');
+  if (source === target) return bad('source and target must differ');
+
+  const connectionType = body.connectionType?.trim();
+  if (connectionType && !(SEMBLE_CONNECTION_TYPES as readonly string[]).includes(connectionType)) {
+    return bad('Unknown connectionType');
+  }
+
+  const note = body.note?.trim();
+  if (note && new TextEncoder().encode(note).length > MAX_NOTE_BYTES) {
+    return bad(`note must be ${MAX_NOTE_BYTES} bytes or fewer`);
+  }
+
+  const rkey = generateTid();
+  const record = buildSembleConnectionRecord(
+    { source, target, connectionType, note },
+    new Date().toISOString()
+  );
+
+  const pdsClient = createPDSClient(session);
+  const result = await pdsClient.putRecord('network.cosmik.connection', rkey, record);
+
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ uri: result.data.uri, cid: result.data.cid, rkey }), {
+    status: 201,
     headers: { 'Content-Type': 'application/json' },
   });
 }

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -194,6 +194,61 @@ export async function handleCreateSembleCard(request: Request, env: Env): Promis
 }
 
 /**
+ * GET /api/integrations/semble/cards — list all URL cards in the user's PDS.
+ *
+ * This is intentionally read live rather than cached: cards may have been made
+ * in Semble itself, and the connection picker must search that whole library,
+ * not only articles the reader also saved in Skyreader.
+ */
+export async function handleListSembleCards(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const checkResult = checkIntegrationScopes(session, 'semble');
+  if (checkResult) return checkResult;
+
+  const pdsClient = createPDSClient(session);
+  const result = await pdsClient.listAllRecords<{
+    type?: string;
+    url?: string;
+    content?: { url?: string; metadata?: { title?: string; author?: string } };
+    createdAt?: string;
+  }>('network.cosmik.card');
+
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const cards = result.data.flatMap((record) => {
+    if (record.value.type && record.value.type !== 'URL') return [];
+    const url = record.value.content?.url ?? record.value.url;
+    if (!url || !isHttpUrl(url)) return [];
+    return [
+      {
+        uri: record.uri,
+        cid: record.cid,
+        url,
+        title: record.value.content?.metadata?.title,
+        author: record.value.content?.metadata?.author,
+        createdAt: record.value.createdAt,
+      },
+    ];
+  });
+
+  return new Response(JSON.stringify({ cards, truncated: result.truncated ?? false }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
  * GET /api/integrations/semble/collections — list user's network.cosmik.collection records
  */
 export async function handleListSembleCollections(request: Request, env: Env): Promise<Response> {

--- a/backend/test/semble-connection.spec.ts
+++ b/backend/test/semble-connection.spec.ts
@@ -64,6 +64,16 @@ function post(body: unknown, method = 'POST') {
   });
 }
 
+function getCards() {
+  return new IncomingRequest('http://localhost/api/integrations/semble/cards', {
+    method: 'GET',
+    headers: {
+      Cookie: `session_id=${SESSION}`,
+      Origin: env.FRONTEND_URL,
+    },
+  });
+}
+
 async function call(req: Request): Promise<{ status: number; body: any }> {
   const ctx = createExecutionContext();
   const res = await worker.fetch(req, env, ctx);
@@ -83,6 +93,65 @@ describe('the connection scope is split from the Semble scopes', () => {
     for (const scope of SEMBLE_CONNECTION_SCOPES) {
       expect(SEMBLE_SCOPES).not.toContain(scope);
     }
+  });
+});
+
+describe('GET /api/integrations/semble/cards', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists every URL card in the reader PDS for connection search', async () => {
+    const listAllRecords = vi.fn(async () => ({
+      success: true as const,
+      truncated: false,
+      data: [
+        {
+          uri: `at://${DID}/network.cosmik.card/c1`,
+          cid: 'bafy1',
+          value: {
+            type: 'URL',
+            content: {
+              url: TARGET,
+              metadata: { title: 'A careful rebuttal', author: 'A. Reader' },
+            },
+            createdAt: '2026-08-26T00:00:00.000Z',
+          },
+        },
+        {
+          uri: `at://${DID}/network.cosmik.card/note1`,
+          cid: 'bafy2',
+          value: { type: 'NOTE', content: {} },
+        },
+      ],
+    }));
+    vi.spyOn(pdsClient, 'createPDSClient').mockReturnValue({ listAllRecords } as never);
+
+    const { status, body } = await call(getCards());
+
+    expect(status).toBe(200);
+    expect(listAllRecords).toHaveBeenCalledWith('network.cosmik.card');
+    expect(body).toEqual({
+      cards: [
+        {
+          uri: `at://${DID}/network.cosmik.card/c1`,
+          cid: 'bafy1',
+          url: TARGET,
+          title: 'A careful rebuttal',
+          author: 'A. Reader',
+          createdAt: '2026-08-26T00:00:00.000Z',
+        },
+      ],
+      truncated: false,
+    });
+  });
+
+  it('keeps the existing Semble scope gate for listing cards', async () => {
+    await reset('repo:network.cosmik.connection');
+
+    const { status, body } = await call(getCards());
+
+    expect(status).toBe(403);
+    expect(body).toMatchObject({ error: 'scope_upgrade_required', integration: 'semble' });
   });
 });
 

--- a/backend/test/semble-connection.spec.ts
+++ b/backend/test/semble-connection.spec.ts
@@ -1,0 +1,214 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src/index';
+import * as pdsClient from '../src/services/pds-client';
+import {
+  GRANULAR_SCOPES,
+  SEMBLE_SCOPES,
+  SEMBLE_CONNECTION_SCOPES,
+  ALL_POSSIBLE_SCOPES,
+} from '../src/config/scopes';
+
+// Route-level coverage for POST /api/integrations/semble/connections: the record
+// shape written to the PDS (a foreign, unversioned lexicon — so it's pinned
+// verbatim), the validation gate, and the scope split that keeps existing Semble
+// card saves working for sessions that predate the connection scope.
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+const DID = 'did:plc:sembleconn';
+const SESSION = 'sess-semble-conn';
+const COLLECTION = 'network.cosmik.connection';
+
+const SOURCE = 'https://example.test/the-article';
+const TARGET = 'https://other.test/the-rebuttal';
+
+// What a session gets after re-authing: everything login requests.
+const FULL_SCOPES = ALL_POSSIBLE_SCOPES;
+// A pre-existing Semble user: card/collection scopes, but not the connection one.
+const OLD_SEMBLE_SCOPES = `${GRANULAR_SCOPES} ${SEMBLE_SCOPES.join(' ')}`;
+
+async function reset(grantedScopes = FULL_SCOPES) {
+  await env.DB.prepare('DELETE FROM sessions WHERE did = ?').bind(DID).run();
+  await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(DID).run();
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url, tier, created_at)
+     VALUES (?, 'conn.bsky.social', 'https://pds.test', 'free', unixepoch())`
+  )
+    .bind(DID)
+    .run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at, granted_scopes)
+     VALUES (?, ?, 'conn.bsky.social', 'https://pds.test', 'tok', 'rtok', ?, ?, ?)`
+  )
+    .bind(SESSION, DID, JSON.stringify({ kty: 'EC' }), Date.now() + 3_600_000, grantedScopes)
+    .run();
+}
+
+function fakePds(
+  putRecord = vi.fn(async () => ({ success: true, data: { uri: 'at://x', cid: 'c' } }))
+) {
+  vi.spyOn(pdsClient, 'createPDSClient').mockReturnValue({ putRecord } as never);
+  return putRecord;
+}
+
+function post(body: unknown, method = 'POST') {
+  return new IncomingRequest('http://localhost/api/integrations/semble/connections', {
+    method,
+    headers: {
+      Cookie: `session_id=${SESSION}`,
+      Origin: env.FRONTEND_URL,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function call(req: Request): Promise<{ status: number; body: any }> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+describe('the connection scope is split from the Semble scopes', () => {
+  it('is requested at login', () => {
+    for (const scope of SEMBLE_CONNECTION_SCOPES) {
+      expect(ALL_POSSIBLE_SCOPES).toContain(scope);
+    }
+  });
+
+  it('is not part of SEMBLE_SCOPES — card saves must not start failing', () => {
+    for (const scope of SEMBLE_CONNECTION_SCOPES) {
+      expect(SEMBLE_SCOPES).not.toContain(scope);
+    }
+  });
+});
+
+describe('POST /api/integrations/semble/connections', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('writes a network.cosmik.connection under a TID rkey and returns it', async () => {
+    const putRecord = fakePds(
+      vi.fn(async () => ({
+        success: true,
+        data: { uri: `at://${DID}/${COLLECTION}/abc`, cid: 'bafyconn' },
+      }))
+    );
+
+    const { status, body } = await call(
+      post({ source: SOURCE, target: TARGET, connectionType: 'SUPPORTS', note: 'Worth reading.' })
+    );
+
+    expect(status).toBe(201);
+    expect(body).toMatchObject({ uri: `at://${DID}/${COLLECTION}/abc`, cid: 'bafyconn' });
+    expect(putRecord).toHaveBeenCalledTimes(1);
+
+    const [collection, rkey, record] = putRecord.mock.calls[0] as unknown as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(collection).toBe(COLLECTION);
+    expect(rkey).toMatch(/^[a-z0-9]{13,}$/); // a freshly minted TID
+    expect(record.$type).toBe(COLLECTION);
+    expect(record.source).toBe(SOURCE);
+    expect(record.target).toBe(TARGET);
+    expect(record.connectionType).toBe('SUPPORTS');
+    expect(record.note).toBe('Worth reading.');
+    expect(typeof record.createdAt).toBe('string');
+    expect(record.updatedAt).toBe(record.createdAt);
+    expect(body.rkey).toBe(rkey);
+  });
+
+  it('omits the optional fields rather than writing empty ones', async () => {
+    const putRecord = fakePds();
+    await call(post({ source: SOURCE, target: TARGET }));
+
+    const record = (putRecord.mock.calls[0] as unknown as [string, string, object])[2];
+    expect(record).not.toHaveProperty('connectionType');
+    expect(record).not.toHaveProperty('note');
+  });
+
+  it('trims the endpoints before writing them', async () => {
+    const putRecord = fakePds();
+    await call(post({ source: `  ${SOURCE} `, target: `${TARGET}\n` }));
+
+    const record = (
+      putRecord.mock.calls[0] as unknown as [string, string, Record<string, string>]
+    )[2];
+    expect(record.source).toBe(SOURCE);
+    expect(record.target).toBe(TARGET);
+  });
+
+  it.each([
+    ['a missing target', { source: SOURCE }],
+    ['a non-http source', { source: 'javascript:alert(1)', target: TARGET }],
+    ['a non-http target', { source: SOURCE, target: 'not a url' }],
+    ['an unknown connectionType', { source: SOURCE, target: TARGET, connectionType: 'ENDORSES' }],
+    ['an edge to itself', { source: SOURCE, target: ` ${SOURCE}` }],
+  ])('rejects %s with a 400 and writes nothing', async (_label, body) => {
+    const putRecord = fakePds();
+    const res = await call(post(body));
+    expect(res.status).toBe(400);
+    expect(putRecord).not.toHaveBeenCalled();
+  });
+
+  it('rejects a note over 1000 bytes', async () => {
+    const putRecord = fakePds();
+    // 501 two-byte characters: under the limit by character count, over it by bytes.
+    const res = await call(post({ source: SOURCE, target: TARGET, note: 'é'.repeat(501) }));
+    expect(res.status).toBe(400);
+    expect(putRecord).not.toHaveBeenCalled();
+  });
+
+  it('accepts a note of exactly 1000 bytes', async () => {
+    const putRecord = fakePds();
+    const res = await call(post({ source: SOURCE, target: TARGET, note: 'a'.repeat(1000) }));
+    expect(res.status).toBe(201);
+    expect(putRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers 403 scope_upgrade_required for a session without the connection scope', async () => {
+    await reset(OLD_SEMBLE_SCOPES);
+    const putRecord = fakePds();
+
+    const { status, body } = await call(post({ source: SOURCE, target: TARGET }));
+
+    expect(status).toBe(403);
+    expect(body.error).toBe('scope_upgrade_required');
+    // The frontend banner keys off the reader-facing integration name.
+    expect(body.integration).toBe('semble');
+    expect(putRecord).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a PDS failure as a 502', async () => {
+    fakePds(vi.fn(async () => ({ success: false, error: 'PDS unavailable' })) as never);
+    const { status, body } = await call(post({ source: SOURCE, target: TARGET }));
+    expect(status).toBe(502);
+    expect(body.error).toBe('PDS unavailable');
+  });
+
+  it('rejects a non-POST method', async () => {
+    const { status } = await call(post(undefined, 'GET'));
+    expect(status).toBe(405);
+  });
+});
+
+describe('GET /api/integrations/status', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports the connection scope separately from the Semble scopes', async () => {
+    await reset(OLD_SEMBLE_SCOPES);
+    const req = new IncomingRequest('http://localhost/api/integrations/status', {
+      headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+    });
+    const { status, body } = await call(req);
+    expect(status).toBe(200);
+    expect(body.scopeStatus.semble).toBe(true);
+    expect(body.scopeStatus.sembleConnections).toBe(false);
+  });
+});

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -22,6 +22,7 @@
   import RefreshProgressBar from '$lib/components/RefreshProgressBar.svelte';
   import ShareComposer from '$lib/components/feed/ShareComposer.svelte';
   import IntegrationSaveDialog from '$lib/components/feed/IntegrationSaveDialog.svelte';
+  import SembleConnectionDialog from '$lib/components/feed/SembleConnectionDialog.svelte';
 
   let { children }: { children: Snippet } = $props();
 
@@ -253,6 +254,7 @@
 <RefreshProgressBar />
 <ShareComposer />
 <IntegrationSaveDialog />
+<SembleConnectionDialog />
 
 <div class="app-container">
   <Sidebar />

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -49,6 +49,7 @@
   import { auth } from '$lib/stores/auth.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { integrationSaveStore } from '$lib/stores/integrationSave.svelte';
+  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
   import { toggleSavedLink } from '$lib/utils/saveLink';
   import { preferences } from '$lib/stores/preferences.svelte';
   import ArticleCardView from './ArticleCardView.svelte';
@@ -869,6 +870,17 @@
     integrationSaveStore.openPicker('semble', integrationTarget);
   }
 
+  // Drawing an edge from this article. Gated like the Semble save lane (signed
+  // in), and handed the card page the panel resolved: Semble keys cards by exact
+  // URL string, so that variant is the one an edge has to name to roll up there.
+  function createConnection() {
+    sembleConnectionStore.openFor({
+      url: itemUrl,
+      title: itemTitle,
+      cardUrl: atmosphere.sembleContext?.cardUrl ?? null,
+    });
+  }
+
   function saveToMargin() {
     integrationSaveStore.openPicker('margin', {
       url: integrationTarget.url,
@@ -976,6 +988,7 @@
   onEditShare={editShare}
   onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
   onSaveConnection={auth.user ? toggleSavedLink : undefined}
+  onCreateConnection={auth.user && itemUrl ? createConnection : undefined}
   isConnectionSaved={(url) => savesStore.isSaved(url)}
   onMentionClick={(did) => sidebarStore.openAddFeedModalForDid(did)}
   onCloseOverflow={() => (overflowMenuOpen = false)}

--- a/frontend/src/lib/components/ArticleCardView.svelte
+++ b/frontend/src/lib/components/ArticleCardView.svelte
@@ -100,6 +100,7 @@
     onEditShare,
     onOpenAuthor,
     onSaveConnection,
+    onCreateConnection,
     isConnectionSaved,
     onMentionClick,
     onCloseOverflow,
@@ -420,6 +421,7 @@
         {onCreateInLane}
         {onOpenAuthor}
         {onSaveConnection}
+        {onCreateConnection}
         {isConnectionSaved}
       />
       <div class="article-actions">

--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { toastStore } from '$lib/stores/toast.svelte';
+  import { safeHref } from '$lib/utils/sanitize';
 </script>
 
 {#if toastStore.toasts.length > 0}
@@ -14,6 +15,11 @@
           <span class="icon">&#10007;</span>
         {/if}
         <span>{toast.message}</span>
+        {#if toast.action}
+          <a class="toast-action" href={safeHref(toast.action.href)} target="_blank" rel="noopener"
+            >{toast.action.label}</a
+          >
+        {/if}
       </div>
     {/each}
   </div>
@@ -43,6 +49,20 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     color: var(--color-text);
     animation: slide-in 0.2s ease-out;
+  }
+
+  /* The container is click-through so a toast never eats the page underneath;
+     a link has to opt itself back in. */
+  .toast-action {
+    pointer-events: auto;
+    margin-left: 0.25rem;
+    font-weight: var(--weight-medium);
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .toast-action:hover {
+    text-decoration: underline;
   }
 
   .toast-success {

--- a/frontend/src/lib/components/articleCardView.types.ts
+++ b/frontend/src/lib/components/articleCardView.types.ts
@@ -267,6 +267,9 @@ export interface ArticleCardViewProps {
   /** Toggle a Semble-connected article into the reader's Saved list. Absent when
    *  the reader can't save; the control then doesn't render. */
   onSaveConnection?: (url: string) => void | Promise<void>;
+  /** Draw a Semble connection of the reader's own from this article. Absent when
+   *  the reader can't write one (signed out). */
+  onCreateConnection?: () => void;
   /** Reactive saved-state predicate for a connected article's URL. */
   isConnectionSaved?: (url: string) => boolean;
   // A @mention in the note/body was clicked — open the add-feed dialog for the DID.

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -59,6 +59,7 @@ function render(props: {
   stream?: { loading: boolean; failed?: boolean; entries: DiscussionEntryVM[] };
   onSaveConnection?: (url: string) => void | Promise<void>;
   isConnectionSaved?: (url: string) => boolean;
+  onCreateConnection?: () => void;
 }): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
@@ -72,6 +73,7 @@ function render(props: {
       sembleContext: props.sembleContext,
       onSaveConnection: props.onSaveConnection,
       isConnectionSaved: props.isConnectionSaved,
+      onCreateConnection: props.onCreateConnection,
     },
   });
   flushSync();
@@ -183,6 +185,43 @@ describe('AtmospherePanel Semble connections', () => {
     const target = render({ sembleContext: emptyContext });
     expect(target.querySelector('.semble-context')).toBeNull();
     expect(target.querySelector('.discussion-empty')?.textContent).toContain('Nothing readable');
+  });
+
+  // Drawing an edge is the one thing a reader can add to an article nobody has
+  // written about — so it can't be the affordance that disappears with the
+  // Semble block it normally lives in.
+  it('offers a connection on an article Semble has never seen', () => {
+    const clicks: number[] = [];
+    const target = render({ onCreateConnection: () => clicks.push(1) });
+    expect(target.querySelector('.semble-context')).toBeNull();
+    const cta = target.querySelector('.semble-connect') as HTMLButtonElement;
+    expect(cta).not.toBeNull();
+    expect(cta.textContent?.trim()).toBe('Draw the first connection');
+    cta.click();
+    expect(clicks.length).toBe(1);
+  });
+
+  it('offers it too when the context came back with nothing in it', () => {
+    const target = render({ sembleContext: emptyContext, onCreateConnection: () => {} });
+    expect(target.querySelector('.semble-context')).toBeNull();
+    expect(target.querySelector('.semble-connect')).not.toBeNull();
+  });
+
+  // One invitation per panel: standing on its own it is already where the
+  // compose row is, and the row's chip would repeat it a few pixels away.
+  it('does not say it twice', () => {
+    const empty = render({ onCreateConnection: () => {} });
+    expect(empty.querySelectorAll('.semble-connect, .compose-connect').length).toBe(1);
+    expect(empty.querySelector('.compose-connect')).toBeNull();
+
+    const held = render({
+      sembleContext: { ...emptyContext, connections: [connection('out')] },
+      onCreateConnection: () => {},
+    });
+    // With a block to live in, the invitation is up there and the row's chip is
+    // the quick way back to it.
+    expect(held.querySelector('.semble-context .semble-connect')).not.toBeNull();
+    expect(held.querySelector('.compose-connect')).not.toBeNull();
   });
 
   it('keeps the retry when a lane failed and only Semble context came back', () => {

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -170,12 +170,8 @@
   const undisclosed = $derived(
     activeFilter === 'all' && settled && total > shown ? total - shown : 0
   );
-  const hasComposeRow = $derived(
-    Boolean(composeLead) || creatable.length > 0 || Boolean(onCreateConnection)
-  );
-  const showSemble = $derived(
-    Boolean(sembleContext) && (activeFilter === 'all' || activeFilter === 'semble')
-  );
+  const sembleLaneVisible = $derived(activeFilter === 'all' || activeFilter === 'semble');
+  const showSemble = $derived(Boolean(sembleContext) && sembleLaneVisible);
   // Whether Semble actually returned something to read. A context object that
   // came back empty (the saver fallback, or an API answer with nothing in it) is
   // not content: it must not stand in for the people who aren't there, or the
@@ -188,6 +184,23 @@
           sembleContext.collections.length ||
           sembleContext.connections.length)
       )
+  );
+  // Whether Semble's own block is on screen. It is where "connect this to
+  // something" lives — so on an article Semble has never seen (no block at all)
+  // the invitation has to stand on its own further down, or drawing an edge
+  // would be offered only where edges already exist.
+  const showSembleBlock = $derived(
+    showSemble && Boolean(sembleContext) && (hasSembleContent || Boolean(sembleContext?.incomplete))
+  );
+  // Exactly one connect control per panel: inside Semble's block when there is
+  // one, otherwise on its own above the compose row. The row's chip would sit a
+  // few pixels from that standalone one, saying the same thing twice.
+  const showComposeConnect = $derived(Boolean(onCreateConnection) && showSembleBlock);
+  const showStandaloneConnect = $derived(
+    Boolean(onCreateConnection) && !showSembleBlock && sembleLaneVisible
+  );
+  const hasComposeRow = $derived(
+    Boolean(composeLead) || creatable.length > 0 || showComposeConnect
   );
 
   // ── Semble's graph, folded ──────────────────────────────────────────────
@@ -372,7 +385,25 @@
   </button>
 {/snippet}
 
-{#if lanesOpen && (total > 0 || hasComposeRow)}
+<!-- The way into Semble's graph. Quiet, in the block's own disclosure
+     vocabulary — an offer, not a call to action. Rendered wherever it currently
+     belongs, so it reads the same whether or not Semble already holds anything
+     about this article. -->
+{#snippet connectCta()}
+  <button
+    type="button"
+    class="semble-disclose semble-connect"
+    onclick={(e) => {
+      e.stopPropagation();
+      onCreateConnection?.();
+    }}
+  >
+    <Icon name="link" size={12} />
+    {connectionGroups.length ? 'Connect this to something' : 'Draw the first connection'}
+  </button>
+{/snippet}
+
+{#if lanesOpen && (total > 0 || hasComposeRow || showStandaloneConnect)}
   <section class="discussion" class:no-heading={!showHeading} id={panelId} aria-label="Discussion">
     {#if showHeading}
       <div class="discussion-head">
@@ -416,7 +447,7 @@
          material: a person, and what they did with this article. Rendering it in
          the stream's own grammar (avatar, head line, payload beneath) keeps it
          from reading as a second document bolted above the discussion. -->
-    {#if showSemble && sembleContext && (hasSembleContent || sembleContext.incomplete)}
+    {#if showSembleBlock && sembleContext}
       <section class="semble-context" aria-label="What Semble holds about this article">
         {#if sembleContext.collections.length}
           <p class="semble-filed">
@@ -592,20 +623,9 @@
         {/if}
 
         <!-- Where the graph already is, so adding to it doesn't mean scrolling
-             past everything to the compose row. Quiet, in the block's own
-             disclosure vocabulary — an offer, not a call to action. -->
+             past everything to the compose row. -->
         {#if onCreateConnection}
-          <button
-            type="button"
-            class="semble-disclose semble-connect"
-            onclick={(e) => {
-              e.stopPropagation();
-              onCreateConnection?.();
-            }}
-          >
-            <Icon name="link" size={12} />
-            {connectionGroups.length ? 'Connect this to something' : 'Draw the first connection'}
-          </button>
+          {@render connectCta()}
         {/if}
 
         {#if sembleContext.cardUrl && (connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
@@ -890,6 +910,14 @@
       {/if}
     {/if}
 
+    <!-- An empty discussion is the case where drawing an edge matters most: the
+         reader has just finished something nobody else has written about, and
+         the connection they can make is the only thing there is to add. With no
+         Semble block to carry it, the invitation stands here on its own. -->
+    {#if showStandaloneConnect}
+      <div class="semble-connect-standalone">{@render connectCta()}</div>
+    {/if}
+
     {#if hasComposeRow}
       <div class="discussion-compose">
         <span class="compose-label">Add yours</span>
@@ -911,12 +939,13 @@
         {/each}
         <!-- Drawing an edge is not "adding yours" in a lane — it says something
              about how two pieces relate, not about this one. It sits last in the
-             row, in the same vocabulary, so it's reachable from every surface
-             even on an article Semble has never seen. -->
-        {#if onCreateConnection}
+             row, in the same vocabulary. Only when Semble's block is carrying
+             the other one: without it the standalone invitation above is already
+             right here, and two of them would say the same thing twice. -->
+        {#if showComposeConnect}
           <button
             type="button"
-            class="compose-btn"
+            class="compose-btn compose-connect"
             title="Connect this to another article on Semble"
             onclick={(e) => {
               e.stopPropagation();
@@ -1278,6 +1307,13 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3125rem;
+  }
+
+  /* Standing on its own (no Semble block above it), it needs the breathing room
+     the block's own gap would have given it. */
+  .semble-connect-standalone {
+    display: flex;
+    margin-top: 0.5rem;
   }
 
   /* Reads as the last pill in the strip rather than a control beneath it. */

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -66,6 +66,7 @@
     onOpenAuthor,
     onRetry,
     onSaveConnection,
+    onCreateConnection,
     isConnectionSaved,
   }: {
     laneRow?: LaneRowVM[];
@@ -86,6 +87,10 @@
      *  the reader can't save (signed out), and the control doesn't render at
      *  all. Async — a save fetches and extracts the article first. */
     onSaveConnection?: (url: string) => void | Promise<void>;
+    /** Draw a connection of the reader's own from this article. Absent when the
+     *  reader can't write one (signed out), and no control renders. Skyreader
+     *  could always *show* Semble's graph; this is the way into it. */
+    onCreateConnection?: () => void;
     /** Reactive saved-state predicate, so the control reads as state rather than
      *  as an invitation the reader has already accepted. */
     isConnectionSaved?: (url: string) => boolean;
@@ -165,7 +170,9 @@
   const undisclosed = $derived(
     activeFilter === 'all' && settled && total > shown ? total - shown : 0
   );
-  const hasComposeRow = $derived(Boolean(composeLead) || creatable.length > 0);
+  const hasComposeRow = $derived(
+    Boolean(composeLead) || creatable.length > 0 || Boolean(onCreateConnection)
+  );
   const showSemble = $derived(
     Boolean(sembleContext) && (activeFilter === 'all' || activeFilter === 'semble')
   );
@@ -584,6 +591,23 @@
           </button>
         {/if}
 
+        <!-- Where the graph already is, so adding to it doesn't mean scrolling
+             past everything to the compose row. Quiet, in the block's own
+             disclosure vocabulary — an offer, not a call to action. -->
+        {#if onCreateConnection}
+          <button
+            type="button"
+            class="semble-disclose semble-connect"
+            onclick={(e) => {
+              e.stopPropagation();
+              onCreateConnection?.();
+            }}
+          >
+            <Icon name="link" size={12} />
+            {connectionGroups.length ? 'Connect this to something' : 'Draw the first connection'}
+          </button>
+        {/if}
+
         {#if sembleContext.cardUrl && (connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
           <p class="semble-foot">
             {#if connectionsBeyond > 0}Showing {connectionsGot} of {connectionsHeld} connections.{/if}
@@ -885,6 +909,24 @@
             <span>{lane.label}</span>
           </button>
         {/each}
+        <!-- Drawing an edge is not "adding yours" in a lane — it says something
+             about how two pieces relate, not about this one. It sits last in the
+             row, in the same vocabulary, so it's reachable from every surface
+             even on an article Semble has never seen. -->
+        {#if onCreateConnection}
+          <button
+            type="button"
+            class="compose-btn"
+            title="Connect this to another article on Semble"
+            onclick={(e) => {
+              e.stopPropagation();
+              onCreateConnection?.();
+            }}
+          >
+            <span class="compose-icon"><Icon name="link" size={14} /></span>
+            <span>Connect</span>
+          </button>
+        {/if}
       </div>
     {/if}
   </section>
@@ -1230,6 +1272,12 @@
 
   .semble-disclose-block {
     margin-top: 0;
+  }
+
+  .semble-connect {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3125rem;
   }
 
   /* Reads as the last pill in the strip rather than a control beneath it. */

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -11,6 +11,7 @@
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { integrationSaveStore } from '$lib/stores/integrationSave.svelte';
+  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { useAtmosphere } from '$lib/hooks/useAtmosphere.svelte';
   import { getExternalArticleLink } from '$lib/utils/linkPost';
@@ -142,6 +143,20 @@
     };
   }
 
+  // Gated exactly like the Semble save lane: signed in is the whole condition.
+  // A session without the connection scope still gets the dialog — it says so up
+  // front rather than hiding a capability the reader can have by logging in again.
+  function createConnection() {
+    const data = extractSembleMetadata(readerItem);
+    sembleConnectionStore.openFor({
+      url: data.url,
+      title: data.title,
+      // Semble keys cards by exact URL string, and the card page the panel
+      // resolved carries the variant Semble actually holds.
+      cardUrl: atmosphere.sembleContext?.cardUrl ?? null,
+    });
+  }
+
   function createInLane(id: LaneId) {
     if (id === 'semble') {
       integrationSaveStore.openPicker('semble', extractSembleMetadata(readerItem));
@@ -173,6 +188,7 @@
     onCreateInLane={createInLane}
     onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
     onSaveConnection={auth.user ? toggleSavedLink : undefined}
+    onCreateConnection={auth.user && itemUrl ? createConnection : undefined}
     isConnectionSaved={(url) => savesStore.isSaved(url)}
     composeLead={canShareLinkblog ? shareControl : undefined}
   />

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -11,6 +11,8 @@
   import { linkPostContentStore } from '$lib/stores/linkPostContent.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { integrationSaveStore } from '$lib/stores/integrationSave.svelte';
+  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
+  import { mentionLaneItemsStore } from '$lib/stores/mentionLaneItems.svelte';
   import { socialStore } from '$lib/stores/social.svelte';
   import { db } from '$lib/services/db';
   import { saveCollectionPiece, isCollectionPieceSaved } from '$lib/utils/collectionPiece';
@@ -73,6 +75,23 @@
 
   function saveToMargin() {
     integrationSaveStore.openPicker('margin', extractMarginMetadata(readerItem));
+  }
+
+  // Drawing an edge from what you just read. The discussion at the end of the
+  // article offers this too, but only there — and an article nobody has written
+  // about is exactly when the connection you can draw is the only thing to add.
+  // So it also sits in the reader's own menus, where it never depends on what
+  // the Atmosphere happened to return.
+  function connectOnSemble() {
+    const data = extractSembleMetadata(readerItem);
+    sembleConnectionStore.openFor({
+      url: data.url,
+      title: data.title,
+      // Semble keys cards by the exact URL string. If the discussion below has
+      // already resolved this article's card page, that page carries the variant
+      // Semble actually holds — a plain cache read, null until then.
+      cardUrl: mentionLaneItemsStore.get(data.url, 'semble')?.sembleContext?.cardUrl ?? null,
+    });
   }
 
   let styleMenuOpen = $state(false);
@@ -580,6 +599,11 @@
         icon: 'margin',
         onclick: saveToMargin,
       });
+      items.push({
+        label: 'Connect on Semble',
+        icon: 'link',
+        onclick: connectOnSemble,
+      });
     }
 
     if (onRemove) {
@@ -1081,6 +1105,16 @@
                 >
                   <Icon name="margin" size={18} />
                   <span>Save to Margin</span>
+                </button>
+                <button
+                  class="sheet-action-btn"
+                  onclick={() => {
+                    connectOnSemble();
+                    styleSheetOpen = false;
+                  }}
+                >
+                  <Icon name="link" size={18} />
+                  <span>Connect on Semble</span>
                 </button>
               {/if}
               <button

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
@@ -208,12 +208,20 @@ describe('SembleConnectionDialog', () => {
     expect(q('.chosen-url')!.textContent).toBe('https://semble-only.test/connected-thinking');
   });
 
-  it('shows search results in an anchored popover', () => {
+  // Floating, so typing never reflows the dialog — and fixed rather than
+  // absolute, since the scrolling modal body clips an absolute child.
+  it('shows search results in a fixed popover anchored to the field', () => {
     render();
     typeInField('rebuttal');
 
-    expect(q('.results-popover')).not.toBeNull();
-    expect(q('.search-shell')?.contains(q('.results-popover'))).toBe(true);
+    const popover = q<HTMLElement>('.results-popover');
+    expect(popover).not.toBeNull();
+    expect(q('.search-shell')?.contains(popover)).toBe(true);
+    // Scoped component CSS isn't applied here, so the proof that the popover
+    // is placed against the field is the geometry the measure pass writes.
+    expect(popover!.style.top).not.toBe('');
+    expect(popover!.style.left).not.toBe('');
+    expect(popover!.style.maxHeight).not.toBe('');
   });
 
   it('offers no swap for a non-directional relation', () => {

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
@@ -46,6 +46,21 @@ const savedArticles = [
     publishedAt: null,
     savedAt: '2026-01-01T00:00:00.000Z',
   },
+  {
+    rkey: 'r2',
+    uri: 'at://did:plc:reader/x/r2',
+    url: 'https://example.test/the-article/',
+    title: 'The resolved article variant',
+    author: null,
+    description: null,
+    content: null,
+    contentType: null,
+    domain: 'example.test',
+    image: null,
+    wordCount: null,
+    publishedAt: null,
+    savedAt: '2026-01-02T00:00:00.000Z',
+  },
 ];
 
 vi.mock('$lib/stores/saves.svelte', () => ({
@@ -62,10 +77,13 @@ const { sembleConnectionStore } = await import('$lib/stores/sembleConnection.sve
 
 let component: Record<string, unknown> | undefined;
 
-function render() {
+function render(source?: { url: string; title?: string; cardUrl?: string }) {
   const target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(Host, { target }) as Record<string, unknown>;
+  component = mount(Host, { target, props: source ? { source } : undefined }) as Record<
+    string,
+    unknown
+  >;
   flushSync();
 }
 
@@ -120,6 +138,29 @@ describe('SembleConnectionDialog', () => {
     typeInField('https://example.test/the-article');
     expect(document.body.textContent).toContain("That's the article you're on");
     expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(true);
+  });
+
+  it('refuses the exact URL variant resolved by the Semble card', () => {
+    render({
+      url: 'https://example.test/the-article',
+      title: 'The Article',
+      cardUrl: 'https://semble.so/url/https%3A%2F%2Fexample.test%2Fthe-article%2F',
+    });
+    typeInField('https://example.test/the-article/');
+
+    expect(document.body.textContent).toContain("That's the article you're on");
+    expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(true);
+  });
+
+  it('excludes the resolved Semble URL variant from Saved results', () => {
+    render({
+      url: 'https://example.test/the-article',
+      title: 'The Article',
+      cardUrl: 'https://semble.so/url/https%3A%2F%2Fexample.test%2Fthe-article%2F',
+    });
+    typeInField('resolved article variant');
+
+    expect(q('.result')).toBeNull();
   });
 
   it('finds the other end in the reader own saved list', () => {

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+const createSembleConnection = vi.fn(async () => ({
+  uri: 'at://did:plc:reader/network.cosmik.connection/abc',
+  cid: 'bafy',
+  rkey: 'abc',
+}));
+let scopeStatus: Record<string, boolean> = { semble: true, margin: false, sembleConnections: true };
+
+class FakeScopeUpgradeError extends Error {}
+
+vi.mock('$lib/services/api', () => ({
+  api: {
+    createSembleConnection: (...args: unknown[]) => createSembleConnection(...(args as [])),
+    getIntegrationStatus: vi.fn(async () => ({ scopeStatus })),
+  },
+  ScopeUpgradeError: FakeScopeUpgradeError,
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+  auth: {
+    get user() {
+      return { did: 'did:plc:reader', handle: 'reader.bsky.social', pdsUrl: 'https://pds.test' };
+    },
+  },
+}));
+
+vi.mock('$lib/stores/mentionLaneItems.svelte', () => ({
+  mentionLaneItemsStore: { addSembleConnection: vi.fn() },
+}));
+
+const savedArticles = [
+  {
+    rkey: 'r1',
+    uri: 'at://did:plc:reader/x/r1',
+    url: 'https://other.test/the-rebuttal',
+    title: 'A careful rebuttal',
+    author: null,
+    description: null,
+    content: null,
+    contentType: null,
+    domain: 'other.test',
+    image: null,
+    wordCount: null,
+    publishedAt: null,
+    savedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+vi.mock('$lib/stores/saves.svelte', () => ({
+  savesStore: {
+    get articles() {
+      return savedArticles;
+    },
+    load: vi.fn(async () => {}),
+  },
+}));
+
+const Host = (await import('./SembleConnectionDialog.test-host.svelte')).default;
+const { sembleConnectionStore } = await import('$lib/stores/sembleConnection.svelte');
+
+let component: Record<string, unknown> | undefined;
+
+function render() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(Host, { target }) as Record<string, unknown>;
+  flushSync();
+}
+
+function q<T extends Element>(selector: string): T | null {
+  return document.body.querySelector<T>(selector);
+}
+
+function pill(label: string): HTMLButtonElement {
+  const found = [...document.body.querySelectorAll<HTMLButtonElement>('.type-pill')].find(
+    (b) => b.textContent?.trim() === label
+  );
+  if (!found) throw new Error(`no "${label}" pill`);
+  return found;
+}
+
+function typeInField(value: string) {
+  const input = q<HTMLInputElement>('.search-input')!;
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+beforeEach(() => {
+  createSembleConnection.mockClear();
+  scopeStatus = { semble: true, margin: false, sembleConnections: true };
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  sembleConnectionStore.close();
+  document.body.innerHTML = '';
+});
+
+describe('SembleConnectionDialog', () => {
+  it('cannot be submitted until the other end is named', () => {
+    render();
+    expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(true);
+
+    typeInField('https://other.test/the-rebuttal');
+    expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(false);
+  });
+
+  it('takes a pasted URL as the answer, without a confirming click', () => {
+    render();
+    typeInField('https://other.test/the-rebuttal');
+    expect(q('.chosen-url')!.textContent).toBe('https://other.test/the-rebuttal');
+  });
+
+  it('refuses an edge from the article to itself', () => {
+    render();
+    typeInField('https://example.test/the-article');
+    expect(document.body.textContent).toContain("That's the article you're on");
+    expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(true);
+  });
+
+  it('finds the other end in the reader own saved list', () => {
+    render();
+    typeInField('rebuttal');
+    const result = q<HTMLButtonElement>('.result')!;
+    expect(result.textContent).toContain('A careful rebuttal');
+
+    result.click();
+    flushSync();
+    expect(q('.chosen-url')!.textContent).toBe('https://other.test/the-rebuttal');
+  });
+
+  it('offers no swap for a non-directional relation', () => {
+    render();
+    // RELATED is the default and reads the same both ways.
+    expect(q('.swap')).toBeNull();
+
+    pill('supports').click();
+    flushSync();
+    expect(q('.swap')).not.toBeNull();
+
+    pill('helpful').click();
+    flushSync();
+    expect(q('.swap')).toBeNull();
+  });
+
+  it('drops a flip made under a directional relation when a symmetric one is picked', async () => {
+    render();
+    typeInField('https://other.test/the-rebuttal');
+    pill('supports').click();
+    flushSync();
+    q<HTMLButtonElement>('.swap')!.click();
+    flushSync();
+
+    pill('related').click();
+    flushSync();
+    q<HTMLButtonElement>('.btn-primary')!.click();
+    await vi.waitFor(() => expect(createSembleConnection).toHaveBeenCalled());
+
+    // Not reversed: the article is still the source.
+    expect(createSembleConnection).toHaveBeenCalledWith({
+      source: 'https://example.test/the-article',
+      target: 'https://other.test/the-rebuttal',
+      connectionType: 'RELATED',
+      note: undefined,
+    });
+  });
+
+  it('submits the relation, direction and note the reader chose', async () => {
+    render();
+    typeInField('https://other.test/the-rebuttal');
+    pill('leads to').click();
+    flushSync();
+    q<HTMLButtonElement>('.swap')!.click();
+    flushSync();
+
+    const note = q<HTMLTextAreaElement>('.note')!;
+    note.value = 'Read in this order.';
+    note.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    q<HTMLButtonElement>('.btn-primary')!.click();
+    await vi.waitFor(() => expect(createSembleConnection).toHaveBeenCalled());
+
+    expect(createSembleConnection).toHaveBeenCalledWith({
+      source: 'https://other.test/the-rebuttal',
+      target: 'https://example.test/the-article',
+      connectionType: 'LEADS_TO',
+      note: 'Read in this order.',
+    });
+  });
+
+  it('refuses a note over the lexicon limit', () => {
+    render();
+    typeInField('https://other.test/the-rebuttal');
+    const note = q<HTMLTextAreaElement>('.note')!;
+    note.value = 'a'.repeat(1001);
+    note.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    expect(q<HTMLButtonElement>('.btn-primary')!.disabled).toBe(true);
+  });
+
+  it('says up front that a session without the scope will have to log in again', async () => {
+    scopeStatus = { semble: true, margin: false, sembleConnections: false };
+    render();
+    await vi.waitFor(() => {
+      flushSync();
+      expect(document.body.textContent).toContain("You'll be asked to log in again");
+    });
+  });
+});

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.component.test.ts
@@ -7,12 +7,22 @@ const createSembleConnection = vi.fn(async () => ({
   rkey: 'abc',
 }));
 let scopeStatus: Record<string, boolean> = { semble: true, margin: false, sembleConnections: true };
+let sembleCards = [
+  {
+    uri: 'at://did:plc:reader/network.cosmik.card/c1',
+    cid: 'bafycard',
+    url: 'https://semble-only.test/connected-thinking',
+    title: 'Connected thinking in Semble',
+    author: 'A Semble author',
+  },
+];
 
 class FakeScopeUpgradeError extends Error {}
 
 vi.mock('$lib/services/api', () => ({
   api: {
     createSembleConnection: (...args: unknown[]) => createSembleConnection(...(args as [])),
+    listSembleCards: vi.fn(async () => ({ cards: sembleCards, truncated: false })),
     getIntegrationStatus: vi.fn(async () => ({ scopeStatus })),
   },
   ScopeUpgradeError: FakeScopeUpgradeError,
@@ -109,6 +119,15 @@ function typeInField(value: string) {
 beforeEach(() => {
   createSembleConnection.mockClear();
   scopeStatus = { semble: true, margin: false, sembleConnections: true };
+  sembleCards = [
+    {
+      uri: 'at://did:plc:reader/network.cosmik.card/c1',
+      cid: 'bafycard',
+      url: 'https://semble-only.test/connected-thinking',
+      title: 'Connected thinking in Semble',
+      author: 'A Semble author',
+    },
+  ];
 });
 
 afterEach(() => {
@@ -172,6 +191,29 @@ describe('SembleConnectionDialog', () => {
     result.click();
     flushSync();
     expect(q('.chosen-url')!.textContent).toBe('https://other.test/the-rebuttal');
+  });
+
+  it('finds cards created in Semble even when they are not saved in Skyreader', async () => {
+    render();
+    await vi.waitFor(() => {
+      flushSync();
+      typeInField('connected thinking');
+      expect(q<HTMLButtonElement>('.result')?.textContent).toContain(
+        'Connected thinking in Semble'
+      );
+    });
+
+    q<HTMLButtonElement>('.result')!.click();
+    flushSync();
+    expect(q('.chosen-url')!.textContent).toBe('https://semble-only.test/connected-thinking');
+  });
+
+  it('shows search results in an anchored popover', () => {
+    render();
+    typeInField('rebuttal');
+
+    expect(q('.results-popover')).not.toBeNull();
+    expect(q('.search-shell')?.contains(q('.results-popover'))).toBe(true);
   });
 
   it('offers no swap for a non-directional relation', () => {

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
@@ -22,6 +22,7 @@
   import { savesStore } from '$lib/stores/saves.svelte';
   import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
   import { matchesTerms, normalize, parseQuery } from '$lib/services/savedSearch';
+  import { sembleSourceUrl } from '$lib/utils/semble';
   import {
     NON_DIRECTIONAL_CONNECTION_TYPES,
     SEMBLE_CONNECTION_TYPES,
@@ -36,6 +37,7 @@
 
   let open = $derived(sembleConnectionStore.open);
   let source = $derived(sembleConnectionStore.source);
+  let articleUrl = $derived(source ? sembleSourceUrl(source.cardUrl, source.url) : '');
   let submitting = $derived(sembleConnectionStore.submitting);
 
   let query = $state('');
@@ -124,7 +126,6 @@
   let results = $derived.by((): SavedItem[] => {
     const terms = parseQuery(query);
     if (terms.length === 0 || queryIsUrl) return [];
-    const articleUrl = source?.url;
     const out: SavedItem[] = [];
     for (const item of savesStore.articles) {
       if (item.url === articleUrl) continue;
@@ -159,7 +160,7 @@
   // ── The sentence, and whether it can be drawn ───────────────────────────
   let noteBytes = $derived(new TextEncoder().encode(note.trim()).length);
   let noteTooLong = $derived(noteBytes > MAX_NOTE_BYTES);
-  let sameUrl = $derived(Boolean(targetUrl) && targetUrl === source?.url);
+  let sameUrl = $derived(Boolean(targetUrl) && targetUrl === articleUrl);
   let canSubmit = $derived(
     Boolean(source) && Boolean(targetUrl) && !sameUrl && !noteTooLong && !submitting
   );

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
@@ -1,0 +1,680 @@
+<script lang="ts">
+  // Drawing one edge, in one breath.
+  //
+  // Mounted once in AppShell and driven by sembleConnectionStore, so any reading
+  // surface can open it (the same architecture as the collection picker).
+  //
+  // <!--
+  // THESIS: a connection is a SENTENCE — this article, a relation, that one —
+  //   so the dialog is read top to bottom as that sentence being completed,
+  //   not as a form with four labelled fields.
+  // OWN-WORLD: the reading room's modal chrome, flat surfaces, one interaction
+  //   blue, system sans. Nothing new is invented here.
+  // STORY: the reader finishes something, thinks "this answers that", names the
+  //   other piece (pasted, or out of their own Saved list), picks the relation,
+  //   and it's drawn.
+  // FIRST VIEWPORT: the sentence with one end already filled, then the field
+  //   that fills the other, then the relations.
+  // -->
+  import Modal from '$lib/components/common/Modal.svelte';
+  import Icon from '$lib/components/Icon.svelte';
+  import { api } from '$lib/services/api';
+  import { savesStore } from '$lib/stores/saves.svelte';
+  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
+  import { matchesTerms, normalize, parseQuery } from '$lib/services/savedSearch';
+  import {
+    NON_DIRECTIONAL_CONNECTION_TYPES,
+    SEMBLE_CONNECTION_TYPES,
+    type SavedItem,
+    type SembleConnectionType,
+  } from '$lib/types';
+
+  /** Saved articles offered at once. The field is for finding one, not browsing. */
+  const RESULT_LIMIT = 6;
+  /** Semble's lexicon caps the note here (atproto string maxLength = UTF-8 bytes). */
+  const MAX_NOTE_BYTES = 1000;
+
+  let open = $derived(sembleConnectionStore.open);
+  let source = $derived(sembleConnectionStore.source);
+  let submitting = $derived(sembleConnectionStore.submitting);
+
+  let query = $state('');
+  let targetUrl = $state('');
+  let targetTitle = $state<string | undefined>(undefined);
+  let connectionType = $state<SembleConnectionType>('RELATED');
+  let note = $state('');
+  let reversed = $state(false);
+
+  // Whether this session can write a connection at all. Read once and cached for
+  // the tab: it's a property of the session, and every existing session lacks the
+  // scope — saying so up front beats failing on submit.
+  let hasScope = $state<boolean | null>(null);
+  let scopeChecked = false;
+
+  $effect(() => {
+    if (!open) {
+      query = '';
+      targetUrl = '';
+      targetTitle = undefined;
+      connectionType = 'RELATED';
+      note = '';
+      reversed = false;
+      return;
+    }
+    void savesStore.load();
+    if (scopeChecked) return;
+    scopeChecked = true;
+    api
+      .getIntegrationStatus()
+      .then((status) => {
+        hasScope = status.scopeStatus.sembleConnections ?? false;
+      })
+      .catch(() => {
+        // Advisory only — a failed check must not block the write.
+        hasScope = null;
+      });
+  });
+
+  function hostOf(url: string): string {
+    try {
+      return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  }
+
+  function labelFor(url: string, title?: string | null): string {
+    return title?.trim() || hostOf(url);
+  }
+
+  /** `LEADS_TO` → `leads to`, the way the panel already renders relations. */
+  function typeLabel(type: SembleConnectionType): string {
+    return type.toLowerCase().replace(/_/g, ' ');
+  }
+
+  let directional = $derived(!NON_DIRECTIONAL_CONNECTION_TYPES.includes(connectionType));
+
+  // A non-directional relation reads the same either way, so the swap control
+  // has nothing to do — and a flip made under a directional type must not
+  // silently survive into the record, since the backend writes the edge
+  // whichever way round it's handed.
+  function chooseType(type: SembleConnectionType) {
+    connectionType = type;
+    if (NON_DIRECTIONAL_CONNECTION_TYPES.includes(type)) reversed = false;
+  }
+
+  // ── Finding the other end ───────────────────────────────────────────────
+  // Two ways in, one field: paste a URL, or search what you've already saved.
+  // Typing a URL is its own answer, so the result list gets out of the way.
+  let queryIsUrl = $derived(isHttpUrl(query.trim()));
+
+  function isHttpUrl(value: string): boolean {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  function savedHaystack(item: SavedItem): string {
+    return normalize([item.title, item.author, item.domain, item.url].filter(Boolean).join(' '));
+  }
+
+  let results = $derived.by((): SavedItem[] => {
+    const terms = parseQuery(query);
+    if (terms.length === 0 || queryIsUrl) return [];
+    const articleUrl = source?.url;
+    const out: SavedItem[] = [];
+    for (const item of savesStore.articles) {
+      if (item.url === articleUrl) continue;
+      if (!matchesTerms(savedHaystack(item), terms)) continue;
+      out.push(item);
+      if (out.length >= RESULT_LIMIT) break;
+    }
+    return out;
+  });
+
+  function chooseSaved(item: SavedItem) {
+    targetUrl = item.url;
+    targetTitle = item.title ?? undefined;
+    query = '';
+  }
+
+  function clearTarget() {
+    targetUrl = '';
+    targetTitle = undefined;
+  }
+
+  // A pasted URL is the answer as soon as it's a URL — no second confirming click.
+  $effect(() => {
+    const trimmed = query.trim();
+    if (isHttpUrl(trimmed)) {
+      targetUrl = trimmed;
+      targetTitle = undefined;
+      query = '';
+    }
+  });
+
+  // ── The sentence, and whether it can be drawn ───────────────────────────
+  let noteBytes = $derived(new TextEncoder().encode(note.trim()).length);
+  let noteTooLong = $derived(noteBytes > MAX_NOTE_BYTES);
+  let sameUrl = $derived(Boolean(targetUrl) && targetUrl === source?.url);
+  let canSubmit = $derived(
+    Boolean(source) && Boolean(targetUrl) && !sameUrl && !noteTooLong && !submitting
+  );
+
+  let fromLabel = $derived(
+    reversed
+      ? labelFor(targetUrl, targetTitle)
+      : labelFor(source?.url ?? '', source?.title ?? undefined)
+  );
+  let toLabel = $derived(
+    reversed
+      ? labelFor(source?.url ?? '', source?.title ?? undefined)
+      : labelFor(targetUrl, targetTitle)
+  );
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    void sembleConnectionStore.submit({
+      targetUrl,
+      targetTitle,
+      connectionType,
+      note: note.trim() || undefined,
+      reversed,
+    });
+  }
+</script>
+
+<Modal
+  {open}
+  onclose={() => sembleConnectionStore.close()}
+  maxWidth="520px"
+  title="Connect on Semble"
+>
+  <div class="connect-body">
+    {#if hasScope === false}
+      <p class="notice notice-warn">
+        <span class="notice-icon" aria-hidden="true"><Icon name="alert-circle" size={15} /></span>
+        <span>You'll be asked to log in again to allow this.</span>
+      </p>
+    {/if}
+
+    <!-- The sentence. One end is fixed (what you're reading); the other is the
+         blank the field below fills, so it stays visible as a blank. -->
+    <p class="sentence">
+      <span class="end" class:blank={!(reversed ? targetUrl : source)}>{fromLabel || '…'}</span>
+      <span class="relation">
+        <Icon name="arrow-right" size={14} />
+        <span class="relation-type">{typeLabel(connectionType)}</span>
+        <Icon name="arrow-right" size={14} />
+      </span>
+      <span class="end" class:blank={!(reversed ? source : targetUrl)}>{toLabel || '…'}</span>
+    </p>
+
+    {#if directional}
+      <button
+        type="button"
+        class="swap"
+        onclick={() => (reversed = !reversed)}
+        disabled={!targetUrl}
+      >
+        <Icon name="refresh-cw" size={13} />
+        Swap direction
+      </button>
+    {/if}
+
+    <!-- The other end -->
+    {#if targetUrl}
+      <div class="chosen">
+        <span class="chosen-icon" aria-hidden="true"><Icon name="link" size={14} /></span>
+        <span class="chosen-text">
+          <span class="chosen-title">{labelFor(targetUrl, targetTitle)}</span>
+          <span class="chosen-url">{targetUrl}</span>
+        </span>
+        <button
+          type="button"
+          class="chosen-clear"
+          onclick={clearTarget}
+          aria-label="Choose a different article"
+        >
+          <Icon name="x" size={14} />
+        </button>
+      </div>
+      {#if sameUrl}
+        <p class="field-error">That's the article you're on. Pick a different one.</p>
+      {/if}
+    {:else}
+      <div class="search-row">
+        <span class="search-icon" aria-hidden="true"><Icon name="search" size={16} /></span>
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+          type="text"
+          class="search-input"
+          placeholder="Paste a URL, or search your saved articles"
+          aria-label="The other end of the connection"
+          bind:value={query}
+          autofocus
+        />
+      </div>
+      {#if results.length > 0}
+        <ul class="results">
+          {#each results as item (item.rkey)}
+            <li>
+              <button type="button" class="result" onclick={() => chooseSaved(item)}>
+                <span class="result-title">{labelFor(item.url, item.title)}</span>
+                <span class="result-host">{hostOf(item.url)}</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {:else if parseQuery(query).length > 0 && !queryIsUrl}
+        <p class="hint">Nothing saved matches. Paste a URL instead.</p>
+      {/if}
+    {/if}
+
+    <!-- The relation -->
+    <div class="types" role="radiogroup" aria-label="Connection type">
+      {#each SEMBLE_CONNECTION_TYPES as type (type)}
+        <button
+          type="button"
+          class="type-pill"
+          class:selected={connectionType === type}
+          role="radio"
+          aria-checked={connectionType === type}
+          onclick={() => chooseType(type)}
+        >
+          {typeLabel(type)}
+        </button>
+      {/each}
+    </div>
+
+    <textarea
+      class="note"
+      rows="2"
+      placeholder="Why? (optional)"
+      aria-label="Note"
+      bind:value={note}></textarea>
+    {#if noteBytes > MAX_NOTE_BYTES - 100}
+      <p class="field-error" class:soft={!noteTooLong}>
+        {MAX_NOTE_BYTES - noteBytes} characters left
+      </p>
+    {/if}
+  </div>
+
+  {#snippet footer()}
+    <button
+      class="btn btn-secondary"
+      onclick={() => sembleConnectionStore.close()}
+      disabled={submitting}
+      type="button">Cancel</button
+    >
+    <button class="btn btn-primary" onclick={handleSubmit} disabled={!canSubmit} type="button">
+      {submitting ? 'Connecting…' : 'Connect'}
+    </button>
+  {/snippet}
+</Modal>
+
+<style>
+  .connect-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 0;
+  }
+
+  /* ── Notice ─────────────────────────────────────────────────
+     Same shape as the collection picker's, so an out-of-band
+     message reads the same wherever the reader meets it. */
+  .notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: var(--text-md);
+    line-height: var(--leading-snug);
+    color: var(--color-text-secondary);
+  }
+
+  .notice-warn {
+    padding: 0.5rem 0.625rem;
+    border-radius: 6px;
+    background: var(--color-bg-secondary);
+  }
+
+  .notice-icon {
+    display: flex;
+    flex-shrink: 0;
+    margin-top: 0.0625rem;
+    color: var(--color-warning);
+  }
+
+  /* ── The sentence ───────────────────────────────────────────
+     Reads left to right as what will be written. The unfilled end
+     stays a visible blank rather than collapsing. */
+  .sentence {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: var(--text-lg);
+    line-height: var(--leading-snug);
+    color: var(--color-text);
+  }
+
+  .end {
+    flex: 1 1 8rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: var(--weight-medium);
+  }
+
+  .end.blank {
+    color: var(--color-text-secondary);
+    font-weight: var(--weight-normal);
+  }
+
+  .relation {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-shrink: 0;
+    color: var(--color-primary);
+    font-size: var(--text-sm);
+  }
+
+  .relation-type {
+    font-weight: var(--weight-medium);
+  }
+
+  .swap {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3125rem;
+    padding: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .swap:hover:not(:disabled) {
+    color: var(--color-primary);
+  }
+
+  .swap:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  /* ── The other end ──────────────────────────────────────────── */
+  .search-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4375rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    transition: border-color 0.15s ease;
+  }
+
+  .search-row:focus-within {
+    border-color: var(--color-primary);
+  }
+
+  .search-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-family: inherit;
+    font-size: var(--text-lg);
+    color: var(--color-text);
+  }
+
+  .search-input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  .results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .result {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    width: 100%;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    font: inherit;
+    text-align: left;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .result:hover {
+    background: var(--color-bg-secondary);
+  }
+
+  .result:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+
+  .result-title {
+    font-size: var(--text-md);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .result-host {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .chosen {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+  }
+
+  .chosen-icon {
+    display: flex;
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .chosen-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .chosen-title,
+  .chosen-url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chosen-title {
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
+  }
+
+  .chosen-url {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .chosen-clear {
+    display: flex;
+    flex-shrink: 0;
+    padding: 0.25rem;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .chosen-clear:hover {
+    color: var(--color-text);
+  }
+
+  .hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .field-error {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-error);
+  }
+
+  .field-error.soft {
+    color: var(--color-text-secondary);
+  }
+
+  /* ── The relation ───────────────────────────────────────────── */
+  .types {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .type-pill {
+    padding: 0.25rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: none;
+    font: inherit;
+    font-size: var(--text-sm);
+    line-height: var(--leading-none);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .type-pill:hover {
+    color: var(--color-text);
+  }
+
+  .type-pill.selected {
+    border-color: var(--color-primary);
+    background: var(--color-sidebar-active);
+    color: var(--color-primary);
+    font-weight: var(--weight-medium);
+  }
+
+  .type-pill:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .note {
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    font-family: inherit;
+    font-size: var(--text-md);
+    line-height: var(--leading-snug);
+    color: var(--color-text);
+    resize: vertical;
+  }
+
+  .note:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+
+  .note::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  /* ── Buttons ─────────────────────────────────────────────────
+     Same vocabulary as the collection picker's footer. */
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: var(--text-lg);
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background-color 0.2s ease;
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: var(--color-bg-secondary);
+  }
+
+  .btn-primary {
+    background: var(--color-primary);
+    color: #ffffff;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-dark);
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .search-row,
+    .type-pill,
+    .btn {
+      transition: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
@@ -192,6 +192,67 @@
     query = '';
   }
 
+  // The results float over the dialog rather than sitting in its flow: an
+  // in-flow list reflows and resizes the modal on every keystroke. But the
+  // modal body scrolls (`overflow-y: auto`), which clips an absolutely
+  // positioned child at the footer — so the popover is `position: fixed`,
+  // whose containing block is the viewport, and is measured against the field.
+  let searchRow = $state<HTMLElement | null>(null);
+  let showResults = $derived(parseQuery(query).length > 0 && !queryIsUrl);
+  let popover = $state<{
+    top?: number;
+    bottom?: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+
+  /** Gap between the field and the popover, and from the popover to the viewport edge. */
+  const POPOVER_GAP = 4;
+  const VIEWPORT_MARGIN = 8;
+  /** Below this much room underneath, the list is better off opening upward. */
+  const FLIP_THRESHOLD = 120;
+  const POPOVER_MAX_HEIGHT = 240;
+
+  function measurePopover() {
+    if (!searchRow) {
+      popover = null;
+      return;
+    }
+    const rect = searchRow.getBoundingClientRect();
+    const below = window.innerHeight - rect.bottom - POPOVER_GAP - VIEWPORT_MARGIN;
+    const above = rect.top - POPOVER_GAP - VIEWPORT_MARGIN;
+    const flip = below < FLIP_THRESHOLD && above > below;
+    const maxHeight = Math.max(0, Math.min(POPOVER_MAX_HEIGHT, flip ? above : below));
+    // Anchored by the edge it grows from, so a short list hugs the field
+    // either way round.
+    popover = flip
+      ? {
+          bottom: window.innerHeight - rect.top + POPOVER_GAP,
+          left: rect.left,
+          width: rect.width,
+          maxHeight,
+        }
+      : { top: rect.bottom + POPOVER_GAP, left: rect.left, width: rect.width, maxHeight };
+  }
+
+  $effect(() => {
+    if (!showResults) {
+      popover = null;
+      return;
+    }
+    // A longer list can outgrow the room below and need flipping.
+    results.length;
+    measurePopover();
+    window.addEventListener('resize', measurePopover);
+    // Capture phase: the modal body is the scroller, not the window.
+    window.addEventListener('scroll', measurePopover, true);
+    return () => {
+      window.removeEventListener('resize', measurePopover);
+      window.removeEventListener('scroll', measurePopover, true);
+    };
+  });
+
   function clearTarget() {
     targetUrl = '';
     targetTitle = undefined;
@@ -298,7 +359,7 @@
       {/if}
     {:else}
       <div class="search-shell">
-        <div class="search-row">
+        <div class="search-row" bind:this={searchRow}>
           <span class="search-icon" aria-hidden="true"><Icon name="search" size={16} /></span>
           <!-- svelte-ignore a11y_autofocus -->
           <input
@@ -307,15 +368,23 @@
             placeholder="Paste a URL, or search your Semble cards"
             aria-label="The other end of the connection"
             role="combobox"
-            aria-expanded={parseQuery(query).length > 0 && !queryIsUrl}
+            aria-expanded={showResults}
             aria-controls="semble-card-results"
             aria-autocomplete="list"
             bind:value={query}
             autofocus
           />
         </div>
-        {#if parseQuery(query).length > 0 && !queryIsUrl}
-          <div class="results-popover" id="semble-card-results">
+        {#if showResults && popover}
+          <div
+            class="results-popover"
+            id="semble-card-results"
+            style:left="{popover.left}px"
+            style:width="{popover.width}px"
+            style:max-height="{popover.maxHeight}px"
+            style:top={popover.top === undefined ? undefined : `${popover.top}px`}
+            style:bottom={popover.bottom === undefined ? undefined : `${popover.bottom}px`}
+          >
             {#if results.length > 0}
               <ul class="results">
                 {#each results as item (item.key)}
@@ -479,7 +548,7 @@
 
   /* ── The other end ──────────────────────────────────────────── */
   .search-shell {
-    position: relative;
+    min-width: 0;
   }
 
   .search-row {
@@ -527,13 +596,11 @@
     flex-direction: column;
   }
 
+  /* Fixed, not absolute: the scrolling modal body would clip an absolutely
+     positioned child. Coordinates come from `measurePopover`. */
   .results-popover {
-    position: absolute;
+    position: fixed;
     z-index: 2;
-    top: calc(100% + 0.25rem);
-    left: 0;
-    right: 0;
-    max-height: 15rem;
     overflow-y: auto;
     padding: 0.25rem;
     border: 1px solid var(--color-border);

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.svelte
@@ -27,8 +27,17 @@
     NON_DIRECTIONAL_CONNECTION_TYPES,
     SEMBLE_CONNECTION_TYPES,
     type SavedItem,
+    type SembleCard,
     type SembleConnectionType,
   } from '$lib/types';
+
+  type SearchItem = {
+    key: string;
+    url: string;
+    title?: string;
+    author?: string;
+    domain?: string;
+  };
 
   /** Saved articles offered at once. The field is for finding one, not browsing. */
   const RESULT_LIMIT = 6;
@@ -46,6 +55,9 @@
   let connectionType = $state<SembleConnectionType>('RELATED');
   let note = $state('');
   let reversed = $state(false);
+  let sembleCards = $state<SembleCard[]>([]);
+  let cardsLoading = $state(false);
+  let cardsLoadedForOpen = false;
 
   // Whether this session can write a connection at all. Read once and cached for
   // the tab: it's a property of the session, and every existing session lacks the
@@ -61,9 +73,28 @@
       connectionType = 'RELATED';
       note = '';
       reversed = false;
+      sembleCards = [];
+      cardsLoading = false;
+      cardsLoadedForOpen = false;
       return;
     }
     void savesStore.load();
+    if (!cardsLoadedForOpen) {
+      cardsLoadedForOpen = true;
+      cardsLoading = true;
+      api
+        .listSembleCards()
+        .then(({ cards }) => {
+          sembleCards = cards;
+        })
+        .catch(() => {
+          // Local Saved search remains useful if Semble cannot be reached.
+          sembleCards = [];
+        })
+        .finally(() => {
+          cardsLoading = false;
+        });
+    }
     if (scopeChecked) return;
     scopeChecked = true;
     api
@@ -119,16 +150,35 @@
     }
   }
 
-  function savedHaystack(item: SavedItem): string {
+  function savedHaystack(item: SearchItem): string {
     return normalize([item.title, item.author, item.domain, item.url].filter(Boolean).join(' '));
   }
 
-  let results = $derived.by((): SavedItem[] => {
+  let results = $derived.by((): SearchItem[] => {
     const terms = parseQuery(query);
     if (terms.length === 0 || queryIsUrl) return [];
-    const out: SavedItem[] = [];
-    for (const item of savesStore.articles) {
+    const candidates: SearchItem[] = [
+      ...sembleCards.map((card) => ({
+        key: card.uri,
+        url: card.url,
+        title: card.title,
+        author: card.author,
+        domain: hostOf(card.url),
+      })),
+      ...savesStore.articles.map((item: SavedItem) => ({
+        key: item.uri,
+        url: item.url,
+        title: item.title ?? undefined,
+        author: item.author ?? undefined,
+        domain: item.domain ?? undefined,
+      })),
+    ];
+    const seen = new Set<string>();
+    const out: SearchItem[] = [];
+    for (const item of candidates) {
       if (item.url === articleUrl) continue;
+      if (seen.has(item.url)) continue;
+      seen.add(item.url);
       if (!matchesTerms(savedHaystack(item), terms)) continue;
       out.push(item);
       if (out.length >= RESULT_LIMIT) break;
@@ -136,7 +186,7 @@
     return out;
   });
 
-  function chooseSaved(item: SavedItem) {
+  function chooseSaved(item: SearchItem) {
     targetUrl = item.url;
     targetTitle = item.title ?? undefined;
     query = '';
@@ -247,32 +297,44 @@
         <p class="field-error">That's the article you're on. Pick a different one.</p>
       {/if}
     {:else}
-      <div class="search-row">
-        <span class="search-icon" aria-hidden="true"><Icon name="search" size={16} /></span>
-        <!-- svelte-ignore a11y_autofocus -->
-        <input
-          type="text"
-          class="search-input"
-          placeholder="Paste a URL, or search your saved articles"
-          aria-label="The other end of the connection"
-          bind:value={query}
-          autofocus
-        />
+      <div class="search-shell">
+        <div class="search-row">
+          <span class="search-icon" aria-hidden="true"><Icon name="search" size={16} /></span>
+          <!-- svelte-ignore a11y_autofocus -->
+          <input
+            type="text"
+            class="search-input"
+            placeholder="Paste a URL, or search your Semble cards"
+            aria-label="The other end of the connection"
+            role="combobox"
+            aria-expanded={parseQuery(query).length > 0 && !queryIsUrl}
+            aria-controls="semble-card-results"
+            aria-autocomplete="list"
+            bind:value={query}
+            autofocus
+          />
+        </div>
+        {#if parseQuery(query).length > 0 && !queryIsUrl}
+          <div class="results-popover" id="semble-card-results">
+            {#if results.length > 0}
+              <ul class="results">
+                {#each results as item (item.key)}
+                  <li>
+                    <button type="button" class="result" onclick={() => chooseSaved(item)}>
+                      <span class="result-title">{labelFor(item.url, item.title)}</span>
+                      <span class="result-host">{hostOf(item.url)}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="hint">
+                {cardsLoading ? 'Checking your Semble cards…' : 'No matches. Paste a URL instead.'}
+              </p>
+            {/if}
+          </div>
+        {/if}
       </div>
-      {#if results.length > 0}
-        <ul class="results">
-          {#each results as item (item.rkey)}
-            <li>
-              <button type="button" class="result" onclick={() => chooseSaved(item)}>
-                <span class="result-title">{labelFor(item.url, item.title)}</span>
-                <span class="result-host">{hostOf(item.url)}</span>
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {:else if parseQuery(query).length > 0 && !queryIsUrl}
-        <p class="hint">Nothing saved matches. Paste a URL instead.</p>
-      {/if}
     {/if}
 
     <!-- The relation -->
@@ -416,6 +478,10 @@
   }
 
   /* ── The other end ──────────────────────────────────────────── */
+  .search-shell {
+    position: relative;
+  }
+
   .search-row {
     display: flex;
     align-items: center;
@@ -459,6 +525,21 @@
     padding: 0;
     display: flex;
     flex-direction: column;
+  }
+
+  .results-popover {
+    position: absolute;
+    z-index: 2;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    right: 0;
+    max-height: 15rem;
+    overflow-y: auto;
+    padding: 0.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   }
 
   .result {

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.test-host.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.test-host.svelte
@@ -1,10 +1,23 @@
 <script lang="ts">
   import SembleConnectionDialog from './SembleConnectionDialog.svelte';
-  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
+  import {
+    sembleConnectionStore,
+    type SembleConnectionSource,
+  } from '$lib/stores/sembleConnection.svelte';
 
-  sembleConnectionStore.openFor({
-    url: 'https://example.test/the-article',
-    title: 'The Article',
+  interface Props {
+    source?: SembleConnectionSource;
+  }
+
+  let {
+    source = {
+      url: 'https://example.test/the-article',
+      title: 'The Article',
+    },
+  }: Props = $props();
+
+  $effect(() => {
+    sembleConnectionStore.openFor(source);
   });
 </script>
 

--- a/frontend/src/lib/components/feed/SembleConnectionDialog.test-host.svelte
+++ b/frontend/src/lib/components/feed/SembleConnectionDialog.test-host.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import SembleConnectionDialog from './SembleConnectionDialog.svelte';
+  import { sembleConnectionStore } from '$lib/stores/sembleConnection.svelte';
+
+  sembleConnectionStore.openFor({
+    url: 'https://example.test/the-article',
+    title: 'The Article',
+  });
+</script>
+
+<SembleConnectionDialog />

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -15,6 +15,7 @@ import type {
   ParsedFeed,
   SaveBacking,
   SembleCollection,
+  SembleCard,
   SembleConnectionType,
   SocialContextResult,
   ArticleMentions,
@@ -1070,6 +1071,10 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify(data),
     });
+  }
+
+  async listSembleCards(): Promise<{ cards: SembleCard[]; truncated: boolean }> {
+    return this.fetch('/api/integrations/semble/cards');
   }
 
   /**

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -15,6 +15,7 @@ import type {
   ParsedFeed,
   SaveBacking,
   SembleCollection,
+  SembleConnectionType,
   SocialContextResult,
   ArticleMentions,
   MentionLaneEntry,
@@ -1066,6 +1067,25 @@ class ApiClient {
     collectionResults?: { uri: string; error?: string }[];
   }> {
     return this.fetch('/api/integrations/semble/cards', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  /**
+   * Draw a Semble connection: a typed edge from `source` to `target`, written to
+   * the reader's own PDS. Online-only — a connection is a deliberate act on live
+   * context, so there's no queued variant. A session without the connection
+   * scope gets a 403 the shared fetch wrapper turns into `ScopeUpgradeError`
+   * (and the global re-login banner).
+   */
+  async createSembleConnection(data: {
+    source: string;
+    target: string;
+    connectionType?: SembleConnectionType;
+    note?: string;
+  }): Promise<{ uri: string; cid: string; rkey: string }> {
+    return this.fetch('/api/integrations/semble/connections', {
       method: 'POST',
       body: JSON.stringify(data),
     });

--- a/frontend/src/lib/stores/mentionLaneItems.svelte.ts
+++ b/frontend/src/lib/stores/mentionLaneItems.svelte.ts
@@ -81,7 +81,44 @@ function createMentionLaneItemsStore() {
     return cache.get(keyFor(url, lane));
   }
 
-  return { load, get };
+  /**
+   * Show a connection the reader just drew, now.
+   *
+   * The Semble block is served from the feed proxy's mention cache and Semble's
+   * own firehose indexing, so a fresh edge is minutes-to-hours away from coming
+   * back through `load`. Rather than let the panel read as if nothing happened,
+   * the new edge is prepended into the already-resolved context for this URL.
+   * A no-op when the lane hasn't been resolved yet — there's no list to echo
+   * into, and the eventual load will carry it.
+   */
+  function addSembleConnection(url: string, connection: SembleContext['connections'][number]) {
+    const key = keyFor(url, 'semble');
+    const state = cache.get(key);
+    if (!state?.sembleContext) return;
+    const context = state.sembleContext;
+    if (context.connections.some((c) => c.id === connection.id)) return;
+    // The counts are what the "Showing 6 of 41 connections" line reads from, so
+    // they move with the list — otherwise the echo makes the panel contradict
+    // its own footer.
+    const stats = context.stats
+      ? {
+          ...context.stats,
+          connections: {
+            ...context.stats.connections,
+            total: context.stats.connections.total + 1,
+            [connection.direction === 'out' ? 'outgoing' : 'incoming']:
+              context.stats.connections[connection.direction === 'out' ? 'outgoing' : 'incoming'] +
+              1,
+          },
+        }
+      : context.stats;
+    set(key, {
+      ...state,
+      sembleContext: { ...context, stats, connections: [connection, ...context.connections] },
+    });
+  }
+
+  return { load, get, addSembleConnection };
 }
 
 export const mentionLaneItemsStore = createMentionLaneItemsStore();

--- a/frontend/src/lib/stores/sembleConnection.component.test.ts
+++ b/frontend/src/lib/stores/sembleConnection.component.test.ts
@@ -1,0 +1,257 @@
+// Named `.component.test.ts` so it runs in the project that compiles runes —
+// the store is a `.svelte.ts` module and `$state` needs the Svelte plugin.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+
+class FakeScopeUpgradeError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'scope upgrade');
+    this.name = 'ScopeUpgradeError';
+  }
+}
+
+const createSembleConnection = vi.fn();
+
+vi.mock('$lib/services/api', () => ({
+  api: {
+    createSembleConnection: (...args: unknown[]) => createSembleConnection(...args),
+  },
+  ScopeUpgradeError: FakeScopeUpgradeError,
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+  auth: {
+    get user() {
+      return {
+        did: 'did:plc:reader',
+        handle: 'reader.bsky.social',
+        displayName: 'The Reader',
+        avatarUrl: null,
+        pdsUrl: 'https://pds.test',
+      };
+    },
+  },
+}));
+
+const addSembleConnection = vi.fn();
+vi.mock('$lib/stores/mentionLaneItems.svelte', () => ({
+  mentionLaneItemsStore: {
+    addSembleConnection: (...args: unknown[]) => addSembleConnection(...args),
+  },
+}));
+
+const { sembleConnectionStore } = await import('./sembleConnection.svelte');
+const { toastStore } = await import('./toast.svelte');
+
+const ARTICLE = 'https://example.test/the-article';
+const SLASHED = 'https://example.test/the-article/';
+const TARGET = 'https://other.test/the-rebuttal';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const OK = { uri: 'at://did:plc:reader/network.cosmik.connection/abc', cid: 'bafy', rkey: 'abc' };
+
+beforeEach(() => {
+  createSembleConnection.mockReset();
+  addSembleConnection.mockReset();
+  sembleConnectionStore.close();
+  for (const toast of [...toastStore.toasts]) toastStore.remove(toast.id);
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe('sembleConnectionStore', () => {
+  it('writes the edge in the direction the reader chose', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({ url: ARTICLE, title: 'The Article' });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'SUPPORTS',
+      note: '  Worth reading.  ',
+      reversed: false,
+    });
+
+    expect(createSembleConnection).toHaveBeenCalledWith({
+      source: ARTICLE,
+      target: TARGET,
+      connectionType: 'SUPPORTS',
+      note: 'Worth reading.',
+    });
+    expect(sembleConnectionStore.open).toBe(false);
+  });
+
+  it('swaps the endpoints when the reader flipped the arrow', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'LEADS_TO',
+      reversed: true,
+    });
+
+    expect(createSembleConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ source: TARGET, target: ARTICLE })
+    );
+  });
+
+  it('names the URL variant Semble actually holds, out of the card page', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({
+      url: ARTICLE,
+      cardUrl: `https://semble.so/url/${encodeURIComponent(SLASHED)}`,
+    });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+
+    expect(createSembleConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ source: SLASHED })
+    );
+  });
+
+  it('omits an empty note rather than writing one', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      note: '   ',
+      reversed: false,
+    });
+
+    expect(createSembleConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ note: undefined })
+    );
+  });
+
+  it('blocks a second submit while the first is in flight', async () => {
+    // Semble dedupes identical edges through its own API; a direct PDS write
+    // does not, so a double-click would mint two records.
+    const gate = deferred<typeof OK>();
+    createSembleConnection.mockReturnValue(gate.promise);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    const first = sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+    flushSync();
+    expect(sembleConnectionStore.submitting).toBe(true);
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+    expect(createSembleConnection).toHaveBeenCalledTimes(1);
+
+    gate.resolve(OK);
+    await first;
+    expect(createSembleConnection).toHaveBeenCalledTimes(1);
+    expect(sembleConnectionStore.submitting).toBe(false);
+  });
+
+  it('will not close out from under an in-flight write', async () => {
+    const gate = deferred<typeof OK>();
+    createSembleConnection.mockReturnValue(gate.promise);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    const inFlight = sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+    sembleConnectionStore.close();
+    expect(sembleConnectionStore.open).toBe(true);
+
+    gate.resolve(OK);
+    await inFlight;
+  });
+
+  it('echoes the new edge into the panel, since Semble will not serve it back yet', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      targetTitle: 'The Rebuttal',
+      connectionType: 'LEADS_TO',
+      reversed: false,
+    });
+
+    expect(addSembleConnection).toHaveBeenCalledTimes(1);
+    const [url, connection] = addSembleConnection.mock.calls[0];
+    expect(url).toBe(ARTICLE);
+    expect(connection).toMatchObject({
+      id: OK.uri,
+      direction: 'out',
+      // Rendered the way the panel already renders relations.
+      type: 'leads to',
+      curator: { did: 'did:plc:reader', handle: 'reader.bsky.social' },
+      other: { url: TARGET, title: 'The Rebuttal' },
+    });
+  });
+
+  it('echoes a reversed edge as incoming', async () => {
+    createSembleConnection.mockResolvedValue(OK);
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'SUPPORTS',
+      reversed: true,
+    });
+
+    expect(addSembleConnection.mock.calls[0][1]).toMatchObject({ direction: 'in' });
+  });
+
+  it('leaves the re-login banner to say it: no second, vaguer toast', async () => {
+    createSembleConnection.mockRejectedValue(new FakeScopeUpgradeError());
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+
+    expect(toastStore.toasts).toHaveLength(0);
+    expect(sembleConnectionStore.open).toBe(false);
+    expect(addSembleConnection).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dialog open on an ordinary failure so the reader can retry', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    createSembleConnection.mockRejectedValue(new Error('PDS unavailable'));
+    sembleConnectionStore.openFor({ url: ARTICLE });
+
+    await sembleConnectionStore.submit({
+      targetUrl: TARGET,
+      connectionType: 'RELATED',
+      reversed: false,
+    });
+
+    expect(sembleConnectionStore.open).toBe(true);
+    expect(sembleConnectionStore.submitting).toBe(false);
+    expect(toastStore.toasts[0]).toMatchObject({
+      state: 'error',
+      message: "Couldn't connect on Semble — PDS unavailable",
+    });
+    expect(addSembleConnection).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/sembleConnection.svelte.ts
+++ b/frontend/src/lib/stores/sembleConnection.svelte.ts
@@ -1,0 +1,154 @@
+// Drawing a Semble connection — a typed edge from the article you're reading to
+// another URL — as one global session.
+//
+// Deliberately the same architecture as integrationSave: a store here, a dialog
+// mounted once in AppShell, so any reading surface can open it without threading
+// props. What differs is the write path.
+//
+// Online-only, no offline queue. A connection is a deliberate act on the context
+// in front of the reader — unlike a card save there's nothing to reconcile later,
+// and queueing would add sync-queue surface for a write nobody makes blind. A
+// failure keeps the toast and invites a retry.
+//
+// Semble's own API dedupes identical edges; a direct PDS write doesn't, so a
+// double-click would mint two records. `submitting` is what stops that.
+import { api, ScopeUpgradeError } from '$lib/services/api';
+import { auth } from '$lib/stores/auth.svelte';
+import { toastStore } from '$lib/stores/toast.svelte';
+import { mentionLaneItemsStore } from '$lib/stores/mentionLaneItems.svelte';
+import { sembleCardUrl, sembleSourceUrl } from '$lib/utils/semble';
+import type { SembleConnectionType } from '$lib/types';
+
+export interface SembleConnectionSource {
+  /** The article the reader is on — the fixed end of the edge. */
+  url: string;
+  title?: string;
+  /** This URL's card page on semble.so, when the panel already resolved one. */
+  cardUrl?: string | null;
+}
+
+export interface SembleConnectionSubmission {
+  /** The other end: pasted, or picked out of the reader's Saved list. */
+  targetUrl: string;
+  targetTitle?: string;
+  connectionType: SembleConnectionType;
+  note?: string;
+  /** True when the reader flipped the arrow, making the target the source. */
+  reversed: boolean;
+}
+
+function createSembleConnectionStore() {
+  let open = $state(false);
+  let submitting = $state(false);
+  let source = $state<SembleConnectionSource | null>(null);
+
+  function openFor(data: SembleConnectionSource) {
+    if (!data.url) return;
+    source = data;
+    open = true;
+  }
+
+  function close() {
+    if (submitting) return;
+    open = false;
+    source = null;
+  }
+
+  async function submit(input: SembleConnectionSubmission) {
+    if (submitting) return;
+    const article = source;
+    if (!article) return;
+
+    // Semble keys cards by the exact URL string, so the variant its card page
+    // holds ("/post" vs "/post/") is the one an edge has to name if it's going
+    // to roll up onto that page. When the panel gave us a cardUrl, it is
+    // literally that variant, encoded — prefer it over our own copy.
+    const articleUrl = sembleSourceUrl(article.cardUrl, article.url);
+    const from = input.reversed ? input.targetUrl : articleUrl;
+    const to = input.reversed ? articleUrl : input.targetUrl;
+
+    submitting = true;
+    const toastId = toastStore.add('Connecting on Semble…');
+    try {
+      const result = await api.createSembleConnection({
+        source: from,
+        target: to,
+        connectionType: input.connectionType,
+        note: input.note?.trim() || undefined,
+      });
+
+      // Semble's AppView won't serve this edge back for a while (firehose index
+      // + the proxy's mention cache), so put it in the panel ourselves rather
+      // than leave the reader looking at a list their own act isn't in.
+      echoIntoPanel(article.url, input, result.uri);
+
+      open = false;
+      source = null;
+      toastStore.update(toastId, 'success', 'Connected on Semble', {
+        label: 'View',
+        href: article.cardUrl || sembleCardUrl(article.url) || undefined,
+      });
+    } catch (err) {
+      // The global banner already says "log in again" — a second, vaguer copy of
+      // the same news in a toast is noise.
+      if (err instanceof ScopeUpgradeError) {
+        toastStore.remove(toastId);
+        open = false;
+        source = null;
+        return;
+      }
+      console.error('Failed to create Semble connection:', err);
+      const message = err instanceof Error ? err.message : 'Please try again';
+      toastStore.update(toastId, 'error', `Couldn't connect on Semble — ${message}`);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  /** Prepend the reader's own new edge into the article's resolved Semble block. */
+  function echoIntoPanel(articleUrl: string, input: SembleConnectionSubmission, uri: string) {
+    const user = auth.user;
+    if (!user) return;
+    mentionLaneItemsStore.addSembleConnection(articleUrl, {
+      id: uri,
+      // Direction is read from the article's side: an unreversed edge points out
+      // of what the reader is on.
+      direction: input.reversed ? 'in' : 'out',
+      type: input.connectionType.toLowerCase().replace(/_/g, ' '),
+      note: input.note?.trim() || null,
+      curator: {
+        did: user.did,
+        handle: user.handle,
+        name: user.displayName ?? null,
+        avatarUrl: user.avatarUrl ?? null,
+      },
+      createdAt: new Date().toISOString(),
+      other: {
+        url: input.targetUrl,
+        title: input.targetTitle ?? null,
+        description: null,
+        siteName: null,
+        imageUrl: null,
+      },
+    });
+  }
+
+  return {
+    get open() {
+      return open;
+    },
+    get submitting() {
+      return submitting;
+    },
+    /** The article the dialog is open for — the fixed end of the edge. */
+    get source() {
+      return source;
+    },
+    /** Open the dialog with `data` as the fixed end of the edge. */
+    openFor,
+    close,
+    submit,
+  };
+}
+
+export const sembleConnectionStore = createSembleConnectionStore();

--- a/frontend/src/lib/stores/toast.svelte.ts
+++ b/frontend/src/lib/stores/toast.svelte.ts
@@ -1,9 +1,16 @@
 type ToastState = 'pending' | 'success' | 'error';
 
+/** One link out, for a result the reader may want to go look at. */
+export interface ToastAction {
+  label: string;
+  href: string;
+}
+
 interface Toast {
   id: number;
   message: string;
   state: ToastState;
+  action?: ToastAction;
 }
 
 let nextId = 0;
@@ -15,13 +22,21 @@ function add(message: string): number {
   return id;
 }
 
-function update(id: number, state: ToastState, message?: string) {
+function update(
+  id: number,
+  state: ToastState,
+  message?: string,
+  action?: { label: string; href?: string }
+) {
   const t = toasts.find((t) => t.id === id);
   if (!t) return;
   t.state = state;
   if (message) t.message = message;
+  if (action?.href) t.action = { label: action.label, href: action.href };
   if (state === 'success' || state === 'error') {
-    setTimeout(() => remove(id), state === 'success' ? 2000 : 4000);
+    // A toast carrying somewhere to go has to outlive the glance that notices it.
+    const linger = t.action ? 6000 : state === 'success' ? 2000 : 4000;
+    setTimeout(() => remove(id), linger);
   }
 }
 

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1221,6 +1221,16 @@ export interface SembleCollection {
   createdAt?: string;
 }
 
+/** A URL card from the reader's own Semble repository. */
+export interface SembleCard {
+  uri: string;
+  cid: string;
+  url: string;
+  title?: string;
+  author?: string;
+  createdAt?: string;
+}
+
 export interface MarginCollection {
   uri: string;
   cid: string;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1129,8 +1129,37 @@ export interface IntegrationStatus {
   scopeStatus: {
     margin: boolean;
     semble: boolean;
+    /**
+     * Writing a Semble *connection* needs a scope no pre-existing session holds,
+     * and it's checked separately from the card/collection scopes so those keep
+     * working. Optional: a backend older than the connection endpoint omits it.
+     */
+    sembleConnections?: boolean;
   };
 }
+
+/**
+ * Semble's connection types, exact casing (`network.cosmik.connection`).
+ * `RELATED` and `HELPFUL` are non-directional; the rest read source → target.
+ */
+export const SEMBLE_CONNECTION_TYPES = [
+  'RELATED',
+  'SUPPORTS',
+  'OPPOSES',
+  'ADDRESSES',
+  'HELPFUL',
+  'LEADS_TO',
+  'SUPPLEMENT',
+  'EXPLAINER',
+] as const;
+
+export type SembleConnectionType = (typeof SEMBLE_CONNECTION_TYPES)[number];
+
+/** The two relations that read the same both ways — swapping them is meaningless. */
+export const NON_DIRECTIONAL_CONNECTION_TYPES: readonly SembleConnectionType[] = [
+  'RELATED',
+  'HELPFUL',
+];
 
 // External-backed saves: which engine backs the Saved list (one per account).
 // Mirrors the backend SaveBacking union (backend/src/routes/settings.ts).

--- a/frontend/src/lib/utils/semble.test.ts
+++ b/frontend/src/lib/utils/semble.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { sembleCardUrl, sembleSourceUrl } from './semble';
+
+const ARTICLE = 'https://example.test/post';
+const SLASHED = 'https://example.test/post/';
+
+describe('sembleCardUrl', () => {
+  it('builds the card page the proxy builds', () => {
+    expect(sembleCardUrl(ARTICLE)).toBe(`https://semble.so/url/${encodeURIComponent(ARTICLE)}`);
+  });
+
+  it('has no card page without a URL', () => {
+    expect(sembleCardUrl(null)).toBeNull();
+    expect(sembleCardUrl(undefined)).toBeNull();
+    expect(sembleCardUrl('')).toBeNull();
+  });
+});
+
+describe('sembleSourceUrl', () => {
+  it('recovers the exact variant Semble keyed the card under', () => {
+    // The proxy resolved the trailing-slash form; an edge written against our
+    // own copy would land on a different card.
+    expect(sembleSourceUrl(sembleCardUrl(SLASHED), ARTICLE)).toBe(SLASHED);
+  });
+
+  it('falls back when the panel never resolved a card page', () => {
+    expect(sembleSourceUrl(null, ARTICLE)).toBe(ARTICLE);
+    expect(sembleSourceUrl(undefined, ARTICLE)).toBe(ARTICLE);
+  });
+
+  it('falls back on a card URL that is not semble.so', () => {
+    expect(sembleSourceUrl(`https://evil.test/url/${encodeURIComponent(SLASHED)}`, ARTICLE)).toBe(
+      ARTICLE
+    );
+  });
+
+  it('falls back on an unexpected path shape', () => {
+    expect(sembleSourceUrl('https://semble.so/collections/abc', ARTICLE)).toBe(ARTICLE);
+  });
+
+  it('falls back when the encoded segment is not an http(s) URL', () => {
+    expect(
+      sembleSourceUrl(`https://semble.so/url/${encodeURIComponent('javascript:alert(1)')}`, ARTICLE)
+    ).toBe(ARTICLE);
+  });
+});

--- a/frontend/src/lib/utils/semble.ts
+++ b/frontend/src/lib/utils/semble.ts
@@ -1,0 +1,35 @@
+// Semble's URL keying, on the reader's side.
+//
+// Semble identifies a card by the *exact* URL string, so `/post` and `/post/`
+// are two different cards (see feed-proxy/src/semble-client.ts, which picks
+// between the variants by which one actually holds anything). That matters when
+// writing a connection: an edge naming the wrong variant is real, but it rolls
+// up onto a card page the reader was never looking at.
+
+/** This URL's card page on semble.so — the same construction the proxy uses. */
+export function sembleCardUrl(url: string | null | undefined): string | null {
+  return url ? `https://semble.so/url/${encodeURIComponent(url)}` : null;
+}
+
+/**
+ * Recover the URL string Semble actually holds for an article, out of the card
+ * page the panel resolved (`https://semble.so/url/<encoded>`). That encoded
+ * segment *is* the variant Semble keyed the card under, so it beats our own copy
+ * of the article URL. Falls back to `fallback` when there's no card page yet, or
+ * it isn't the shape we expect.
+ */
+export function sembleSourceUrl(cardUrl: string | null | undefined, fallback: string): string {
+  if (!cardUrl) return fallback;
+  try {
+    const parsed = new URL(cardUrl);
+    if (parsed.hostname !== 'semble.so') return fallback;
+    const match = parsed.pathname.match(/^\/url\/(.+)$/);
+    if (!match) return fallback;
+    const decoded = decodeURIComponent(match[1]);
+    const asUrl = new URL(decoded);
+    if (asUrl.protocol !== 'http:' && asUrl.protocol !== 'https:') return fallback;
+    return decoded;
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
Skyreader can create typed, directional Semble connections from the reader and write them as `network.cosmik.connection` records to the reader's PDS.

This revision addresses the latest review feedback — *"need a way to make a connection even if the discussion is empty"*:

- The connect invitation no longer lives only inside Semble's context block, which doesn't render when Semble holds nothing about the article. The panel now carries exactly one connect control in every state: inside the Semble block when there is one, standing on its own above the compose row when there isn't (the compose row's chip stands down in that case, so the offer isn't repeated a few pixels apart).
- The reader's overflow menu and mobile action sheet gained "Connect on Semble", beside Save to Semble — an entry point that doesn't depend on what the Atmosphere returned. It reuses the already-resolved Semble card page URL when the discussion has loaded one, so the exact-variant self-edge guard still applies.

Earlier revisions in this PR:

- Search results render in a stable, anchored dropdown, so the modal no longer jumps as matches appear.
- The picker searches every URL card in the reader's Semble repository, merged and deduplicated with local Skyreader Saved items.
- Exact Semble URL variants remain excluded to prevent self-edges.

Checks:

- Frontend full test suite: 482 passed across 35 files (3 new regression tests for the empty-discussion case)
- Frontend `npm run check`: 0 errors, 20 pre-existing warnings, formatting clean

Remaining risks: Semble AppView ingestion of third-party connection records still requires live staging verification with a re-authenticated account. Untouched by this revision, and carried over from earlier review rounds: opening the dialog fires the card listing unconditionally, which can raise the global scope-upgrade banner for sessions without the Semble card scope; and the results popover is still inside the modal body's scroll box, so a full result list may clip.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-xikhpttmi6uwrczx4hsfclvh)
