### PR TITLE
Rank the discussion stream by engagement, not just recency

### DIFF
--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -272,6 +272,9 @@ export interface MentionLaneEntryResult {
   // highlighted passage it targets (distinct from the comment in `note`).
   verb: string | null;
   quote: string | null;
+  // The reference's own like count — what the merged discussion ranks on.
+  // Bluesky lane only and best-effort there; null everywhere else.
+  likeCount: number | null;
 }
 
 export interface SembleContextResult {

--- a/feed-proxy/src/bsky-appview.ts
+++ b/feed-proxy/src/bsky-appview.ts
@@ -6,7 +6,9 @@
  * lane has a per-entry metric to rank by — a linkblog note, a margin.at
  * annotation and a Semble card each *are* one save, with no second-order signal
  * attached. So this is deliberately small: one batched `app.bsky.feed.getPosts`
- * per lane expand, behind the lane's own cache.
+ * per lane expand, behind the lane's own cache. The same response carries each
+ * post's own timestamp, which comes along free and gives the caller a recency
+ * tiebreak over candidates it hasn't fetched from their PDS yet.
  *
  * Entirely best-effort. Every failure — a timeout, a 5xx, a post the appview no
  * longer serves — yields an absent entry in the map, and the caller falls back
@@ -16,9 +18,13 @@
  */
 
 const APPVIEW_BASE = 'https://public.api.bsky.app/xrpc';
-// getPosts' own documented cap. The lane resolves at most MAX_ENTRIES (8), so in
-// practice one call always covers a lane; the slice is a guard, not a pager.
-const MAX_URIS = 25;
+/**
+ * getPosts' own documented cap, and therefore the size of the candidate pool a
+ * lane can rank in one call (see MAX_RANKED_CANDIDATES in mention-lane.ts). The
+ * slice below is a guard, not a pager: a caller that hands over more URIs than
+ * this loses the tail rather than paging for it.
+ */
+export const GET_POSTS_MAX_URIS = 25;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const HEADERS = {
   'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
@@ -26,17 +32,29 @@ const HEADERS = {
 };
 
 interface GetPostsResponse {
-  posts?: Array<{ uri?: unknown; likeCount?: unknown }>;
+  posts?: Array<{ uri?: unknown; likeCount?: unknown; record?: { createdAt?: unknown } }>;
+}
+
+/** What one batched call tells us about a post: how carried it is, and when. */
+export interface PostEngagement {
+  likeCount: number;
+  // The post's own timestamp, so a caller ranking candidates can break ties on
+  // recency without paying a PDS round trip per candidate to learn the date.
+  // Null when the record carries none.
+  createdAt: string | null;
 }
 
 /**
- * Like counts for a batch of `at://` post URIs, keyed by the URI the appview
+ * Engagement for a batch of `at://` post URIs, keyed by the URI the appview
  * echoes back. URIs the appview omits (deleted, blocked, never existed) are
  * simply absent — as is every URI when the call fails outright.
  */
-export async function fetchPostLikeCounts(uris: string[]): Promise<Map<string, number>> {
-  const out = new Map<string, number>();
-  const wanted = [...new Set(uris.filter((uri) => uri.startsWith('at://')))].slice(0, MAX_URIS);
+export async function fetchPostEngagement(uris: string[]): Promise<Map<string, PostEngagement>> {
+  const out = new Map<string, PostEngagement>();
+  const wanted = [...new Set(uris.filter((uri) => uri.startsWith('at://')))].slice(
+    0,
+    GET_POSTS_MAX_URIS
+  );
   if (wanted.length === 0) return out;
 
   try {
@@ -53,7 +71,11 @@ export async function fetchPostLikeCounts(uris: string[]): Promise<Map<string, n
       if (typeof post?.uri !== 'string') continue;
       const count = post.likeCount;
       if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) continue;
-      out.set(post.uri, Math.floor(count));
+      const createdAt = post.record?.createdAt;
+      out.set(post.uri, {
+        likeCount: Math.floor(count),
+        createdAt: typeof createdAt === 'string' ? createdAt : null,
+      });
     }
   } catch (error) {
     console.error('[bsky-appview] getPosts error:', error);

--- a/feed-proxy/src/bsky-appview.ts
+++ b/feed-proxy/src/bsky-appview.ts
@@ -1,0 +1,62 @@
+/**
+ * The one engagement number the Atmosphere actually publishes: a Bluesky post's
+ * like count, read from the public appview.
+ *
+ * The discussion stream ranks its entries by engagement, and only the Bluesky
+ * lane has a per-entry metric to rank by — a linkblog note, a margin.at
+ * annotation and a Semble card each *are* one save, with no second-order signal
+ * attached. So this is deliberately small: one batched `app.bsky.feed.getPosts`
+ * per lane expand, behind the lane's own cache.
+ *
+ * Entirely best-effort. Every failure — a timeout, a 5xx, a post the appview no
+ * longer serves — yields an absent entry in the map, and the caller falls back
+ * to the recency order it used before. A missing adornment is not an error, so
+ * nothing here throws and nothing routes through the Constellation breaker (a
+ * different host, with its own health).
+ */
+
+const APPVIEW_BASE = 'https://public.api.bsky.app/xrpc';
+// getPosts' own documented cap. The lane resolves at most MAX_ENTRIES (8), so in
+// practice one call always covers a lane; the slice is a guard, not a pager.
+const MAX_URIS = 25;
+const FETCH_TIMEOUT_MS = 10 * 1000;
+const HEADERS = {
+  'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
+  Accept: 'application/json',
+};
+
+interface GetPostsResponse {
+  posts?: Array<{ uri?: unknown; likeCount?: unknown }>;
+}
+
+/**
+ * Like counts for a batch of `at://` post URIs, keyed by the URI the appview
+ * echoes back. URIs the appview omits (deleted, blocked, never existed) are
+ * simply absent — as is every URI when the call fails outright.
+ */
+export async function fetchPostLikeCounts(uris: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const wanted = [...new Set(uris.filter((uri) => uri.startsWith('at://')))].slice(0, MAX_URIS);
+  if (wanted.length === 0) return out;
+
+  try {
+    const qs = new URLSearchParams();
+    for (const uri of wanted) qs.append('uris', uri);
+    // A fixed, trusted host: no SSRF surface, so this skips safeFetch's DNS pass.
+    const res = await fetch(`${APPVIEW_BASE}/app.bsky.feed.getPosts?${qs}`, {
+      headers: HEADERS,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return out;
+    const data = (await res.json()) as GetPostsResponse;
+    for (const post of data.posts ?? []) {
+      if (typeof post?.uri !== 'string') continue;
+      const count = post.likeCount;
+      if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) continue;
+      out.set(post.uri, Math.floor(count));
+    }
+  } catch (error) {
+    console.error('[bsky-appview] getPosts error:', error);
+  }
+  return out;
+}

--- a/feed-proxy/src/mention-lane.test.ts
+++ b/feed-proxy/src/mention-lane.test.ts
@@ -22,15 +22,40 @@ function seedDid(db: Database, did: string, handle: string) {
   );
 }
 
-// Mock /links/all (source discovery), /links (per-source records), and PDS
-// getRecord (the per-record note). `records` maps rkey → record value.
+// How the Bluesky appview answers `getPosts` for a case: which at-URIs it knows
+// a like count for, and whether it answers at all. Omitted → it 404s, which is
+// the "no counts, sort by date" path every other case exercises.
+type AppviewMock = {
+  likes?: Record<string, number>;
+  /** Answer with this status instead of the counts (e.g. 500). */
+  status?: number;
+  /** Fail the connection outright. */
+  throws?: boolean;
+};
+
+// Mock /links/all (source discovery), /links (per-source records), PDS
+// getRecord (the per-record note), and the Bluesky appview's getPosts (the
+// per-post like count). `records` maps rkey → record value.
 function mockConstellation(
   linksAll: Record<string, Record<string, { distinct_dids: number }>>,
   recsBySource: Record<string, Array<{ did: string; rkey: string }>>,
-  records: Record<string, Record<string, unknown>> = {}
+  records: Record<string, Record<string, unknown>> = {},
+  appview?: AppviewMock
 ) {
   return spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
     const url = new URL(String(input));
+    if (url.hostname === 'public.api.bsky.app') {
+      if (!appview) return new Response('{}', { status: 404 });
+      if (appview.throws) throw new TypeError('connection refused');
+      if (appview.status) return new Response('{}', { status: appview.status });
+      // The appview returns only the posts it can serve — a deleted or blocked
+      // one is simply missing from the list, not nulled out.
+      const posts = url.searchParams
+        .getAll('uris')
+        .filter((uri) => (appview.likes ?? {})[uri] !== undefined)
+        .map((uri) => ({ uri, likeCount: appview.likes![uri] }));
+      return new Response(JSON.stringify({ posts }));
+    }
     if (url.pathname === '/links/all') {
       return new Response(JSON.stringify({ links: linksAll }));
     }
@@ -96,6 +121,97 @@ describe('getMentionLaneItems', () => {
       collections: [],
       verb: null,
       quote: null,
+      // The appview isn't mocked in this case, so the count degrades to null
+      // and the lane still resolves — the whole failure mode, in one line.
+      likeCount: null,
+    });
+  });
+
+  // The Bluesky lane is the only one with a per-entry engagement number, and the
+  // discussion stream ranks on it — so the count has to arrive with the entries,
+  // and its absence has to be survivable.
+  describe('Bluesky like counts', () => {
+    // Two authors on one source, so the batched appview call has to key its
+    // counts by at-URI rather than by position.
+    function mockTwoPosts(appview?: AppviewMock) {
+      return mockConstellation(
+        { 'app.bsky.feed.post': { '.embed.external.uri': { distinct_dids: 2 } } },
+        {
+          'app.bsky.feed.post|.embed.external.uri': [
+            { did: 'did:plc:alice', rkey: 'post1' },
+            { did: 'did:plc:bob', rkey: 'post2' },
+          ],
+        },
+        { post1: { text: 'great read' }, post2: { text: 'also good' } },
+        appview
+      );
+    }
+
+    it('stamps each entry with its own post’s like count', async () => {
+      const db = freshDb();
+      seedDid(db, 'did:plc:alice', 'alice.test');
+      seedDid(db, 'did:plc:bob', 'bob.test');
+      mockTwoPosts({
+        likes: {
+          'at://did:plc:alice/app.bsky.feed.post/post1': 12,
+          'at://did:plc:bob/app.bsky.feed.post/post2': 0,
+        },
+      });
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.map((e) => [e.did, e.likeCount])).toEqual([
+        ['did:plc:alice', 12],
+        ['did:plc:bob', 0],
+      ]);
+    });
+
+    it('leaves a post the appview no longer serves at null', async () => {
+      const db = freshDb();
+      seedDid(db, 'did:plc:alice', 'alice.test');
+      seedDid(db, 'did:plc:bob', 'bob.test');
+      // Bob's post was deleted: the appview omits it from the response.
+      mockTwoPosts({ likes: { 'at://did:plc:alice/app.bsky.feed.post/post1': 3 } });
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.map((e) => e.likeCount)).toEqual([3, null]);
+    });
+
+    it('still resolves the lane when the appview errors', async () => {
+      const db = freshDb();
+      seedDid(db, 'did:plc:alice', 'alice.test');
+      seedDid(db, 'did:plc:bob', 'bob.test');
+      mockTwoPosts({ status: 500 });
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.map((e) => e.note)).toEqual(['great read', 'also good']);
+      expect(entries.every((e) => e.likeCount === null)).toBe(true);
+    });
+
+    it('still resolves the lane when the appview is unreachable', async () => {
+      const db = freshDb();
+      seedDid(db, 'did:plc:alice', 'alice.test');
+      seedDid(db, 'did:plc:bob', 'bob.test');
+      mockTwoPosts({ throws: true });
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.length).toBe(2);
+      expect(entries.every((e) => e.likeCount === null)).toBe(true);
+    });
+
+    it('asks the appview nothing for a lane that has no like counts', async () => {
+      const db = freshDb();
+      seedDid(db, 'did:plc:frank', 'frank.test');
+      const spy = mockConstellation(
+        { 'at.margin.note': { '.target.source': { distinct_dids: 1 } } },
+        { 'at.margin.note|.target.source': [{ did: 'did:plc:frank', rkey: 'note1' }] },
+        { note1: { motivation: 'commenting', body: { value: 'a note' } } }
+      );
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'margin');
+      expect(entries[0].likeCount).toBeNull();
+      expect(
+        spy.mock.calls.some((call) => String(call[0]).includes('public.api.bsky.app'))
+      ).toBeFalse();
     });
   });
 
