### PR TITLE
Prefer title matches in saved search

### DIFF
--- a/e2e/saved-search.spec.ts
+++ b/e2e/saved-search.spec.ts
@@ -45,6 +45,43 @@ async function seedLibrary(testUser: TestUser) {
 }
 
 test.describe('Saved search', () => {
+  test('ranks title matches above newer body matches and restores date order on clear', async ({
+    authedPage,
+    testUser,
+  }) => {
+    const now = Date.now();
+    await seedSavedArticle(testUser, {
+      url: 'https://example.com/newer-body-match',
+      title: 'A Newer Essay',
+      description: 'A dispatch about the night sky',
+      content: '<p>A field guide to constellations.</p>',
+      savedAt: now,
+    });
+    await seedSavedArticle(testUser, {
+      url: 'https://example.com/older-title-match',
+      title: 'Constellations in the Title',
+      description: 'An older dispatch',
+      savedAt: now - 60_000,
+    });
+
+    await authedPage.goto('/saved');
+    const cards = authedPage.locator('article.bookmark-card');
+    await expect(cards).toHaveCount(2, { timeout: 15_000 });
+    await expect(cards.nth(0)).toContainText('A Newer Essay');
+    await expect(cards.nth(1)).toContainText('Constellations in the Title');
+
+    await authedPage.getByRole('button', { name: 'Search saved items' }).click();
+    const input = authedPage.getByTestId('saved-search-input');
+    await input.fill('constellations');
+    await expect(cards).toHaveCount(2);
+    await expect(cards.nth(0)).toContainText('Constellations in the Title');
+    await expect(cards.nth(1)).toContainText('A Newer Essay');
+
+    await input.fill('');
+    await expect(cards.nth(0)).toContainText('A Newer Essay');
+    await expect(cards.nth(1)).toContainText('Constellations in the Title');
+  });
+
   test('filters the saved list by title, body text, and clears back', async ({
     authedPage,
     testUser,

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -111,6 +111,7 @@ export interface SeedSavedArticleOpts {
   wordCount?: number;
   author?: string;
   description?: string;
+  savedAt?: number;
 }
 
 export async function seedSavedArticle(
@@ -119,7 +120,7 @@ export async function seedSavedArticle(
 ): Promise<string> {
   const rkey = opts.rkey || generateTid();
   const recordUri = `at://${user.did}/app.skyreader.feed.saved/${rkey}`;
-  const nowMs = Date.now();
+  const nowMs = opts.savedAt ?? Date.now();
   const source = opts.source || 'url';
   const domain = sqlNullableString(opts.domain);
   const contentType = opts.contentType || 'webpage';

--- a/frontend/src/lib/services/savedSearch.test.ts
+++ b/frontend/src/lib/services/savedSearch.test.ts
@@ -6,6 +6,10 @@ import {
   matchesTerms,
   normalize,
   parseQuery,
+  RANK_BODY,
+  RANK_METADATA,
+  RANK_TITLE,
+  searchRank,
   splitHighlights,
   toIndexText,
   MAX_INDEX_CHARS,
@@ -135,6 +139,44 @@ describe('matchesSearch', () => {
 
   it('treats an empty query as no filter', () => {
     expect(matchesSearch(metadata, [], null, keys)).toBe(true);
+  });
+});
+
+describe('searchRank', () => {
+  const title = normalize('Café Ownership Explained');
+  const metadata = normalize('Café Ownership Explained by Ada example.com');
+  const bodyTerms = new Map([['guid-1', new Set(['quokkatelemetry'])]]);
+
+  it('ranks all-title matches first, including pre-normalized diacritic matches', () => {
+    expect(searchRank(title, metadata, ['cafe', 'ownership'], bodyTerms, () => ['rkey1'])).toBe(
+      RANK_TITLE
+    );
+  });
+
+  it('uses metadata rank when one term only appears outside the title', () => {
+    expect(searchRank(title, metadata, ['ownership', 'ada'], bodyTerms, () => ['rkey1'])).toBe(
+      RANK_METADATA
+    );
+  });
+
+  it('uses body rank when a term matches the corpus under a secondary key', () => {
+    expect(
+      searchRank(title, metadata, ['ownership', 'quokkatelemetry'], bodyTerms, () => [
+        'rkey1',
+        'guid-1',
+      ])
+    ).toBe(RANK_BODY);
+  });
+
+  it('returns null when a term matches nowhere or the body corpus is unavailable', () => {
+    expect(
+      searchRank(title, metadata, ['ownership', 'sourdough'], bodyTerms, () => ['guid-1'])
+    ).toBe(null);
+    expect(searchRank(title, metadata, ['quokkatelemetry'], null, () => ['guid-1'])).toBe(null);
+  });
+
+  it('treats an empty query as a title-tier match', () => {
+    expect(searchRank(title, metadata, [], null, () => [])).toBe(RANK_TITLE);
   });
 });
 

--- a/frontend/src/lib/services/savedSearch.ts
+++ b/frontend/src/lib/services/savedSearch.ts
@@ -104,6 +104,36 @@ export function matchesTerms(haystack: string, terms: string[]): boolean {
   return true;
 }
 
+export const RANK_TITLE = 0;
+export const RANK_METADATA = 1;
+export const RANK_BODY = 2;
+
+/** Tier of a match (lower sorts first), or null when the item doesn't match. */
+export function searchRank(
+  title: string,
+  metadata: string,
+  terms: string[],
+  bodyMatchTerms: Map<string, Set<string>> | null,
+  bodyKeys: () => string[]
+): number | null {
+  let rank = RANK_TITLE;
+  let keys: string[] | null = null;
+
+  for (const term of terms) {
+    if (matchesTerms(title, [term])) continue;
+    if (matchesTerms(metadata, [term])) {
+      rank = Math.max(rank, RANK_METADATA);
+      continue;
+    }
+    if (bodyMatchTerms === null) return null;
+    keys ??= bodyKeys();
+    if (!keys.some((key) => bodyMatchTerms.get(key)?.has(term) === true)) return null;
+    rank = RANK_BODY;
+  }
+
+  return rank;
+}
+
 /**
  * Does one item satisfy the query, given its normalized metadata haystack and
  * the per-key term sets the body corpus matched?
@@ -124,14 +154,7 @@ export function matchesSearch(
   bodyMatchTerms: Map<string, Set<string>> | null,
   bodyKeys: () => string[]
 ): boolean {
-  if (terms.length === 0) return true;
-  let keys: string[] | null = null;
-  return terms.every((term) => {
-    if (matchesTerms(metadata, [term])) return true;
-    if (bodyMatchTerms === null) return false;
-    keys ??= bodyKeys();
-    return keys.some((key) => bodyMatchTerms.get(key)?.has(term) === true);
-  });
+  return searchRank('', metadata, terms, bodyMatchTerms, bodyKeys) !== null;
 }
 
 /**

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -19,7 +19,7 @@ import type {
   ReadingLengthFilter,
   SortOrder,
 } from '$lib/types';
-import { htmlToText, matchesSearch, normalize } from '$lib/services/savedSearch';
+import { htmlToText, normalize, searchRank } from '$lib/services/savedSearch';
 import {
   isRssSource,
   isDocumentsSource,
@@ -229,18 +229,8 @@ export function searchHaystack(item: FeedDisplayItem): string {
   return normalize(parts.filter(Boolean).join(' '));
 }
 
-/**
- * A saved item matches a search when every term hits its metadata or the save's
- * full article text — each term free to hit in either (the corpus is built
- * asynchronously, so body hits land a beat after metadata hits on the very
- * first search).
- */
-function matchesSavedSearch(
-  item: FeedDisplayItem,
-  terms: string[],
-  bodyMatchTerms: Map<string, Set<string>> | null
-): boolean {
-  return matchesSearch(searchHaystack(item), terms, bodyMatchTerms, () => searchKeysForItem(item));
+function titleHaystack(item: FeedDisplayItem): string {
+  return normalize(item.item.title ?? '');
 }
 
 function createFeedViewStore() {
@@ -886,12 +876,26 @@ function createFeedViewStore() {
       });
     }
 
-    // Search, last: it runs after the merge/dedup above so it can't perturb the
-    // bookmark-vs-article dedup, and it composes with every channel filter.
+    // Search, last: it runs after merge/dedup and every channel filter, then
+    // owns ordering while active. Stable tier sorting preserves the active
+    // sort within title, metadata, and body matches.
     const searchTerms = savedSearchStore.terms;
     if (searchTerms.length > 0) {
       const bodyMatchTerms = savedSearchStore.bodyMatchTerms;
-      items = items.filter((item) => matchesSavedSearch(item, searchTerms, bodyMatchTerms));
+      const ranks = new Map<FeedDisplayItem, number>();
+      items = items.filter((item) => {
+        const rank = searchRank(
+          titleHaystack(item),
+          searchHaystack(item),
+          searchTerms,
+          bodyMatchTerms,
+          () => searchKeysForItem(item)
+        );
+        if (rank === null) return false;
+        ranks.set(item, rank);
+        return true;
+      });
+      items.sort((a, b) => ranks.get(a)! - ranks.get(b)!);
     }
 
     return items;


### PR DESCRIPTION
## Summary

- rank saved-article search matches by title, other metadata, then full text
- preserve the active saved-list sort within each match tier
- add unit coverage for ranking semantics and deterministic E2E ordering coverage

## Checks

- `cd frontend && npm run test` — 454 passed
- `cd frontend && npm run check` — passed (20 pre-existing warnings)
- `npm run test:e2e` — blocked before tests because Bun is not installed in the runner

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-4khub6sj5ky6uiettoqvd2hb)
