### PR TITLE
Add saved search to Home

### DIFF
--- a/e2e/home-search.spec.ts
+++ b/e2e/home-search.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from './fixtures';
+import { seedItemLabel, seedSavedArticle, type TestUser } from './seed';
+
+const BODY_WORD = 'quokkatelemetry';
+
+async function seedHomeLibrary(testUser: TestUser) {
+  await seedSavedArticle(testUser, {
+    url: 'https://example.com/gardening',
+    title: 'Gardening Basics',
+    domain: 'example.com',
+    content: '<p>Tomatoes want sun and patience.</p>',
+  });
+  await seedSavedArticle(testUser, {
+    url: 'https://example.com/ownership',
+    title: 'Ownership Explained',
+    domain: 'example.com',
+    content: `<p>The body-only marker is ${BODY_WORD}.</p>`,
+  });
+  const archivedRkey = await seedSavedArticle(testUser, {
+    url: 'https://example.com/sourdough',
+    title: 'Sourdough Notes',
+    domain: 'example.com',
+    content: '<p>Feed the starter twice a day.</p>',
+  });
+  await seedItemLabel(testUser, {
+    itemKey: `at://${testUser.did}/app.skyreader.feed.saved/${archivedRkey}`,
+    itemType: 'saved',
+    label: 'archived',
+  });
+}
+
+test.describe('Home search', () => {
+  test('replaces lanes with title and body results, then restores them on clear', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedHomeLibrary(testUser);
+    await authedPage.goto('/home');
+    await expect(authedPage.getByLabel('Recently saved', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+    const input = authedPage.getByTestId('saved-search-input');
+    await input.fill('gardening');
+    await expect(authedPage.getByText('Gardening Basics')).toBeVisible();
+    await expect(authedPage.getByLabel('Recently saved', { exact: true })).not.toBeVisible();
+
+    await input.fill(BODY_WORD);
+    await expect(authedPage.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
+    await expect(authedPage.locator('mark', { hasText: BODY_WORD })).toBeVisible();
+
+    await input.fill('');
+    await expect(authedPage.getByLabel('Recently saved', { exact: true })).toBeVisible();
+  });
+
+  test('hands an archived-only query to the Saved archive', async ({ authedPage, testUser }) => {
+    await seedHomeLibrary(testUser);
+    await authedPage.goto('/home');
+    await authedPage.locator('body').press('/');
+    const input = authedPage.getByTestId('saved-search-input');
+    await expect(input).toBeFocused();
+    await input.fill('sourdough');
+
+    const hint = authedPage.getByRole('button', { name: '1 match in your Saved archive' });
+    await expect(hint).toBeVisible({ timeout: 10_000 });
+    await hint.click();
+
+    await expect(authedPage).toHaveURL(/\/saved$/);
+    await expect(authedPage.getByText('Sourdough Notes')).toBeVisible();
+    await expect(authedPage.getByTestId('saved-search-input')).toHaveValue('sourdough');
+  });
+
+  test.describe('on a mobile viewport', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('the bottom bar opens search', async ({ authedPage, testUser }) => {
+      await seedHomeLibrary(testUser);
+      await authedPage.goto('/home');
+      await expect(authedPage.getByLabel('Recently saved', { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+      await expect(authedPage.getByTestId('saved-search-input')).toBeFocused();
+    });
+  });
+});

--- a/e2e/home-search.spec.ts
+++ b/e2e/home-search.spec.ts
@@ -42,13 +42,19 @@ test.describe('Home search', () => {
 
     await authedPage.getByRole('button', { name: 'Search saved items' }).click();
     const input = authedPage.getByTestId('saved-search-input');
+    // Scope every result assertion to the results region. Home shows the same
+    // save in several lanes, so an unscoped title lookup matches more than once
+    // during the debounce beat before search replaces them — and a strict-mode
+    // violation fails the expect on the spot instead of being retried away.
+    const results = authedPage.getByLabel('Saved search results');
+
     await input.fill('gardening');
-    await expect(authedPage.getByText('Gardening Basics')).toBeVisible();
+    await expect(results.getByText('Gardening Basics')).toBeVisible();
     await expect(authedPage.getByLabel('Recently saved', { exact: true })).not.toBeVisible();
 
     await input.fill(BODY_WORD);
-    await expect(authedPage.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
-    await expect(authedPage.locator('mark', { hasText: BODY_WORD })).toBeVisible();
+    await expect(results.getByText('Ownership Explained')).toBeVisible({ timeout: 10_000 });
+    await expect(results.locator('mark', { hasText: BODY_WORD })).toBeVisible();
 
     await input.fill('');
     await expect(authedPage.getByLabel('Recently saved', { exact: true })).toBeVisible();
@@ -57,6 +63,12 @@ test.describe('Home search', () => {
   test('hands an archived-only query to the Saved archive', async ({ authedPage, testUser }) => {
     await seedHomeLibrary(testUser);
     await authedPage.goto('/home');
+    // Wait for the loaded page before pressing a global shortcut: the handler is
+    // registered on mount, and a `/` that lands before that is simply dropped.
+    await expect(authedPage.getByLabel('Recently saved', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+
     await authedPage.locator('body').press('/');
     const input = authedPage.getByTestId('saved-search-input');
     await expect(input).toBeFocused();

--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -126,8 +126,8 @@ test.describe('Saved search', () => {
 
     // Client-side navigation, deliberately: a full reload would rebuild every
     // store and hide the residual-state bug this covers.
-    await authedPage.getByRole('link', { name: 'Home' }).click();
-    await expect(authedPage).toHaveURL(/\/home$/);
+    await authedPage.getByRole('link', { name: 'Feeds' }).click();
+    await expect(authedPage).toHaveURL(/\/feeds$/);
     await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
 
     // Off the saved surface, "/" is the switcher again.
@@ -138,7 +138,7 @@ test.describe('Saved search', () => {
     await expect(authedPage.getByRole('listbox')).toHaveCount(0);
 
     // And coming back is a clean list, not the query from last time.
-    await authedPage.getByRole('button', { name: 'Saved' }).first().click();
+    await authedPage.goto('/saved');
     await expect(
       authedPage
         .getByLabel('Recently saved', { exact: true })

--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -125,9 +125,10 @@ test.describe('Saved search', () => {
     await expect(authedPage.getByText('An Afternoon at the Café')).not.toBeVisible();
 
     // Client-side navigation, deliberately: a full reload would rebuild every
-    // store and hide the residual-state bug this covers.
-    await authedPage.getByRole('link', { name: 'Feeds' }).click();
-    await expect(authedPage).toHaveURL(/\/feeds$/);
+    // store and hide the residual-state bug this covers. Highlights rather than
+    // Home, because Home is a search surface too and would keep owning "/".
+    await authedPage.getByRole('link', { name: 'Highlights' }).click();
+    await expect(authedPage).toHaveURL(/\/highlights$/);
     await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
 
     // Off the saved surface, "/" is the switcher again.
@@ -137,13 +138,15 @@ test.describe('Saved search', () => {
     await authedPage.keyboard.press('Escape');
     await expect(authedPage.getByRole('listbox')).toHaveCount(0);
 
-    // And coming back is a clean list, not the query from last time.
-    await authedPage.goto('/saved');
-    await expect(
-      authedPage
-        .getByLabel('Recently saved', { exact: true })
-        .getByRole('button', { name: 'An Afternoon at the Café' })
-    ).toBeVisible({ timeout: 15_000 });
+    // And coming back is a clean list, not the query from last time — again
+    // client-side, so the stores are the same ones that held the query. Wait for
+    // the URL first: the assertion below must read the Saved list, not the page
+    // we are leaving, which still shows the same card for a frame.
+    await authedPage.getByRole('button', { name: 'Saved' }).first().click();
+    await expect(authedPage).toHaveURL(/\/saved$/);
+    await expect(authedPage.getByText('An Afternoon at the Café')).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(authedPage.getByTestId('saved-search-input')).toHaveCount(0);
   });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@types/node": "^26.3.0",
         "@vite-pwa/sveltekit": "^1.1.0",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^30.0.1",
         "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^4.1.1",
@@ -4055,6 +4056,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@types/node": "^26.3.0",
     "@vite-pwa/sveltekit": "^1.1.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^30.0.1",
     "prettier": "^3.9.6",
     "prettier-plugin-svelte": "^4.1.1",

--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -481,7 +481,8 @@
   // exists at all: the global `/` shortcut asks the store whether there is a
   // row to open. The view filters can't answer that — they survive unmount.
   $effect(() => {
-    savedSearchStore.setSurfaceActive(isSavedView);
+    if (isSavedView) savedSearchStore.claimSurface('saved');
+    else savedSearchStore.releaseSurface('saved');
   });
 
   onDestroy(() => {
@@ -490,7 +491,7 @@
     }
     // Leaving the surface ends the search; a stale query must not come back
     // pre-applied (and silently emptying the list) on the next visit.
-    savedSearchStore.setSurfaceActive(false);
+    savedSearchStore.releaseSurface('saved');
     document.removeEventListener('visibilitychange', handleVisibilityChange);
   });
 </script>

--- a/frontend/src/lib/components/feed/HomePage.svelte
+++ b/frontend/src/lib/components/feed/HomePage.svelte
@@ -15,6 +15,10 @@
   import NotificationList from '$lib/components/NotificationList.svelte';
   import HomeLane from '$lib/components/feed/HomeLane.svelte';
   import MagazineRail from '$lib/components/feed/MagazineRail.svelte';
+  import SavedSearchBar from '$lib/components/feed/SavedSearchBar.svelte';
+  import SavedCard from '$lib/components/feed/SavedCard.svelte';
+  import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';
+  import Icon from '$lib/components/Icon.svelte';
   import { goto } from '$app/navigation';
   import type { LaneCardVM } from '$lib/components/feed/homeLane';
   import { savesStore } from '$lib/stores/saves.svelte';
@@ -26,6 +30,7 @@
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
+  import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
   import { useScrollDirection } from '$lib/hooks/useScrollDirection.svelte';
   import { getFaviconUrl } from '$lib/utils/favicon';
@@ -34,6 +39,8 @@
   import { preferences, type CardDensity, type DefaultView } from '$lib/stores/preferences.svelte';
   import {
     datePresetToMs,
+    feedViewStore,
+    matchesSavedSearch,
     matchesReadingLength,
     type FeedDisplayItem,
   } from '$lib/stores/feedView.svelte';
@@ -58,6 +65,7 @@
   const RECENT_CAP = 12;
   const CHANNEL_CAP = 12;
   const WORDS_PER_MIN = 200;
+  const SEARCH_PAGE_SIZE = 50;
 
   // --- Browser-tab title ---
   $effect(() => {
@@ -168,6 +176,56 @@
     }
     return out;
   });
+
+  function asDisplayItem(s: SavedItem): FeedDisplayItem {
+    return { type: 'saved', item: s, key: displayKey(s) };
+  }
+
+  let homeSearchItems = $derived.by((): FeedDisplayItem[] => {
+    if (!savedSearchStore.active) return [];
+    return enriched
+      .map((e) => asDisplayItem(e.s))
+      .filter((item) =>
+        matchesSavedSearch(item, savedSearchStore.terms, savedSearchStore.bodyMatchTerms)
+      )
+      .sort((a, b) => {
+        const aSaved = a.type === 'saved' ? new Date(a.item.savedAt).getTime() : 0;
+        const bSaved = b.type === 'saved' ? new Date(b.item.savedAt).getTime() : 0;
+        return bSaved - aSaved;
+      });
+  });
+
+  let archivedMatchCount = $derived.by(() => {
+    if (!savedSearchStore.active) return 0;
+    return savesStore.articles.filter((s) => {
+      if (!keysFor(s).some((key) => itemLabelsStore.isArchived(key))) return false;
+      return matchesSavedSearch(
+        asDisplayItem(s),
+        savedSearchStore.terms,
+        savedSearchStore.bodyMatchTerms
+      );
+    }).length;
+  });
+
+  let visibleSearchCount = $state(SEARCH_PAGE_SIZE);
+  let visibleSearchItems = $derived(homeSearchItems.slice(0, visibleSearchCount));
+
+  $effect(() => {
+    savedSearchStore.appliedQuery;
+    visibleSearchCount = SEARCH_PAGE_SIZE;
+  });
+
+  $effect(() => {
+    savedSearchStore.claimSurface('home');
+  });
+
+  onDestroy(() => savedSearchStore.releaseSurface('home'));
+
+  function openArchiveMatches() {
+    savedSearchStore.beginHandoff();
+    feedViewStore.setSavedView('archive');
+    void goto('/saved');
+  }
 
   // The Home card reflects the user's durable current magazine (if any). Mint a
   // new one on demand and open it straight away; past issues stay reachable via
@@ -337,6 +395,10 @@
     if (vm.displayItem.type === 'saved') void savesStore.prefetchContent(vm.displayItem.item.rkey);
   }
 
+  function prefetchSearchItem(item: FeedDisplayItem) {
+    if (item.type === 'saved') void savesStore.prefetchContent(item.item.rkey);
+  }
+
   // --- Mobile chrome (mirrors the feed / highlights pages) ---
   const scrollDirection = useScrollDirection();
   let feedSwitcherOpen = $state(false);
@@ -361,6 +423,17 @@
   <header class="home-header" class:scrolled>
     <div class="header-inner">
       <NavigationDropdown currentTitle="Home" />
+      <button
+        class="search-button"
+        class:active={savedSearchStore.open || savedSearchStore.active}
+        onclick={() => savedSearchStore.toggle()}
+        aria-label="Search saved items"
+        aria-pressed={savedSearchStore.open}
+        title="Search saved (/)"
+      >
+        <Icon name="search" size={16} />
+        <span>Search</span>
+      </button>
     </div>
   </header>
 
@@ -400,7 +473,11 @@
       </div>
     </div>
 
-    {#if !isLoading}
+    {#if savedSearchStore.open && !readerItem}
+      <SavedSearchBar />
+    {/if}
+
+    {#if !isLoading && !savedSearchStore.active}
       <MagazineRail
         issues={magazineStore.magazines}
         generating={magazineStore.generating}
@@ -409,7 +486,48 @@
       />
     {/if}
 
-    {#if isLoading}
+    {#if savedSearchStore.active}
+      <section class="search-results" aria-label="Saved search results">
+        <p class="match-count" aria-live="polite">
+          {homeSearchItems.length}
+          {homeSearchItems.length === 1 ? 'match' : 'matches'}
+        </p>
+
+        {#each visibleSearchItems as displayItem (displayItem.key)}
+          <SavedCard
+            {displayItem}
+            onOpen={() => reader.openReader(displayItem)}
+            onHover={() => prefetchSearchItem(displayItem)}
+            onArchive={() => handleArchive(displayItem)}
+            onRemove={() => handleRemove(displayItem)}
+          />
+        {/each}
+
+        {#if homeSearchItems.length === 0}
+          <EmptyState
+            title={`No matches for “${savedSearchStore.appliedQuery}”`}
+            description={archivedMatchCount > 0
+              ? `Nothing here matches. Your Saved archive has ${archivedMatchCount} match${archivedMatchCount === 1 ? '' : 'es'}.`
+              : 'Try fewer or different words.'}
+            actionText={archivedMatchCount > 0
+              ? `${archivedMatchCount} match${archivedMatchCount === 1 ? '' : 'es'} in your Saved archive`
+              : undefined}
+            onAction={archivedMatchCount > 0 ? openArchiveMatches : undefined}
+          />
+        {:else if archivedMatchCount > 0}
+          <button class="archive-hint" onclick={openArchiveMatches}>
+            {archivedMatchCount}
+            {archivedMatchCount === 1 ? 'match' : 'matches'} in your Saved archive
+          </button>
+        {/if}
+
+        <InfiniteScrollSentinel
+          hasMore={visibleSearchCount < homeSearchItems.length}
+          isLoading={false}
+          onLoadMore={() => (visibleSearchCount += SEARCH_PAGE_SIZE)}
+        />
+      </section>
+    {:else if isLoading}
       <HomeLane title="Continue reading" icon="clock" items={[]} loading onOpen={() => {}} />
       <HomeLane title="Random picks" icon="layers" items={[]} loading onOpen={() => {}} />
     {:else if !hasAnyLane}
@@ -486,6 +604,8 @@
       onOpenFilterSheet={() => {}}
       hasActiveFilters={false}
       hideFilterButton={true}
+      onOpenSearch={() => savedSearchStore.openSearch()}
+      searchActive={savedSearchStore.active}
     />
 
     <BottomSheet
@@ -577,6 +697,65 @@
     padding: 0.625rem 1rem;
     display: flex;
     align-items: center;
+    justify-content: space-between;
+  }
+
+  .search-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.55rem;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+  }
+
+  .search-button:hover,
+  .search-button.active {
+    background: var(--color-bg-secondary, #f5f5f5);
+    color: var(--color-text);
+  }
+
+  .search-button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .search-results {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .match-count {
+    margin: 0;
+    padding: 0.75rem 1rem 0.35rem;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+  }
+
+  .archive-hint {
+    align-self: center;
+    margin: 1rem;
+    padding: 0.35rem 0.55rem;
+    border: 0;
+    background: transparent;
+    color: var(--color-primary);
+    font: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+  }
+
+  .archive-hint:hover {
+    text-decoration: underline;
+  }
+
+  .archive-hint:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .home-body {

--- a/frontend/src/lib/components/feed/MobileBottomBar.svelte
+++ b/frontend/src/lib/components/feed/MobileBottomBar.svelte
@@ -16,7 +16,7 @@
     onOpenNotifications: () => void;
     hasActiveFilters: boolean;
     hideFilterButton?: boolean;
-    /** Saved views only: the header's search button isn't reachable down here. */
+    /** Saved and Home views: the header's search button isn't reachable down here. */
     onOpenSearch?: () => void;
     searchActive?: boolean;
   }

--- a/frontend/src/lib/services/savedSearchSurface.test.ts
+++ b/frontend/src/lib/services/savedSearchSurface.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { transitionSavedSearchSurface, type SavedSearchSurfaceState } from './savedSearchSurface';
+
+const initial: SavedSearchSurfaceState = { owner: null, handoffPending: false };
+
+describe('saved search surface ownership', () => {
+  it('ignores a stale release after a newer surface claims search', () => {
+    const home = transitionSavedSearchSurface(initial, { type: 'claim', owner: 'home' }).state;
+    const saved = transitionSavedSearchSurface(home, { type: 'claim', owner: 'saved' }).state;
+    const staleRelease = transitionSavedSearchSurface(saved, { type: 'release', owner: 'home' });
+
+    expect(staleRelease.state.owner).toBe('saved');
+    expect(staleRelease.close).toBe(false);
+  });
+
+  it('closes search when the current owner releases it', () => {
+    const home = transitionSavedSearchSurface(initial, { type: 'claim', owner: 'home' }).state;
+    const release = transitionSavedSearchSurface(home, { type: 'release', owner: 'home' });
+
+    expect(release.state.owner).toBeNull();
+    expect(release.close).toBe(true);
+  });
+
+  it('preserves search for exactly one surface handoff', () => {
+    const home = transitionSavedSearchSurface(initial, { type: 'claim', owner: 'home' }).state;
+    const handoff = transitionSavedSearchSurface(home, { type: 'begin-handoff' }).state;
+    const release = transitionSavedSearchSurface(handoff, { type: 'release', owner: 'home' });
+    const claim = transitionSavedSearchSurface(release.state, { type: 'claim', owner: 'saved' });
+    const finalRelease = transitionSavedSearchSurface(claim.state, {
+      type: 'release',
+      owner: 'saved',
+    });
+
+    expect(release.close).toBe(false);
+    expect(claim.reopen).toBe(true);
+    expect(claim.state.handoffPending).toBe(false);
+    expect(finalRelease.close).toBe(true);
+  });
+});

--- a/frontend/src/lib/services/savedSearchSurface.ts
+++ b/frontend/src/lib/services/savedSearchSurface.ts
@@ -1,0 +1,38 @@
+export type SavedSearchSurfaceOwner = 'saved' | 'home';
+
+export interface SavedSearchSurfaceState {
+  owner: SavedSearchSurfaceOwner | null;
+  handoffPending: boolean;
+}
+
+export type SavedSearchSurfaceEvent =
+  | { type: 'claim'; owner: SavedSearchSurfaceOwner }
+  | { type: 'release'; owner: SavedSearchSurfaceOwner }
+  | { type: 'begin-handoff' };
+
+export function transitionSavedSearchSurface(
+  state: SavedSearchSurfaceState,
+  event: SavedSearchSurfaceEvent
+): { state: SavedSearchSurfaceState; close: boolean; reopen: boolean } {
+  if (event.type === 'begin-handoff') {
+    return { state: { ...state, handoffPending: true }, close: false, reopen: false };
+  }
+
+  if (event.type === 'claim') {
+    return {
+      state: { owner: event.owner, handoffPending: false },
+      close: false,
+      reopen: state.handoffPending,
+    };
+  }
+
+  if (state.owner !== event.owner) {
+    return { state, close: false, reopen: false };
+  }
+
+  return {
+    state: { ...state, owner: null },
+    close: !state.handoffPending,
+    reopen: false,
+  };
+}

--- a/frontend/src/lib/stores/feedView.component.test.ts
+++ b/frontend/src/lib/stores/feedView.component.test.ts
@@ -1,0 +1,49 @@
+import 'fake-indexeddb/auto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { feedViewStore } from './feedView.svelte';
+import { savedSearchStore } from './savedSearch.svelte';
+
+const emptyFilters = {
+  feed: null,
+  saved: null,
+  sharer: null,
+  following: null,
+  feeds: null,
+};
+
+afterEach(() => {
+  savedSearchStore.releaseSurface('saved');
+  savedSearchStore.releaseSurface('home');
+  savedSearchStore.reset();
+  vi.useRealTimers();
+});
+
+describe('feed view saved-search transitions', () => {
+  it('preserves a Home query through Saved filter initialization', () => {
+    vi.useFakeTimers();
+    savedSearchStore.claimSurface('home');
+    savedSearchStore.openSearch();
+    savedSearchStore.setQuery('needle');
+    vi.advanceTimersByTime(150);
+
+    savedSearchStore.beginHandoff();
+    savedSearchStore.releaseSurface('home');
+    feedViewStore.setFilters({ ...emptyFilters, saved: 'true' });
+    savedSearchStore.claimSurface('saved');
+
+    expect(savedSearchStore.query).toBe('needle');
+    expect(savedSearchStore.appliedQuery).toBe('needle');
+    expect(savedSearchStore.open).toBe(true);
+  });
+
+  it('resets search on an ordinary saved-surface change', () => {
+    savedSearchStore.claimSurface('saved');
+    savedSearchStore.openSearch();
+    savedSearchStore.setQuery('stale');
+
+    feedViewStore.setFilters({ ...emptyFilters, saved: 'true', view: 'another-channel' });
+
+    expect(savedSearchStore.query).toBe('');
+    expect(savedSearchStore.open).toBe(false);
+  });
+});

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -235,7 +235,7 @@ export function searchHaystack(item: FeedDisplayItem): string {
  * asynchronously, so body hits land a beat after metadata hits on the very
  * first search).
  */
-function matchesSavedSearch(
+export function matchesSavedSearch(
   item: FeedDisplayItem,
   terms: string[],
   bodyMatchTerms: Map<string, Set<string>> | null
@@ -1538,7 +1538,7 @@ function createFeedViewStore() {
       // must never silently empty the list you land on. Compared rather than
       // reset unconditionally because this runs on every URL change, including
       // ones that don't move the view. Leaving the surface entirely is the page's
-      // job (`savedSearchStore.setSurfaceActive(false)` on unmount): this only
+      // job (`savedSearchStore.releaseSurface('saved')` on unmount): this only
       // runs while `FeedPage` is mounted, so it can't see that transition.
       const nextSavedKey = `${filters.saved ?? ''}|${filters.view ?? ''}`;
       if (nextSavedKey !== currentSavedKey) {

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -1543,7 +1543,10 @@ function createFeedViewStore() {
       const nextSavedKey = `${filters.saved ?? ''}|${filters.view ?? ''}`;
       if (nextSavedKey !== currentSavedKey) {
         currentSavedKey = nextSavedKey;
-        savedSearchStore.reset();
+        // Home can deliberately carry its query into the Saved archive. The
+        // pending handoff survives this URL initialization and is consumed by
+        // FeedPage's subsequent saved-surface claim.
+        savedSearchStore.resetForSurfaceChange();
       }
       feedFilter = filters.feed;
       savedFilter = filters.saved;

--- a/frontend/src/lib/stores/savedSearch.svelte.ts
+++ b/frontend/src/lib/stores/savedSearch.svelte.ts
@@ -4,6 +4,10 @@ import { api } from '$lib/services/api';
 import { syncStore } from './sync.svelte';
 import { matchesTerms, parseQuery, toIndexText } from '$lib/services/savedSearch';
 import type { SavedItem } from '$lib/types';
+import {
+  transitionSavedSearchSurface,
+  type SavedSearchSurfaceOwner,
+} from '$lib/services/savedSearchSurface';
 
 // Search over the saved library. Metadata (title/author/description/domain/url)
 // is matched synchronously inside the saved-items pipeline; full article text is
@@ -22,14 +26,17 @@ function createSavedSearchStore() {
   let appliedQuery = $state('');
   // Whether the search row is showing. Cleared with the query.
   let open = $state(false);
-  // Whether a saved surface is mounted right now, i.e. whether there is a
+  // Whether a saved or Home surface is mounted right now, i.e. whether there is a
   // search row for a global entry point like `/` to open. The view filters
   // can't answer that — they keep their last value after the page unmounts, so
   // one visit to /saved would leave `/` hijacked on every other route. The
   // saved page owns this flag; leaving the surface also drops the query, which
   // is ephemeral session state and would otherwise silently filter the list on
   // the next visit.
-  let surfaceActive = $state(false);
+  let surfaceOwner = $state<'saved' | 'home' | null>(null);
+  // A navigation from Home search to the Saved archive can carry the ephemeral
+  // query across exactly one surface transition.
+  let handoffPending = false;
   // Bumped to ask the input to take focus (opening via `/` or the toolbar button).
   let focusRequest = $state(0);
 
@@ -208,10 +215,32 @@ function createSavedSearchStore() {
     clear();
   }
 
-  function setSurfaceActive(on: boolean) {
-    if (surfaceActive === on) return;
-    surfaceActive = on;
-    if (!on) closeSearch();
+  function claimSurface(owner: 'saved' | 'home') {
+    const result = transitionSavedSearchSurface(
+      { owner: surfaceOwner, handoffPending },
+      { type: 'claim', owner }
+    );
+    surfaceOwner = result.state.owner;
+    handoffPending = result.state.handoffPending;
+    if (result.reopen && query.trim()) openSearch();
+  }
+
+  function releaseSurface(owner: SavedSearchSurfaceOwner) {
+    const result = transitionSavedSearchSurface(
+      { owner: surfaceOwner, handoffPending },
+      { type: 'release', owner }
+    );
+    surfaceOwner = result.state.owner;
+    handoffPending = result.state.handoffPending;
+    if (result.close) closeSearch();
+  }
+
+  function beginHandoff() {
+    const result = transitionSavedSearchSurface(
+      { owner: surfaceOwner, handoffPending },
+      { type: 'begin-handoff' }
+    );
+    handoffPending = result.state.handoffPending;
   }
 
   return {
@@ -235,10 +264,13 @@ function createSavedSearchStore() {
     },
     /** True while a saved surface is mounted and can show the search row. */
     get available() {
-      return surfaceActive;
+      return surfaceOwner !== null;
     },
-    /** Saved-surface lifecycle, owned by `FeedPage`. Leaving resets the search. */
-    setSurfaceActive,
+    /** Search-surface lifecycle. A stale owner cannot revoke a newer claim. */
+    claimSurface,
+    releaseSurface,
+    /** Preserve the current query across the next search-surface transition. */
+    beginHandoff,
     get focusRequest() {
       return focusRequest;
     },

--- a/frontend/src/lib/stores/savedSearch.svelte.ts
+++ b/frontend/src/lib/stores/savedSearch.svelte.ts
@@ -243,6 +243,11 @@ function createSavedSearchStore() {
     handoffPending = result.state.handoffPending;
   }
 
+  /** Reset for a URL-driven saved-surface change unless a handoff is in flight. */
+  function resetForSurfaceChange() {
+    if (!handoffPending) closeSearch();
+  }
+
   return {
     get query() {
       return query;
@@ -284,6 +289,7 @@ function createSavedSearchStore() {
     },
     /** Full reset, used when leaving the saved view. */
     reset: closeSearch,
+    resetForSurfaceChange,
     /**
      * Incremental cache maintenance, called from savesStore's write points. A
      * no-op until the corpus exists — the first search builds it from scratch.


### PR DESCRIPTION
Adds in-place saved-library search to Home with desktop, keyboard, and mobile entry points.

- Reuses saved matching, cards, offline body corpus, paging, and in-place reader behavior.
- Preserves an archived-only query through the Home-to-Saved route initialization handoff.
- Covers the real filter initialization transition and ordinary channel-reset behavior.
- Fixes the three Playwright failures this branch's E2E additions introduced: an unscoped title
  lookup that hit two lanes, a `/` pressed before the shortcut was registered, and a "Feeds" link
  that does not exist.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-xv7neiadbug4e5f26if52mc6)

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-hxi4wzeplkiunm5qhpv2rvac)