@@ -135,6 +251,7 @@ describe('getMentionLaneItems', () => {
         collections: [],
         verb: null,
         quote: null,
+        likeCount: null,
       },
     ]);
   });
@@ -170,6 +287,7 @@ describe('getMentionLaneItems', () => {
         collections: [],
         verb: null,
         quote: null,
+        likeCount: null,
       },
     ]);
   });
@@ -238,6 +356,7 @@ describe('getMentionLaneItems', () => {
         ],
         verb: null,
         quote: null,
+        likeCount: null,
       },
     ]);
   });
@@ -274,6 +393,7 @@ describe('getMentionLaneItems', () => {
         collections: [],
         verb: 'highlighted',
         quote: 'the owned library',
+        likeCount: null,
       },
     ]);
   });

--- a/feed-proxy/src/mention-lane.test.ts
+++ b/feed-proxy/src/mention-lane.test.ts
@@ -27,6 +27,8 @@ function seedDid(db: Database, did: string, handle: string) {
 // the "no counts, sort by date" path every other case exercises.
 type AppviewMock = {
   likes?: Record<string, number>;
+  /** The post record's own createdAt, per at-URI. Absent → the appview serves none. */
+  dates?: Record<string, string>;
   /** Answer with this status instead of the counts (e.g. 500). */
   status?: number;
   /** Fail the connection outright. */
@@ -53,7 +55,11 @@ function mockConstellation(
       const posts = url.searchParams
         .getAll('uris')
         .filter((uri) => (appview.likes ?? {})[uri] !== undefined)
-        .map((uri) => ({ uri, likeCount: appview.likes![uri] }));
+        .map((uri) => ({
+          uri,
+          likeCount: appview.likes![uri],
+          record: { createdAt: (appview.dates ?? {})[uri] },
+        }));
       return new Response(JSON.stringify({ posts }));
     }
     if (url.pathname === '/links/all') {
@@ -195,6 +201,106 @@ describe('getMentionLaneItems', () => {
 
       const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
       expect(entries.length).toBe(2);
+      expect(entries.every((e) => e.likeCount === null)).toBe(true);
+    });
+
+    // Constellation returns linking records in its own index order, so the
+    // eight a busy article shows have to be chosen after the counts arrive —
+    // ranking a list that was already truncated would only reorder a sample.
+    function mockCrowdedPost(appview?: AppviewMock, db?: Database) {
+      const authors = Array.from({ length: 12 }, (_, i) => ({
+        did: `did:plc:u${i}`,
+        rkey: `post${i}`,
+      }));
+      if (db) for (const a of authors) seedDid(db, a.did, `${a.did.slice(8)}.test`);
+      return mockConstellation(
+        { 'app.bsky.feed.post': { '.embed.external.uri': { distinct_dids: authors.length } } },
+        { 'app.bsky.feed.post|.embed.external.uri': authors },
+        {},
+        appview
+      );
+    }
+
+    it('ranks the whole discovered pool, not just the first eight', async () => {
+      const db = freshDb();
+      // The one post everyone carried is the last one the index returns.
+      const spy = mockCrowdedPost(
+        {
+          likes: {
+            'at://did:plc:u11/app.bsky.feed.post/post11': 99,
+            'at://did:plc:u2/app.bsky.feed.post/post2': 5,
+          },
+        },
+        db
+      );
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+
+      expect(entries.length).toBe(8);
+      expect(entries.map((e) => e.did).slice(0, 2)).toEqual(['did:plc:u11', 'did:plc:u2']);
+      // Unscored candidates fall in behind, still in index order.
+      expect(entries.map((e) => e.did).slice(2)).toEqual([
+        'did:plc:u0',
+        'did:plc:u1',
+        'did:plc:u3',
+        'did:plc:u4',
+        'did:plc:u5',
+        'did:plc:u6',
+      ]);
+      // One appview call, carrying every candidate — not one per post.
+      const appviewCalls = spy.mock.calls.filter((call) =>
+        String(call[0]).includes('public.api.bsky.app')
+      );
+      expect(appviewCalls.length).toBe(1);
+      expect(new URL(String(appviewCalls[0][0])).searchParams.getAll('uris').length).toBe(12);
+      // Only the survivors cost a PDS round trip for their post record.
+      const fetchedPosts = spy.mock.calls
+        .map((call) => new URL(String(call[0])))
+        .filter(
+          (url) =>
+            url.pathname === '/xrpc/com.atproto.repo.getRecord' &&
+            url.searchParams.get('collection') === 'app.bsky.feed.post'
+        )
+        .map((url) => url.searchParams.get('rkey'));
+      expect(fetchedPosts.sort()).toEqual(
+        ['post11', 'post2', 'post0', 'post1', 'post3', 'post4', 'post5', 'post6'].sort()
+      );
+    });
+
+    it('breaks like-count ties on the post date the same call returns', async () => {
+      const db = freshDb();
+      // Nobody liked anything, so the pool is chosen purely on recency — and the
+      // two newest posts are the last two the index returns.
+      const uri = (i: number) => `at://did:plc:u${i}/app.bsky.feed.post/post${i}`;
+      const likes: Record<string, number> = {};
+      const dates: Record<string, string> = {};
+      for (let i = 0; i < 12; i++) {
+        likes[uri(i)] = 0;
+        dates[uri(i)] = `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`;
+      }
+      mockCrowdedPost({ likes, dates }, db);
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.map((e) => e.did).slice(0, 2)).toEqual(['did:plc:u11', 'did:plc:u10']);
+      expect(entries.length).toBe(8);
+      expect(entries.some((e) => e.did === 'did:plc:u0')).toBeFalse();
+    });
+
+    it('falls back to the first eight in index order when the appview errors', async () => {
+      const db = freshDb();
+      mockCrowdedPost({ status: 500 }, db);
+
+      const { entries } = await getMentionLaneItems(db, ARTICLE, 'bluesky');
+      expect(entries.map((e) => e.did)).toEqual([
+        'did:plc:u0',
+        'did:plc:u1',
+        'did:plc:u2',
+        'did:plc:u3',
+        'did:plc:u4',
+        'did:plc:u5',
+        'did:plc:u6',
+        'did:plc:u7',
+      ]);
       expect(entries.every((e) => e.likeCount === null)).toBe(true);
     });
 

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -33,7 +33,7 @@ import { resolveHandle, resolvePdsUrl } from './did-resolver';
 import { safeFetch } from './ssrf-guard';
 import { resolveSiteMeta, buildCanonicalUrl, parseAtUri } from './standard-site';
 import { constellationGet, constellationGetResult } from './constellation-client';
-import { fetchPostLikeCounts } from './bsky-appview';
+import { fetchPostEngagement, GET_POSTS_MAX_URIS } from './bsky-appview';
 import { extractContentText } from './document-content';
 import {
   fetchSembleContext,
@@ -56,6 +56,14 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 // One entry per author; bound the per-record PDS fetches behind an expand.
 const MAX_ENTRIES = 8;
+// The Bluesky lane discovers more candidates than it shows and keeps the
+// most-liked MAX_ENTRIES of them. Constellation returns linking records in its
+// own index order, not by engagement, so ranking a list already truncated to
+// eight would just reorder an arbitrary sample — and on a busy article the post
+// everyone carried is exactly the one sitting outside it. Capped at the
+// appview's batch limit so the wider pool still costs one call; only the eight
+// survivors are fetched from their PDS, so the expensive work is unchanged.
+const MAX_RANKED_CANDIDATES = GET_POSTS_MAX_URIS;
 // Over-fetch linking records before dedup-by-author so the cap is met after dups.
 const LINKS_PAGE_LIMIT = 30;
 
@@ -132,8 +140,21 @@ interface LinksAllResponse {
   links?: Record<string, Record<string, { records?: number; distinct_dids?: number }>>;
 }
 
+interface LinkingRecord {
+  did: string;
+  collection: string;
+  rkey: string;
+}
+
 interface LinksResponse {
-  linking_records?: Array<{ did: string; collection: string; rkey: string }>;
+  linking_records?: LinkingRecord[];
+}
+
+// A candidate that survived selection, carrying whatever engagement number it
+// was ranked on so the resolved entry can be stamped with it.
+interface PickedRecord {
+  rec: LinkingRecord;
+  likeCount: number | null;
 }
 
 interface CacheRow {
@@ -414,6 +435,53 @@ export class MentionLaneUnavailableError extends Error {
 }
 
 /**
+ * Choose the MAX_ENTRIES records a lane will actually resolve, from the wider
+ * pool discovery turned up.
+ *
+ * The Bluesky lane scores its whole pool with one batched appview call and keeps
+ * the most-liked — so an article with thirty posts about it leads with the ones
+ * people carried, not with whichever eight the index happened to return first.
+ * Ties fall back to recency, using the post date the same call hands over (the
+ * entry's own createdAt still comes from the PDS record; asking every candidate
+ * for it is exactly the cost the cap exists to avoid). The sort is stable, so a
+ * candidate the appview never mentioned — or an appview that didn't answer at
+ * all, leaving every candidate unscored — keeps the index's order, which is the
+ * first-N list this lane returned before ranking existed.
+ *
+ * No other lane has a per-entry metric — a linkblog note, a margin.at annotation
+ * and a Semble card each *are* one save — so they take the head of the pool
+ * unscored.
+ */
+async function pickLaneRecords(
+  laneId: LaneId,
+  candidates: LinkingRecord[]
+): Promise<PickedRecord[]> {
+  if (laneId !== 'bluesky') {
+    return candidates.slice(0, MAX_ENTRIES).map((rec) => ({ rec, likeCount: null }));
+  }
+  const uris = candidates.map((rec) => `at://${rec.did}/${rec.collection}/${rec.rkey}`);
+  const engagement = await fetchPostEngagement(uris);
+  return candidates
+    .map((rec, i) => {
+      const post = engagement.get(uris[i]);
+      const at = post?.createdAt ? Date.parse(post.createdAt) : NaN;
+      return { rec, likeCount: post?.likeCount ?? null, postedAt: Number.isFinite(at) ? at : null };
+    })
+    .sort((a, b) => {
+      const byLikes = (b.likeCount ?? 0) - (a.likeCount ?? 0);
+      if (byLikes !== 0) return byLikes;
+      // Undated candidates sort last within their like bucket, matching the
+      // surface's own rule for an entry with no timestamp.
+      if (a.postedAt === null || b.postedAt === null) {
+        return a.postedAt === b.postedAt ? 0 : a.postedAt === null ? 1 : -1;
+      }
+      return b.postedAt - a.postedAt;
+    })
+    .slice(0, MAX_ENTRIES)
+    .map(({ rec, likeCount }) => ({ rec, likeCount }));
+}
+
+/**
  * Resolve the people inside one lane for an article URL, served from
  * `constellation_cache` when fresh. Returns an empty list for a bad URL, an
  * unknown lane, or a PDS failure on an individual record. Throws
@@ -512,11 +580,14 @@ export async function getMentionLaneItems(
   }
 
   // Gather linking records across this lane's sources, dedup by author (a person
-  // may link via several paths), capped.
+  // may link via several paths), capped. A rankable lane gathers a wider pool
+  // than it will show and picks from it below; every other lane's cap is the
+  // number of entries it returns, since discovery order is all it has to go on.
+  const poolLimit = laneId === 'bluesky' ? MAX_RANKED_CANDIDATES : MAX_ENTRIES;
   const seen = new Set<string>();
-  const picked: Array<{ did: string; collection: string; rkey: string }> = [];
+  const candidates: LinkingRecord[] = [];
   for (const src of sources) {
-    if (picked.length >= MAX_ENTRIES) break;
+    if (candidates.length >= poolLimit) break;
     const links = await constellationGetResult<LinksResponse>('/links', {
       target: src.target,
       collection: src.collection,
@@ -527,29 +598,22 @@ export async function getMentionLaneItems(
     for (const rec of links.data?.linking_records ?? []) {
       if (seen.has(rec.did)) continue;
       seen.add(rec.did);
-      picked.push({ did: rec.did, collection: rec.collection, rkey: rec.rkey });
-      if (picked.length >= MAX_ENTRIES) break;
+      candidates.push({ did: rec.did, collection: rec.collection, rkey: rec.rkey });
+      if (candidates.length >= poolLimit) break;
     }
   }
   // The index said this lane has people; if we then couldn't reach it to ask who,
   // an empty list would read as "nobody" — which is the one thing we know is
   // false here.
-  if (picked.length === 0 && unreachable) throw new MentionLaneUnavailableError();
+  if (candidates.length === 0 && unreachable) throw new MentionLaneUnavailableError();
 
-  const entries = await Promise.all(picked.map((rec) => resolveEntry(db, laneId, rec)));
-
-  // Rank material for the merged discussion: one batched appview call stamps the
-  // Bluesky lane's posts with their like counts. `picked` and `entries` are
-  // index-aligned (the map above), so the record's AT-URI keys the stamp. On any
-  // failure the counts stay null and the surface falls back to recency.
-  if (laneId === 'bluesky' && entries.length > 0) {
-    const uris = picked.map((rec) => `at://${rec.did}/${rec.collection}/${rec.rkey}`);
-    const likes = await fetchPostLikeCounts(uris);
-    entries.forEach((entry, i) => {
-      const count = likes.get(uris[i]);
-      if (count !== undefined) entry.likeCount = count;
-    });
-  }
+  const picked = await pickLaneRecords(laneId, candidates);
+  const entries = await Promise.all(picked.map((p) => resolveEntry(db, laneId, p.rec)));
+  // `picked` and `entries` are index-aligned (the map above), so each entry
+  // carries the count its record was ranked on.
+  entries.forEach((entry, i) => {
+    entry.likeCount = picked[i].likeCount;
+  });
 
   const result: MentionLaneItemsResult =
     laneId === 'semble'

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -33,6 +33,7 @@ import { resolveHandle, resolvePdsUrl } from './did-resolver';
 import { safeFetch } from './ssrf-guard';
 import { resolveSiteMeta, buildCanonicalUrl, parseAtUri } from './standard-site';
 import { constellationGet, constellationGetResult } from './constellation-client';
+import { fetchPostLikeCounts } from './bsky-appview';
 import { extractContentText } from './document-content';
 import {
   fetchSembleContext,
@@ -95,6 +96,11 @@ export interface MentionLaneEntry {
   // The highlighted passage a margin.at note targets (its TextQuoteSelector),
   // distinct from the user's own comment in `note`. Null elsewhere.
   quote: string | null;
+  // How many likes the reference itself has — the surface's engagement sort key.
+  // Bluesky lane only, and best-effort even there: null when the appview didn't
+  // answer or no longer serves the post. Every other lane is null by nature,
+  // since a note or a save carries no second-order count (see bsky-appview.ts).
+  likeCount: number | null;
 }
 
 export interface MentionLaneItemsResult {
@@ -383,11 +389,14 @@ async function resolveEntry(
     collections,
     verb,
     quote,
+    // Stamped by the caller for the Bluesky lane, in one batched appview call
+    // across the whole lane rather than a fetch per entry.
+    likeCount: null,
   };
 }
 
 function cacheKey(laneId: LaneId, normUrl: string): string {
-  return `lane-items2:${laneId}|${normUrl}`;
+  return `lane-items3:${laneId}|${normUrl}`;
 }
 
 /**
@@ -464,6 +473,9 @@ export async function getMentionLaneItems(
         collections: [],
         verb: null,
         quote: null,
+        // A Semble card has no like count of its own — the article-level save
+        // count lives in `sembleContext.stats`, not on a person's entry.
+        likeCount: null,
       }));
       const result = { entries, sembleContext };
       writeCacheJson(db, key, result, now);
@@ -525,6 +537,20 @@ export async function getMentionLaneItems(
   if (picked.length === 0 && unreachable) throw new MentionLaneUnavailableError();
 
   const entries = await Promise.all(picked.map((rec) => resolveEntry(db, laneId, rec)));
+
+  // Rank material for the merged discussion: one batched appview call stamps the
+  // Bluesky lane's posts with their like counts. `picked` and `entries` are
+  // index-aligned (the map above), so the record's AT-URI keys the stamp. On any
+  // failure the counts stay null and the surface falls back to recency.
+  if (laneId === 'bluesky' && entries.length > 0) {
+    const uris = picked.map((rec) => `at://${rec.did}/${rec.collection}/${rec.rkey}`);
+    const likes = await fetchPostLikeCounts(uris);
+    entries.forEach((entry, i) => {
+      const count = likes.get(uris[i]);
+      if (count !== undefined) entry.likeCount = count;
+    });
+  }
+
   const result: MentionLaneItemsResult =
     laneId === 'semble'
       ? {

--- a/frontend/src/lib/components/articleCardView.types.ts
+++ b/frontend/src/lib/components/articleCardView.types.ts
@@ -48,6 +48,12 @@ export interface LanePersonVM {
   verb: string | null;
   /** margin.at lane only: the highlighted passage, distinct from the `note` comment. */
   quote: string | null;
+  /**
+   * Likes on the reference itself — what the discussion stream ranks on.
+   * Bluesky lane only and best-effort there; null elsewhere and for any payload
+   * resolved before the count existed.
+   */
+  likeCount: number | null;
 }
 
 /** `all` is the resting state of the discussion: every lane, one stream. */
@@ -88,7 +94,11 @@ export interface DiscussionEntryVM extends LanePersonVM {
   cleanNote: string | null;
 }
 
-/** The merged, filtered, chronologically ordered discussion. */
+/**
+ * The merged, filtered discussion, ranked by engagement: the most-liked
+ * references lead, with recency as the tiebreak (so the entries carrying no
+ * count — every lane but Bluesky — stay newest-first among themselves).
+ */
 export interface DiscussionStreamVM {
   /**
    * Nobody has asked for the people yet — the host hasn't opened the stream (the

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import AtmospherePanel from './AtmospherePanel.svelte';
-import type { LaneRowVM, SembleContextVM } from '../articleCardView.types';
+import type { DiscussionEntryVM, LaneRowVM, SembleContextVM } from '../articleCardView.types';
 
 const mounted: Record<string, any>[] = [];
 
@@ -56,7 +56,7 @@ function connection(direction: 'in' | 'out'): SembleContextVM['connections'][num
 
 function render(props: {
   sembleContext?: SembleContextVM;
-  stream?: { loading: boolean; failed?: boolean; entries: [] };
+  stream?: { loading: boolean; failed?: boolean; entries: DiscussionEntryVM[] };
   onSaveConnection?: (url: string) => void | Promise<void>;
   isConnectionSaved?: (url: string) => boolean;
 }): HTMLElement {
@@ -259,5 +259,70 @@ describe('AtmospherePanel Semble collections', () => {
       },
     });
     expect(target.querySelector('.semble-foot')?.textContent).toContain('Semble holds more than');
+  });
+});
+
+// The stream leads with the most-liked references, and an invisible sort key
+// reads as random order — so the number that decided the rank is on the row.
+describe('AtmospherePanel entry engagement', () => {
+  afterEach(() => {
+    for (const component of mounted.splice(0)) unmount(component);
+    document.body.innerHTML = '';
+  });
+
+  function entry(did: string, likeCount: number | null): DiscussionEntryVM {
+    return {
+      did,
+      handle: `${did}.test`,
+      displayName: null,
+      avatar: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      note: 'said something',
+      url: null,
+      collections: [],
+      verb: null,
+      quote: null,
+      likeCount,
+      key: `bluesky|${did}|`,
+      lane: 'bluesky',
+      laneLabel: 'Bluesky',
+      laneIcon: 'bluesky',
+      headVerb: 'posted',
+      relativeTime: '2d ago',
+      isoTime: '2026-01-01T00:00:00.000Z',
+      cleanNote: 'said something',
+    };
+  }
+
+  function likeLines(entries: DiscussionEntryVM[]): (string | null)[] {
+    const target = render({ stream: { loading: false, entries } });
+    return [...target.querySelectorAll('.entry')].map(
+      (row) => row.querySelector('.entry-likes')?.textContent ?? null
+    );
+  }
+
+  it('names the count that ranked the entry, singular and plural', () => {
+    expect(likeLines([entry('did:plc:many', 12), entry('did:plc:one', 1)])).toEqual([
+      '12 likes',
+      '1 like',
+    ]);
+  });
+
+  it('scores nothing when there is nothing to score', () => {
+    // Zero likes and a lane with no metric at all read the same: no meta.
+    expect(likeLines([entry('did:plc:zero', 0), entry('did:plc:none', null)])).toEqual([
+      null,
+      null,
+    ]);
+  });
+
+  it('renders the entries in the order it was handed them', () => {
+    const target = render({
+      stream: { loading: false, entries: [entry('did:plc:top', 40), entry('did:plc:next', 2)] },
+    });
+    expect([...target.querySelectorAll('.entry-likes')].map((n) => n.textContent)).toEqual([
+      '40 likes',
+      '2 likes',
+    ]);
   });
 });

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -308,6 +308,11 @@
     return source.charAt(0).toUpperCase();
   }
 
+  // The engagement number the stream ranked on, as it reads in the head line.
+  function likeLabel(count: number): string {
+    return `${count} ${count === 1 ? 'like' : 'likes'}`;
+  }
+
   function monogramFor(entry: DiscussionEntryVM): string {
     return monogram(entry.displayName?.trim() || entry.handle || entry.did.replace('did:plc:', ''));
   }
@@ -628,6 +633,14 @@
                   <time class="entry-time" datetime={entry.isoTime ?? undefined}
                     >{entry.relativeTime}</time
                   >
+                {/if}
+                <!-- The stream leads with the most-liked references, so the
+                     number that decided the order is on the row. Plain muted
+                     text, and absent entirely at zero — a quiet discussion
+                     shouldn't be scored. -->
+                {#if entry.likeCount}
+                  <span class="entry-sep" aria-hidden="true">·</span>
+                  <span class="entry-likes">{likeLabel(entry.likeCount)}</span>
                 {/if}
                 {#if entry.url}
                   <a
@@ -1367,6 +1380,7 @@
 
   .entry-verb,
   .entry-sep,
+  .entry-likes,
   .entry-time {
     flex-shrink: 0;
     white-space: nowrap;

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -4,9 +4,10 @@
 // highlighted / saved it, and who. This is the wiring the feed card, the
 // fullscreen reader, and any future surface have in common: fetching the
 // per-lane counts, folding LANE_META into a render-ready row VM, resolving the
-// people, and merging every lane into ONE chronological stream. The
-// mode-specific bits — whether a lane can be created from this surface, and what
-// "create" does — stay with the caller and are injected as getters.
+// people, and merging every lane into ONE engagement-ranked stream (most-liked
+// first, recency as the tiebreak — see discussionSort). The mode-specific bits —
+// whether a lane can be created from this surface, and what "create" does — stay
+// with the caller and are injected as getters.
 //
 // The merge is the point: an article's discussion is one conversation that
 // happens to be spread across four networks, not four lists to click between.
@@ -32,6 +33,7 @@ import { articleMentionsStore } from '$lib/stores/articleMentions.svelte';
 import { mentionLaneItemsStore } from '$lib/stores/mentionLaneItems.svelte';
 import { preferences } from '$lib/stores/preferences.svelte';
 import { cleanDiscussionNote } from '$lib/utils/discussionNote';
+import { byEngagement } from '$lib/utils/discussionSort';
 import { formatRelativeDate } from '$lib/utils/date';
 
 // Per-lane display metadata. The count + verb come from the network breakdown;
@@ -106,7 +108,7 @@ export interface AtmosphereApi {
   readonly filters: DiscussionFilterVM[];
   /** The chip currently in effect. */
   readonly activeFilter: DiscussionFilterId;
-  /** The merged, filtered, newest-first discussion. */
+  /** The merged, filtered discussion: most-liked first, newest as the tiebreak. */
   readonly stream: DiscussionStreamVM;
   readonly sembleContext: SembleContextVM | undefined;
   /** Total references across lanes — the headline count on the Discussion button. */
@@ -263,8 +265,8 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     }
   }
 
-  // The merge: every lane's people in one newest-first list, each entry told
-  // which lane it came from and cleaned of the titles and links the article
+  // The merge: every lane's people in one engagement-ranked list, each entry
+  // told which lane it came from and cleaned of the titles and links the article
   // already shows, then split into what people SAID and what merely relinked.
   const stream = $derived.by<DiscussionStreamVM>(() => {
     // Nothing has been asked for yet. Distinct from loading: with no request in
@@ -304,7 +306,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
         });
       }
     }
