### PR TITLE
Fix discussion title cleanup boundaries

### DIFF
--- a/frontend/src/lib/utils/discussionNote.test.ts
+++ b/frontend/src/lib/utils/discussionNote.test.ts
@@ -38,8 +38,27 @@ describe('cleanDiscussionNote', () => {
     );
   });
 
+  it('keeps a headline phrase woven into the end of a sentence', () => {
+    const post =
+      "Paul's article prompted a long one from me: What is the purpose of protocols?\n\nconnectedplaces.online/the-purpose-...";
+    expect(cleanDiscussionNote(post, ['The Purpose of Protocols', 'Connected Places'])).toBe(
+      "Paul's article prompted a long one from me: What is the purpose of protocols?"
+    );
+  });
+
   it('lines up when the title punctuation splits differently', () => {
-    expect(cleanDiscussionNote('A/B testing is underrated', 'A/B testing')).toBe('is underrated');
+    expect(cleanDiscussionNote('A/B testing is underrated', 'A/B testing')).toBe(
+      'A/B testing is underrated'
+    );
+    expect(cleanDiscussionNote('A/B testing: worth your time', 'A/B testing')).toBe(
+      'worth your time'
+    );
+  });
+
+  it('strips a headline set apart on its own line', () => {
+    expect(cleanDiscussionNote('Never Be Angry at Work\nWorth your time', TITLE)).toBe(
+      'Worth your time'
+    );
   });
 
   it('leaves a quoted phrase alone when it is not the whole headline', () => {
@@ -98,5 +117,14 @@ describe('cleanDiscussionNote', () => {
     expect(cleanDiscussionNote(null, TITLE)).toBe(null);
     expect(cleanDiscussionNote('   ', TITLE)).toBe(null);
     expect(cleanDiscussionNote('a plain thought', undefined)).toBe('a plain thought');
+  });
+
+  it('never exposes its internal title boundary marker', () => {
+    const cleaned = cleanDiscussionNote(
+      'Never Be Angry at Work\nA useful follow-up https://example.com/article',
+      TITLE
+    );
+    expect(cleaned).toBe('A useful follow-up');
+    expect(cleaned).not.toContain('\uE000');
   });
 });

--- a/frontend/src/lib/utils/discussionNote.test.ts
+++ b/frontend/src/lib/utils/discussionNote.test.ts
@@ -46,6 +46,29 @@ describe('cleanDiscussionNote', () => {
     );
   });
 
