### PR TITLE
Add Leaflet comments to discussion

### DIFF
--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -828,6 +828,35 @@ export async function handleV2Mentions(request: Request, env: Env): Promise<Resp
     });
   }
 
+  const docUris = body.docUris;
+  if (docUris !== undefined) {
+    if (
+      !docUris ||
+      typeof docUris !== 'object' ||
+      Array.isArray(docUris) ||
+      Object.keys(docUris).length > 50
+    ) {
+      return new Response(JSON.stringify({ error: 'Invalid docUris map' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const requestedUrls = new Set(urls);
+    const invalidEntry = Object.entries(docUris).some(
+      ([url, uri]) =>
+        !requestedUrls.has(url) ||
+        typeof uri !== 'string' ||
+        !uri.startsWith('at://') ||
+        uri.length > 2048
+    );
+    if (invalidEntry) {
+      return new Response(JSON.stringify({ error: 'Invalid docUris map' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
   const emptyFor = (url: string): ArticleMentionsResult => ({
     url,
     total: 0,
@@ -836,7 +865,7 @@ export async function handleV2Mentions(request: Request, env: Env): Promise<Resp
 
   try {
     const client = new FeedProxyClient(env);
-    const results = await client.fetchArticleMentions(urls, body.docUris);
+    const results = await client.fetchArticleMentions(urls, docUris);
     return new Response(JSON.stringify({ items: results }), {
       headers: { 'Content-Type': 'application/json' },
     });

--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -804,7 +804,7 @@ export async function handleV2Mentions(request: Request, env: Env): Promise<Resp
     });
   }
 
-  let body: { urls?: string[] };
+  let body: { urls?: string[]; docUris?: Record<string, string> };
   try {
     body = await request.json();
   } catch {
@@ -836,7 +836,7 @@ export async function handleV2Mentions(request: Request, env: Env): Promise<Resp
 
   try {
     const client = new FeedProxyClient(env);
-    const results = await client.fetchArticleMentions(urls);
+    const results = await client.fetchArticleMentions(urls, body.docUris);
     return new Response(JSON.stringify({ items: results }), {
       headers: { 'Content-Type': 'application/json' },
     });
@@ -867,7 +867,7 @@ export async function handleV2MentionLane(request: Request, env: Env): Promise<R
     });
   }
 
-  let body: { url?: string; lane?: string };
+  let body: { url?: string; lane?: string; docUri?: string };
   try {
     body = await request.json();
   } catch {
@@ -887,7 +887,7 @@ export async function handleV2MentionLane(request: Request, env: Env): Promise<R
 
   try {
     const client = new FeedProxyClient(env);
-    const result = await client.fetchMentionLaneItems(url, lane);
+    const result = await client.fetchMentionLaneItems(url, lane, body.docUri);
     return new Response(JSON.stringify(result), {
       headers: { 'Content-Type': 'application/json' },
     });

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -245,6 +245,10 @@ export interface ArticleMentionsResult {
   url: string;
   total: number;
   lanes: MentionLaneResult[];
+  // A background enrichment is in flight for this URL, so these counts may still
+  // grow (a cold URL, or one whose document target is only now being resolved).
+  // The client re-polls on it rather than guessing from a zero total.
+  pending?: boolean;
 }
 
 interface RawMentionsResponse {

--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -660,10 +660,13 @@ export class FeedProxyClient {
    * original URL. Best-effort adornment — the proxy returns empty per URL on a
    * cold/sub-threshold lookup and enriches in the background for a later poll.
    */
-  async fetchArticleMentions(urls: string[]): Promise<ArticleMentionsResult[]> {
+  async fetchArticleMentions(
+    urls: string[],
+    docUris?: Record<string, string>
+  ): Promise<ArticleMentionsResult[]> {
     const raw = await this.fetch<RawMentionsResponse>('/mentions', {
       method: 'POST',
-      body: JSON.stringify({ urls }),
+      body: JSON.stringify({ urls, ...(docUris ? { docUris } : {}) }),
     });
 
     if (!raw.items) {
@@ -679,10 +682,14 @@ export class FeedProxyClient {
    * to the post / card / highlight. Resolved lazily on lane expand. Best-effort —
    * the proxy returns an empty list rather than error on a Constellation outage.
    */
-  async fetchMentionLaneItems(url: string, lane: string): Promise<MentionLaneItemsResult> {
+  async fetchMentionLaneItems(
+    url: string,
+    lane: string,
+    docUri?: string
+  ): Promise<MentionLaneItemsResult> {
     const raw = await this.fetch<RawMentionLaneResponse>('/mention-lane', {
       method: 'POST',
-      body: JSON.stringify({ url, lane }),
+      body: JSON.stringify({ url, lane, ...(docUri ? { docUri } : {}) }),
     });
 
     if (!raw.entries) {

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -1164,6 +1164,12 @@ export function initDatabase(db: Database): void {
   if (!mentionColumns.some((column) => column.name === 'doc_uri')) {
     db.run(`ALTER TABLE mention_cache ADD COLUMN doc_uri TEXT`);
   }
+  // When the article origin was last asked which standard.site document it
+  // advertises. NULL means never asked, which is what makes an existing row
+  // eligible for one document lookup on the next read (see mentions.ts).
+  if (!mentionColumns.some((column) => column.name === 'doc_checked_at')) {
+    db.run(`ALTER TABLE mention_cache ADD COLUMN doc_checked_at INTEGER`);
+  }
 }
 
 // Discover RSS/Atom feeds and advertised standard.site URIs for a site URL.
@@ -1311,6 +1317,9 @@ export function createApp(db: Database, config: AppConfig) {
   const inFlightContext = new Map<string, Promise<SocialContext>>();
   // Collapse concurrent mention enrichments for the same normalized URL.
   const inFlightMentions = new Map<string, Promise<void>>();
+  // Which of those in-flight enrichments will resolve the article's document
+  // target (see triggerMentionEnrich).
+  const inFlightResolvesDoc = new Set<string>();
   // Collapse concurrent feed-discovery probes for the same site URL (uncached:
   // each call fetches the site + HEAD-probes common paths).
   const inFlightDiscover = new Map<string, Promise<DiscoverResult>>();
@@ -1336,10 +1345,25 @@ export function createApp(db: Database, config: AppConfig) {
   // Fire-and-forget background enrichment of an article's mention breakdown,
   // deduped per normalized URL. The decay gate inside enrichMentions makes most
   // of these no-ops (fresh/settled rows), so callers can trigger liberally.
-  function triggerMentionEnrich(normUrl: string, docUri?: string): void {
-    if (inFlightMentions.has(normUrl)) return;
-    const promise = enrichMentions(db, normUrl, docUri).finally(() => {
-      inFlightMentions.delete(normUrl);
+  //
+  // Dedup is by URL *and strength*: a read-path trigger resolves the article's
+  // document target while a warm-loop one doesn't, so plain URL dedup would let
+  // an in-flight warm enrich swallow the only request that can find a Leaflet
+  // comment. A stronger request chains behind the weaker one instead of racing
+  // it on the same row.
+  function triggerMentionEnrich(
+    normUrl: string,
+    options: { docUri?: string; resolveDocument?: boolean } = {}
+  ): void {
+    const pending = inFlightMentions.get(normUrl);
+    if (pending && (!options.resolveDocument || inFlightResolvesDoc.has(normUrl))) return;
+    if (options.resolveDocument) inFlightResolvesDoc.add(normUrl);
+    const run = () => enrichMentions(db, normUrl, options);
+    const promise: Promise<void> = (pending ? pending.then(run, run) : run()).finally(() => {
+      if (inFlightMentions.get(normUrl) === promise) {
+        inFlightMentions.delete(normUrl);
+        inFlightResolvesDoc.delete(normUrl);
+      }
     });
     inFlightMentions.set(normUrl, promise);
   }
@@ -1351,6 +1375,9 @@ export function createApp(db: Database, config: AppConfig) {
   function warmFeedItemMentions(feed: ParsedFeed): void {
     for (const item of feed.items.slice(0, WARM_MENTION_ITEM_CAP)) {
       const normUrl = normalizeArticleUrl(item.url);
+      // No `resolveDocument`: pre-warming a whole feed must stay Constellation-only.
+      // Resolving document targets costs an origin fetch per URL, which the read
+      // path pays for the handful of articles someone actually opens.
       if (normUrl) triggerMentionEnrich(normUrl);
     }
   }
@@ -3066,9 +3093,20 @@ export function createApp(db: Database, config: AppConfig) {
         typeof candidate === 'string' && candidate.startsWith('at://') && candidate.length <= 2048
           ? candidate
           : undefined;
-      const { normUrl, mentions, shouldEnrich } = readCachedMentions(db, url, now, docUri);
-      if (fresh && shouldEnrich && normUrl) triggerMentionEnrich(normUrl, docUri);
-      return { url, total: mentions.total, lanes: mentions.lanes };
+      // The read path is the demand gate for document-target resolution: someone
+      // actually opened or scrolled to this article, so it can afford one bounded
+      // origin fetch (persisted, so it happens once per URL, not once per read).
+      const { normUrl, mentions, shouldEnrich } = readCachedMentions(db, url, now, {
+        docUri,
+        resolveDocument: true,
+      });
+      const enriching = Boolean(fresh && shouldEnrich && normUrl);
+      if (enriching) triggerMentionEnrich(normUrl!, { docUri, resolveDocument: true });
+      // `pending` tells the client these counts may still grow, so it knows to
+      // re-poll. A zero total is the obvious case, but not the only one: a URL
+      // with cached Bluesky mentions whose Leaflet lane is about to be discovered
+      // comes back non-zero and would otherwise look settled.
+      return { url, total: mentions.total, lanes: mentions.lanes, pending: enriching };
     });
 
     return c.json({ items });

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -1160,6 +1160,10 @@ export function initDatabase(db: Database): void {
 		)
 	`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_mention_cache_checked_at ON mention_cache(checked_at)`);
+  const mentionColumns = db.query<{ name: string }, []>(`PRAGMA table_info(mention_cache)`).all();
+  if (!mentionColumns.some((column) => column.name === 'doc_uri')) {
+    db.run(`ALTER TABLE mention_cache ADD COLUMN doc_uri TEXT`);
+  }
 }
 
 // Discover RSS/Atom feeds and advertised standard.site URIs for a site URL.
@@ -1332,9 +1336,9 @@ export function createApp(db: Database, config: AppConfig) {
   // Fire-and-forget background enrichment of an article's mention breakdown,
   // deduped per normalized URL. The decay gate inside enrichMentions makes most
   // of these no-ops (fresh/settled rows), so callers can trigger liberally.
-  function triggerMentionEnrich(normUrl: string): void {
+  function triggerMentionEnrich(normUrl: string, docUri?: string): void {
     if (inFlightMentions.has(normUrl)) return;
-    const promise = enrichMentions(db, normUrl).finally(() => {
+    const promise = enrichMentions(db, normUrl, docUri).finally(() => {
       inFlightMentions.delete(normUrl);
     });
     inFlightMentions.set(normUrl, promise);
@@ -3033,7 +3037,7 @@ export function createApp(db: Database, config: AppConfig) {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
-    let body: { urls?: string[] };
+    let body: { urls?: string[]; docUris?: Record<string, string> };
     try {
       body = await c.req.json();
     } catch {
@@ -3057,8 +3061,13 @@ export function createApp(db: Database, config: AppConfig) {
       // Dedup repeated URLs in one batch; only the first triggers enrichment.
       const fresh = !seen.has(url);
       seen.add(url);
-      const { normUrl, mentions, shouldEnrich } = readCachedMentions(db, url, now);
-      if (fresh && shouldEnrich && normUrl) triggerMentionEnrich(normUrl);
+      const candidate = body.docUris?.[url];
+      const docUri =
+        typeof candidate === 'string' && candidate.startsWith('at://') && candidate.length <= 2048
+          ? candidate
+          : undefined;
+      const { normUrl, mentions, shouldEnrich } = readCachedMentions(db, url, now, docUri);
+      if (fresh && shouldEnrich && normUrl) triggerMentionEnrich(normUrl, docUri);
       return { url, total: mentions.total, lanes: mentions.lanes };
     });
 
@@ -3068,13 +3077,13 @@ export function createApp(db: Database, config: AppConfig) {
   // "See existing items" for one mention lane (Phase 5). Resolves the people who
   // referenced an article URL via that lane — handle, note, link out — lazily
   // when the reader expands the lane. Adornment only: degrades to an empty list.
-  const KNOWN_LANES = new Set<LaneId>(['linkblog', 'bluesky', 'margin', 'semble']);
+  const KNOWN_LANES = new Set<LaneId>(['linkblog', 'leaflet', 'bluesky', 'margin', 'semble']);
   app.post('/mention-lane', async (c) => {
     if (proxySecret && c.req.header('X-Proxy-Secret') !== proxySecret) {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
-    let body: { url?: string; lane?: string };
+    let body: { url?: string; lane?: string; docUri?: string };
     try {
       body = await c.req.json();
     } catch {
@@ -3088,13 +3097,19 @@ export function createApp(db: Database, config: AppConfig) {
     if (!lane || !KNOWN_LANES.has(lane as LaneId)) {
       return c.json({ error: 'Unknown lane' }, 400);
     }
+    const docUri =
+      typeof body.docUri === 'string' &&
+      body.docUri.startsWith('at://') &&
+      body.docUri.length <= 2048
+        ? body.docUri
+        : undefined;
 
     // Coalesce concurrent expansions of the same (url, lane): each runs a full
     // Constellation + per-author PDS fan-out before the result lands in the cache.
-    const laneKey = `${url}|${lane}`;
+    const laneKey = `${url}|${lane}|${lane === 'leaflet' ? (docUri ?? '') : ''}`;
     let pending = inFlightLane.get(laneKey);
     if (!pending) {
-      pending = getMentionLaneItems(db, url, lane as LaneId).finally(() =>
+      pending = getMentionLaneItems(db, url, lane as LaneId, docUri).finally(() =>
         inFlightLane.delete(laneKey)
       );
       inFlightLane.set(laneKey, pending);

--- a/feed-proxy/src/lanes.ts
+++ b/feed-proxy/src/lanes.ts
@@ -5,7 +5,7 @@
  * URL is the target of many record types. Rather than a flat 'who linked this'
  * count, we bucket each meaningful `(collection, path)` source into a named
  * **lane** with its own honest verb — a linkblog *note*, a Bluesky *post*, a
- * margin.at *highlight*, a Semble *save* are four different things, and lumping
+ * Leaflet *comment*, margin.at *highlight*, and Semble *save* are different things, and lumping
  * them into one number ('linked this') is dishonest (saving ≠ discussing).
  *
  * The whitelist is **path-precise, not collection-precise**: verified live,
@@ -16,12 +16,12 @@
  * discussing anything). A lane counts a path only if its collection is laned
  * AND the path isn't excluded.
  *
- * All four NSIDs/paths verified live against constellation.microcosm.blue
- * (2026-06-01). The registry is the only hardcoded surface; Constellation
+ * All five NSIDs/paths verified live against constellation.microcosm.blue
+ * (2026-08-25). The registry is the only hardcoded surface; Constellation
  * reports which sources actually exist per URL.
  */
 
-export type LaneId = 'linkblog' | 'bluesky' | 'margin' | 'semble';
+export type LaneId = 'linkblog' | 'leaflet' | 'bluesky' | 'margin' | 'semble';
 
 export interface Lane {
   id: LaneId;
@@ -53,6 +53,15 @@ export const LANES: Lane[] = [
     // site.standard.document links an article via the website-card ref
     // (.links[].uri) or an inline body facet — both are real references.
     collections: ['site.standard.document'],
+  },
+  {
+    id: 'leaflet',
+    label: 'Leaflet',
+    verb: 'commented',
+    noun: 'Leaflet comment',
+    icon: 'leaflet',
+    collections: ['pub.leaflet.comment'],
+    excludePaths: ['.attachment.document'],
   },
   {
     id: 'bluesky',

--- a/feed-proxy/src/mention-lane.test.ts
+++ b/feed-proxy/src/mention-lane.test.ts
@@ -42,7 +42,8 @@ function mockConstellation(
   linksAll: Record<string, Record<string, { distinct_dids: number }>>,
   recsBySource: Record<string, Array<{ did: string; rkey: string }>>,
   records: Record<string, Record<string, unknown>> = {},
-  appview?: AppviewMock
+  appview?: AppviewMock,
+  linksAllByTarget?: Record<string, Record<string, Record<string, { distinct_dids: number }>>>
 ) {
   return spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
     const url = new URL(String(input));
@@ -63,7 +64,8 @@ function mockConstellation(
       return new Response(JSON.stringify({ posts }));
     }
     if (url.pathname === '/links/all') {
-      return new Response(JSON.stringify({ links: linksAll }));
+      const target = url.searchParams.get('target') ?? '';
+      return new Response(JSON.stringify({ links: linksAllByTarget?.[target] ?? linksAll }));
     }
     if (url.pathname === '/links') {
       const key = `${url.searchParams.get('collection')}|${url.searchParams.get('path')}`;
@@ -95,8 +97,8 @@ describe('getMentionLaneItems', () => {
     const docUri = 'at://did:plc:publisher/site.standard.document/post1';
     seedDid(db, 'did:plc:alice', 'alice.test');
 
-    mockConstellation(
-      { 'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } } },
+    const fetchSpy = mockConstellation(
+      {},
       { 'pub.leaflet.comment|.subject': [{ did: 'did:plc:alice', rkey: 'comment1' }] },
       {
         comment1: {
@@ -104,7 +106,9 @@ describe('getMentionLaneItems', () => {
           createdAt: '2026-08-25T12:00:00.000Z',
           reply: { parent: 'at://did:plc:bob/pub.leaflet.comment/parent' },
         },
-      }
+      },
+      undefined,
+      { [docUri]: { 'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } } } }
     );
 
     const { entries } = await getMentionLaneItems(db, ARTICLE, 'leaflet', docUri);
@@ -113,9 +117,37 @@ describe('getMentionLaneItems', () => {
       note: 'A thoughtful comment',
       createdAt: '2026-08-25T12:00:00.000Z',
       verb: 'replied',
-      url: null,
+      url: ARTICLE,
       quote: null,
     });
+    expect(
+      fetchSpy.mock.calls
+        .map(([input]) => new URL(String(input)))
+        .filter((url) => url.pathname === '/links/all')
+        .map((url) => url.searchParams.get('target'))
+    ).toContain(docUri);
+  });
+
+  it('falls back to the document URI persisted with mention counts', async () => {
+    const db = freshDb();
+    const docUri = 'at://did:plc:publisher/site.standard.document/post1';
+    seedDid(db, 'did:plc:alice', 'alice.test');
+    db.run(
+      `INSERT INTO mention_cache
+        (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri)
+       VALUES (?, ?, 1, '[]', ?, ?, ?)`,
+      ['11ddf42a96099890', ARTICLE, Date.now(), Date.now(), docUri]
+    );
+    mockConstellation(
+      {},
+      { 'pub.leaflet.comment|.subject': [{ did: 'did:plc:alice', rkey: 'comment1' }] },
+      { comment1: { plaintext: 'Persisted target' } },
+      undefined,
+      { [docUri]: { 'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } } } }
+    );
+
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'leaflet');
+    expect(entries[0]?.note).toBe('Persisted target');
   });
 
   it('resolves a Bluesky lane: permalink + note, deduped across paths', async () => {

--- a/feed-proxy/src/mention-lane.test.ts
+++ b/feed-proxy/src/mention-lane.test.ts
@@ -90,6 +90,34 @@ describe('getMentionLaneItems', () => {
     resetConstellationBreaker();
   });
 
+  it('resolves Leaflet comments from a document URI and marks replies', async () => {
+    const db = freshDb();
+    const docUri = 'at://did:plc:publisher/site.standard.document/post1';
+    seedDid(db, 'did:plc:alice', 'alice.test');
+
+    mockConstellation(
+      { 'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } } },
+      { 'pub.leaflet.comment|.subject': [{ did: 'did:plc:alice', rkey: 'comment1' }] },
+      {
+        comment1: {
+          plaintext: 'A thoughtful comment',
+          createdAt: '2026-08-25T12:00:00.000Z',
+          reply: { parent: 'at://did:plc:bob/pub.leaflet.comment/parent' },
+        },
+      }
+    );
+
+    const { entries } = await getMentionLaneItems(db, ARTICLE, 'leaflet', docUri);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      note: 'A thoughtful comment',
+      createdAt: '2026-08-25T12:00:00.000Z',
+      verb: 'replied',
+      url: null,
+      quote: null,
+    });
+  });
+
   it('resolves a Bluesky lane: permalink + note, deduped across paths', async () => {
     const db = freshDb();
     seedDid(db, 'did:plc:alice', 'alice.test');

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -367,6 +367,14 @@ async function resolveEntry(
       createdAt = recordDate(value, 'publishedAt', 'createdAt');
       break;
     }
+    case 'leaflet': {
+      if (value) {
+        note = firstString(value.plaintext);
+        verb = value.reply ? 'replied' : null;
+      }
+      createdAt = recordDate(value, 'createdAt');
+      break;
+    }
     case 'margin': {
       // at.margin.note — a W3C-style web annotation. Surface its motivation as
       // the honest per-note verb, the highlighted passage (TextQuoteSelector
@@ -416,8 +424,8 @@ async function resolveEntry(
   };
 }
 
-function cacheKey(laneId: LaneId, normUrl: string): string {
-  return `lane-items3:${laneId}|${normUrl}`;
+function cacheKey(laneId: LaneId, normUrl: string, docUri?: string): string {
+  return `lane-items3:${laneId}|${normUrl}${laneId === 'leaflet' ? `|${docUri ?? ''}` : ''}`;
 }
 
 /**
@@ -492,12 +500,13 @@ async function pickLaneRecords(
 export async function getMentionLaneItems(
   db: Database,
   rawUrl: string,
-  laneId: LaneId
+  laneId: LaneId,
+  docUri?: string
 ): Promise<MentionLaneItemsResult> {
   const normUrl = normalizeArticleUrl(rawUrl);
   if (!normUrl) return { entries: [] };
 
-  const key = cacheKey(laneId, normUrl);
+  const key = cacheKey(laneId, normUrl, docUri);
   const now = Date.now();
   const cached = db
     .query<CacheRow, [string]>(
@@ -559,7 +568,8 @@ export async function getMentionLaneItems(
   // Set by any call the host didn't answer. An empty result that carries this is
   // "we don't know", not "nobody" — see MentionLaneUnavailableError.
   let unreachable = false;
-  for (const target of constellationTargets(normUrl)) {
+  const targets = [...constellationTargets(normUrl), ...(docUri ? [docUri] : [])];
+  for (const target of targets) {
     const all = await constellationGetResult<LinksAllResponse>('/links/all', { target });
     if (!all.reachable) unreachable = true;
     for (const [collection, paths] of Object.entries(all.data?.links ?? {})) {

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -35,6 +35,7 @@ import { resolveSiteMeta, buildCanonicalUrl, parseAtUri } from './standard-site'
 import { constellationGet, constellationGetResult } from './constellation-client';
 import { fetchPostEngagement, GET_POSTS_MAX_URIS } from './bsky-appview';
 import { extractContentText } from './document-content';
+import { hashUrl } from './mentions';
 import {
   fetchSembleContext,
   isEmptySembleContext,
@@ -335,7 +336,8 @@ function recordDate(value: Record<string, unknown> | null, ...keys: string[]): s
 async function resolveEntry(
   db: Database,
   laneId: LaneId,
-  rec: { did: string; collection: string; rkey: string }
+  rec: { did: string; collection: string; rkey: string },
+  articleUrl: string
 ): Promise<MentionLaneEntry> {
   const { did, collection, rkey } = rec;
   // Identity and the record itself are independent lookups — run them together
@@ -368,6 +370,9 @@ async function resolveEntry(
       break;
     }
     case 'leaflet': {
+      // Leaflet comments are read-only here; link back to the published document
+      // so the reader can continue the conversation on its native surface.
+      url = articleUrl;
       if (value) {
         note = firstString(value.plaintext);
         verb = value.reply ? 'replied' : null;
@@ -506,7 +511,13 @@ export async function getMentionLaneItems(
   const normUrl = normalizeArticleUrl(rawUrl);
   if (!normUrl) return { entries: [] };
 
-  const key = cacheKey(laneId, normUrl, docUri);
+  const persistedDocUri = db
+    .query<{ doc_uri: string | null }, [string]>(
+      'SELECT doc_uri FROM mention_cache WHERE url_hash = ?'
+    )
+    .get(hashUrl(normUrl))?.doc_uri;
+  const effectiveDocUri = docUri ?? persistedDocUri ?? undefined;
+  const key = cacheKey(laneId, normUrl, effectiveDocUri);
   const now = Date.now();
   const cached = db
     .query<CacheRow, [string]>(
@@ -568,7 +579,10 @@ export async function getMentionLaneItems(
   // Set by any call the host didn't answer. An empty result that carries this is
   // "we don't know", not "nobody" — see MentionLaneUnavailableError.
   let unreachable = false;
-  const targets = [...constellationTargets(normUrl), ...(docUri ? [docUri] : [])];
+  const targets = [
+    ...constellationTargets(normUrl),
+    ...(laneId === 'leaflet' && effectiveDocUri ? [effectiveDocUri] : []),
+  ];
   for (const target of targets) {
     const all = await constellationGetResult<LinksAllResponse>('/links/all', { target });
     if (!all.reachable) unreachable = true;
@@ -618,7 +632,7 @@ export async function getMentionLaneItems(
   if (candidates.length === 0 && unreachable) throw new MentionLaneUnavailableError();
 
   const picked = await pickLaneRecords(laneId, candidates);
-  const entries = await Promise.all(picked.map((p) => resolveEntry(db, laneId, p.rec)));
+  const entries = await Promise.all(picked.map((p) => resolveEntry(db, laneId, p.rec, normUrl)));
   // `picked` and `entries` are index-aligned (the map above), so each entry
   // carries the count its record was ranked on.
   entries.forEach((entry, i) => {

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -318,6 +318,64 @@ describe('enrichMentions + readCachedMentions', () => {
     (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
   });
 
+  it('persists a document URI only when its canonical URL matches the article', async () => {
+    const db = freshDb();
+    const did = 'did:plc:publisher';
+    const docUri = `at://${did}/site.standard.document/post1`;
+    db.run('INSERT INTO did_cache (did, pds_url, handle, cached_at) VALUES (?, ?, ?, ?)', [
+      did,
+      'https://pds.example',
+      'publisher.test',
+      Date.now(),
+    ]);
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/xrpc/com.atproto.repo.getRecord') {
+        return new Response(
+          JSON.stringify({ value: { site: 'https://example.com', path: '/the-article' } })
+        );
+      }
+      return new Response(JSON.stringify({ links: {} }));
+    }) as unknown as typeof fetch);
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+
+    const row = db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get();
+    expect(row?.doc_uri).toBe(docUri);
+    expect(
+      spy.mock.calls.some(([input]) => new URL(String(input)).searchParams.get('target') === docUri)
+    ).toBe(true);
+  });
+
+  it('rejects a document URI whose canonical URL does not match the article', async () => {
+    const db = freshDb();
+    const did = 'did:plc:attacker';
+    const docUri = `at://${did}/site.standard.document/post1`;
+    db.run('INSERT INTO did_cache (did, pds_url, handle, cached_at) VALUES (?, ?, ?, ?)', [
+      did,
+      'https://pds.example',
+      'attacker.test',
+      Date.now(),
+    ]);
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/xrpc/com.atproto.repo.getRecord') {
+        return new Response(
+          JSON.stringify({ value: { site: 'https://attacker.example', path: '/bait' } })
+        );
+      }
+      return new Response(JSON.stringify({ links: {} }));
+    }) as unknown as typeof fetch);
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+
+    const row = db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get();
+    expect(row?.doc_uri).toBeNull();
+    expect(
+      spy.mock.calls.some(([input]) => new URL(String(input)).searchParams.get('target') === docUri)
+    ).toBe(false);
+  });
+
   it('caches a breakdown and serves it above threshold; flags cold URLs to enrich', async () => {
     const db = freshDb();
     const now = Date.now();

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -165,6 +165,40 @@ describe('computeMentions', () => {
     expect(result.total).toBe(3);
   });
 
+  it('uses the document target only for Leaflet sources', async () => {
+    const docUri = 'at://did:plc:publisher/site.standard.document/post1';
+    const spy = spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      const target = url.searchParams.get('target');
+      if (url.pathname === '/links/all') {
+        return new Response(
+          JSON.stringify({
+            links:
+              target === docUri
+                ? {
+                    'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } },
+                    'app.bsky.feed.post': { '.embed.record.uri': { distinct_dids: 1 } },
+                  }
+                : {},
+          })
+        );
+      }
+      if (url.pathname === '/links/distinct-dids') {
+        return new Response(JSON.stringify({ total: 1, linking_dids: ['did:plc:alice'] }));
+      }
+      return new Response('{}', { status: 404 });
+    }) as unknown as typeof fetch);
+
+    const result = await computeMentions(ARTICLE, docUri);
+    expect(result.lanes.map((lane) => lane.lane)).toEqual(['leaflet']);
+    expect(
+      spy.mock.calls
+        .map(([input]) => new URL(String(input)))
+        .filter((url) => url.pathname === '/links/all')
+        .map((url) => url.searchParams.get('target'))
+    ).toContain(docUri);
+  });
+
   it('counts distinct DIDs, not raw records — one chatty account never inflates a lane', async () => {
     // Constellation's /links/distinct-dids dedups server-side: even if one account
     // posted the URL many times, it reports that account once with an honest total.

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -103,6 +103,8 @@ describe('constellationTargets', () => {
 describe('laneForSource', () => {
   it('buckets known collections and ignores excluded paths', () => {
     expect(laneForSource('site.standard.document', '.links[].uri')?.id).toBe('linkblog');
+    expect(laneForSource('pub.leaflet.comment', '.subject')?.id).toBe('leaflet');
+    expect(laneForSource('pub.leaflet.comment', '.attachment.document')).toBeNull();
     expect(laneForSource('app.bsky.feed.post', '.embed.external.uri')?.id).toBe('bluesky');
     expect(laneForSource('at.margin.note', '.target.source')?.id).toBe('margin');
     expect(laneForSource('network.cosmik.card', '.content.url')?.id).toBe('semble');
@@ -259,6 +261,25 @@ describe('computeMentions', () => {
 });
 
 describe('enrichMentions + readCachedMentions', () => {
+  it('marks a fresh URL-only row due when a document URI arrives', () => {
+    const db = freshDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO mention_cache
+        (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri)
+       VALUES (?, ?, 0, '[]', ?, ?, NULL)`,
+      ['11ddf42a96099890', ARTICLE, now, now]
+    );
+
+    const cached = readCachedMentions(
+      db,
+      ARTICLE,
+      now,
+      'at://did:plc:publisher/site.standard.document/post1'
+    );
+    expect(cached.shouldEnrich).toBe(true);
+  });
+
   afterEach(() => {
     (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
   });

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -318,21 +318,15 @@ describe('enrichMentions + readCachedMentions', () => {
     (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
   });
 
-  it('persists a document URI only when its canonical URL matches the article', async () => {
+  it('persists a document URI only when the article advertises it', async () => {
     const db = freshDb();
     const did = 'did:plc:publisher';
     const docUri = `at://${did}/site.standard.document/post1`;
-    db.run('INSERT INTO did_cache (did, pds_url, handle, cached_at) VALUES (?, ?, ?, ?)', [
-      did,
-      'https://pds.example',
-      'publisher.test',
-      Date.now(),
-    ]);
     const spy = spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
       const url = new URL(String(input));
-      if (url.pathname === '/xrpc/com.atproto.repo.getRecord') {
+      if (url.href === ARTICLE) {
         return new Response(
-          JSON.stringify({ value: { site: 'https://example.com', path: '/the-article' } })
+          `<html><head><link rel="site.standard.document" href="${docUri}"></head>`
         );
       }
       return new Response(JSON.stringify({ links: {} }));
@@ -347,23 +341,19 @@ describe('enrichMentions + readCachedMentions', () => {
     ).toBe(true);
   });
 
-  it('rejects a document URI whose canonical URL does not match the article', async () => {
+  it('rejects an attacker document that self-asserts the article URL', async () => {
     const db = freshDb();
     const did = 'did:plc:attacker';
     const docUri = `at://${did}/site.standard.document/post1`;
-    db.run('INSERT INTO did_cache (did, pds_url, handle, cached_at) VALUES (?, ?, ?, ?)', [
-      did,
-      'https://pds.example',
-      'attacker.test',
-      Date.now(),
-    ]);
     const spy = spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
       const url = new URL(String(input));
       if (url.pathname === '/xrpc/com.atproto.repo.getRecord') {
         return new Response(
-          JSON.stringify({ value: { site: 'https://attacker.example', path: '/bait' } })
+          JSON.stringify({ value: { site: 'https://example.com', path: '/the-article' } })
         );
       }
+      if (url.href === ARTICLE)
+        return new Response('<html><head></head><body>victim</body></html>');
       return new Response(JSON.stringify({ links: {} }));
     }) as unknown as typeof fetch);
 
@@ -373,6 +363,11 @@ describe('enrichMentions + readCachedMentions', () => {
     expect(row?.doc_uri).toBeNull();
     expect(
       spy.mock.calls.some(([input]) => new URL(String(input)).searchParams.get('target') === docUri)
+    ).toBe(false);
+    expect(
+      spy.mock.calls.some(
+        ([input]) => new URL(String(input)).pathname === '/xrpc/com.atproto.repo.getRecord'
+      )
     ).toBe(false);
   });
 

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -371,6 +371,47 @@ describe('enrichMentions + readCachedMentions', () => {
     ).toBe(false);
   });
 
+  it('clears a due document target when the article stops advertising it', async () => {
+    const db = freshDb();
+    const docUri = 'at://did:plc:publisher/site.standard.document/post1';
+    let advertisesDocument = true;
+    const queriedDocumentTargets: string[] = [];
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.href === ARTICLE) {
+        return new Response(
+          advertisesDocument
+            ? `<html><head><link rel="site.standard.document" href="${docUri}"></head></html>`
+            : '<html><head></head><body>updated article</body></html>'
+        );
+      }
+      const target = url.searchParams.get('target');
+      if (target === docUri) queriedDocumentTargets.push(target);
+      return new Response(JSON.stringify({ links: {} }));
+    }) as unknown as typeof fetch);
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+    expect(
+      db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get()?.doc_uri
+    ).toBe(docUri);
+    expect(queriedDocumentTargets.length).toBeGreaterThan(0);
+
+    advertisesDocument = false;
+    db.run('UPDATE mention_cache SET checked_at = ?', [Date.now() - 2 * 60 * 60 * 1000]);
+    const documentQueriesBeforeRecheck = queriedDocumentTargets.length;
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!);
+
+    const row = db
+      .query<{ doc_uri: string | null; lanes_json: string }, []>(
+        'SELECT doc_uri, lanes_json FROM mention_cache'
+      )
+      .get();
+    expect(row?.doc_uri).toBeNull();
+    expect(queriedDocumentTargets).toHaveLength(documentQueriesBeforeRecheck);
+    expect(JSON.parse(row?.lanes_json ?? '[]')).toEqual([]);
+  });
+
   it('caches a breakdown and serves it above threshold; flags cold URLs to enrich', async () => {
     const db = freshDb();
     const now = Date.now();

--- a/feed-proxy/src/mentions.test.ts
+++ b/feed-proxy/src/mentions.test.ts
@@ -305,13 +305,34 @@ describe('enrichMentions + readCachedMentions', () => {
       ['11ddf42a96099890', ARTICLE, now, now]
     );
 
-    const cached = readCachedMentions(
-      db,
-      ARTICLE,
-      now,
-      'at://did:plc:publisher/site.standard.document/post1'
-    );
+    const cached = readCachedMentions(db, ARTICLE, now, {
+      docUri: 'at://did:plc:publisher/site.standard.document/post1',
+      resolveDocument: true,
+    });
     expect(cached.shouldEnrich).toBe(true);
+  });
+
+  it('flags a fresh row whose document target was never looked up, with no client hint', () => {
+    const db = freshDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO mention_cache
+        (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri, doc_checked_at)
+       VALUES (?, ?, 3, '[]', ?, ?, NULL, NULL)`,
+      ['11ddf42a96099890', ARTICLE, now, now]
+    );
+
+    // The read path can resolve a document target, so an unlooked-at row is
+    // enrichable even though its counts are fresh and non-zero.
+    expect(readCachedMentions(db, ARTICLE, now, { resolveDocument: true }).shouldEnrich).toBe(true);
+    // The warm loop can't, so it must not be told to re-run for that reason.
+    expect(readCachedMentions(db, ARTICLE, now).shouldEnrich).toBe(false);
+
+    // Once looked at, the read path stops re-asking too.
+    db.run('UPDATE mention_cache SET doc_checked_at = ?', [now]);
+    expect(readCachedMentions(db, ARTICLE, now, { resolveDocument: true }).shouldEnrich).toBe(
+      false
+    );
   });
 
   afterEach(() => {
@@ -332,13 +353,102 @@ describe('enrichMentions + readCachedMentions', () => {
       return new Response(JSON.stringify({ links: {} }));
     }) as unknown as typeof fetch);
 
-    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, { docUri, resolveDocument: true });
 
     const row = db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get();
     expect(row?.doc_uri).toBe(docUri);
     expect(
       spy.mock.calls.some(([input]) => new URL(String(input)).searchParams.get('target') === docUri)
     ).toBe(true);
+  });
+
+  it('discovers the document target from the article origin with no client hint', async () => {
+    const db = freshDb();
+    const docUri = 'at://did:plc:publisher/site.standard.document/post1';
+    // The case the whole feature exists for: a URL-keyed item (a saved article,
+    // an RSS item, a link post's target) whose page *is* a standard.site
+    // document. The client has no at:// URI to offer, and pub.leaflet.comment
+    // targets the document — never the https URL — so without discovery the
+    // Leaflet lane is unreachable.
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.href === ARTICLE) {
+        return new Response(`<html><head><link rel="alternate" href="${docUri}"></head></html>`);
+      }
+      if (url.pathname === '/links/all') {
+        return new Response(
+          JSON.stringify({
+            links:
+              url.searchParams.get('target') === docUri
+                ? { 'pub.leaflet.comment': { '.subject': { distinct_dids: 1 } } }
+                : {},
+          })
+        );
+      }
+      return new Response(JSON.stringify({ total: 1, linking_dids: ['did:plc:commenter'] }));
+    }) as unknown as typeof fetch);
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, { resolveDocument: true });
+
+    const row = db
+      .query<{ doc_uri: string | null; lanes_json: string }, []>(
+        'SELECT doc_uri, lanes_json FROM mention_cache'
+      )
+      .get();
+    expect(row?.doc_uri).toBe(docUri);
+    expect(JSON.parse(row?.lanes_json ?? '[]').map((l: { lane: string }) => l.lane)).toEqual([
+      'leaflet',
+    ]);
+  });
+
+  it('never fetches the article origin without resolveDocument', async () => {
+    const db = freshDb();
+    const originFetches: string[] = [];
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.href === ARTICLE) {
+        originFetches.push(url.href);
+        return new Response('<html><head></head></html>');
+      }
+      return new Response(JSON.stringify({ links: {} }));
+    }) as unknown as typeof fetch);
+
+    // The warm loop pre-warms up to 25 items per feed refresh; paying an origin
+    // fetch for each is exactly the load the demand gate exists to avoid.
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!);
+
+    expect(originFetches).toHaveLength(0);
+    // And it must not claim the lookup was done, or the read path would skip it.
+    expect(
+      db
+        .query<{ doc_checked_at: number | null }, []>('SELECT doc_checked_at FROM mention_cache')
+        .get()?.doc_checked_at
+    ).toBeNull();
+  });
+
+  it("prefers the origin's own target over a mismatched client candidate", async () => {
+    const db = freshDb();
+    const real = 'at://did:plc:publisher/site.standard.document/post1';
+    const claimed = 'at://did:plc:attacker/site.standard.document/post1';
+    const queried: string[] = [];
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const url = new URL(String(input));
+      if (url.href === ARTICLE) {
+        return new Response(`<html><head><link rel="alternate" href="${real}"></head></html>`);
+      }
+      const target = url.searchParams.get('target');
+      if (target?.startsWith('at://')) queried.push(target);
+      return new Response(JSON.stringify({ links: {} }));
+    }) as unknown as typeof fetch);
+
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, {
+      docUri: claimed,
+      resolveDocument: true,
+    });
+
+    const row = db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get();
+    expect(row?.doc_uri).toBe(real);
+    expect(queried).not.toContain(claimed);
   });
 
   it('rejects an attacker document that self-asserts the article URL', async () => {
@@ -357,7 +467,7 @@ describe('enrichMentions + readCachedMentions', () => {
       return new Response(JSON.stringify({ links: {} }));
     }) as unknown as typeof fetch);
 
-    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, { docUri, resolveDocument: true });
 
     const row = db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get();
     expect(row?.doc_uri).toBeNull();
@@ -390,7 +500,7 @@ describe('enrichMentions + readCachedMentions', () => {
       return new Response(JSON.stringify({ links: {} }));
     }) as unknown as typeof fetch);
 
-    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, docUri);
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, { docUri, resolveDocument: true });
     expect(
       db.query<{ doc_uri: string | null }, []>('SELECT doc_uri FROM mention_cache').get()?.doc_uri
     ).toBe(docUri);
@@ -400,7 +510,7 @@ describe('enrichMentions + readCachedMentions', () => {
     db.run('UPDATE mention_cache SET checked_at = ?', [Date.now() - 2 * 60 * 60 * 1000]);
     const documentQueriesBeforeRecheck = queriedDocumentTargets.length;
 
-    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!);
+    await enrichMentions(db, normalizeArticleUrl(ARTICLE)!, { resolveDocument: true });
 
     const row = db
       .query<{ doc_uri: string | null; lanes_json: string }, []>(

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -73,7 +73,7 @@ interface MentionCacheRow {
   doc_uri: string | null;
 }
 
-function hashUrl(url: string): string {
+export function hashUrl(url: string): string {
   const hasher = new Bun.CryptoHasher('sha256');
   hasher.update(url);
   return hasher.digest('hex').slice(0, 16);
@@ -128,6 +128,7 @@ export async function computeMentions(normUrl: string, docUri?: string): Promise
   let queryCount = 0;
   const targets = [...constellationTargets(normUrl), ...(docUri ? [docUri] : [])];
   for (const target of targets) {
+    const isDocumentTarget = target === docUri;
     const all = await constellationGet<LinksAllResponse>('/links/all', { target });
     if (!all?.links) continue;
     // Collect the laned (collection, path) sources Constellation actually reports,
@@ -136,7 +137,7 @@ export async function computeMentions(normUrl: string, docUri?: string): Promise
       for (const [path, stats] of Object.entries(paths)) {
         if (!stats?.distinct_dids) continue;
         const lane = laneForSource(collection, path);
-        if (!lane) continue;
+        if (!lane || (isDocumentTarget && lane.id !== 'leaflet')) continue;
         if (queryCount >= MAX_SOURCE_QUERIES) break;
         queryCount++;
         sources.push({ target, laneId: lane.id, collection, path });

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -24,7 +24,7 @@ import { Database } from 'bun:sqlite';
 import { normalizeArticleUrl, constellationTargets } from './url-normalize';
 import { LANES, laneForSource, type LaneId } from './lanes';
 import { constellationGet } from './constellation-client';
-import { resolveDocumentCanonicalUrl } from './standard-site';
+import { articleAdvertisesDocument } from './standard-site';
 
 // DIDs paged per (collection, path). One page is exact for the common small
 // count; very popular URLs cap here and render as '<n>+'.
@@ -257,8 +257,7 @@ export async function enrichMentions(
     .get(hashUrl(normUrl));
   let verifiedDocUri = existing?.doc_uri ?? undefined;
   if (docUri && !existing?.doc_uri) {
-    const canonicalUrl = await resolveDocumentCanonicalUrl(db, docUri);
-    if (canonicalUrl && normalizeArticleUrl(canonicalUrl) === normUrl) verifiedDocUri = docUri;
+    if (await articleAdvertisesDocument(normUrl, docUri)) verifiedDocUri = docUri;
   }
   if (existing && !(verifiedDocUri && !existing.doc_uri) && !isDue(existing, now)) return;
   const effectiveDocUri = verifiedDocUri;

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -70,6 +70,7 @@ interface MentionCacheRow {
   lanes_json: string;
   first_seen_at: number;
   checked_at: number;
+  doc_uri: string | null;
 }
 
 function hashUrl(url: string): string {
@@ -119,13 +120,14 @@ async function fetchSourceDids(
  * `/links/all`, bucket them into lanes, union distinct DIDs per lane and across
  * all lanes. Returns lanes in registry (priority) order, non-empty only.
  */
-export async function computeMentions(normUrl: string): Promise<ArticleMentions> {
+export async function computeMentions(normUrl: string, docUri?: string): Promise<ArticleMentions> {
   // Probe both trailing-slash forms (Constellation matches the target string
   // exactly) and carry the matching target with each source so we fetch its DIDs
   // against the form that actually has links. See constellationTargets.
   const sources: Array<{ target: string; laneId: LaneId; collection: string; path: string }> = [];
   let queryCount = 0;
-  for (const target of constellationTargets(normUrl)) {
+  const targets = [...constellationTargets(normUrl), ...(docUri ? [docUri] : [])];
+  for (const target of targets) {
     const all = await constellationGet<LinksAllResponse>('/links/all', { target });
     if (!all?.links) continue;
     // Collect the laned (collection, path) sources Constellation actually reports,
@@ -214,7 +216,8 @@ function rowToMentions(row: MentionCacheRow): ArticleMentions {
 export function readCachedMentions(
   db: Database,
   rawUrl: string,
-  now: number
+  now: number,
+  docUri?: string
 ): {
   normUrl: string | null;
   mentions: ArticleMentions;
@@ -232,7 +235,7 @@ export function readCachedMentions(
   // Surface every real reference, down to a single linker — a row with zero DIDs
   // naturally renders empty (no lanes), so no threshold is needed to suppress it.
   const mentions = rowToMentions(row);
-  return { normUrl, mentions, shouldEnrich: isDue(row, now) };
+  return { normUrl, mentions, shouldEnrich: (Boolean(docUri) && !row.doc_uri) || isDue(row, now) };
 }
 
 /**
@@ -241,16 +244,21 @@ export function readCachedMentions(
  * a settled/fresh row). Preserves `first_seen_at` across updates so the decay
  * curve is anchored to first sighting, not last check. Best-effort — never throws.
  */
-export async function enrichMentions(db: Database, normUrl: string): Promise<void> {
+export async function enrichMentions(
+  db: Database,
+  normUrl: string,
+  docUri?: string
+): Promise<void> {
   const now = Date.now();
   const existing = db
     .query<MentionCacheRow, [string]>('SELECT * FROM mention_cache WHERE url_hash = ?')
     .get(hashUrl(normUrl));
-  if (existing && !isDue(existing, now)) return;
+  if (existing && !(docUri && !existing.doc_uri) && !isDue(existing, now)) return;
+  const effectiveDocUri = docUri ?? existing?.doc_uri ?? undefined;
 
   let mentions: ArticleMentions;
   try {
-    mentions = await computeMentions(normUrl);
+    mentions = await computeMentions(normUrl, effectiveDocUri);
   } catch (error) {
     console.error(`[mentions] enrich error for ${normUrl}:`, error);
     return;
@@ -258,12 +266,21 @@ export async function enrichMentions(db: Database, normUrl: string): Promise<voi
 
   const firstSeen = existing?.first_seen_at ?? now;
   db.run(
-    `INSERT INTO mention_cache (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at)
-		VALUES (?, ?, ?, ?, ?, ?)
+    `INSERT INTO mention_cache (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(url_hash) DO UPDATE SET
 			total_dids = excluded.total_dids,
 			lanes_json = excluded.lanes_json,
-			checked_at = excluded.checked_at`,
-    [hashUrl(normUrl), normUrl, mentions.total, JSON.stringify(mentions.lanes), firstSeen, now]
+			checked_at = excluded.checked_at,
+			doc_uri = COALESCE(excluded.doc_uri, mention_cache.doc_uri)`,
+    [
+      hashUrl(normUrl),
+      normUrl,
+      mentions.total,
+      JSON.stringify(mentions.lanes),
+      firstSeen,
+      now,
+      effectiveDocUri ?? null,
+    ]
   );
 }

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -24,6 +24,7 @@ import { Database } from 'bun:sqlite';
 import { normalizeArticleUrl, constellationTargets } from './url-normalize';
 import { LANES, laneForSource, type LaneId } from './lanes';
 import { constellationGet } from './constellation-client';
+import { resolveDocumentCanonicalUrl } from './standard-site';
 
 // DIDs paged per (collection, path). One page is exact for the common small
 // count; very popular URLs cap here and render as '<n>+'.
@@ -254,8 +255,13 @@ export async function enrichMentions(
   const existing = db
     .query<MentionCacheRow, [string]>('SELECT * FROM mention_cache WHERE url_hash = ?')
     .get(hashUrl(normUrl));
-  if (existing && !(docUri && !existing.doc_uri) && !isDue(existing, now)) return;
-  const effectiveDocUri = docUri ?? existing?.doc_uri ?? undefined;
+  let verifiedDocUri = existing?.doc_uri ?? undefined;
+  if (docUri && !existing?.doc_uri) {
+    const canonicalUrl = await resolveDocumentCanonicalUrl(db, docUri);
+    if (canonicalUrl && normalizeArticleUrl(canonicalUrl) === normUrl) verifiedDocUri = docUri;
+  }
+  if (existing && !(verifiedDocUri && !existing.doc_uri) && !isDue(existing, now)) return;
+  const effectiveDocUri = verifiedDocUri;
 
   let mentions: ArticleMentions;
   try {

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -255,11 +255,23 @@ export async function enrichMentions(
   const existing = db
     .query<MentionCacheRow, [string]>('SELECT * FROM mention_cache WHERE url_hash = ?')
     .get(hashUrl(normUrl));
-  let verifiedDocUri = existing?.doc_uri ?? undefined;
-  if (docUri && !existing?.doc_uri) {
-    if (await articleAdvertisesDocument(normUrl, docUri)) verifiedDocUri = docUri;
+  const due = !existing || isDue(existing, now);
+  if (existing && !due && (existing.doc_uri || !docUri)) return;
+
+  // A document target is shared by every reader of this URL. Revalidate a
+  // persisted target whenever its mention row is due so a removed or temporary
+  // origin advertisement cannot keep contributing Leaflet comments forever.
+  let verifiedDocUri: string | undefined;
+  const candidateDocUri = existing?.doc_uri ?? docUri;
+  if (candidateDocUri && (due || !existing?.doc_uri)) {
+    if (await articleAdvertisesDocument(normUrl, candidateDocUri)) {
+      verifiedDocUri = candidateDocUri;
+    }
+  } else {
+    verifiedDocUri = existing?.doc_uri ?? undefined;
   }
-  if (existing && !(verifiedDocUri && !existing.doc_uri) && !isDue(existing, now)) return;
+  // A fresh URL-only row is recomputed only for a verified document upgrade.
+  if (existing && !due && !verifiedDocUri) return;
   const effectiveDocUri = verifiedDocUri;
 
   let mentions: ArticleMentions;
@@ -278,7 +290,7 @@ export async function enrichMentions(
 			total_dids = excluded.total_dids,
 			lanes_json = excluded.lanes_json,
 			checked_at = excluded.checked_at,
-			doc_uri = COALESCE(excluded.doc_uri, mention_cache.doc_uri)`,
+			doc_uri = excluded.doc_uri`,
     [
       hashUrl(normUrl),
       normUrl,

--- a/feed-proxy/src/mentions.ts
+++ b/feed-proxy/src/mentions.ts
@@ -24,7 +24,7 @@ import { Database } from 'bun:sqlite';
 import { normalizeArticleUrl, constellationTargets } from './url-normalize';
 import { LANES, laneForSource, type LaneId } from './lanes';
 import { constellationGet } from './constellation-client';
-import { articleAdvertisesDocument } from './standard-site';
+import { advertisedDocuments } from './standard-site';
 
 // DIDs paged per (collection, path). One page is exact for the common small
 // count; very popular URLs cap here and render as '<n>+'.
@@ -45,6 +45,13 @@ const HOT_RECHECK_MS = 60 * 60 * 1000;
 const COOL_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const COOL_RECHECK_MS = 12 * 60 * 60 * 1000;
 const SETTLED_RECHECK_MS = 7 * 24 * 60 * 60 * 1000;
+
+// A backstop on how long a resolved document target is trusted. Revalidation
+// normally rides the mention decay gate (a due row re-asks the origin), but the
+// warm loop resets `checked_at` without ever looking at an origin — so a feed
+// item could stay perpetually not-due and keep a removed advertisement alive.
+// This bounds that: the read path re-asks at least this often either way.
+const DOC_RECHECK_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface MentionLane {
   lane: LaneId;
@@ -72,6 +79,11 @@ interface MentionCacheRow {
   first_seen_at: number;
   checked_at: number;
   doc_uri: string | null;
+  // When we last asked the article origin which document it advertises. Distinct
+  // from `doc_uri`: NULL means "never looked", while a stamp with a NULL doc_uri
+  // means "looked, this URL is not a document" — so a plain article doesn't pay
+  // for an origin fetch on every read.
+  doc_checked_at: number | null;
 }
 
 export function hashUrl(url: string): string {
@@ -212,14 +224,20 @@ function rowToMentions(row: MentionCacheRow): ArticleMentions {
 /**
  * Read the cached mention breakdown for a raw article URL, with no network call.
  * Returns the breakdown (empty when below threshold or absent), plus whether a
- * background enrichment is warranted (missing row, or due per the decay gate).
+ * background enrichment is warranted (missing row, due per the decay gate, or
+ * carrying a document target we haven't resolved yet).
  * `normUrl` is null when the URL isn't a usable http(s) target.
+ *
+ * `resolveDocument` is the caller saying it will let the enrichment fetch the
+ * article origin (the demand-gated read path does; the warm loop doesn't), so a
+ * row that has never had its document target looked up counts as enrichable
+ * only for callers that can actually resolve it.
  */
 export function readCachedMentions(
   db: Database,
   rawUrl: string,
   now: number,
-  docUri?: string
+  options: { docUri?: string; resolveDocument?: boolean } = {}
 ): {
   normUrl: string | null;
   mentions: ArticleMentions;
@@ -237,7 +255,8 @@ export function readCachedMentions(
   // Surface every real reference, down to a single linker — a row with zero DIDs
   // naturally renders empty (no lanes), so no threshold is needed to suppress it.
   const mentions = rowToMentions(row);
-  return { normUrl, mentions, shouldEnrich: (Boolean(docUri) && !row.doc_uri) || isDue(row, now) };
+  const needsDocLookup = Boolean(options.resolveDocument) && !row.doc_checked_at;
+  return { normUrl, mentions, shouldEnrich: needsDocLookup || isDue(row, now) };
 }
 
 /**
@@ -245,34 +264,59 @@ export function readCachedMentions(
  * decay gate first (so concurrent triggers and warm-loop overlap don't re-query
  * a settled/fresh row). Preserves `first_seen_at` across updates so the decay
  * curve is anchored to first sighting, not last check. Best-effort — never throws.
+ *
+ * `resolveDocument` allows one bounded fetch of the article origin to learn which
+ * standard.site document (if any) this URL *is* — the only way a Leaflet comment
+ * is reachable, since `pub.leaflet.comment` targets the document's at:// URI and
+ * never the https URL. It is demand-gated (the read path passes it, the feed warm
+ * loop does not) and the answer is persisted either way, so a URL costs at most
+ * one origin fetch per decay window rather than one per read.
  */
 export async function enrichMentions(
   db: Database,
   normUrl: string,
-  docUri?: string
+  options: { docUri?: string; resolveDocument?: boolean } = {}
 ): Promise<void> {
+  const { docUri, resolveDocument = false } = options;
   const now = Date.now();
   const existing = db
     .query<MentionCacheRow, [string]>('SELECT * FROM mention_cache WHERE url_hash = ?')
     .get(hashUrl(normUrl));
   const due = !existing || isDue(existing, now);
-  if (existing && !due && (existing.doc_uri || !docUri)) return;
 
-  // A document target is shared by every reader of this URL. Revalidate a
-  // persisted target whenever its mention row is due so a removed or temporary
-  // origin advertisement cannot keep contributing Leaflet comments forever.
-  let verifiedDocUri: string | undefined;
-  const candidateDocUri = existing?.doc_uri ?? docUri;
-  if (candidateDocUri && (due || !existing?.doc_uri)) {
-    if (await articleAdvertisesDocument(normUrl, candidateDocUri)) {
-      verifiedDocUri = candidateDocUri;
-    }
-  } else {
-    verifiedDocUri = existing?.doc_uri ?? undefined;
+  // Ask the origin which document it advertises when we're recomputing anyway,
+  // when we've never asked, or when the last answer has aged out. A
+  // recently-resolved target is otherwise left alone — that stamp is what keeps a
+  // plain article from re-fetching its own HTML on every reader who opens it.
+  const docCheckedAt = existing?.doc_checked_at ?? null;
+  const wantDocLookup =
+    resolveDocument && (due || !docCheckedAt || now - docCheckedAt > DOC_RECHECK_MS);
+  if (existing && !due && !wantDocLookup) return;
+
+  // The document target is shared by every reader of this URL, and the origin is
+  // the only authority on it: a client-supplied candidate counts only if the page
+  // actually advertises it, and a URL-keyed item (a saved article, an RSS item)
+  // gets the page's own target with no client involvement at all. Revalidating on
+  // every due re-poll means a removed advertisement stops contributing comments.
+  let docUriChanged = false;
+  let effectiveDocUri = existing?.doc_uri ?? undefined;
+  if (wantDocLookup) {
+    const advertised = await advertisedDocuments(normUrl);
+    const resolved =
+      (docUri && advertised.includes(docUri) ? docUri : undefined) ?? advertised[0] ?? undefined;
+    docUriChanged = (resolved ?? null) !== (existing?.doc_uri ?? null);
+    effectiveDocUri = resolved;
   }
-  // A fresh URL-only row is recomputed only for a verified document upgrade.
-  if (existing && !due && !verifiedDocUri) return;
-  const effectiveDocUri = verifiedDocUri;
+
+  // Nothing new to compute: a fresh row that looked for a target and found the
+  // one it already had. Still record that we looked, so the next read is free.
+  if (existing && !due && !docUriChanged) {
+    db.run('UPDATE mention_cache SET doc_checked_at = ? WHERE url_hash = ?', [
+      now,
+      hashUrl(normUrl),
+    ]);
+    return;
+  }
 
   let mentions: ArticleMentions;
   try {
@@ -283,14 +327,18 @@ export async function enrichMentions(
   }
 
   const firstSeen = existing?.first_seen_at ?? now;
+  // A warm-loop enrich never looked for a target, so it must not stamp
+  // `doc_checked_at` — that would tell the read path the lookup was already done.
+  const nextDocCheckedAt = wantDocLookup ? now : docCheckedAt;
   db.run(
-    `INSERT INTO mention_cache (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO mention_cache (url_hash, url, total_dids, lanes_json, first_seen_at, checked_at, doc_uri, doc_checked_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(url_hash) DO UPDATE SET
 			total_dids = excluded.total_dids,
 			lanes_json = excluded.lanes_json,
 			checked_at = excluded.checked_at,
-			doc_uri = excluded.doc_uri`,
+			doc_uri = excluded.doc_uri,
+			doc_checked_at = excluded.doc_checked_at`,
     [
       hashUrl(normUrl),
       normUrl,
@@ -299,6 +347,7 @@ export async function enrichMentions(
       firstSeen,
       now,
       effectiveDocUri ?? null,
+      nextDocCheckedAt,
     ]
   );
 }

--- a/feed-proxy/src/standard-site.ts
+++ b/feed-proxy/src/standard-site.ts
@@ -26,6 +26,9 @@ const MAX_LIST_PAGES = 5; // listRecords pages of 100 → up to 500 scanned
 const FETCH_TIMEOUT_MS = 30 * 1000;
 const DOCUMENT_ADVERTISEMENT_TIMEOUT_MS = 10 * 1000;
 const DOCUMENT_ADVERTISEMENT_MAX_BYTES = 1024 * 1024;
+// A page advertising more than a couple of document records is malformed or
+// hostile; we only ever use the first, so bound the scan.
+const MAX_ADVERTISED_DOCUMENTS = 5;
 // A Standard Reader "Collection" (a site.standard.document carrying a
 // `readerCollection`) curates other documents by at:// URI. We resolve each to a
 // title/canonical-URL preview, bounded so a hostile or runaway edition can't fan
@@ -250,18 +253,20 @@ export function buildCanonicalUrl(baseUrl: string, path: string): string {
 }
 
 /**
- * Verify that an article origin advertises a caller-supplied standard.site
- * document URI. The document record's site/path fields are author-controlled,
- * so they cannot establish this binding: the public article itself must name
- * the exact record in a <link> tag, matching standard.site discovery.
+ * The standard.site document URIs an article origin advertises, in document
+ * order, read from the page's own <link> tags (matching standard.site
+ * discovery — see runDiscover's `standardSites`).
+ *
+ * This is the authority on which document a URL *is*. A document record's
+ * site/path fields are author-controlled, so they cannot establish the binding
+ * in either direction: the public article itself must name the exact record.
+ * Callers use it two ways — discovering a target for a URL-keyed item (a saved
+ * article, an RSS item, a link post's target), and verifying one a client
+ * supplied. Returns [] for an unreachable, oversized, or non-advertising page,
+ * which is a real answer ("this URL is not a document"), not an error.
  */
-export async function articleAdvertisesDocument(
-  articleUrl: string,
-  documentUri: string
-): Promise<boolean> {
-  const parsed = parseAtUri(documentUri);
-  if (!parsed || parsed.collection !== 'site.standard.document') return false;
-
+export async function advertisedDocuments(articleUrl: string): Promise<string[]> {
+  const documents: string[] = [];
   try {
     const response = await safeFetch(articleUrl, {
       headers: {
@@ -272,17 +277,17 @@ export async function articleAdvertisesDocument(
     });
     if (!response.ok) {
       await response.body?.cancel().catch(() => {});
-      return false;
+      return documents;
     }
 
     const contentLength = Number(response.headers.get('Content-Length'));
     if (Number.isFinite(contentLength) && contentLength > DOCUMENT_ADVERTISEMENT_MAX_BYTES) {
       await response.body?.cancel().catch(() => {});
-      return false;
+      return documents;
     }
 
     const reader = response.body?.getReader();
-    if (!reader) return false;
+    if (!reader) return documents;
     const decoder = new TextDecoder();
     let total = 0;
     let html = '';
@@ -292,20 +297,26 @@ export async function articleAdvertisesDocument(
       total += value.byteLength;
       if (total > DOCUMENT_ADVERTISEMENT_MAX_BYTES) {
         await reader.cancel().catch(() => {});
-        return false;
+        return documents;
       }
       html += decoder.decode(value, { stream: true });
     }
     html += decoder.decode();
 
+    // The at:// href is the reliable signal regardless of `rel` — Leaflet emits
+    // the same URI as both rel="alternate" and rel="site.standard.document".
     for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
       const href = match[0].match(/\bhref\s*=\s*["']([^"']+)["']/i)?.[1];
-      if (href === documentUri) return true;
+      if (!href || documents.includes(href)) continue;
+      const parsed = parseAtUri(href);
+      if (parsed?.collection !== 'site.standard.document') continue;
+      documents.push(href);
+      if (documents.length >= MAX_ADVERTISED_DOCUMENTS) break;
     }
   } catch (error) {
-    console.error('[standard-site] document advertisement verification error:', error);
+    console.error('[standard-site] document advertisement lookup error:', error);
   }
-  return false;
+  return documents;
 }
 
 async function fetchRecord<T>(

--- a/feed-proxy/src/standard-site.ts
+++ b/feed-proxy/src/standard-site.ts
@@ -247,6 +247,34 @@ export function buildCanonicalUrl(baseUrl: string, path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
+/**
+ * Resolve a caller-supplied standard.site document URI to the document's own
+ * canonical public URL. Mention enrichment uses this before attaching an AT-URI
+ * to the shared URL cache, so a client cannot associate an unrelated document
+ * (and its Leaflet comments) with an arbitrary article URL.
+ */
+export async function resolveDocumentCanonicalUrl(
+  db: Database,
+  documentUri: string
+): Promise<string | null> {
+  const parsed = parseAtUri(documentUri);
+  if (!parsed || parsed.collection !== 'site.standard.document') return null;
+
+  const pdsUrl = await resolvePdsUrl(db, parsed.did);
+  if (!pdsUrl) return null;
+  const document = await fetchRecord<DocumentRecord>(
+    pdsUrl,
+    parsed.did,
+    parsed.collection,
+    parsed.rkey
+  );
+  if (!document) return null;
+
+  const { baseUrl } = await resolveSiteMeta(db, document.site || '');
+  if (!baseUrl) return null;
+  return buildCanonicalUrl(baseUrl, document.path || '') || null;
+}
+
 async function fetchRecord<T>(
   pdsUrl: string,
   did: string,

--- a/feed-proxy/src/standard-site.ts
+++ b/feed-proxy/src/standard-site.ts
@@ -24,6 +24,8 @@ const PUBLICATION_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
 export const MAX_DOCUMENTS_PER_AUTHOR = 100;
 const MAX_LIST_PAGES = 5; // listRecords pages of 100 → up to 500 scanned
 const FETCH_TIMEOUT_MS = 30 * 1000;
+const DOCUMENT_ADVERTISEMENT_TIMEOUT_MS = 10 * 1000;
+const DOCUMENT_ADVERTISEMENT_MAX_BYTES = 1024 * 1024;
 // A Standard Reader "Collection" (a site.standard.document carrying a
 // `readerCollection`) curates other documents by at:// URI. We resolve each to a
 // title/canonical-URL preview, bounded so a hostile or runaway edition can't fan
@@ -248,31 +250,62 @@ export function buildCanonicalUrl(baseUrl: string, path: string): string {
 }
 
 /**
- * Resolve a caller-supplied standard.site document URI to the document's own
- * canonical public URL. Mention enrichment uses this before attaching an AT-URI
- * to the shared URL cache, so a client cannot associate an unrelated document
- * (and its Leaflet comments) with an arbitrary article URL.
+ * Verify that an article origin advertises a caller-supplied standard.site
+ * document URI. The document record's site/path fields are author-controlled,
+ * so they cannot establish this binding: the public article itself must name
+ * the exact record in a <link> tag, matching standard.site discovery.
  */
-export async function resolveDocumentCanonicalUrl(
-  db: Database,
+export async function articleAdvertisesDocument(
+  articleUrl: string,
   documentUri: string
-): Promise<string | null> {
+): Promise<boolean> {
   const parsed = parseAtUri(documentUri);
-  if (!parsed || parsed.collection !== 'site.standard.document') return null;
+  if (!parsed || parsed.collection !== 'site.standard.document') return false;
 
-  const pdsUrl = await resolvePdsUrl(db, parsed.did);
-  if (!pdsUrl) return null;
-  const document = await fetchRecord<DocumentRecord>(
-    pdsUrl,
-    parsed.did,
-    parsed.collection,
-    parsed.rkey
-  );
-  if (!document) return null;
+  try {
+    const response = await safeFetch(articleUrl, {
+      headers: {
+        'User-Agent': 'Skyreader/1.0 (+https://skyreader.app)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(DOCUMENT_ADVERTISEMENT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
+      return false;
+    }
 
-  const { baseUrl } = await resolveSiteMeta(db, document.site || '');
-  if (!baseUrl) return null;
-  return buildCanonicalUrl(baseUrl, document.path || '') || null;
+    const contentLength = Number(response.headers.get('Content-Length'));
+    if (Number.isFinite(contentLength) && contentLength > DOCUMENT_ADVERTISEMENT_MAX_BYTES) {
+      await response.body?.cancel().catch(() => {});
+      return false;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return false;
+    const decoder = new TextDecoder();
+    let total = 0;
+    let html = '';
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > DOCUMENT_ADVERTISEMENT_MAX_BYTES) {
+        await reader.cancel().catch(() => {});
+        return false;
+      }
+      html += decoder.decode(value, { stream: true });
+    }
+    html += decoder.decode();
+
+    for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+      const href = match[0].match(/\bhref\s*=\s*["']([^"']+)["']/i)?.[1];
+      if (href === documentUri) return true;
+    }
+  } catch (error) {
+    console.error('[standard-site] document advertisement verification error:', error);
+  }
+  return false;
 }
 
 async function fetchRecord<T>(

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -394,7 +394,7 @@
   // document's canonical URL.
   const atmosphere = useAtmosphere({
     itemUrl: () => itemUrl,
-    itemAtUri: () => (isDocumentMode ? document?.recordUri : undefined),
+    itemAtUri: () => (isDocumentMode && !isLinkPostMode ? document?.recordUri : undefined),
     itemTitle: () => itemTitle,
     sourceTitle: () => displayFeedTitle,
     isShared: () => currentlyShared,

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -376,6 +376,8 @@
         // states — so the discussion's compose row never repeats it a few pixels
         // away inside the same footer band.
         return false;
+      case 'leaflet':
+        return false;
       case 'semble':
       case 'margin':
         // The collection picker is global, so these are offered wherever the
@@ -392,6 +394,7 @@
   // document's canonical URL.
   const atmosphere = useAtmosphere({
     itemUrl: () => itemUrl,
+    itemAtUri: () => (isDocumentMode ? document?.recordUri : undefined),
     itemTitle: () => itemTitle,
     sourceTitle: () => displayFeedTitle,
     isShared: () => currentlyShared,
@@ -404,6 +407,8 @@
     switch (id) {
       case 'linkblog':
         if (!currentlyShared) composeShare();
+        break;
+      case 'leaflet':
         break;
       case 'semble':
         saveToSemble();

--- a/frontend/src/lib/components/Icon.svelte
+++ b/frontend/src/lib/components/Icon.svelte
@@ -49,6 +49,7 @@
     | 'highlighter'
     | 'send'
     | 'semble'
+    | 'leaflet'
     | 'margin'
     | 'arrow-right'
     | 'at-sign'
@@ -298,6 +299,9 @@
         stroke="none"
       />
     </g>
+  {:else if name === 'leaflet'}
+    <path d="M20 4c-7 0-13 3.5-14.5 9.5C4.7 16.7 6.8 20 10 20c6 0 10-7 10-16Z" />
+    <path d="M5 21c2.5-5.5 6.5-9.5 12-12" />
   {:else if name === 'arrow-right'}
     <line x1="5" y1="12" x2="19" y2="12" />
     <polyline points="12 5 19 12 12 19" />

--- a/frontend/src/lib/components/articleCardView.types.ts
+++ b/frontend/src/lib/components/articleCardView.types.ts
@@ -10,7 +10,7 @@ import type { ReaderCollection, ReaderCollectionItem, SembleContext } from '$lib
  * card's visual design iterable from mock data (see /dev/cards).
  */
 
-export type LaneId = 'linkblog' | 'bluesky' | 'margin' | 'semble';
+export type LaneId = 'linkblog' | 'leaflet' | 'bluesky' | 'margin' | 'semble';
 
 /** One Atmosphere-row lane chip, with LANE_META already folded in. */
 export interface LaneRowVM {

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -8,7 +8,7 @@
   //
   // <!--
   // THESIS: an article's discussion is ONE conversation that happens to be
-  //   spread across four networks. It refuses the tab strip that made the reader
+  //   spread across several networks. It refuses the tab strip that made the reader
   //   click through four bordered boxes — two of them empty — to find out what
   //   anyone said, and refuses the handle-over-content list that came with it.
   // OWN-WORLD: the app's own reading-room system, at list density: flat,

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -103,12 +103,14 @@
   // saving again is how you put it in another collection.
   function laneCanCreate(id: LaneId): boolean {
     if (id === 'linkblog') return false;
+    if (id === 'leaflet') return false;
     if (id === 'semble' || id === 'margin') return Boolean(auth.user);
     return true;
   }
 
   const atmosphere = useAtmosphere({
     itemUrl: () => itemUrl,
+    itemAtUri: () => (readerItem.type === 'document' ? readerItem.item.recordUri : undefined),
     itemTitle: () => title,
     // A bridge posts the publication's name as often as the headline, so the
     // note cleaner needs both to recognize a bare relink.

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -110,7 +110,8 @@
 
   const atmosphere = useAtmosphere({
     itemUrl: () => itemUrl,
-    itemAtUri: () => (readerItem.type === 'document' ? readerItem.item.recordUri : undefined),
+    itemAtUri: () =>
+      readerItem.type === 'document' && !linkPostUrl ? readerItem.item.recordUri : undefined,
     itemTitle: () => title,
     // A bridge posts the publication's name as often as the headline, so the
     // note cleaner needs both to recognize a bare relink.

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -214,7 +214,8 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     const out = new Map<LaneId, ReturnType<typeof mentionLaneItemsStore.get>>();
     if (!url || !streamOpen) return out;
     for (const lane of laneRow) {
-      if (lane.count > 0) out.set(lane.id, mentionLaneItemsStore.get(url, lane.id));
+      if (lane.count > 0)
+        out.set(lane.id, mentionLaneItemsStore.get(url, lane.id, opts.itemAtUri?.()));
     }
     return out;
   });

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -10,7 +10,7 @@
 // with the caller and are injected as getters.
 //
 // The merge is the point: an article's discussion is one conversation that
-// happens to be spread across four networks, not four lists to click between.
+// happens to be spread across several networks, not separate lists to click between.
 // Lanes survive as filters over that stream. Resolving people is the expensive
 // path (a PDS fetch per record), so nothing loads until the host calls
 // `openStream()` — the card on its Discussion toggle, the reader when the
@@ -49,6 +49,13 @@ export const LANE_META: Record<
     noun: 'note',
     createLabel: 'Write a note',
   },
+  leaflet: {
+    icon: 'leaflet',
+    label: 'Leaflet',
+    verb: 'commented',
+    noun: 'comment',
+    createLabel: 'Comment on Leaflet',
+  },
   bluesky: {
     icon: 'bluesky',
     label: 'Bluesky',
@@ -71,11 +78,13 @@ export const LANE_META: Record<
     createLabel: 'Save to Semble',
   },
 };
-export const LANE_ORDER: LaneId[] = ['linkblog', 'bluesky', 'margin', 'semble'];
+export const LANE_ORDER: LaneId[] = ['linkblog', 'leaflet', 'bluesky', 'margin', 'semble'];
 
 export interface UseAtmosphereOptions {
   /** The URL whose Atmosphere references we resolve (reactive getter). */
   itemUrl: () => string;
+  /** The document AT-URI Leaflet comments target, when this is a document item. */
+  itemAtUri?: () => string | undefined;
   /**
    * Whether the item is shared to the user's own linkblog. Drives the "mine"
    * tint and keeps the Blogs lane visible the moment you share, before the
@@ -130,7 +139,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
   // Batched + deduped + memoized inside the store, so this is cheap to fire.
   $effect(() => {
     const url = opts.itemUrl();
-    if (url) articleMentionsStore.fetch(url);
+    if (url) articleMentionsStore.fetch(url, opts.itemAtUri?.());
   });
 
   const mentionLaneMap = $derived.by(() => {
@@ -194,7 +203,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     const url = opts.itemUrl();
     if (!url) return;
     for (const lane of laneRow) {
-      if (lane.count > 0) mentionLaneItemsStore.load(url, lane.id);
+      if (lane.count > 0) mentionLaneItemsStore.load(url, lane.id, { docUri: opts.itemAtUri?.() });
     }
   });
 
@@ -261,7 +270,8 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     if (id !== 'all') {
       const url = opts.itemUrl();
       const lane = laneRow.find((l) => l.id === id);
-      if (url && lane && lane.count > 0) mentionLaneItemsStore.load(url, id);
+      if (url && lane && lane.count > 0)
+        mentionLaneItemsStore.load(url, id, { docUri: opts.itemAtUri?.() });
     }
   }
 
@@ -346,7 +356,8 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     if (!url) return;
     streamOpen = true;
     for (const lane of laneRow) {
-      if (lane.count > 0) mentionLaneItemsStore.load(url, lane.id, { force: true });
+      if (lane.count > 0)
+        mentionLaneItemsStore.load(url, lane.id, { force: true, docUri: opts.itemAtUri?.() });
     }
   }
 

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -654,10 +654,13 @@ class ApiClient {
   // Network-wide article mentions (Phase 5) — per-lane breakdown of who across
   // the Atmosphere referenced these URLs. Best-effort adornment; degrades to
   // empty per URL.
-  async fetchArticleMentions(urls: string[]): Promise<{ items: ArticleMentions[] }> {
+  async fetchArticleMentions(
+    urls: string[],
+    docUris?: Record<string, string>
+  ): Promise<{ items: ArticleMentions[] }> {
     return this.fetch('/api/v2/mentions', {
       method: 'POST',
-      body: JSON.stringify({ urls }),
+      body: JSON.stringify({ urls, ...(docUris ? { docUris } : {}) }),
     });
   }
 
@@ -666,11 +669,12 @@ class ApiClient {
   // lane is expanded. Best-effort adornment; degrades to an empty list.
   async fetchMentionLaneItems(
     url: string,
-    lane: string
+    lane: string,
+    docUri?: string
   ): Promise<{ entries: MentionLaneEntry[]; sembleContext?: SembleContext }> {
     return this.fetch('/api/v2/mention-lane', {
       method: 'POST',
-      body: JSON.stringify({ url, lane }),
+      body: JSON.stringify({ url, lane, ...(docUri ? { docUri } : {}) }),
     });
   }
 

--- a/frontend/src/lib/stores/articleMentions.svelte.ts
+++ b/frontend/src/lib/stores/articleMentions.svelte.ts
@@ -11,7 +11,8 @@
 // hours/days — so we fetch by URL, not off the cached article. Requests are
 // batched (cards mount in bursts) and deduped; results memoized per URL for the
 // session. The proxy caches the expensive work and enriches cold URLs in the
-// background, so a first miss is retried a couple times shortly after.
+// background, so a first miss — or any answer it flags as still enriching — is
+// retried a couple times shortly after.
 
 import { api } from '$lib/services/api';
 import type { ArticleMentions } from '$lib/types';
@@ -20,8 +21,9 @@ const FLUSH_DELAY_MS = 80;
 const MAX_BATCH = 50;
 const OFFLINE_RETRY_MS = 4000;
 // Cold URLs enrich in the background proxy-side; re-poll to catch them. A single
-// retry loses the race when Constellation is slow, so retry twice with a
-// lengthening backoff (5s, then 10s) before giving up until the card remounts.
+// retry loses the race when Constellation is slow — and a document-target lookup
+// adds an origin fetch on top — so retry twice with a lengthening backoff (5s,
+// then 10s) before giving up until the card remounts.
 const COLD_RETRY_MS = 5000;
 const MAX_COLD_RETRIES = 2;
 // Cap the session memo so a long scroll session can't grow it without bound.
@@ -78,9 +80,12 @@ function createArticleMentionsStore() {
         // FIFO eviction below (delete-then-set moves it to the end).
         next.delete(item.url);
         next.set(item.url, item);
-        // A zero may be genuine or just not-yet-enriched; retry a couple times
-        // with a lengthening backoff to outlast a slow background enrichment.
-        if (item.total === 0) {
+        // Re-poll while the proxy says an enrichment is in flight, and on a zero
+        // total (which also covers a proxy failure, where nothing is enriching
+        // and the field never arrives). A non-zero total is not proof the answer
+        // is settled: an article's Leaflet lane is discovered on the read path
+        // and can land after its Bluesky and Semble counts are already cached.
+        if (item.pending || item.total === 0) {
           const attempts = coldRetries.get(item.url) ?? 0;
           if (attempts < MAX_COLD_RETRIES) {
             coldRetries.set(item.url, attempts + 1);

--- a/frontend/src/lib/stores/articleMentions.svelte.ts
+++ b/frontend/src/lib/stores/articleMentions.svelte.ts
@@ -37,7 +37,8 @@ function createArticleMentionsStore() {
   const requested = new Set<string>();
   // How many cold retries each URL has had (bounds re-polling to MAX_COLD_RETRIES).
   const coldRetries = new Map<string, number>();
-  let pending = new Set<string>();
+  const docUrisByUrl = new Map<string, string>();
+  let pending = new Map<string, string | undefined>();
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
   function scheduleFlush(delay = FLUSH_DELAY_MS) {
@@ -57,13 +58,20 @@ function createArticleMentionsStore() {
       return;
     }
 
-    const all = [...pending];
+    const all = [...pending.entries()];
     const batch = all.slice(0, MAX_BATCH);
-    pending = new Set(all.slice(MAX_BATCH));
+    pending = new Map(all.slice(MAX_BATCH));
     if (pending.size > 0) scheduleFlush();
 
     try {
-      const res = await api.fetchArticleMentions(batch);
+      const urls = batch.map(([url]) => url);
+      const docUris = Object.fromEntries(
+        batch.filter((entry): entry is [string, string] => Boolean(entry[1]))
+      );
+      const res = await api.fetchArticleMentions(
+        urls,
+        Object.keys(docUris).length ? docUris : undefined
+      );
       const next = new Map(cache);
       for (const item of res.items ?? []) {
         // Re-insert at the tail so a just-seen URL counts as freshest for the
@@ -88,26 +96,33 @@ function createArticleMentionsStore() {
         next.delete(oldest);
         requested.delete(oldest);
         coldRetries.delete(oldest);
+        docUrisByUrl.delete(oldest);
       }
       cache = next;
     } catch (e) {
       // Silent degradation — let these URLs be retried by a later mount.
       console.error('Failed to fetch article mentions:', e);
-      for (const url of batch) requested.delete(url);
+      for (const [url] of batch) requested.delete(url);
     }
   }
 
   function requeue(url: string) {
-    pending.add(url);
+    pending.set(url, docUrisByUrl.get(url));
     scheduleFlush();
   }
 
   // Request the mention breakdown for an article URL. No-op if already fetched
   // or in flight. Safe to call from every card's mount — calls are batched.
-  function fetch(url: string): void {
-    if (!url || requested.has(url)) return;
+  function fetch(url: string, docUri?: string): void {
+    if (!url) return;
+    // A URL-only card may mount before the document version of the same item.
+    // Let the later AT-URI upgrade through so Leaflet doesn't stay hidden behind
+    // the session's URL-keyed memoization.
+    const addsDocUri = Boolean(docUri) && !docUrisByUrl.has(url);
+    if (requested.has(url) && !addsDocUri) return;
     requested.add(url);
-    pending.add(url);
+    if (docUri) docUrisByUrl.set(url, docUri);
+    pending.set(url, docUri);
     scheduleFlush();
   }
 

--- a/frontend/src/lib/stores/mentionLaneItems.svelte.ts
+++ b/frontend/src/lib/stores/mentionLaneItems.svelte.ts
@@ -44,7 +44,7 @@ function createMentionLaneItemsStore() {
 
   // Kick off resolution for a lane. No-op once loaded or in flight. Safe to call
   // every time a lane is expanded.
-  function load(url: string, lane: string, options?: { force?: boolean }): void {
+  function load(url: string, lane: string, options?: { force?: boolean; docUri?: string }): void {
     if (!url) return;
     const key = keyFor(url, lane);
     const existing = cache.get(key);
@@ -53,7 +53,7 @@ function createMentionLaneItemsStore() {
 
     set(key, LOADING);
     const p = api
-      .fetchMentionLaneItems(url, lane)
+      .fetchMentionLaneItems(url, lane, options?.docUri)
       .then((res) => {
         set(key, {
           loading: false,

--- a/frontend/src/lib/stores/mentionLaneItems.svelte.ts
+++ b/frontend/src/lib/stores/mentionLaneItems.svelte.ts
@@ -27,8 +27,8 @@ export type LaneItemsState = {
 
 const LOADING: LaneItemsState = { loading: true, loaded: false, failed: false, entries: [] };
 
-function keyFor(url: string, lane: string): string {
-  return `${lane}|${url}`;
+function keyFor(url: string, lane: string, docUri?: string): string {
+  return `${lane}|${url}${lane === 'leaflet' ? `|${docUri ?? ''}` : ''}`;
 }
 
 function createMentionLaneItemsStore() {
@@ -46,7 +46,7 @@ function createMentionLaneItemsStore() {
   // every time a lane is expanded.
   function load(url: string, lane: string, options?: { force?: boolean; docUri?: string }): void {
     if (!url) return;
-    const key = keyFor(url, lane);
+    const key = keyFor(url, lane, options?.docUri);
     const existing = cache.get(key);
     if (existing?.loaded || inFlight.has(key)) return;
     if (existing?.failed && !options?.force) return;
@@ -77,8 +77,8 @@ function createMentionLaneItemsStore() {
 
   // The resolved state for a (url, lane), or undefined before the first load.
   // Reactive.
-  function get(url: string, lane: string): LaneItemsState | undefined {
-    return cache.get(keyFor(url, lane));
+  function get(url: string, lane: string, docUri?: string): LaneItemsState | undefined {
+    return cache.get(keyFor(url, lane, docUri));
   }
 
   return { load, get };

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -747,7 +747,7 @@ export interface SocialContextResult {
 // with its honest verb and a distinct-DID count. `capped` marks a count that hit
 // the lookup page cap and is a lower bound.
 export interface MentionLane {
-  lane: 'linkblog' | 'bluesky' | 'margin' | 'semble';
+  lane: 'linkblog' | 'leaflet' | 'bluesky' | 'margin' | 'semble';
   label: string;
   verb: string;
   noun: string;
@@ -764,6 +764,10 @@ export interface ArticleMentions {
   url: string;
   total: number;
   lanes: MentionLane[];
+  // A background enrichment is still running for this URL, so these counts may
+  // grow. Drives the store's re-poll — a non-zero total is not proof the answer
+  // is settled (a URL's Leaflet lane can arrive after its Bluesky one).
+  pending?: boolean;
 }
 
 // One resolved reference inside a lane (Phase 5 "see existing items"): a person

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -743,7 +743,7 @@ export interface SocialContextResult {
 }
 
 // One source lane of network-wide mentions for an article (Phase 5): a kind of
-// reference (linkblog note / Bluesky post / margin.at highlight / Semble save)
+// reference (linkblog note / Leaflet comment / Bluesky post / margin.at highlight / Semble save)
 // with its honest verb and a distinct-DID count. `capped` marks a count that hit
 // the lookup page cap and is a lower bound.
 export interface MentionLane {

--- a/frontend/src/lib/utils/discussionSort.ts
+++ b/frontend/src/lib/utils/discussionSort.ts
@@ -1,6 +1,6 @@
 // How the merged discussion is ordered.
 //
-// The stream is one conversation spread across four networks, and the panel
+// The stream is one conversation spread across several networks, and the panel
 // previews only its first few rows before a fold — so the order decides what a
 // reader actually sees. It leads with the references that carried: most-liked
 // first, recency as the tiebreak.


### PR DESCRIPTION
## Summary

- add Leaflet as a read-only discussion lane for standard.site documents
- isolate document AT-URI lookups to Leaflet and require origin advertisement before shared caching
- revalidate persisted Leaflet targets whenever mention rows become due
- merge current main and preserve its kind-based discussion tabs alongside the Leaflet lane

## Checks

- `git diff --check`
- Frontend, feed-proxy, and backend checks could not start because dependencies are not installed in this checkout (`svelte-kit`, `tsc`, and `vitest` are unavailable)

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-bg2n2rrg4e3i4at2wclo6zd4)