-    entries.sort(newestFirst);
+    entries.sort(byEngagement);
 
     // Split the conversation from the distribution. An entry with no words, no
     // quoted passage and no named collection is a bare link drop — a bridge or a
@@ -338,17 +340,6 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
       linkOnly,
     };
   });
-
-  // Newest first; an undated reference (a record with no timestamp we could
-  // parse) sorts to the end rather than pretending to be new.
-  function newestFirst(a: DiscussionEntryVM, b: DiscussionEntryVM): number {
-    const at = a.createdAt ? Date.parse(a.createdAt) : NaN;
-    const bt = b.createdAt ? Date.parse(b.createdAt) : NaN;
-    if (Number.isNaN(at) && Number.isNaN(bt)) return 0;
-    if (Number.isNaN(at)) return 1;
-    if (Number.isNaN(bt)) return -1;
-    return bt - at;
-  }
 
   function retry() {
     const url = opts.itemUrl();

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -793,6 +793,12 @@ export interface MentionLaneEntry {
   // (distinct from the user's comment in `note`). Null for other lanes.
   verb: string | null;
   quote: string | null;
+  // Likes on the reference itself — the merged discussion's sort key. Bluesky
+  // lane only (no other network publishes a per-reference count) and
+  // best-effort even there: null when the appview didn't answer, and absent
+  // entirely from a payload an older proxy cached. Adornment, so a missing
+  // count ranks as 0 rather than failing anything.
+  likeCount: number | null;
 }
 
 export interface CommunityHighlightNote {

--- a/frontend/src/lib/utils/discussionSort.test.ts
+++ b/frontend/src/lib/utils/discussionSort.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { byEngagement, newestFirst } from './discussionSort';
+import type { LanePersonVM } from '$lib/components/articleCardView.types';
+
+function entry(
+  did: string,
+  hoursAgo: number | null,
+  likeCount: number | null = null
+): LanePersonVM {
+  return {
+    did,
+    handle: `${did}.test`,
+    displayName: null,
+    avatar: null,
+    createdAt: hoursAgo === null ? null : new Date(Date.now() - hoursAgo * 3_600_000).toISOString(),
+    note: null,
+    url: null,
+    collections: [],
+    verb: null,
+    quote: null,
+    likeCount,
+  };
+}
+
+const order = (entries: LanePersonVM[]) => [...entries].sort(byEngagement).map((e) => e.did);
+
+describe('byEngagement', () => {
+  it('leads with the most-liked reference, not the newest', () => {
+    expect(order([entry('fresh', 1, 0), entry('carried', 40, 12)])).toEqual(['carried', 'fresh']);
+  });
+
+  it('keeps entries with no metric newest-first among themselves', () => {
+    // Every lane but Bluesky is null by nature — the order they had before.
+    expect(order([entry('old', 40), entry('new', 2), entry('mid', 20)])).toEqual([
+      'new',
+      'mid',
+      'old',
+    ]);
+  });
+
+  it('breaks a tie in likes by recency', () => {
+    expect(order([entry('older', 30, 5), entry('newer', 3, 5)])).toEqual(['newer', 'older']);
+  });
+
+  it('treats a missing count as zero, so an old payload keeps its place', () => {
+    // A payload cached before the field existed: `likeCount` is simply absent.
+    const stale = { ...entry('stale', 2) } as LanePersonVM;
+    delete (stale as Partial<LanePersonVM>).likeCount;
+    expect(order([entry('liked', 40, 3), stale, entry('zero', 30, 0)])).toEqual([
+      'liked',
+      'stale',
+      'zero',
+    ]);
+  });
+
+  it('sorts an undated reference last rather than pretending it is new', () => {
+    expect(order([entry('undated', null), entry('dated', 40)])).toEqual(['dated', 'undated']);
+  });
+
+  it('still ranks an undated reference by its likes', () => {
+    expect(order([entry('undated', null, 9), entry('dated', 1, 2)])).toEqual(['undated', 'dated']);
+  });
+});
+
+describe('newestFirst', () => {
+  it('ignores likes entirely — it is only the tiebreak', () => {
+    const entries = [entry('old', 40, 99), entry('new', 1, 0)];
+    expect([...entries].sort(newestFirst).map((e) => e.did)).toEqual(['new', 'old']);
+  });
+});

--- a/frontend/src/lib/utils/discussionSort.ts
+++ b/frontend/src/lib/utils/discussionSort.ts
@@ -1,0 +1,38 @@
+// How the merged discussion is ordered.
+//
+// The stream is one conversation spread across four networks, and the panel
+// previews only its first few rows before a fold — so the order decides what a
+// reader actually sees. It leads with the references that carried: most-liked
+// first, recency as the tiebreak.
+//
+// Only the Bluesky lane publishes a per-entry engagement number (see the proxy's
+// bsky-appview.ts); a linkblog note, a margin.at annotation and a Semble card
+// each *are* one save, with nothing second-order attached. Those rank as 0, which
+// leaves them in exactly the order they had before — newest-first among
+// themselves, beneath whatever the network actually amplified.
+//
+// Pure, so the ordering is testable without mounting anything.
+import type { LanePersonVM } from '$lib/components/articleCardView.types';
+
+/**
+ * Newest first; an undated reference (a record with no timestamp we could parse)
+ * sorts to the end rather than pretending to be new.
+ */
+export function newestFirst(a: LanePersonVM, b: LanePersonVM): number {
+  const at = a.createdAt ? Date.parse(a.createdAt) : NaN;
+  const bt = b.createdAt ? Date.parse(b.createdAt) : NaN;
+  if (Number.isNaN(at) && Number.isNaN(bt)) return 0;
+  if (Number.isNaN(at)) return 1;
+  if (Number.isNaN(bt)) return -1;
+  return bt - at;
+}
+
+/**
+ * Most-liked first, then newest first. `?? 0` covers both a lane with no metric
+ * and a cached payload from before the field existed, so either way the entry
+ * keeps its old relative position instead of being pushed anywhere new.
+ */
+export function byEngagement(a: LanePersonVM, b: LanePersonVM): number {
+  const diff = (b.likeCount ?? 0) - (a.likeCount ?? 0);
+  return diff !== 0 ? diff : newestFirst(a, b);
+}

--- a/frontend/src/routes/dev/cards/fixtures.ts
+++ b/frontend/src/routes/dev/cards/fixtures.ts
@@ -95,6 +95,7 @@ export function streamEntry(lane: LaneId, seed: StreamEntrySeed): DiscussionEntr
     collections: [],
     verb: null,
     quote: null,
+    likeCount: null,
     ...seed,
     createdAt,
     headVerb: seed.verb ?? (seed.collections?.length ? null : meta.verb),

--- a/frontend/src/routes/dev/discussion/+page.svelte
+++ b/frontend/src/routes/dev/discussion/+page.svelte
@@ -5,6 +5,7 @@
   // backend (see ../+layout.ts).
   import AtmospherePanel from '$lib/components/feed/AtmospherePanel.svelte';
   import { hoursAgo, laneVM, splitStream, streamEntry } from '../cards/fixtures';
+  import { byEngagement } from '$lib/utils/discussionSort';
   import type { DiscussionFilterId, SembleContextVM } from '$lib/components/articleCardView.types';
   import Showcase from '../_harness/Showcase.svelte';
   import Case from '../_harness/Case.svelte';
@@ -34,12 +35,29 @@
   // bridge post that is nothing but the headline and two links, an annotation
   // with a quoted passage, a save filed into named collections, an entry with no
   // profile record at all, and one with no date.
+  //
+  // Authored in date order and sorted below the way the hook sorts it — likes
+  // first, recency as the tiebreak — so the ranking is something you can see
+  // here rather than something you have to trust. Only Bluesky entries carry a
+  // count; every other lane is null and keeps its old newest-first order.
   const entries = [
+    streamEntry('bluesky', {
+      did: 'did:plc:grace',
+      handle: 'grace.bsky.social',
+      displayName: 'Grace Lindqvist',
+      createdAt: hoursAgo(1),
+      likeCount: 1,
+      // Newest in the list and still not the lead: one like doesn't outrank a
+      // post the network actually carried.
+      note: 'Just found this. Saving it for the train home.',
+      url: 'https://bsky.app/profile/grace.bsky.social/post/3kgrace',
+    }),
     streamEntry('bluesky', {
       did: 'did:plc:alice',
       handle: 'alice.bsky.social',
       displayName: 'Alice Mbeki',
       createdAt: hoursAgo(2),
+      likeCount: 12,
       note: 'Best take on this I have read all year. The second half is the part worth arguing with, and I think the author knows it.',
       url: 'https://bsky.app/profile/alice.bsky.social/post/3kabc',
     }),
@@ -75,8 +93,20 @@
       did: 'did:plc:hn',
       handle: 'betterhn20.e-work.xyz',
       createdAt: hoursAgo(31),
+      likeCount: 3,
       note: 'The Article Title https://example.com/the-article (https://news.ycombinator.com/item?id=49396811)',
       url: 'https://bsky.app/profile/betterhn20.e-work.xyz/post/3kbot',
+    }),
+    // A day and a half old, and still what the network actually carried — the
+    // whole point of ranking by likes rather than by clock.
+    streamEntry('bluesky', {
+      did: 'did:plc:frank',
+      handle: 'frank.bsky.social',
+      displayName: 'Frank Osei',
+      createdAt: hoursAgo(34),
+      likeCount: 128,
+      note: 'The argument in the second half is the one worth having, and almost nobody quoting this has got to it yet.',
+      url: 'https://bsky.app/profile/frank.bsky.social/post/3kfrank',
     }),
     streamEntry('bluesky', {
       did: 'did:plc:lobsters',
@@ -112,7 +142,7 @@
       note: 'The Publication Name example.com/the-article',
       url: 'https://bsky.app/profile/example.com.web.brid.gy/post/3kr3',
     }),
-  ];
+  ].sort(byEngagement);
 
   // What Semble knows about the URL beyond the people already in the stream:
   // aggregate counts, collection placements, standalone notes, and the typed
