### PR TITLE
Fix SW activation race in the PWA test helper

### DIFF
--- a/e2e-pwa/helpers.ts
+++ b/e2e-pwa/helpers.ts
@@ -12,7 +12,10 @@ export function waitForControl(page: Page, timeoutMs = 15000) {
       (await navigator.serviceWorker.register('/service-worker.js'));
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
-      if (reg.active && navigator.serviceWorker.controller) break;
+      // `reg.active` is populated the moment the worker enters *activating*, and
+      // clientsClaim() sets the controller during activation too — so both can be
+      // true while the state is still 'activating'. Wait for the terminal state.
+      if (reg.active?.state === 'activated' && navigator.serviceWorker.controller) break;
       await new Promise((r) => setTimeout(r, 200));
     }
     return {


### PR DESCRIPTION
The PWA lifecycle test flakes in CI (most recently on the run for #404, which touches nothing PWA-related):

```
[chromium] service worker lifecycle › registers, precaches the full build, activates, and controls the page
  Expected: "activated"
  Received: "activating"
  e2e-pwa/service-worker.spec.ts:10
```

`waitForControl` broke out of its poll loop on `reg.active && navigator.serviceWorker.controller`, but neither condition implies activation finished. `reg.active` is populated the moment the worker enters the *activating* state, and `clientsClaim()` sets `navigator.serviceWorker.controller` during activation too. So both can be true while `reg.active.state === 'activating'`, and on a loaded runner the poll tick can land before the activate handler's cache cleanup resolves.

Poll on the terminal state instead. The deadline is unchanged, so a genuinely stuck worker still fails with the same snapshot it does today.

Verified locally: `npm run test:pwa` passes on chromium (12/12) and webkit (5 passed, 7 skipped by the existing browser guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)