+  it('keeps a quoted headline that is the subject of the sentence', () => {
+    expect(cleanDiscussionNote('“Never Be Angry at Work” changed my management style', TITLE)).toBe(
+      '“Never Be Angry at Work” changed my management style'
+    );
+    expect(cleanDiscussionNote('"Never Be Angry at Work" is required reading', TITLE)).toBe(
+      '"Never Be Angry at Work" is required reading'
+    );
+  });
+
+  it('keeps a headline that ends in its own question mark mid-sentence', () => {
+    expect(
+      cleanDiscussionNote('What Is the Purpose of Protocols? asks Paul, and answers well', [
+        'What Is the Purpose of Protocols?',
+      ])
+    ).toBe('What Is the Purpose of Protocols? asks Paul, and answers well');
+  });
+
+  it('still strips a quoted headline a bridge sets off with a dash', () => {
+    expect(cleanDiscussionNote('“Never Be Angry at Work” — worth your time', TITLE)).toBe(
+      'worth your time'
+    );
+  });
+
   it('lines up when the title punctuation splits differently', () => {
     expect(cleanDiscussionNote('A/B testing is underrated', 'A/B testing')).toBe(
       'A/B testing is underrated'
@@ -94,6 +117,12 @@ describe('cleanDiscussionNote', () => {
     expect(cleanDiscussionNote('Never Be Angry at Work Discussion', TITLE)).toBe(null);
     expect(cleanDiscussionNote('Comments', TITLE)).toBe(null);
     expect(cleanDiscussionNote('discussion: https://news.ycombinator.com/item?id=1', TITLE)).toBe(
+      null
+    );
+  });
+
+  it('drops a note left as bare punctuation once the link is gone', () => {
+    expect(cleanDiscussionNote('Never Be Angry at Work ( https://example.com/a )', TITLE)).toBe(
       null
     );
   });

--- a/frontend/src/lib/utils/discussionNote.ts
+++ b/frontend/src/lib/utils/discussionNote.ts
@@ -8,10 +8,12 @@
  * standing in for the link's label. Reprinting that under the article the reader
  * just finished is noise wearing a person's handle.
  *
- * So: drop the links, drop the titles we already show above, drop a bare link
- * label, and if nothing is left, say nothing. The caller decides what an entry
- * with no words looks like — see AtmospherePanel, which collects them into one
- * "Also linked" line instead of giving each an empty row.
+ * So: drop the links, drop titles that stand apart (set off by a link, a line
+ * break, punctuation, or the edge of the post), drop a bare link label, and if
+ * nothing is left, say nothing. A title woven into the author's sentence stays.
+ * The caller decides what an entry with no words looks like — see
+ * AtmospherePanel, which collects them into one "Also linked" line instead of
+ * giving each an empty row.
  */
 
 // Full URLs, including the wrapping parens a bot uses to tack a discussion link
@@ -22,6 +24,10 @@ const URL_PATTERN = /\(?\bhttps?:\/\/[^\s)]+\)?/gi;
 // carries the link's *display* form ("lucumr.pocoo.org/2026/8/22/fa…") while the
 // real href lives in a facet we never see here.
 const BARE_URL_PATTERN = /\(?\b(?:www\.)?(?:[a-z0-9-]+\.)+[a-z]{2,24}(?:\/[^\s)]*)?\)?/gi;
+
+// Pass two keeps the boundary left by a link or line break long enough for title
+// stripping to distinguish boilerplate from a title woven into a sentence.
+const BOUNDARY = '\uE000';
 
 // Only treat a dotted token as a URL when it carries a path or ends in a TLD
 // people actually link to. Without this, "node.js" and "etc.)" get eaten.
@@ -145,15 +151,61 @@ function withoutTrailingRun(words: string[], key: string): string[] | null {
 
 // Remove one title from either end of the text. Returns the text unchanged when
 // it isn't there.
-function stripTitle(text: string, title: string): string {
+function hasLeadingBoundary(runWords: string[], remainderWords: string[]): boolean {
+  if (!remainderWords.length) return true;
+  if (remainderWords[0] === BOUNDARY) return true;
+  if (/^[\-–—·•|,:;.!?…'"“”‘’([{]/u.test(remainderWords[0])) return true;
+  if (/[\-–—·•|,:;.!?…'"“”‘’\])}]$/u.test(runWords.at(-1) ?? '')) return true;
+  return LINK_LABELS.has(comparable(remainderWords[0]));
+}
+
+function hasTrailingBoundary(remainderWords: string[]): boolean {
+  if (!remainderWords.length) return true;
+  const last = remainderWords.at(-1) ?? '';
+  return last === BOUNDARY || /[\-–—·•|,:;.!?…'"“”‘’\])}]$/u.test(last);
+}
+
+function stripTitle(text: string, title: string, gated: boolean): string {
   const key = comparable(title);
   // A very short title ("Notes", "AI") shows up inside ordinary sentences, so
   // only strip one long enough to be unmistakably the article's or the site's.
   if (key.length < 8) return text;
   if (comparable(text) === key) return '';
   const words = text.split(/\s+/).filter(Boolean);
-  const remainder = withoutLeadingRun(words, key) ?? withoutTrailingRun(words, key);
-  return remainder ? remainder.join(' ') : text;
+  const leading = withoutLeadingRun(words, key);
+  if (leading) {
+    const run = words.slice(0, words.length - leading.length);
+    if (!gated || hasLeadingBoundary(run, leading)) return leading.join(' ');
+  }
+  const trailing = withoutTrailingRun(words, key);
+  if (trailing && (!gated || hasTrailingBoundary(trailing))) return trailing.join(' ');
+  return text;
+}
+
+function cleanPass(
+  note: string,
+  titles: (string | null | undefined)[],
+  gated: boolean
+): string | null {
+  const replacement = gated ? ` ${BOUNDARY} ` : ' ';
+  let text = note
+    .replace(URL_PATTERN, replacement)
+    .replace(BARE_URL_PATTERN, (match) => (looksLikeLink(match) ? replacement : match));
+  if (gated) text = text.replace(/[\r\n]+/g, replacement);
+
+  for (const title of titles) {
+    const trimmed = title?.trim();
+    if (trimmed) text = stripTitle(text, trimmed, gated);
+    if (!text.trim()) break;
+  }
+
+  const cleaned = text
+    .replaceAll(BOUNDARY, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(EDGE_NOISE, '')
+    .trim();
+  if (!cleaned || LINK_LABELS.has(comparable(cleaned))) return null;
+  return cleaned;
 }
 
 /**
@@ -169,20 +221,9 @@ export function cleanDiscussionNote(
 ): string | null {
   if (!note) return null;
 
-  let text = note
-    .replace(URL_PATTERN, ' ')
-    .replace(BARE_URL_PATTERN, (match) => (looksLikeLink(match) ? ' ' : match));
-
   const list = Array.isArray(titles) ? titles : [titles];
-  for (const title of list) {
-    const trimmed = title?.trim();
-    if (trimmed) text = stripTitle(text, trimmed);
-    if (!text.trim()) break;
-  }
-
-  const cleaned = text.replace(/\s+/g, ' ').replace(EDGE_NOISE, '').trim();
-  if (!cleaned) return null;
-  // All that survived was the link's own label.
-  if (LINK_LABELS.has(comparable(cleaned))) return null;
-  return cleaned;
+  // Preserve the old aggressive algorithm as the boilerplate verdict so every
+  // existing bridge/bot-only post still collapses into "Also linked".
+  if (!cleanPass(note, list, false)) return null;
+  return cleanPass(note, list, true);
 }

--- a/frontend/src/lib/utils/discussionNote.ts
+++ b/frontend/src/lib/utils/discussionNote.ts
@@ -9,8 +9,10 @@
  * just finished is noise wearing a person's handle.
  *
  * So: drop the links, drop titles that stand apart (set off by a link, a line
- * break, punctuation, or the edge of the post), drop a bare link label, and if
- * nothing is left, say nothing. A title woven into the author's sentence stays.
+ * break, a separator, or the edge of the post), drop a bare link label, and if
+ * nothing is left, say nothing. A title woven into the author's sentence stays —
+ * including one they quoted, since the marks around “Never Be Angry at Work”
+ * enclose a noun phrase, they don't set a headline apart from a comment.
  * The caller decides what an entry with no words looks like — see
  * AtmospherePanel, which collects them into one "Also linked" line instead of
  * giving each an empty row.
@@ -101,9 +103,37 @@ const LINK_LABELS = new Set([
   'more',
 ]);
 
-// Whatever dangles once the URLs and the titles are gone: separators, empty
-// brackets, trailing punctuation with nothing in front of it.
-const EDGE_NOISE = /^[\s\-–—·•|:,.;"'“”()[\]]+|[\s\-–—·•|:,;"'“”()[\]]+$/g;
+// Whatever dangles once the URLs and the titles are gone: separators, trailing
+// punctuation with nothing in front of it. Quotes and brackets are left to
+// `dropUnpairedEdges`, which keeps the pair an author actually wrote.
+const EDGE_NOISE = /^[\s\-–—·•|:,.;]+|[\s\-–—·•|:,;]+$/g;
+
+// The other half of a quote or bracket. An author's own marks come in pairs; a
+// lone one is residue from a URL or a title we removed.
+const EDGE_PAIRS = new Map([
+  ['“', '”'],
+  ['”', '“'],
+  ['‘', '’'],
+  ['’', '‘'],
+  ['"', '"'],
+  ["'", "'"],
+  ['(', ')'],
+  [')', '('],
+  ['[', ']'],
+  [']', '['],
+]);
+
+// Punctuation that genuinely sets a headline apart from a person's own words:
+// the dashes, bullets, pipes and colons a bridge puts between the two. Quotes
+// and brackets are deliberately absent — they wrap a title being *used* in a
+// sentence, so treating them as a separator is how a real sentence loses its
+// subject.
+const SEPARATOR_AFTER_TITLE = /[\-–—·•|,:;]$/u;
+const SEPARATOR_BEFORE_REMAINDER = /^[\-–—·•|,:;.…]/u;
+
+// A note the trims reduced to a matched pair of brackets and nothing else is
+// still nothing said. Emoji and other real characters survive this check.
+const PUNCTUATION_ONLY = /^[\s\-–—·•|:,.;!?…"'“”‘’()[\]{}]*$/u;
 
 // Compare loosely — a bridge rewrites punctuation and casing freely, so an exact
 // match would miss almost every real duplicate.
@@ -154,8 +184,11 @@ function withoutTrailingRun(words: string[], key: string): string[] | null {
 function hasLeadingBoundary(runWords: string[], remainderWords: string[]): boolean {
   if (!remainderWords.length) return true;
   if (remainderWords[0] === BOUNDARY) return true;
-  if (/^[\-–—·•|,:;.!?…'"“”‘’([{]/u.test(remainderWords[0])) return true;
-  if (/[\-–—·•|,:;.!?…'"“”‘’\])}]$/u.test(runWords.at(-1) ?? '')) return true;
+  if (SEPARATOR_BEFORE_REMAINDER.test(remainderWords[0])) return true;
+  // Only a separator hanging off the title counts. A closing quote or bracket
+  // means the sentence carried the title, and sentence-ending punctuation is
+  // usually the headline's own ("What Is the Purpose of Protocols? asks Paul").
+  if (SEPARATOR_AFTER_TITLE.test(runWords.at(-1) ?? '')) return true;
   return LINK_LABELS.has(comparable(remainderWords[0]));
 }
 
@@ -182,6 +215,37 @@ function stripTitle(text: string, title: string, gated: boolean): string {
   return text;
 }
 
+// Shed a quote or bracket at either edge only when its partner is gone.
+function dropUnpairedEdges(text: string): string {
+  let out = text;
+  for (;;) {
+    const first = out.at(0) ?? '';
+    const firstPartner = EDGE_PAIRS.get(first);
+    if (firstPartner && !out.slice(1).includes(firstPartner)) {
+      out = out.slice(1).trim();
+      continue;
+    }
+    const last = out.at(-1) ?? '';
+    const lastPartner = EDGE_PAIRS.get(last);
+    if (lastPartner && !out.slice(0, -1).includes(lastPartner)) {
+      out = out.slice(0, -1).trim();
+      continue;
+    }
+    return out;
+  }
+}
+
+// Both trims can expose more of the other's work — a stripped title can leave
+// `— “` behind — so alternate until the edges stop moving.
+function trimEdges(text: string): string {
+  let out = text.trim();
+  for (;;) {
+    const next = dropUnpairedEdges(out.replace(EDGE_NOISE, '').trim());
+    if (next === out) return out;
+    out = next;
+  }
+}
+
 function cleanPass(
   note: string,
   titles: (string | null | undefined)[],
@@ -199,12 +263,10 @@ function cleanPass(
     if (!text.trim()) break;
   }
 
-  const cleaned = text
-    .replaceAll(BOUNDARY, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(EDGE_NOISE, '')
-    .trim();
-  if (!cleaned || LINK_LABELS.has(comparable(cleaned))) return null;
+  const cleaned = trimEdges(text.replaceAll(BOUNDARY, ' ').replace(/\s+/g, ' '));
+  if (!cleaned || PUNCTUATION_ONLY.test(cleaned) || LINK_LABELS.has(comparable(cleaned))) {
+    return null;
+  }
   return cleaned;
 }
 


### PR DESCRIPTION
Preserves article-title phrases when they are woven into discussion prose while retaining existing bridge/bot collapse behavior.

- Uses boundary-aware display cleanup after the unchanged aggressive boilerplate verdict.

- Only a real separator (dash, bullet, pipe, colon, comma, semicolon) opens the leading-title gate. A closing quote or bracket around a headline, or the headline's own trailing `?`/`!`, no longer counts — `"Never Be Angry at Work" changed my management style` keeps its subject.

- Quotes and brackets survive edge trimming while their partner is present, so a preserved quoted title keeps both marks; a note trimmed to bare punctuation still collapses into "Also linked".

- Adds regressions for the reported post, quoted and question-mark headlines in prose, the dash-separated bridge form that must still strip, leading prose, line boundaries, and marker scrubbing.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-73w6mbztxbmbaahzr2wejts4)
[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-nlsm7uqshwivjepcahd7ozxy)