@@ -331,7 +361,7 @@
 
 <Showcase
   title="Discussion"
-  description="What the Atmosphere said about one article, merged into a single chronological stream. Lanes are filters over it, not four lists to click between. The filter chips below are live."
+  description="What the Atmosphere said about one article, merged into a single stream ranked by engagement — most-liked first, newest as the tiebreak. Lanes are filters over it, not four lists to click between. The filter chips below are live."
 >
   <Case
     name="Reader · the whole discussion"


### PR DESCRIPTION
Sorts the Atmosphere discussion stream by engagement instead of pure recency: the most-liked references lead, with recency as the tiebreak.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-cikgzduibhve5un3nqpmsyxp) · [previous artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-g6sttkwwn6q2tc3i3vzo3cn4)

## What changed

**Feed proxy** — new `bsky-appview.ts`: one batched `app.bsky.feed.getPosts` call per lane expand resolves like counts (and each post's own date) for the Bluesky lane. Fixed trusted host, so no `safeFetch` DNS pass and no Constellation breaker (different host). Entirely best-effort — a timeout, a 5xx, or an omitted post leaves `likeCount: null`. Lane cache key bumped `lane-items2:` → `lane-items3:`.

**Feed proxy — ranking the whole pool.** Discovery gathers up to 25 candidates for the Bluesky lane (the appview's documented batch limit, so the wider pool still costs one call), scores them all, then keeps the top 8. Ranking after truncation would only have reordered whichever eight Constellation's index returned first, and on a busy article the post everyone carried is exactly the one sitting outside that sample. Only the eight survivors are fetched from their PDS, so the expensive per-record work is unchanged. Ties break on the post date the same appview response carries — so the zero-like bucket is chosen by recency rather than index order — and undated candidates sort last, matching the surface's own rule.

**Backend** — `likeCount: number | null` added to `MentionLaneEntryResult`; the route is already a pass-through, so this is a type-honesty edit only.

**Frontend** — the field flows through `MentionLaneEntry` / `LanePersonVM` into the stream. The sort moved out of `useAtmosphere` into a pure `$lib/utils/discussionSort.ts` (`byEngagement` = likes desc, `newestFirst` as the tiebreak) so the ordering is unit-testable. `AtmospherePanel` renders a muted `· 12 likes` next to the relative time, hidden at 0/null — an invisible sort key reads as random order. `/dev/discussion` fixtures carry varied counts and are sorted the same way, so the ranking is visible in the harness.

Only the Bluesky lane has a per-entry metric — a linkblog note, a margin.at annotation and a Semble card each *are* one save. Those rank as 0 and keep exactly their old newest-first order among themselves. `?? 0` also covers a payload cached before the field existed.

## Interpretation note (from the plan)

"Save count" has no per-entry meaning in this data model — the article-level Semble save count already heads the Semble panel and is untouched. If the intent was ordering the **lane filter chips** by their counts instead (they follow a fixed `LANE_ORDER`), that's a separate ~5-line change in `useAtmosphere`; say the word.

Remaining accepted limits: the pool itself is capped at 25 candidates by the appview's batch size, so a discussion with more distinct Bluesky authors than that still ranks a (much larger) sample; and counts refresh with the 5-minute lane cache, so a discussion can reorder between visits — never mid-read, since the sort runs once per derivation. Degradation is total: if the appview doesn't answer, every candidate is unscored and the stable sort returns exactly the first-eight-by-discovery list the lane produced before ranking existed.

## Checks

- `feed-proxy`: `bun test` — 370 pass, 0 fail (3 new cases on top of the earlier 5: the whole 12-candidate pool ranked with only the survivors hitting a PDS, ties broken on post date, appview error falling back to index order). `tsc --noEmit` + prettier clean.
- `frontend`: `vitest run` — 447 pass (31 files). `npm run check` — 0 errors, 19 pre-existing warnings, formatting clean.
- `backend`: `vitest` — 583 pass (53 files).
- Not run: the live check against a real busy Bluesky discussion, and the `/dev/discussion` browser pass — no dev servers or browsers in this environment. The panel's like meta is covered by a mounted component test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
