### PR TITLE
Add Semble similar articles to Discussion

### DIFF
--- a/backend/src/services/feed-proxy-client.ts
+++ b/backend/src/services/feed-proxy-client.ts
@@ -311,6 +311,12 @@ export interface SembleContextResult {
       imageUrl: string | null;
     };
   }>;
+  similar?: Array<{
+    url: string;
+    title: string | null;
+    siteName: string | null;
+    saveCount: number;
+  }>;
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';

--- a/feed-proxy/src/mention-lane.ts
+++ b/feed-proxy/src/mention-lane.ts
@@ -624,6 +624,7 @@ export async function getMentionLaneItems(
             notes: [],
             collections: [],
             connections: [],
+            similar: [],
             truncated: { savers: false, notes: false, collections: false, connections: false },
             incomplete: true,
             source: 'constellation-fallback',

--- a/feed-proxy/src/semble-client.test.ts
+++ b/feed-proxy/src/semble-client.test.ts
@@ -118,6 +118,7 @@ describe('fetchSembleContext similar URLs', () => {
 
     const context = await fetchSembleContext(ARTICLE);
     expect(context?.similar).toHaveLength(8);
+    expect(context && isEmptySembleContext(context)).toBe(false);
     expect(context?.similar[0]).toEqual({
       url: 'https://similar.example/0',
       title: 'Similar 0',

--- a/feed-proxy/src/semble-client.test.ts
+++ b/feed-proxy/src/semble-client.test.ts
@@ -92,6 +92,55 @@ describe('fetchSembleContext connections', () => {
   });
 });
 
+describe('fetchSembleContext similar URLs', () => {
+  afterEach(() => {
+    (globalThis.fetch as ReturnType<typeof spyOn>).mockRestore?.();
+  });
+
+  it('maps, filters, deduplicates, and caps recommendations', async () => {
+    const urls = [
+      { url: ARTICLE, metadata: { title: 'Self' }, urlLibraryCount: 9 },
+      { url: 'javascript:alert(1)', metadata: { title: 'Bad' } },
+      { url: 'https://connected.example/story', metadata: { title: 'Already connected' } },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        url: `https://similar.example/${i}${i === 1 ? '/' : ''}`,
+        metadata: { title: `Similar ${i}`, siteName: 'Similar Site' },
+        urlLibraryCount: i + 1,
+      })),
+      { url: 'https://similar.example/1', metadata: { title: 'Duplicate' } },
+    ];
+    mockSemble({
+      'network.cosmik.connection.getForUrl': {
+        connections: [edge('https://connected.example/story', 'SUPPORTS')],
+      },
+      'network.cosmik.search.getSimilarUrls': { urls },
+    });
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.similar).toHaveLength(8);
+    expect(context?.similar[0]).toEqual({
+      url: 'https://similar.example/0',
+      title: 'Similar 0',
+      siteName: 'Similar Site',
+      saveCount: 1,
+    });
+    expect(context?.similar.some((item) => item.url.includes('connected.example'))).toBe(false);
+    expect(new Set(context?.similar.map((item) => item.url)).size).toBe(8);
+  });
+
+  it('silently omits recommendations when only that call fails', async () => {
+    spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
+      const nsid = new URL(String(input)).pathname.split('/').pop()!;
+      if (nsid === 'network.cosmik.search.getSimilarUrls') throw new Error('recommender down');
+      return new Response('{}', { headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch);
+
+    const context = await fetchSembleContext(ARTICLE);
+    expect(context?.similar).toEqual([]);
+    expect(context?.incomplete).toBe(false);
+  });
+});
+
 // Collections and notes key lists on the reader's side too, and a duplicate key
 // there is fatal, not cosmetic — Svelte throws on it in production as well.
 describe('fetchSembleContext collections and notes', () => {

--- a/feed-proxy/src/semble-client.ts
+++ b/feed-proxy/src/semble-client.ts
@@ -162,15 +162,16 @@ async function pickUrlVariant(
   return best ?? { apiUrl: normUrl, meta: {}, metaOk: false };
 }
 
-/** Semble answered, but with nothing: no people, no notes, no collections, no
- *  edges. Worth naming because it isn't the same as Semble being down, and the
+/** Semble answered, but with nothing: no people, notes, collections, edges, or
+ *  recommendations. Worth naming because it isn't the same as Semble being down, and the
  *  lane treats it differently — see getMentionLaneItems. */
 export function isEmptySembleContext(context: SembleContext): boolean {
   return (
     context.savers.length === 0 &&
     context.notes.length === 0 &&
     context.collections.length === 0 &&
-    context.connections.length === 0
+    context.connections.length === 0 &&
+    context.similar.length === 0
   );
 }
 

--- a/feed-proxy/src/semble-client.ts
+++ b/feed-proxy/src/semble-client.ts
@@ -49,6 +49,7 @@ export interface SembleContext {
       imageUrl: string | null;
     };
   }>;
+  similar: Array<{ url: string; title: string | null; siteName: string | null; saveCount: number }>;
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';
@@ -184,10 +185,14 @@ export async function fetchSembleContext(rawUrl: string): Promise<SembleContext 
     call('network.cosmik.card.getNoteCardsForUrl', apiUrl),
     call('network.cosmik.collection.getForUrl', apiUrl),
     call('network.cosmik.connection.getForUrl', apiUrl, { direction: 'both' }),
+    call('network.cosmik.search.getSimilarUrls', apiUrl, { limit: '8' }),
   ]);
-  if (!metaOk && calls.every((r) => r.status === 'rejected')) return null;
+  const humanCalls = calls.slice(0, 4);
+  if (!metaOk && humanCalls.every((r) => r.status === 'rejected')) return null;
   const value = (i: number): Obj => (calls[i].status === 'fulfilled' ? calls[i].value : {});
-  const [libraries, noteCards, collectionData, connectionData] = [0, 1, 2, 3].map(value);
+  const [libraries, noteCards, collectionData, connectionData, similarData] = [0, 1, 2, 3, 4].map(
+    value
+  );
   const stats = meta.stats
     ? {
         saves: count(meta.stats.libraryCount),
@@ -303,19 +308,47 @@ export async function fetchSembleContext(rawUrl: string): Promise<SembleContext 
           ? -1
           : 1
     );
+  const connectedUrls = new Set(
+    connections.map((connection) => normalizeArticleUrl(connection.other.url))
+  );
+  const similarSeen = new Set<string>();
+  const similar = (Array.isArray(similarData.urls) ? similarData.urls : [])
+    .flatMap((entry: Obj) => {
+      const candidateUrl = httpUrl(entry.url);
+      if (!candidateUrl) return [];
+      const normalized = normalizeArticleUrl(candidateUrl);
+      if (
+        !normalized ||
+        normalized === url ||
+        connectedUrls.has(normalized) ||
+        similarSeen.has(normalized)
+      )
+        return [];
+      similarSeen.add(normalized);
+      return [
+        {
+          url: candidateUrl,
+          title: text(entry.metadata?.title, 500),
+          siteName: text(entry.metadata?.siteName, 256),
+          saveCount: count(entry.urlLibraryCount),
+        },
+      ];
+    })
+    .slice(0, 8);
   return {
     stats,
     savers,
     notes,
     collections,
     connections,
+    similar,
     truncated: {
       savers: hasMore(libraries),
       notes: hasMore(noteCards),
       collections: hasMore(collectionData),
       connections: hasMore(connectionData),
     },
-    incomplete: !metaOk || calls.some((r) => r.status === 'rejected'),
+    incomplete: !metaOk || humanCalls.some((r) => r.status === 'rejected'),
     source: 'semble-api',
     cardUrl: sembleCardUrl(apiUrl),
   };

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -7,7 +7,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import AtmospherePanel from './AtmospherePanel.svelte';
-import type { DiscussionEntryVM, LaneRowVM, SembleContextVM } from '../articleCardView.types';
+import type {
+  DiscussionEntryVM,
+  DiscussionFilterVM,
+  LaneRowVM,
+  SembleContextVM,
+} from '../articleCardView.types';
 
 const mounted: Record<string, any>[] = [];
 
@@ -55,20 +60,29 @@ function connection(direction: 'in' | 'out'): SembleContextVM['connections'][num
   };
 }
 
-function render(props: {
-  sembleContext?: SembleContextVM;
-  stream?: { loading: boolean; failed?: boolean; entries: DiscussionEntryVM[] };
-  onSaveConnection?: (url: string) => void | Promise<void>;
-  isConnectionSaved?: (url: string) => boolean;
-  onCreateConnection?: () => void;
-}): HTMLElement {
+/**
+ * Mount the panel and, optionally, open one of its kind-tabs — through the real
+ * control, so a test that reaches for Semble's graph also proves the tab that
+ * now holds it is reachable.
+ */
+function render(
+  props: {
+    sembleContext?: SembleContextVM;
+    stream?: { loading: boolean; failed?: boolean; entries: DiscussionEntryVM[] };
+    filters?: DiscussionFilterVM[];
+    onSaveConnection?: (url: string) => void | Promise<void>;
+    isConnectionSaved?: (url: string) => boolean;
+    onCreateConnection?: () => void;
+  },
+  tab?: 'connections' | 'related'
+): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(AtmospherePanel, {
     target,
     props: {
       laneRow: [sembleLane],
-      filters: [],
+      filters: props.filters ?? [],
       activeFilter: 'all',
       stream: props.stream ?? { loading: false, entries: [] },
       sembleContext: props.sembleContext,
@@ -79,13 +93,25 @@ function render(props: {
   });
   flushSync();
   mounted.push(component);
+  if (tab) {
+    const control = target.querySelector<HTMLButtonElement>(`[role="tab"][id$="-tab-${tab}"]`);
+    if (!control) throw new Error(`no ${tab} tab rendered`);
+    control.click();
+    flushSync();
+  }
   return target;
 }
 
+/** The panel's currently-open tabpanel, whichever kind it is. */
+function panel(target: HTMLElement): HTMLElement | null {
+  return target.querySelector('.discussion-panel');
+}
+
 function relationLine(direction: 'in' | 'out'): string {
-  const target = render({
-    sembleContext: { ...emptyContext, connections: [connection(direction)] },
-  });
+  const target = render(
+    { sembleContext: { ...emptyContext, connections: [connection(direction)] } },
+    'connections'
+  );
   const line = target.querySelector('.relation');
   return (line?.textContent ?? '').replace(/\s+/g, ' ').trim();
 }
@@ -110,7 +136,7 @@ describe('AtmospherePanel Semble connections', () => {
       id: `connection-${i}`,
       other: { ...connection('out').other, title: `Piece ${i}` },
     }));
-    const target = render({ sembleContext: { ...emptyContext, connections: many } });
+    const target = render({ sembleContext: { ...emptyContext, connections: many } }, 'connections');
     // One curator, one relation, one direction: one row, one sentence.
     expect(target.querySelectorAll('.relation').length).toBe(1);
     expect(target.querySelector('.relation-count')?.textContent).toBe('12');
@@ -124,39 +150,57 @@ describe('AtmospherePanel Semble connections', () => {
       id: 'connection-other-curator',
       curator: { did: 'did:plc:second', handle: 'second.test', name: null, avatarUrl: null },
     };
-    const target = render({
-      sembleContext: { ...emptyContext, connections: [connection('out'), connection('in'), other] },
-    });
+    const target = render(
+      {
+        sembleContext: {
+          ...emptyContext,
+          connections: [connection('out'), connection('in'), other],
+        },
+      },
+      'connections'
+    );
     expect(target.querySelectorAll('.relation').length).toBe(3);
   });
 
   it('says what Semble held back rather than passing a page off as the whole', () => {
-    const target = render({
-      sembleContext: {
-        ...emptyContext,
-        stats: {
-          saves: 0,
-          notes: 0,
-          collections: 0,
-          connections: { total: 27, incoming: 0, outgoing: 27 },
+    const target = render(
+      {
+        sembleContext: {
+          ...emptyContext,
+          stats: {
+            saves: 0,
+            notes: 0,
+            collections: 0,
+            connections: { total: 27, incoming: 0, outgoing: 27 },
+          },
+          connections: [connection('out')],
         },
-        connections: [connection('out')],
       },
-    });
+      'connections'
+    );
     expect(target.querySelector('.semble-foot')?.textContent).toContain('1 of 27 connections');
+    // And the tab count is honest about it too: what it renders, plus a `+`.
+    const tab = target.querySelector('[role="tab"][id$="-tab-connections"]');
+    expect(tab?.textContent?.replace(/\s+/g, ' ').trim()).toBe('Connections 1+');
   });
 
   it('offers no keep control when the reader cannot save', () => {
-    const target = render({ sembleContext: { ...emptyContext, connections: [connection('out')] } });
+    const target = render(
+      { sembleContext: { ...emptyContext, connections: [connection('out')] } },
+      'connections'
+    );
     expect(target.querySelector('.connection-save')).toBeNull();
   });
 
   it('gives every connected article its own keep control, reading saved state', () => {
-    const target = render({
-      sembleContext: { ...emptyContext, connections: [connection('out'), connection('in')] },
-      onSaveConnection: () => {},
-      isConnectionSaved: (url: string) => url === 'https://other.example/piece',
-    });
+    const target = render(
+      {
+        sembleContext: { ...emptyContext, connections: [connection('out'), connection('in')] },
+        onSaveConnection: () => {},
+        isConnectionSaved: (url: string) => url === 'https://other.example/piece',
+      },
+      'connections'
+    );
     const controls = target.querySelectorAll('.connection-save');
     expect(controls.length).toBe(2);
     // Saved state is never carried by colour alone.
@@ -166,25 +210,34 @@ describe('AtmospherePanel Semble connections', () => {
 
   it('hands the connected article\u2019s url to the save handler', () => {
     const saved: string[] = [];
-    const target = render({
-      sembleContext: { ...emptyContext, connections: [connection('out')] },
-      onSaveConnection: (url: string) => void saved.push(url),
-    });
+    const target = render(
+      {
+        sembleContext: { ...emptyContext, connections: [connection('out')] },
+        onSaveConnection: (url: string) => void saved.push(url),
+      },
+      'connections'
+    );
     (target.querySelector('.connection-save') as HTMLButtonElement).click();
     expect(saved).toEqual(['https://other.example/piece']);
   });
 
-  it('treats connections as content, so a connections-only article claims no emptiness', () => {
+  // Emptiness is a fact about one tab now. An article nobody wrote about but
+  // somebody connected says so plainly in Conversation — and the Connections tab
+  // standing beside it, carrying a count, is what says where the rest of it went.
+  it('gives an edges-only article its own tab rather than burying it', () => {
     const target = render({
       sembleContext: { ...emptyContext, connections: [connection('in')] },
     });
-    expect(target.querySelector('.discussion-empty')).toBeNull();
-    expect(target.querySelector('.semble-context')).not.toBeNull();
+    expect(target.querySelector('.discussion-empty')?.textContent).toContain('Nothing readable');
+    const tab = target.querySelector('[role="tab"][id$="-tab-connections"]');
+    expect(tab?.textContent?.replace(/\s+/g, ' ').trim()).toBe('Connections 1');
+    expect(target.querySelector('.relation')).toBeNull();
+    expect(panel(target)?.id).toMatch(/-panel-conversation$/);
   });
 
-  it('still says nobody wrote when the context came back with nothing in it', () => {
+  it('raises no tab strip when Semble holds nothing to put beside the conversation', () => {
     const target = render({ sembleContext: emptyContext });
-    expect(target.querySelector('.semble-context')).toBeNull();
+    expect(target.querySelector('[role="tablist"]')).toBeNull();
     expect(target.querySelector('.discussion-empty')?.textContent).toContain('Nothing readable');
   });
 
@@ -194,7 +247,7 @@ describe('AtmospherePanel Semble connections', () => {
   it('offers a connection on an article Semble has never seen', () => {
     const clicks: number[] = [];
     const target = render({ onCreateConnection: () => clicks.push(1) });
-    expect(target.querySelector('.semble-context')).toBeNull();
+    expect(target.querySelector('[role="tablist"]')).toBeNull();
     const cta = target.querySelector('.semble-connect') as HTMLButtonElement;
     expect(cta).not.toBeNull();
     expect(cta.textContent?.trim()).toBe('Draw the first connection');
@@ -204,25 +257,34 @@ describe('AtmospherePanel Semble connections', () => {
 
   it('offers it too when the context came back with nothing in it', () => {
     const target = render({ sembleContext: emptyContext, onCreateConnection: () => {} });
-    expect(target.querySelector('.semble-context')).toBeNull();
+    expect(target.querySelector('[role="tablist"]')).toBeNull();
     expect(target.querySelector('.semble-connect')).not.toBeNull();
   });
 
-  // One invitation per panel: standing on its own it is already where the
-  // compose row is, and the row's chip would repeat it a few pixels away.
+  // One invitation per panel, and it lives beside the edges it adds to. With a
+  // Connections tab there is exactly one, in there; with no such tab it stands
+  // at the end of the conversation instead.
   it('does not say it twice', () => {
     const empty = render({ onCreateConnection: () => {} });
-    expect(empty.querySelectorAll('.semble-connect, .compose-connect').length).toBe(1);
-    expect(empty.querySelector('.compose-connect')).toBeNull();
+    expect(empty.querySelectorAll('.semble-connect').length).toBe(1);
 
-    const held = render({
-      sembleContext: { ...emptyContext, connections: [connection('out')] },
-      onCreateConnection: () => {},
-    });
-    // With a block to live in, the invitation is up there and the row's chip is
-    // the quick way back to it.
-    expect(held.querySelector('.semble-context .semble-connect')).not.toBeNull();
-    expect(held.querySelector('.compose-connect')).not.toBeNull();
+    const held = render(
+      {
+        sembleContext: { ...emptyContext, connections: [connection('out')] },
+        onCreateConnection: () => {},
+      },
+      'connections'
+    );
+    expect(held.querySelectorAll('.semble-connect').length).toBe(1);
+    expect(held.querySelector('.discussion-panel.graph .semble-connect')).not.toBeNull();
+
+    // ...and it is not also sitting at the end of the conversation.
+    const conversation = held.querySelector<HTMLButtonElement>(
+      '[role="tab"][id$="-tab-conversation"]'
+    );
+    conversation?.click();
+    flushSync();
+    expect(held.querySelector('.semble-connect')).toBeNull();
   });
 
   it('keeps the retry when a lane failed and only Semble context came back', () => {
@@ -231,7 +293,12 @@ describe('AtmospherePanel Semble connections', () => {
       stream: { loading: false, failed: true, entries: [] },
     });
     expect(target.querySelector('.discussion-retry')).not.toBeNull();
-    expect(target.querySelector('.semble-context')).not.toBeNull();
+    // The conversation failed; the graph that did answer is one tab away and
+    // says so, rather than being lost behind the error.
+    expect(target.querySelector('[role="tab"][id$="-tab-connections"]')).not.toBeNull();
+    expect(target.querySelector('.discussion-empty')?.textContent).toContain(
+      "Some of the Atmosphere didn't answer"
+    );
   });
 });
 
@@ -250,7 +317,7 @@ describe('AtmospherePanel Semble similar articles', () => {
     }));
 
   it('renders links, metadata, hostname fallback, and a Semble foot link', () => {
-    const target = render({ sembleContext: { ...emptyContext, similar: similar(2) } });
+    const target = render({ sembleContext: { ...emptyContext, similar: similar(2) } }, 'related');
     const links = target.querySelectorAll('.similar-list .connection-target');
     expect(links.length).toBe(2);
     expect(links[0].getAttribute('href')).toBe('https://similar0.example/story');
@@ -261,25 +328,31 @@ describe('AtmospherePanel Semble similar articles', () => {
 
   it('uses the connection save affordance and saved state', () => {
     const saved: string[] = [];
-    const target = render({
-      sembleContext: { ...emptyContext, similar: similar(1) },
-      onSaveConnection: (url) => void saved.push(url),
-      isConnectionSaved: () => true,
-    });
+    const target = render(
+      {
+        sembleContext: { ...emptyContext, similar: similar(1) },
+        onSaveConnection: (url) => void saved.push(url),
+        isConnectionSaved: () => true,
+      },
+      'related'
+    );
     const button = target.querySelector('.semble-similar .connection-save') as HTMLButtonElement;
     expect(button.getAttribute('aria-pressed')).toBe('true');
     button.click();
     expect(saved).toEqual(['https://similar0.example/story']);
   });
 
-  it('renders nothing when recommendations are empty or absent', () => {
-    expect(render({ sembleContext: emptyContext }).querySelector('.semble-similar')).toBeNull();
+  it('raises no Related tab when there is nothing to recommend', () => {
+    const empty = render({ sembleContext: emptyContext });
+    expect(empty.querySelector('[role="tab"][id$="-tab-related"]')).toBeNull();
+    expect(empty.querySelector('.semble-similar')).toBeNull();
     const { similar: _similar, ...oldContext } = emptyContext;
-    expect(render({ sembleContext: oldContext }).querySelector('.semble-similar')).toBeNull();
+    const absent = render({ sembleContext: oldContext });
+    expect(absent.querySelector('[role="tab"][id$="-tab-related"]')).toBeNull();
   });
 
   it('previews four recommendations and reveals the rest', () => {
-    const target = render({ sembleContext: { ...emptyContext, similar: similar(7) } });
+    const target = render({ sembleContext: { ...emptyContext, similar: similar(7) } }, 'related');
     expect(target.querySelectorAll('.similar-list li').length).toBe(4);
     const disclose = target.querySelector('.semble-similar .semble-disclose') as HTMLButtonElement;
     expect(disclose.textContent?.trim()).toBe('3 more');
@@ -306,13 +379,19 @@ describe('AtmospherePanel Semble collections', () => {
     }));
 
   it('shows the first handful and holds the rest behind a disclosure', () => {
-    const target = render({ sembleContext: { ...emptyContext, collections: collections(20) } });
+    const target = render(
+      { sembleContext: { ...emptyContext, collections: collections(20) } },
+      'connections'
+    );
     expect(target.querySelectorAll('.semble-collection').length).toBe(6);
     expect(target.querySelector('.semble-disclose-inline')?.textContent?.trim()).toBe('14 more');
   });
 
   it('opens the whole strip on request', () => {
-    const target = render({ sembleContext: { ...emptyContext, collections: collections(20) } });
+    const target = render(
+      { sembleContext: { ...emptyContext, collections: collections(20) } },
+      'connections'
+    );
     (target.querySelector('.semble-disclose-inline') as HTMLButtonElement).click();
     flushSync();
     expect(target.querySelectorAll('.semble-collection').length).toBe(20);
@@ -320,38 +399,47 @@ describe('AtmospherePanel Semble collections', () => {
   });
 
   it('leaves a short strip alone', () => {
-    const target = render({ sembleContext: { ...emptyContext, collections: collections(3) } });
+    const target = render(
+      { sembleContext: { ...emptyContext, collections: collections(3) } },
+      'connections'
+    );
     expect(target.querySelectorAll('.semble-collection').length).toBe(3);
     expect(target.querySelector('.semble-disclose-inline')).toBeNull();
   });
 
   it('says how many collections Semble holds beyond the page it sent', () => {
-    const target = render({
-      sembleContext: {
-        ...emptyContext,
-        collections: collections(20),
-        stats: {
-          saves: 30,
-          notes: 0,
-          collections: 47,
-          connections: { total: 0, incoming: 0, outgoing: 0 },
+    const target = render(
+      {
+        sembleContext: {
+          ...emptyContext,
+          collections: collections(20),
+          stats: {
+            saves: 30,
+            notes: 0,
+            collections: 47,
+            connections: { total: 0, incoming: 0, outgoing: 0 },
+          },
+          truncated: { savers: false, notes: false, collections: true, connections: false },
         },
-        truncated: { savers: false, notes: false, collections: true, connections: false },
       },
-    });
+      'connections'
+    );
     expect(target.querySelector('.semble-foot')?.textContent).toContain(
       'Showing 20 of 47 collections.'
     );
   });
 
   it('still admits the page is partial when Semble sent no count to quote', () => {
-    const target = render({
-      sembleContext: {
-        ...emptyContext,
-        collections: collections(20),
-        truncated: { savers: false, notes: false, collections: true, connections: false },
+    const target = render(
+      {
+        sembleContext: {
+          ...emptyContext,
+          collections: collections(20),
+          truncated: { savers: false, notes: false, collections: true, connections: false },
+        },
       },
-    });
+      'connections'
+    );
     expect(target.querySelector('.semble-foot')?.textContent).toContain('Semble holds more than');
   });
 });
@@ -418,5 +506,137 @@ describe('AtmospherePanel entry engagement', () => {
       '40 likes',
       '2 likes',
     ]);
+  });
+});
+
+// Three different kinds of thing had piled up in one column with no boundary
+// between them, and a source filter that cut across all three at once. The tab
+// strip is the boundary: what people SAID, how this is CONNECTED, what to READ
+// NEXT — and the network goes back to being a property of a row.
+describe('AtmospherePanel kind tabs', () => {
+  afterEach(() => {
+    for (const component of mounted.splice(0)) unmount(component);
+    document.body.innerHTML = '';
+  });
+
+  const recommendation = (i: number) => ({
+    url: `https://similar${i}.example/story`,
+    title: `Similar ${i}`,
+    siteName: 'Example Review',
+    saveCount: 2,
+  });
+  const everything: SembleContextVM = {
+    ...emptyContext,
+    notes: [
+      {
+        id: 'note-1',
+        text: 'Pairs badly with the piece it cites.',
+        author: { did: 'did:plc:gia', handle: 'gia.test', name: 'Gia', avatarUrl: null },
+        createdAt: null,
+      },
+    ],
+    collections: [
+      {
+        id: 'collection-1',
+        name: 'Protocols',
+        url: null,
+        author: { did: 'did:plc:erin', handle: 'erin.test' },
+      },
+    ],
+    connections: [connection('out')],
+    similar: [recommendation(0), recommendation(1)],
+  };
+
+  const labels = (target: HTMLElement) =>
+    [...target.querySelectorAll('[role="tab"]')].map((t) =>
+      (t.textContent ?? '').replace(/\s+/g, ' ').trim()
+    );
+
+  it('names the three kinds and counts what each of them holds', () => {
+    const target = render({ sembleContext: everything });
+    // Conversation: the lane reference count, plus the standalone note that now
+    // reads in the stream. Connections: a shelf and an edge are both edges.
+    expect(labels(target)).toEqual(['Conversation 2', 'Connections 2', 'Related 2']);
+    expect(target.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain(
+      'Conversation'
+    );
+  });
+
+  it('drops the heading total, which the Conversation tab is already carrying', () => {
+    expect(render({ sembleContext: everything }).querySelector('.discussion-total')).toBeNull();
+    // With one kind there is no strip, so the heading keeps the count it had.
+    expect(
+      render({}).querySelector('.discussion-total')?.textContent?.replace(/\s+/g, ' ')
+    ).toContain('1 reference across the Atmosphere');
+  });
+
+  it('reads a Semble note in the conversation, not in the graph', () => {
+    const target = render({ sembleContext: everything });
+    expect(target.querySelector('.entry-note')?.textContent).toContain('Pairs badly');
+    target.querySelector<HTMLButtonElement>('[role="tab"][id$="-tab-connections"]')?.click();
+    flushSync();
+    expect(target.querySelector('.entry-note')).toBeNull();
+    expect(target.querySelector('.relation')).not.toBeNull();
+  });
+
+  it('keeps the source filter inside the one tab made of rows', () => {
+    const filters: DiscussionFilterVM[] = [
+      { id: 'all', label: 'All', count: 3, capped: false, icon: null },
+      { id: 'bluesky', label: 'Bluesky', count: 2, capped: false, icon: 'bluesky' },
+      { id: 'semble', label: 'Semble', count: 1, capped: false, icon: 'semble' },
+    ];
+    const target = render({ sembleContext: everything, filters });
+    expect(target.querySelectorAll('.filter-chip').length).toBe(3);
+    // `All` shows no count: it is the tab's number by definition.
+    expect(target.querySelector('.filter-chip')?.querySelector('.filter-count')).toBeNull();
+
+    target.querySelector<HTMLButtonElement>('[role="tab"][id$="-tab-related"]')?.click();
+    flushSync();
+    expect(target.querySelector('.filter-chip')).toBeNull();
+  });
+
+  it('points every tab at the panel it opens, and labels that panel back', () => {
+    const target = render({ sembleContext: everything });
+    const tab = target.querySelector('[role="tab"][aria-selected="true"]')!;
+    const panelEl = target.querySelector('[role="tabpanel"]')!;
+    expect(tab.getAttribute('aria-controls')).toBe(panelEl.id);
+    expect(panelEl.getAttribute('aria-labelledby')).toBe(tab.id);
+    // Only the selected tab is a tab stop; the arrows reach the rest.
+    expect(
+      [...target.querySelectorAll('[role="tab"]')].map((t) => t.getAttribute('tabindex'))
+    ).toEqual(['0', '-1', '-1']);
+  });
+
+  it('moves and selects with the arrow keys, wrapping at both ends', () => {
+    const target = render({ sembleContext: everything });
+    const press = (key: string) =>
+      target
+        .querySelector('[role="tab"][aria-selected="true"]')!
+        .dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+    const selected = () =>
+      target.querySelector('[role="tab"][aria-selected="true"]')!.id.split('-tab-')[1];
+
+    press('ArrowRight');
+    flushSync();
+    expect(selected()).toBe('connections');
+    press('End');
+    flushSync();
+    expect(selected()).toBe('related');
+    press('ArrowRight');
+    flushSync();
+    expect(selected()).toBe('conversation');
+    press('ArrowLeft');
+    flushSync();
+    expect(selected()).toBe('related');
+    press('Home');
+    flushSync();
+    expect(selected()).toBe('conversation');
+  });
+
+  it('leaves other keys to the surface underneath', () => {
+    const target = render({ sembleContext: everything });
+    const event = new KeyboardEvent('keydown', { key: 'j', bubbles: true, cancelable: true });
+    target.querySelector('[role="tab"][aria-selected="true"]')!.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -30,6 +30,7 @@ const emptyContext: SembleContextVM = {
   notes: [],
   collections: [],
   connections: [],
+  similar: [],
   truncated: { savers: false, notes: false, collections: false, connections: false },
   incomplete: false,
   source: 'semble-api',
@@ -231,6 +232,60 @@ describe('AtmospherePanel Semble connections', () => {
     });
     expect(target.querySelector('.discussion-retry')).not.toBeNull();
     expect(target.querySelector('.semble-context')).not.toBeNull();
+  });
+});
+
+describe('AtmospherePanel Semble similar articles', () => {
+  afterEach(() => {
+    for (const component of mounted.splice(0)) unmount(component);
+    document.body.innerHTML = '';
+  });
+
+  const similar = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      url: `https://similar${i}.example/story`,
+      title: i === 1 ? null : `Similar article ${i}`,
+      siteName: i === 1 ? null : 'Example Review',
+      saveCount: i + 1,
+    }));
+
+  it('renders links, metadata, hostname fallback, and a Semble foot link', () => {
+    const target = render({ sembleContext: { ...emptyContext, similar: similar(2) } });
+    const links = target.querySelectorAll('.similar-list .connection-target');
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute('href')).toBe('https://similar0.example/story');
+    expect(links[1].textContent).toBe('similar1.example');
+    expect(target.querySelector('.similar-meta')?.textContent).toContain('Example Review');
+    expect(target.querySelector('.semble-foot')?.textContent).toContain('See all on Semble');
+  });
+
+  it('uses the connection save affordance and saved state', () => {
+    const saved: string[] = [];
+    const target = render({
+      sembleContext: { ...emptyContext, similar: similar(1) },
+      onSaveConnection: (url) => void saved.push(url),
+      isConnectionSaved: () => true,
+    });
+    const button = target.querySelector('.semble-similar .connection-save') as HTMLButtonElement;
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+    button.click();
+    expect(saved).toEqual(['https://similar0.example/story']);
+  });
+
+  it('renders nothing when recommendations are empty or absent', () => {
+    expect(render({ sembleContext: emptyContext }).querySelector('.semble-similar')).toBeNull();
+    const { similar: _similar, ...oldContext } = emptyContext;
+    expect(render({ sembleContext: oldContext }).querySelector('.semble-similar')).toBeNull();
+  });
+
+  it('previews four recommendations and reveals the rest', () => {
+    const target = render({ sembleContext: { ...emptyContext, similar: similar(7) } });
+    expect(target.querySelectorAll('.similar-list li').length).toBe(4);
+    const disclose = target.querySelector('.semble-similar .semble-disclose') as HTMLButtonElement;
+    expect(disclose.textContent?.trim()).toBe('3 more');
+    disclose.click();
+    flushSync();
+    expect(target.querySelectorAll('.similar-list li').length).toBe(7);
   });
 });
 

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -8,21 +8,33 @@
   //
   // <!--
   // THESIS: an article's discussion is ONE conversation that happens to be
-  //   spread across four networks. It refuses the tab strip that made the reader
-  //   click through four bordered boxes — two of them empty — to find out what
-  //   anyone said, and refuses the handle-over-content list that came with it.
+  //   spread across four networks — and the network is a property of a row, not
+  //   a mode of the panel. So it still refuses the per-NETWORK tab strip that
+  //   made the reader click through four bordered boxes, two of them empty, to
+  //   find out what anyone said.
+  //   What it does tab is KIND, because three different kinds of thing had piled
+  //   up here with no boundary between them: what people SAID (every network,
+  //   merged), how this is CONNECTED (Semble's collections and typed edges), and
+  //   what to READ NEXT (Semble's recommendations). Those are not one list, and
+  //   a source filter cut across all three at once — picking "Semble" returned
+  //   savers and a graph and a reading list. Tabs by kind; the source filter
+  //   survives inside Conversation, the one tab where "which network" means
+  //   anything.
   // OWN-WORLD: the app's own reading-room system, at list density: flat,
   //   borderless rows separated by rhythm, one interaction blue, pill filters on
-  //   the sunken tone, hairline rules. The only new material is the person —
-  //   a 30px avatar wearing a small source glyph.
+  //   the sunken tone, hairline rules. The tab strip is text on a hairline with
+  //   a 2px primary rule under the selected mode — no boxes, no fills, nothing
+  //   that reads as chrome the article has to be read around. The only new
+  //   material is the person — a 30px avatar wearing a small source glyph.
   // STORY: the reader finishes an article, sees who else read it and what they
-  //   said, in order, and can answer in the network of their choosing.
-  // FIRST VIEWPORT: heading and total, then filter pills, then the stream —
-  //   avatar left, name and time on the head line, the person's words beneath in
-  //   ink. The ways to add yours sit below a hairline at the end, where a reply
-  //   belongs.
-  // FORM: chronological conversation list; an extension of the established
-  //   surface, so no new visual world.
+  //   said, in order, and can answer in the network of their choosing — then, if
+  //   they want it, where this sits in the graph and what to read after it.
+  // FIRST VIEWPORT: heading, then the tab row carrying each kind and its count,
+  //   then the conversation — avatar left, name and time on the head line, the
+  //   person's words beneath in ink. The ways to add yours sit below a hairline
+  //   at the end, where a reply belongs.
+  // FORM: chronological conversation list under a kind-tab strip; an extension
+  //   of the established surface, so no new visual world.
   // -->
   //
   // Your own posted note is NOT rendered here: the Share control carries the
@@ -139,6 +151,8 @@
 
   let streamExpanded = $state(false);
   let linksExpanded = $state(false);
+  /** Which kind the reader is looking at. See "The three kinds, as tabs" below. */
+  let activeTab = $state<DiscussionTab>('conversation');
   // A different article is a different discussion: nothing stays open across it.
   let expandedFor: string | undefined = undefined;
   $effect(() => {
@@ -146,6 +160,7 @@
       expandedFor = itemUrl;
       streamExpanded = false;
       linksExpanded = false;
+      activeTab = 'conversation';
     }
   });
   // Narrowing to a lane is its own request to see that lane: it starts folded too.
@@ -170,39 +185,13 @@
   const undisclosed = $derived(
     activeFilter === 'all' && settled && total > shown ? total - shown : 0
   );
+  // The source filter lives inside Conversation and reaches every row in it,
+  // Semble's own standalone notes included.
   const sembleLaneVisible = $derived(activeFilter === 'all' || activeFilter === 'semble');
-  const showSemble = $derived(Boolean(sembleContext) && sembleLaneVisible);
-  // Whether Semble actually returned something to read. A context object that
-  // came back empty (the saver fallback, or an API answer with nothing in it) is
-  // not content: it must not stand in for the people who aren't there, or the
-  // panel would go silent instead of saying nobody wrote about this.
-  const hasSembleContent = $derived(
-    showSemble &&
-      Boolean(
-        sembleContext &&
-        (sembleContext.notes.length ||
-          sembleContext.collections.length ||
-          sembleContext.connections.length ||
-          (sembleContext.similar?.length ?? 0))
-      )
-  );
-  // Whether Semble's own block is on screen. It is where "connect this to
-  // something" lives — so on an article Semble has never seen (no block at all)
-  // the invitation has to stand on its own further down, or drawing an edge
-  // would be offered only where edges already exist.
-  const showSembleBlock = $derived(
-    showSemble && Boolean(sembleContext) && (hasSembleContent || Boolean(sembleContext?.incomplete))
-  );
-  // Exactly one connect control per panel: inside Semble's block when there is
-  // one, otherwise on its own above the compose row. The row's chip would sit a
-  // few pixels from that standalone one, saying the same thing twice.
-  const showComposeConnect = $derived(Boolean(onCreateConnection) && showSembleBlock);
-  const showStandaloneConnect = $derived(
-    Boolean(onCreateConnection) && !showSembleBlock && sembleLaneVisible
-  );
-  const hasComposeRow = $derived(
-    Boolean(composeLead) || creatable.length > 0 || showComposeConnect
-  );
+  const sembleNotesAll = $derived(sembleContext?.notes ?? []);
+  const sembleNotes = $derived(sembleLaneVisible ? sembleNotesAll : []);
+  const sembleCollections = $derived(sembleContext?.collections ?? []);
+  const hasComposeRow = $derived(Boolean(composeLead) || creatable.length > 0);
 
   // ── Semble's graph, folded ──────────────────────────────────────────────
   // A curator mapping a topic makes the same edge over and over: same person,
@@ -300,6 +289,122 @@
   const sembleTruncated = $derived(
     Boolean(sembleContext && Object.values(sembleContext.truncated).some(Boolean))
   );
+
+  // ── The three kinds, as tabs ────────────────────────────────────────────
+  // Three different kinds of thing had accumulated in one column with nothing
+  // between them, and the source filter cut across all three at once. They are
+  // separated by KIND instead: what people said, how this is connected, and what
+  // to read next. Conversation always exists — it carries the empty state and
+  // the ways to answer — so a tab strip only appears once Semble gives it
+  // something to sit beside. One tab is not a tab strip.
+  type DiscussionTab = 'conversation' | 'connections' | 'related';
+  interface TabVM {
+    id: DiscussionTab;
+    label: string;
+    count: number;
+    capped: boolean;
+  }
+
+  // Whether Semble returned anything at all to read. A context object that came
+  // back empty (the saver fallback, or an API answer with nothing in it) is not
+  // content: it must not stand in for the people who aren't there, or the panel
+  // would go silent instead of saying nobody wrote about this.
+  const hasSembleContent = $derived(
+    Boolean(sembleContext) &&
+      Boolean(
+        sembleNotesAll.length ||
+        sembleCollections.length ||
+        connectionGroups.length ||
+        similar.length
+      )
+  );
+  // A collection membership and a typed edge are both edges in the same graph —
+  // one to a shelf, one to another article — so the tab counts them together.
+  const connectionsCount = $derived(
+    sembleCollections.length + (sembleContext?.connections.length ?? 0)
+  );
+  const hasConnectionsTab = $derived(connectionsCount > 0);
+  const hasRelatedTab = $derived(similar.length > 0);
+  const tabs = $derived.by<TabVM[]>(() => {
+    const out: TabVM[] = [
+      {
+        id: 'conversation',
+        label: 'Conversation',
+        // The headline reference count, plus Semble's standalone notes — which
+        // are people saying something and now read in the stream with everyone
+        // else, rather than in a block of their own above it.
+        count: total + sembleNotesAll.length,
+        capped,
+      },
+    ];
+    if (hasConnectionsTab)
+      out.push({
+        id: 'connections',
+        label: 'Connections',
+        count: connectionsCount,
+        // The count is what this tab will actually render. Where Semble holds
+        // more than it handed over, the `+` says so and the tab's own foot says
+        // how many.
+        capped: connectionsBeyond > 0 || collectionsBeyond > 0 || sembleTruncated,
+      });
+    if (hasRelatedTab)
+      out.push({ id: 'related', label: 'Related', count: similar.length, capped: false });
+    return out;
+  });
+  const showTabs = $derived(tabs.length > 1);
+
+  // Exactly one connect control per panel. It belongs in the Connections tab,
+  // beside the edges it adds to; on an article Semble holds no edges for there
+  // is no such tab, so the invitation stands at the end of the conversation
+  // instead — which is where it matters most, since an unconnected article is
+  // the one whose first edge is the only thing there is to add.
+  const showStandaloneConnect = $derived(Boolean(onCreateConnection) && !hasConnectionsTab);
+  // What the conversation tab actually put on screen. Its emptiness is its own:
+  // Semble's graph sits behind another tab and can't stand in for people who
+  // never wrote.
+  const conversationShown = $derived(shown + sembleNotes.length);
+
+  // A tab whose content drops out from under it (Semble resolved late, the
+  // reader moved on) falls back to the conversation rather than showing nothing.
+  $effect(() => {
+    if (!tabs.some((tab) => tab.id === activeTab)) activeTab = 'conversation';
+  });
+
+  // Tabs need ids to point `aria-controls` at. The host supplies one when it has
+  // its own toggle to wire up; otherwise the instance mints one.
+  const generatedId = $props.id();
+  const tabBase = $derived(panelId ?? generatedId);
+
+  // A panel is a tabpanel only while there is a strip above it to select from.
+  // Focusable, because APG asks for it and because the reader who just moved a
+  // tab needs somewhere for the caret to land in what they revealed.
+  function tabPanelAttrs(id: DiscussionTab) {
+    if (!showTabs) return {};
+    return {
+      role: 'tabpanel',
+      id: `${tabBase}-panel-${id}`,
+      'aria-labelledby': `${tabBase}-tab-${id}`,
+      tabindex: 0,
+    };
+  }
+
+  // Arrow keys move between tabs and select as they go — the expected contract
+  // for a strip this small, where every panel is already loaded.
+  let tablistEl = $state<HTMLElement | undefined>(undefined);
+  function onTabKeydown(event: KeyboardEvent) {
+    const ids = tabs.map((tab) => tab.id);
+    const from = ids.indexOf(activeTab);
+    let to: number;
+    if (event.key === 'ArrowRight') to = (from + 1) % ids.length;
+    else if (event.key === 'ArrowLeft') to = (from - 1 + ids.length) % ids.length;
+    else if (event.key === 'Home') to = 0;
+    else if (event.key === 'End') to = ids.length - 1;
+    else return;
+    event.preventDefault();
+    event.stopPropagation();
+    activeTab = ids[to];
+    tablistEl?.querySelectorAll<HTMLButtonElement>('[role="tab"]')[to]?.focus();
+  }
 
   function groupSentence(group: ConnectionGroup): string {
     const type = group.type ?? 'connected';
@@ -417,12 +522,16 @@
   </button>
 {/snippet}
 
-{#if lanesOpen && (total > 0 || hasComposeRow || showStandaloneConnect)}
+{#if lanesOpen && (total > 0 || hasComposeRow || showStandaloneConnect || hasConnectionsTab || hasRelatedTab)}
   <section class="discussion" class:no-heading={!showHeading} id={panelId} aria-label="Discussion">
     {#if showHeading}
       <div class="discussion-head">
         <h2 class="discussion-title">Discussion</h2>
-        {#if total > 0}
+        <!-- The total and the Conversation tab's count are the same number, and
+             two lines apart they read as two facts that don't add up. Where
+             there is a tab row it carries every count; where there isn't, the
+             heading keeps the one it always had. -->
+        {#if total > 0 && !showTabs}
           <span class="discussion-total"
             >{total}{capped ? '+' : ''}
             {total === 1 ? 'reference' : 'references'} across the Atmosphere</span
@@ -431,81 +540,84 @@
       </div>
     {/if}
 
-    <!-- Lanes are filters over the one stream, not navigation between four of
-         them. `All` is the resting state; a lane narrows to its own network. -->
-    {#if showFilters}
-      <div class="discussion-filters" role="group" aria-label="Filter by source">
-        {#each filters as filter (filter.id)}
-          {@const isActive = activeFilter === filter.id}
+    <!-- The three kinds, named. Text on a hairline with a 2px rule under the
+         selected one: enough to say these are modes, quiet enough that the
+         article above it stays the loudest thing on the page. It only appears
+         once there is more than one kind to choose between. -->
+    {#if showTabs}
+      <div
+        class="discussion-tabs"
+        role="tablist"
+        aria-label="Kinds of discussion"
+        bind:this={tablistEl}
+      >
+        {#each tabs as tab (tab.id)}
+          {@const isActive = activeTab === tab.id}
           <button
             type="button"
-            class="filter-chip"
+            role="tab"
+            id="{tabBase}-tab-{tab.id}"
+            class="discussion-tab"
             class:active={isActive}
-            aria-pressed={isActive}
+            aria-selected={isActive}
+            aria-controls="{tabBase}-panel-{tab.id}"
+            tabindex={isActive ? 0 : -1}
+            onkeydown={onTabKeydown}
             onclick={(e) => {
               e.stopPropagation();
-              onSelectFilter?.(filter.id);
+              activeTab = tab.id;
             }}
           >
-            {#if filter.icon}
-              <span class="filter-icon"><Icon name={filter.icon} size={13} /></span>
-            {/if}
-            <span class="filter-label">{filter.label}</span>
-            <span class="filter-count">{filter.count}{filter.capped ? '+' : ''}</span>
+            <span>{tab.label}</span>
+            <span class="discussion-tab-count">{tab.count}{tab.capped ? '+' : ''}</span>
           </button>
         {/each}
       </div>
     {/if}
 
-    <!-- Semble's side is a graph, not a conversation, but it is made of the same
-         material: a person, and what they did with this article. Rendering it in
-         the stream's own grammar (avatar, head line, payload beneath) keeps it
-         from reading as a second document bolted above the discussion. -->
-    {#if showSembleBlock && sembleContext}
-      <section class="semble-context" aria-label="What Semble holds about this article">
-        {#if sembleContext.collections.length}
-          <p class="semble-filed">
-            <span class="semble-filed-label">Filed in</span>
-            {#each visibleCollections as collection (collection.id)}
-              {#if collection.url}
-                <a
-                  class="semble-collection"
-                  href={safeHref(collection.url)}
-                  target="_blank"
-                  rel="noopener"
-                  title={collection.name}
-                  onclick={(e) => e.stopPropagation()}
-                  ><Icon name="folder" size={11} /><span class="semble-collection-name"
-                    >{collection.name}</span
-                  ></a
-                >
-              {:else}
-                <span class="semble-collection" title={collection.name}
-                  ><Icon name="folder" size={11} /><span class="semble-collection-name"
-                    >{collection.name}</span
-                  ></span
-                >
-              {/if}
-            {/each}
-            {#if foldedCollections > 0}
+    {#if activeTab === 'conversation'}
+      <!-- What people said, every network in one list. Semble's standalone notes
+           lead it: they are somebody's words about this article, so they read in
+           the stream with everyone else's rather than in a block above them. -->
+      <div class="discussion-panel" {...tabPanelAttrs('conversation')}>
+        <!-- Lanes are filters over the conversation, not navigation between four of
+           them. `All` is the resting state; a lane narrows to its own network.
+           They live here and nowhere else: "which network" is a fact about a
+           row, and only this tab is made of rows. -->
+        {#if showFilters}
+          <div class="discussion-filters" role="group" aria-label="Filter by source">
+            {#each filters as filter (filter.id)}
+              {@const isActive = activeFilter === filter.id}
               <button
                 type="button"
-                class="semble-disclose semble-disclose-inline"
-                aria-expanded={false}
+                class="filter-chip"
+                class:active={isActive}
+                aria-pressed={isActive}
                 onclick={(e) => {
                   e.stopPropagation();
-                  collectionsExpanded = true;
+                  onSelectFilter?.(filter.id);
                 }}
               >
-                {foldedCollections} more
+                {#if filter.icon}
+                  <span class="filter-icon"><Icon name={filter.icon} size={13} /></span>
+                {/if}
+                <span class="filter-label">{filter.label}</span>
+                <!-- `All` carries no count. It is the resting state, so its
+                     number is the tab's number by definition, and two of them a
+                     line apart (one counting Semble's standalone notes, one not)
+                     read as an arithmetic mistake rather than the same fact
+                     twice. -->
+                {#if filter.id !== 'all'}
+                  <span class="filter-count">{filter.count}{filter.capped ? '+' : ''}</span>
+                {/if}
               </button>
-            {/if}
-          </p>
+            {/each}
+          </div>
         {/if}
 
-        {#if sembleContext.notes.length || visibleGroups.length}
+        {#if sembleNotes.length > 0 || visibleEntries.length > 0}
           <ul class="discussion-stream">
-            {#each sembleContext.notes as note (note.id)}
+            {#each sembleNotes as note (note.id)}
               <li class="entry">
                 {@render person(
                   note.author.did,
@@ -526,96 +638,100 @@
               </li>
             {/each}
 
-            <!-- One row per (curator, relation, direction). The sentence is said
-                 once in the head line and the arrow still points the way the
-                 edge does; the titles beneath are the only part that varies. -->
-            {#each visibleGroups as group (group.key)}
-              {@const open = openGroups.includes(group.key)}
-              {@const shown = open ? group.items : group.items.slice(0, GROUP_PREVIEW)}
-              {@const folded = group.items.length - shown.length}
+            {#each visibleEntries as entry (entry.key)}
               <li class="entry">
                 {@render person(
-                  group.curator.did,
-                  group.curator.handle,
-                  group.curator.name,
-                  group.curator.avatarUrl
+                  entry.did,
+                  entry.handle,
+                  entry.displayName,
+                  entry.avatar,
+                  entry.laneIcon,
+                  entry.laneLabel
                 )}
+
                 <div class="entry-body">
                   <div class="entry-head">
-                    <span class="entry-name">{authorName(group.curator)}</span>
-                    <span class="relation" aria-label={groupSentence(group)}>
-                      {#if group.direction === 'out'}
-                        <span class="relation-self">this</span>
-                        <span class="relation-arrow" aria-hidden="true">&rarr;</span>
-                        <span class="relation-type">{group.type ?? 'connected'}</span>
-                      {:else}
-                        <span class="relation-type">{group.type ?? 'connected'}</span>
-                        <span class="relation-arrow" aria-hidden="true">&rarr;</span>
-                        <span class="relation-self">this</span>
-                      {/if}
-                    </span>
-                    {#if group.items.length > 1}
-                      <span class="relation-count">{group.items.length}</span>
+                    <span class="entry-name">{displayNameFor(entry)}</span>
+                    {#if entry.displayName?.trim() && entry.handle}
+                      <span class="entry-handle">@{entry.handle}</span>
+                    {/if}
+                    {#if entry.headVerb}
+                      <span class="entry-verb">{entry.headVerb}</span>
+                    {/if}
+                    {#if entry.relativeTime}
+                      <span class="entry-sep" aria-hidden="true">·</span>
+                      <time class="entry-time" datetime={entry.isoTime ?? undefined}
+                        >{entry.relativeTime}</time
+                      >
+                    {/if}
+                    <!-- The stream leads with the most-liked references, so the
+                     number that decided the order is on the row. Plain muted
+                     text, and absent entirely at zero — a quiet discussion
+                     shouldn't be scored. -->
+                    {#if entry.likeCount}
+                      <span class="entry-sep" aria-hidden="true">·</span>
+                      <span class="entry-likes">{likeLabel(entry.likeCount)}</span>
+                    {/if}
+                    {#if entry.url}
+                      <a
+                        class="entry-out"
+                        href={safeHref(entry.url)}
+                        target="_blank"
+                        rel="noopener"
+                        title="Open on {entry.laneLabel}"
+                        aria-label="Open on {entry.laneLabel}"
+                        onclick={(e) => e.stopPropagation()}
+                      >
+                        <Icon name="external-link" size={13} />
+                      </a>
                     {/if}
                   </div>
-                  <ul class="connection-list">
-                    {#each shown as connection (connection.id)}
-                      {@const saved = isConnectionSaved?.(connection.other.url) ?? false}
-                      {@const busy = savingUrls.includes(connection.other.url)}
-                      <li>
-                        <div class="connection-row">
+
+                  <!-- A margin.at note targets a passage: the passage is the point, so
+                   it leads, with the annotator's own words beneath it. -->
+                  {#if entry.quote}
+                    <p class="entry-quote">{entry.quote}</p>
+                  {/if}
+
+                  {#if entry.cleanNote}
+                    {#if entry.url}
+                      <a
+                        class="entry-note"
+                        href={safeHref(entry.url)}
+                        target="_blank"
+                        rel="noopener"
+                        onclick={(e) => e.stopPropagation()}>{entry.cleanNote}</a
+                      >
+                    {:else}
+                      <p class="entry-note">{entry.cleanNote}</p>
+                    {/if}
+                  {/if}
+
+                  <!-- Semble saves aren't notes — what matters is which collection
+                   the article was filed into. -->
+                  {#if entry.collections?.length}
+                    <div class="entry-collections">
+                      <span class="entry-verb">saved to</span>
+                      {#each entry.collections as col (col.name + (col.url ?? ''))}
+                        {#if col.url}
                           <a
-                            class="connection-target"
-                            href={safeHref(connection.other.url)}
+                            class="entry-collection"
+                            href={col.url}
                             target="_blank"
                             rel="noopener"
-                            onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                            title="Open “{col.name}” on Semble"
+                            onclick={(e) => e.stopPropagation()}
+                            ><Icon name="folder" size={11} />{col.name}</a
                           >
-                          <!-- The one thing a reader wants to do with someone
-                               else's connected article is keep it. The control
-                               stays put rather than appearing on hover: which of
-                               these twenty are already yours is information, not
-                               an affordance to be discovered. -->
-                          {#if onSaveConnection}
-                            <button
-                              type="button"
-                              class="connection-save"
-                              class:saved
-                              class:busy
-                              disabled={busy}
-                              aria-busy={busy}
-                              aria-pressed={saved}
-                              title={saved
-                                ? 'In your Saved list. Remove it'
-                                : 'Save to read in Skyreader'}
-                              aria-label={saved
-                                ? `Remove “${connectionLabel(connection)}” from Saved`
-                                : `Save “${connectionLabel(connection)}” to read in Skyreader`}
-                              onclick={(e) => {
-                                e.stopPropagation();
-                                toggleSave(connection.other.url);
-                              }}
-                            >
-                              <Icon name="bookmark" size={14} />
-                            </button>
-                          {/if}
-                        </div>
-                        {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
-                      </li>
-                    {/each}
-                  </ul>
-                  {#if group.items.length > GROUP_PREVIEW}
-                    <button
-                      type="button"
-                      class="semble-disclose"
-                      aria-expanded={open}
-                      onclick={(e) => {
-                        e.stopPropagation();
-                        toggleGroup(group.key);
-                      }}
-                    >
-                      {open ? 'Show fewer' : `Show ${folded} more`}
-                    </button>
+                        {:else}
+                          <span class="entry-collection"
+                            ><Icon name="folder" size={11} />{col.name}</span
+                          >
+                        {/if}
+                      {/each}
+                    </div>
+                  {:else if entry.lane === 'semble' && !entry.cleanNote}
+                    <p class="entry-note muted">Saved this</p>
                   {/if}
                 </div>
               </li>
@@ -623,422 +739,466 @@
           </ul>
         {/if}
 
-        {#if foldedConnections > 0}
-          <button
-            type="button"
-            class="semble-disclose semble-disclose-block"
-            onclick={(e) => {
-              e.stopPropagation();
-              allGroupsOpen = true;
-            }}
-          >
-            {foldedConnections} more {foldedConnections === 1 ? 'connection' : 'connections'}
-          </button>
+        {#if visibleEntries.length > 0}
+          {#if foldedEntries > 0}
+            <button
+              type="button"
+              class="semble-disclose semble-disclose-block discussion-disclose"
+              aria-expanded={false}
+              onclick={(e) => {
+                e.stopPropagation();
+                streamExpanded = true;
+              }}
+            >
+              Show {foldedEntries} more {foldedEntries === 1 ? 'reply' : 'replies'}
+            </button>
+          {:else if streamExpanded && stream.entries.length > STREAM_PREVIEW}
+            <button
+              type="button"
+              class="semble-disclose semble-disclose-block discussion-disclose"
+              aria-expanded={true}
+              onclick={(e) => {
+                e.stopPropagation();
+                streamExpanded = false;
+              }}
+            >
+              Show fewer
+            </button>
+          {/if}
         {/if}
 
-        <!-- Where the graph already is, so adding to it doesn't mean scrolling
-             past everything to the compose row. -->
-        {#if onCreateConnection}
-          {@render connectCta()}
+        <!-- People are still resolving. Show the shape of what's coming rather than
+         the word "Loading" — the stream is the content here. -->
+        {#if stream.loading}
+          <ul class="discussion-stream skeletons" aria-hidden="true">
+            {#each [0, 1, 2] as row (row)}
+              <li class="entry skeleton-entry">
+                <span class="entry-avatar skeleton-block"></span>
+                <div class="entry-body">
+                  <span class="skeleton-block skeleton-line short"></span>
+                  <span class="skeleton-block skeleton-line"></span>
+                </div>
+              </li>
+            {/each}
+          </ul>
+          <span class="visually-hidden" role="status">Loading the discussion…</span>
         {/if}
 
-        {#if similar.length > 0}
-          <div class="semble-similar">
-            <h3>Similar on Semble</h3>
-            <ul class="similar-list">
-              {#each visibleSimilar as item (item.url)}
-                {@const saved = isConnectionSaved?.(item.url) ?? false}
-                {@const busy = savingUrls.includes(item.url)}
-                <li>
-                  <div class="connection-row">
-                    <div class="similar-body">
-                      <a
-                        class="connection-target"
-                        href={safeHref(item.url)}
-                        target="_blank"
-                        rel="noopener"
-                        onclick={(e) => e.stopPropagation()}>{similarLabel(item)}</a
-                      >
-                      {#if (item.title && item.siteName) || item.saveCount > 1}
-                        <span class="similar-meta">
-                          {#if item.title && item.siteName}{item.siteName}{/if}
-                          {#if item.title && item.siteName && item.saveCount > 1}<span
-                              aria-hidden="true"
-                            >
-                              ·
-                            </span>{/if}
-                          {#if item.saveCount > 1}{item.saveCount} saves{/if}
-                        </span>
+        <!-- Bridges and bots that posted the headline and the URL and nothing else.
+         Each of these used to take a full row with an empty body; as one line
+         they read as what they are — distribution, not discussion — and the
+         people who said something keep the stream to themselves. -->
+        {#if linkOnly.length > 0}
+          <div class="also-linked" class:leading={visibleEntries.length === 0}>
+            <span class="also-linked-label">Also linked by</span>
+            {#each visibleLinks as entry (entry.key)}
+              {@const label = displayNameFor(entry)}
+              {@const hint = entry.relativeTime
+                ? `${label} · ${entry.laneLabel} · ${entry.relativeTime}`
+                : `${label} · ${entry.laneLabel}`}
+              {#if entry.url}
+                <a
+                  class="also-link"
+                  href={safeHref(entry.url)}
+                  target="_blank"
+                  rel="noopener"
+                  title={hint}
+                  onclick={(e) => e.stopPropagation()}
+                >
+                  <span class="also-avatar">
+                    <span class="also-monogram" aria-hidden="true">{monogramFor(entry)}</span>
+                    {#if entry.avatar}
+                      <img
+                        class="also-photo"
+                        src={entry.avatar}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        onerror={hideBrokenAvatar}
+                      />
+                    {/if}
+                  </span>
+                  <span class="also-name">{label}</span>
+                </a>
+              {:else}
+                <span class="also-link" title={hint}>
+                  <span class="also-avatar">
+                    <span class="also-monogram" aria-hidden="true">{monogramFor(entry)}</span>
+                    {#if entry.avatar}
+                      <img
+                        class="also-photo"
+                        src={entry.avatar}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        onerror={hideBrokenAvatar}
+                      />
+                    {/if}
+                  </span>
+                  <span class="also-name">{label}</span>
+                </span>
+              {/if}
+            {/each}
+            <!-- The rest of the linkers stay one click away rather than wrapping the
+             line into a paragraph of names. -->
+            {#if foldedLinks > 0}
+              <button
+                type="button"
+                class="also-link also-more"
+                aria-expanded="false"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  linksExpanded = true;
+                }}
+              >
+                <span class="also-name">{foldedLinks} more</span>
+              </button>
+            {:else if linksExpanded && linkOnly.length > LINKS_PREVIEW}
+              <button
+                type="button"
+                class="also-link also-more"
+                aria-expanded="true"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  linksExpanded = false;
+                }}
+              >
+                <span class="also-name">Show fewer</span>
+              </button>
+            {/if}
+          </div>
+        {/if}
+
+        {#if undisclosed > 0 && shown > 0}
+          <p class="discussion-more">
+            {undisclosed}{capped ? '+' : ''} more, further back.
+          </p>
+        {/if}
+
+        <!-- Emptiness is now a fact about THIS tab: an article nobody wrote about
+           but everybody filed still says so here, and the Connections tab's own
+           count says where the rest of it went. A lane that failed still gets
+           its retry, and still says whether anything else answered. -->
+        {#if settled && conversationShown === 0}
+          {#if stream.failed}
+            <p class="discussion-empty">
+              {hasSembleContent
+                ? "Some of the Atmosphere didn't answer."
+                : "Couldn't reach the Atmosphere just now."}
+              <button type="button" class="discussion-retry" onclick={() => onRetry?.()}>
+                Try again
+              </button>
+            </p>
+          {:else if activeFilter !== 'all'}
+            <p class="discussion-empty">Nothing readable from this one.</p>
+          {:else if total > 0}
+            <p class="discussion-empty">Nothing readable came back.</p>
+          {:else}
+            <p class="discussion-empty">No one has written about this yet.</p>
+          {/if}
+        {/if}
+
+        <!-- With no Connections tab to carry it, the invitation stands here on its
+           own — and this is the case where drawing an edge matters most: the
+           reader has just finished something nobody else has connected, so the
+           edge they can make is the only one there is. -->
+        {#if showStandaloneConnect}
+          <div class="semble-connect-standalone">{@render connectCta()}</div>
+        {/if}
+
+        {#if hasComposeRow}
+          <div class="discussion-compose">
+            <span class="compose-label">Add yours</span>
+            {#if composeLead}{@render composeLead()}{/if}
+            {#each creatable as lane (lane.id)}
+              <button
+                type="button"
+                class="compose-btn"
+                title={lane.createLabel}
+                aria-label={lane.createLabel}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  onCreateInLane?.(lane.id);
+                }}
+              >
+                <span class="compose-icon"><Icon name={lane.icon} size={14} /></span>
+                <span>{lane.label}</span>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {:else if activeTab === 'connections'}
+      <!-- How this article sits in Semble's graph: the shelves it was filed on,
+           and the typed edges somebody drew to and from it. Both are edges — one
+           to a collection, one to another article — which is why they share a
+           tab and a count. -->
+      <div class="discussion-panel graph" {...tabPanelAttrs('connections')}>
+        {#if sembleContext}
+          {#if sembleContext.collections.length}
+            <p class="semble-filed">
+              <span class="semble-filed-label">Filed in</span>
+              {#each visibleCollections as collection (collection.id)}
+                {#if collection.url}
+                  <a
+                    class="semble-collection"
+                    href={safeHref(collection.url)}
+                    target="_blank"
+                    rel="noopener"
+                    title={collection.name}
+                    onclick={(e) => e.stopPropagation()}
+                    ><Icon name="folder" size={11} /><span class="semble-collection-name"
+                      >{collection.name}</span
+                    ></a
+                  >
+                {:else}
+                  <span class="semble-collection" title={collection.name}
+                    ><Icon name="folder" size={11} /><span class="semble-collection-name"
+                      >{collection.name}</span
+                    ></span
+                  >
+                {/if}
+              {/each}
+              {#if foldedCollections > 0}
+                <button
+                  type="button"
+                  class="semble-disclose semble-disclose-inline"
+                  aria-expanded={false}
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    collectionsExpanded = true;
+                  }}
+                >
+                  {foldedCollections} more
+                </button>
+              {/if}
+            </p>
+          {/if}
+
+          {#if visibleGroups.length > 0}
+            <ul class="discussion-stream">
+              <!-- One row per (curator, relation, direction). The sentence is said
+                 once in the head line and the arrow still points the way the
+                 edge does; the titles beneath are the only part that varies. -->
+              {#each visibleGroups as group (group.key)}
+                {@const open = openGroups.includes(group.key)}
+                {@const shown = open ? group.items : group.items.slice(0, GROUP_PREVIEW)}
+                {@const folded = group.items.length - shown.length}
+                <li class="entry">
+                  {@render person(
+                    group.curator.did,
+                    group.curator.handle,
+                    group.curator.name,
+                    group.curator.avatarUrl
+                  )}
+                  <div class="entry-body">
+                    <div class="entry-head">
+                      <span class="entry-name">{authorName(group.curator)}</span>
+                      <span class="relation" aria-label={groupSentence(group)}>
+                        {#if group.direction === 'out'}
+                          <span class="relation-self">this</span>
+                          <span class="relation-arrow" aria-hidden="true">&rarr;</span>
+                          <span class="relation-type">{group.type ?? 'connected'}</span>
+                        {:else}
+                          <span class="relation-type">{group.type ?? 'connected'}</span>
+                          <span class="relation-arrow" aria-hidden="true">&rarr;</span>
+                          <span class="relation-self">this</span>
+                        {/if}
+                      </span>
+                      {#if group.items.length > 1}
+                        <span class="relation-count">{group.items.length}</span>
                       {/if}
                     </div>
-                    {#if onSaveConnection}
+                    <ul class="connection-list">
+                      {#each shown as connection (connection.id)}
+                        {@const saved = isConnectionSaved?.(connection.other.url) ?? false}
+                        {@const busy = savingUrls.includes(connection.other.url)}
+                        <li>
+                          <div class="connection-row">
+                            <a
+                              class="connection-target"
+                              href={safeHref(connection.other.url)}
+                              target="_blank"
+                              rel="noopener"
+                              onclick={(e) => e.stopPropagation()}>{connectionLabel(connection)}</a
+                            >
+                            <!-- The one thing a reader wants to do with someone
+                               else's connected article is keep it. The control
+                               stays put rather than appearing on hover: which of
+                               these twenty are already yours is information, not
+                               an affordance to be discovered. -->
+                            {#if onSaveConnection}
+                              <button
+                                type="button"
+                                class="connection-save"
+                                class:saved
+                                class:busy
+                                disabled={busy}
+                                aria-busy={busy}
+                                aria-pressed={saved}
+                                title={saved
+                                  ? 'In your Saved list. Remove it'
+                                  : 'Save to read in Skyreader'}
+                                aria-label={saved
+                                  ? `Remove “${connectionLabel(connection)}” from Saved`
+                                  : `Save “${connectionLabel(connection)}” to read in Skyreader`}
+                                onclick={(e) => {
+                                  e.stopPropagation();
+                                  toggleSave(connection.other.url);
+                                }}
+                              >
+                                <Icon name="bookmark" size={14} />
+                              </button>
+                            {/if}
+                          </div>
+                          {#if connection.note}<p class="connection-note">{connection.note}</p>{/if}
+                        </li>
+                      {/each}
+                    </ul>
+                    {#if group.items.length > GROUP_PREVIEW}
                       <button
                         type="button"
-                        class="connection-save"
-                        class:saved
-                        class:busy
-                        disabled={busy}
-                        aria-busy={busy}
-                        aria-pressed={saved}
-                        title={saved
-                          ? 'In your Saved list. Remove it'
-                          : 'Save to read in Skyreader'}
-                        aria-label={saved
-                          ? `Remove “${similarLabel(item)}” from Saved`
-                          : `Save “${similarLabel(item)}” to read in Skyreader`}
+                        class="semble-disclose"
+                        aria-expanded={open}
                         onclick={(e) => {
                           e.stopPropagation();
-                          toggleSave(item.url);
+                          toggleGroup(group.key);
                         }}
                       >
-                        <Icon name="bookmark" size={14} />
+                        {open ? 'Show fewer' : `Show ${folded} more`}
                       </button>
                     {/if}
                   </div>
                 </li>
               {/each}
             </ul>
-            {#if foldedSimilar > 0}
-              <button
-                type="button"
-                class="semble-disclose"
-                aria-expanded={similarExpanded}
-                onclick={(e) => {
-                  e.stopPropagation();
-                  similarExpanded = true;
-                }}>{foldedSimilar} more</button
-              >
-            {/if}
-          </div>
-        {/if}
+          {/if}
 
-        {#if sembleContext.cardUrl && (similar.length > 0 || connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
-          <p class="semble-foot">
-            {#if connectionsBeyond > 0}Showing {connectionsGot} of {connectionsHeld} connections.{/if}
-            {#if collectionsBeyond > 0}Showing {collectionsGot} of {collectionsHeld} collections.{/if}
-            {#if sembleContext.incomplete}
-              Some Semble context is unavailable.
-            {:else if sembleTruncated && connectionsBeyond === 0 && collectionsBeyond === 0}
-              Semble holds more than this.
-            {/if}
-            {#if sembleContext.cardUrl}
+          {#if foldedConnections > 0}
+            <button
+              type="button"
+              class="semble-disclose semble-disclose-block"
+              onclick={(e) => {
+                e.stopPropagation();
+                allGroupsOpen = true;
+              }}
+            >
+              {foldedConnections} more {foldedConnections === 1 ? 'connection' : 'connections'}
+            </button>
+          {/if}
+
+          <!-- Where the graph already is, so adding to it doesn't mean scrolling
+             past everything to the compose row. -->
+          {#if onCreateConnection}
+            {@render connectCta()}
+          {/if}
+
+          {#if sembleContext.cardUrl && (connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
+            <p class="semble-foot">
+              {#if connectionsBeyond > 0}Showing {connectionsGot} of {connectionsHeld} connections.{/if}
+              {#if collectionsBeyond > 0}Showing {collectionsGot} of {collectionsHeld} collections.{/if}
+              {#if sembleContext.incomplete}
+                Some Semble context is unavailable.
+              {:else if sembleTruncated && connectionsBeyond === 0 && collectionsBeyond === 0}
+                Semble holds more than this.
+              {/if}
+              {#if sembleContext.cardUrl}
+                <a
+                  href={safeHref(sembleContext.cardUrl)}
+                  target="_blank"
+                  rel="noopener"
+                  onclick={(e) => e.stopPropagation()}>See all on Semble</a
+                >
+              {/if}
+            </p>
+          {/if}
+        {/if}
+      </div>
+    {:else}
+      <!-- What to read next. Not discussion at all, which is exactly why it kept
+           reading as a wall bolted onto the end of one. -->
+      <div class="discussion-panel graph" {...tabPanelAttrs('related')}>
+        {#if sembleContext}
+          {#if similar.length > 0}
+            <div class="semble-similar">
+              <h3>Similar on Semble</h3>
+              <ul class="similar-list">
+                {#each visibleSimilar as item (item.url)}
+                  {@const saved = isConnectionSaved?.(item.url) ?? false}
+                  {@const busy = savingUrls.includes(item.url)}
+                  <li>
+                    <div class="connection-row">
+                      <div class="similar-body">
+                        <a
+                          class="connection-target"
+                          href={safeHref(item.url)}
+                          target="_blank"
+                          rel="noopener"
+                          onclick={(e) => e.stopPropagation()}>{similarLabel(item)}</a
+                        >
+                        {#if (item.title && item.siteName) || item.saveCount > 1}
+                          <span class="similar-meta">
+                            {#if item.title && item.siteName}{item.siteName}{/if}
+                            {#if item.title && item.siteName && item.saveCount > 1}<span
+                                aria-hidden="true"
+                              >
+                                ·
+                              </span>{/if}
+                            {#if item.saveCount > 1}{item.saveCount} saves{/if}
+                          </span>
+                        {/if}
+                      </div>
+                      {#if onSaveConnection}
+                        <button
+                          type="button"
+                          class="connection-save"
+                          class:saved
+                          class:busy
+                          disabled={busy}
+                          aria-busy={busy}
+                          aria-pressed={saved}
+                          title={saved
+                            ? 'In your Saved list. Remove it'
+                            : 'Save to read in Skyreader'}
+                          aria-label={saved
+                            ? `Remove “${similarLabel(item)}” from Saved`
+                            : `Save “${similarLabel(item)}” to read in Skyreader`}
+                          onclick={(e) => {
+                            e.stopPropagation();
+                            toggleSave(item.url);
+                          }}
+                        >
+                          <Icon name="bookmark" size={14} />
+                        </button>
+                      {/if}
+                    </div>
+                  </li>
+                {/each}
+              </ul>
+              {#if foldedSimilar > 0}
+                <button
+                  type="button"
+                  class="semble-disclose"
+                  aria-expanded={similarExpanded}
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    similarExpanded = true;
+                  }}>{foldedSimilar} more</button
+                >
+              {/if}
+            </div>
+          {/if}
+
+          {#if sembleContext.cardUrl}
+            <p class="semble-foot">
               <a
                 href={safeHref(sembleContext.cardUrl)}
                 target="_blank"
                 rel="noopener"
                 onclick={(e) => e.stopPropagation()}>See all on Semble</a
               >
-            {/if}
-          </p>
-        {/if}
-      </section>
-    {/if}
-
-    {#if visibleEntries.length > 0}
-      <ul class="discussion-stream">
-        {#each visibleEntries as entry (entry.key)}
-          <li class="entry">
-            {@render person(
-              entry.did,
-              entry.handle,
-              entry.displayName,
-              entry.avatar,
-              entry.laneIcon,
-              entry.laneLabel
-            )}
-
-            <div class="entry-body">
-              <div class="entry-head">
-                <span class="entry-name">{displayNameFor(entry)}</span>
-                {#if entry.displayName?.trim() && entry.handle}
-                  <span class="entry-handle">@{entry.handle}</span>
-                {/if}
-                {#if entry.headVerb}
-                  <span class="entry-verb">{entry.headVerb}</span>
-                {/if}
-                {#if entry.relativeTime}
-                  <span class="entry-sep" aria-hidden="true">·</span>
-                  <time class="entry-time" datetime={entry.isoTime ?? undefined}
-                    >{entry.relativeTime}</time
-                  >
-                {/if}
-                <!-- The stream leads with the most-liked references, so the
-                     number that decided the order is on the row. Plain muted
-                     text, and absent entirely at zero — a quiet discussion
-                     shouldn't be scored. -->
-                {#if entry.likeCount}
-                  <span class="entry-sep" aria-hidden="true">·</span>
-                  <span class="entry-likes">{likeLabel(entry.likeCount)}</span>
-                {/if}
-                {#if entry.url}
-                  <a
-                    class="entry-out"
-                    href={safeHref(entry.url)}
-                    target="_blank"
-                    rel="noopener"
-                    title="Open on {entry.laneLabel}"
-                    aria-label="Open on {entry.laneLabel}"
-                    onclick={(e) => e.stopPropagation()}
-                  >
-                    <Icon name="external-link" size={13} />
-                  </a>
-                {/if}
-              </div>
-
-              <!-- A margin.at note targets a passage: the passage is the point, so
-                   it leads, with the annotator's own words beneath it. -->
-              {#if entry.quote}
-                <p class="entry-quote">{entry.quote}</p>
-              {/if}
-
-              {#if entry.cleanNote}
-                {#if entry.url}
-                  <a
-                    class="entry-note"
-                    href={safeHref(entry.url)}
-                    target="_blank"
-                    rel="noopener"
-                    onclick={(e) => e.stopPropagation()}>{entry.cleanNote}</a
-                  >
-                {:else}
-                  <p class="entry-note">{entry.cleanNote}</p>
-                {/if}
-              {/if}
-
-              <!-- Semble saves aren't notes — what matters is which collection
-                   the article was filed into. -->
-              {#if entry.collections?.length}
-                <div class="entry-collections">
-                  <span class="entry-verb">saved to</span>
-                  {#each entry.collections as col (col.name + (col.url ?? ''))}
-                    {#if col.url}
-                      <a
-                        class="entry-collection"
-                        href={col.url}
-                        target="_blank"
-                        rel="noopener"
-                        title="Open “{col.name}” on Semble"
-                        onclick={(e) => e.stopPropagation()}
-                        ><Icon name="folder" size={11} />{col.name}</a
-                      >
-                    {:else}
-                      <span class="entry-collection"
-                        ><Icon name="folder" size={11} />{col.name}</span
-                      >
-                    {/if}
-                  {/each}
-                </div>
-              {:else if entry.lane === 'semble' && !entry.cleanNote}
-                <p class="entry-note muted">Saved this</p>
-              {/if}
-            </div>
-          </li>
-        {/each}
-      </ul>
-
-      {#if foldedEntries > 0}
-        <button
-          type="button"
-          class="semble-disclose semble-disclose-block discussion-disclose"
-          aria-expanded={false}
-          onclick={(e) => {
-            e.stopPropagation();
-            streamExpanded = true;
-          }}
-        >
-          Show {foldedEntries} more {foldedEntries === 1 ? 'reply' : 'replies'}
-        </button>
-      {:else if streamExpanded && stream.entries.length > STREAM_PREVIEW}
-        <button
-          type="button"
-          class="semble-disclose semble-disclose-block discussion-disclose"
-          aria-expanded={true}
-          onclick={(e) => {
-            e.stopPropagation();
-            streamExpanded = false;
-          }}
-        >
-          Show fewer
-        </button>
-      {/if}
-    {/if}
-
-    <!-- People are still resolving. Show the shape of what's coming rather than
-         the word "Loading" — the stream is the content here. -->
-    {#if stream.loading}
-      <ul class="discussion-stream skeletons" aria-hidden="true">
-        {#each [0, 1, 2] as row (row)}
-          <li class="entry skeleton-entry">
-            <span class="entry-avatar skeleton-block"></span>
-            <div class="entry-body">
-              <span class="skeleton-block skeleton-line short"></span>
-              <span class="skeleton-block skeleton-line"></span>
-            </div>
-          </li>
-        {/each}
-      </ul>
-      <span class="visually-hidden" role="status">Loading the discussion…</span>
-    {/if}
-
-    <!-- Bridges and bots that posted the headline and the URL and nothing else.
-         Each of these used to take a full row with an empty body; as one line
-         they read as what they are — distribution, not discussion — and the
-         people who said something keep the stream to themselves. -->
-    {#if linkOnly.length > 0}
-      <div class="also-linked" class:leading={visibleEntries.length === 0}>
-        <span class="also-linked-label">Also linked by</span>
-        {#each visibleLinks as entry (entry.key)}
-          {@const label = displayNameFor(entry)}
-          {@const hint = entry.relativeTime
-            ? `${label} · ${entry.laneLabel} · ${entry.relativeTime}`
-            : `${label} · ${entry.laneLabel}`}
-          {#if entry.url}
-            <a
-              class="also-link"
-              href={safeHref(entry.url)}
-              target="_blank"
-              rel="noopener"
-              title={hint}
-              onclick={(e) => e.stopPropagation()}
-            >
-              <span class="also-avatar">
-                <span class="also-monogram" aria-hidden="true">{monogramFor(entry)}</span>
-                {#if entry.avatar}
-                  <img
-                    class="also-photo"
-                    src={entry.avatar}
-                    alt=""
-                    loading="lazy"
-                    decoding="async"
-                    onerror={hideBrokenAvatar}
-                  />
-                {/if}
-              </span>
-              <span class="also-name">{label}</span>
-            </a>
-          {:else}
-            <span class="also-link" title={hint}>
-              <span class="also-avatar">
-                <span class="also-monogram" aria-hidden="true">{monogramFor(entry)}</span>
-                {#if entry.avatar}
-                  <img
-                    class="also-photo"
-                    src={entry.avatar}
-                    alt=""
-                    loading="lazy"
-                    decoding="async"
-                    onerror={hideBrokenAvatar}
-                  />
-                {/if}
-              </span>
-              <span class="also-name">{label}</span>
-            </span>
+            </p>
           {/if}
-        {/each}
-        <!-- The rest of the linkers stay one click away rather than wrapping the
-             line into a paragraph of names. -->
-        {#if foldedLinks > 0}
-          <button
-            type="button"
-            class="also-link also-more"
-            aria-expanded="false"
-            onclick={(e) => {
-              e.stopPropagation();
-              linksExpanded = true;
-            }}
-          >
-            <span class="also-name">{foldedLinks} more</span>
-          </button>
-        {:else if linksExpanded && linkOnly.length > LINKS_PREVIEW}
-          <button
-            type="button"
-            class="also-link also-more"
-            aria-expanded="true"
-            onclick={(e) => {
-              e.stopPropagation();
-              linksExpanded = false;
-            }}
-          >
-            <span class="also-name">Show fewer</span>
-          </button>
-        {/if}
-      </div>
-    {/if}
-
-    {#if undisclosed > 0 && shown > 0 && !hasSembleContent}
-      <p class="discussion-more">
-        {undisclosed}{capped ? '+' : ''} more, further back.
-      </p>
-    {/if}
-
-    <!-- Semble context that carries something counts as readable content, so a
-         connections-only article never claims nothing came back. A lane that
-         failed still gets its retry either way — losing it behind context from a
-         different network would strand the reader on a partial answer. -->
-    {#if settled && shown === 0 && (stream.failed || !hasSembleContent)}
-      {#if stream.failed}
-        <p class="discussion-empty">
-          {hasSembleContent
-            ? "Some of the Atmosphere didn't answer."
-            : "Couldn't reach the Atmosphere just now."}
-          <button type="button" class="discussion-retry" onclick={() => onRetry?.()}>
-            Try again
-          </button>
-        </p>
-      {:else if activeFilter !== 'all'}
-        <p class="discussion-empty">Nothing readable from this one.</p>
-      {:else if total > 0}
-        <p class="discussion-empty">Nothing readable came back.</p>
-      {:else}
-        <p class="discussion-empty">No one has written about this yet.</p>
-      {/if}
-    {/if}
-
-    <!-- An empty discussion is the case where drawing an edge matters most: the
-         reader has just finished something nobody else has written about, and
-         the connection they can make is the only thing there is to add. With no
-         Semble block to carry it, the invitation stands here on its own. -->
-    {#if showStandaloneConnect}
-      <div class="semble-connect-standalone">{@render connectCta()}</div>
-    {/if}
-
-    {#if hasComposeRow}
-      <div class="discussion-compose">
-        <span class="compose-label">Add yours</span>
-        {#if composeLead}{@render composeLead()}{/if}
-        {#each creatable as lane (lane.id)}
-          <button
-            type="button"
-            class="compose-btn"
-            title={lane.createLabel}
-            aria-label={lane.createLabel}
-            onclick={(e) => {
-              e.stopPropagation();
-              onCreateInLane?.(lane.id);
-            }}
-          >
-            <span class="compose-icon"><Icon name={lane.icon} size={14} /></span>
-            <span>{lane.label}</span>
-          </button>
-        {/each}
-        <!-- Drawing an edge is not "adding yours" in a lane — it says something
-             about how two pieces relate, not about this one. It sits last in the
-             row, in the same vocabulary. Only when Semble's block is carrying
-             the other one: without it the standalone invitation above is already
-             right here, and two of them would say the same thing twice. -->
-        {#if showComposeConnect}
-          <button
-            type="button"
-            class="compose-btn compose-connect"
-            title="Connect this to another article on Semble"
-            onclick={(e) => {
-              e.stopPropagation();
-              onCreateConnection?.();
-            }}
-          >
-            <span class="compose-icon"><Icon name="link" size={14} /></span>
-            <span>Connect</span>
-          </button>
         {/if}
       </div>
     {/if}
@@ -1143,23 +1303,89 @@
     gap: 1rem;
   }
 
-  /* Bracketed in hairlines, not boxed. Semble's graph is a different kind of
-     content from the conversation, and a rule above and below says so without
-     lifting it off the page. */
-  .semble-context {
-    margin: 0 0 1rem;
-    padding: 0.875rem 0;
-    border-block: 1px solid var(--color-border);
+  /* The tab row: three kinds, named, on a hairline. Text and a rule, no boxes
+     and no fills — the strip has to say these are modes without becoming chrome
+     the article has to be read around. It scrolls rather than wraps, so a long
+     label can never push the panel into two rows of navigation. */
+  .discussion-tabs {
+    display: flex;
+    gap: 1.25rem;
+    margin-bottom: 0.875rem;
+    border-bottom: 1px solid var(--color-border);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .discussion-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Weight is identical across tabs on purpose: bolding the selected one would
+     re-measure the strip on every switch, and the rule under it already says
+     which is which without moving anything. */
+  .discussion-tab {
+    display: inline-flex;
+    align-items: baseline;
+    flex-shrink: 0;
+    gap: 0.375rem;
+    margin-bottom: -1px;
+    padding: 0 0 0.4375rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: none;
+    font: inherit;
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
+    line-height: var(--leading-snug);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .discussion-tab:hover {
+    color: var(--color-text);
+  }
+
+  /* The selected mode is the only thing in the strip in ink, and the rule under
+     it is the only place the interaction blue lands here. Colour is never the
+     sole carrier: the 2px rule is the shape that says the same thing. */
+  .discussion-tab.active {
+    color: var(--color-text);
+    border-bottom-color: var(--color-primary);
+  }
+
+  .discussion-tab-count {
+    font-size: var(--text-sm);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-secondary);
+  }
+
+  .discussion-tab.active .discussion-tab-count {
+    color: var(--color-primary);
+  }
+
+  .discussion-panel {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+  }
+
+  /* Semble's side is a graph, not a conversation. Its parts are separate
+     statements about the article and want room between them, where the
+     conversation's rows carry their own rhythm. */
+  .discussion-panel.graph {
     gap: 0.875rem;
   }
 
-  /* When the compose row follows immediately it draws its own rule, and two
-     rules with nothing between them is an empty box. This one stands down. */
-  .semble-context:has(+ .discussion-compose) {
-    padding-bottom: 0;
-    border-bottom: 0;
+  /* The panel is the tab's own scroll and focus target; the rule above it is
+     the strip's, so it needs no outline box of its own. */
+  .discussion-panel:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 4px;
+    border-radius: 4px;
   }
 
   /* Where the article is filed. One line of pills reading as a set, with a
@@ -1917,6 +2143,7 @@
   /* Keyboard focus is visible on every control here, in the interaction blue.
      PRODUCT.md's accessibility floor asks for a visible focus state; a 10%-alpha
      wash would technically be "the ring" and practically be invisible. */
+  .discussion-tab:focus-visible,
   .filter-chip:focus-visible,
   .compose-btn:focus-visible,
   .entry-avatar:focus-visible,
@@ -1932,6 +2159,13 @@
 
   .entry-avatar:focus-visible {
     border-radius: 50%;
+  }
+
+  /* The tab's ring hugs the label rather than the underline, so the rule that
+     marks the selection stays readable underneath it. */
+  .discussion-tab:focus-visible {
+    outline-offset: -1px;
+    border-radius: 4px;
   }
 
   .filter-chip:focus-visible,
@@ -1955,6 +2189,17 @@
   /* Inside a feed card the panel rides a sticky footer, so it tightens its
      rhythm and lets the avatar shrink rather than pushing the action row down. */
   @container card (max-width: 34rem) {
+    .discussion-tabs {
+      /* Three labels and three counts have to clear a phone column without
+         clipping. They still scroll if a future label or a large text setting
+         takes them past it, but at the widths the app ships they fit. */
+      gap: 0.75rem;
+    }
+
+    .discussion-tab {
+      font-size: var(--text-sm);
+    }
+
     .discussion-stream {
       gap: 0.8125rem;
     }
@@ -1981,6 +2226,23 @@
       max-width: 22ch;
     }
 
+    .discussion-tabs {
+      /* Three labels and three counts have to clear a phone column without
+         clipping. They still scroll if a future label or a large text setting
+         takes them past it, but at the widths the app ships they fit. */
+      gap: 0.75rem;
+    }
+
+    .discussion-tab {
+      font-size: var(--text-sm);
+    }
+
+    /* The count is the secondary half of the label, so it is the half that
+       gives up a step when the column gets narrow. */
+    .discussion-tab-count {
+      font-size: var(--text-xs);
+    }
+
     .discussion-compose {
       margin-top: 1rem;
       padding-top: 0.75rem;
@@ -1988,6 +2250,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .discussion-tab,
     .filter-chip,
     .entry-out,
     .compose-btn,

--- a/frontend/src/lib/components/feed/AtmospherePanel.svelte
+++ b/frontend/src/lib/components/feed/AtmospherePanel.svelte
@@ -182,7 +182,8 @@
         sembleContext &&
         (sembleContext.notes.length ||
           sembleContext.collections.length ||
-          sembleContext.connections.length)
+          sembleContext.connections.length ||
+          (sembleContext.similar?.length ?? 0))
       )
   );
   // Whether Semble's own block is on screen. It is where "connect this to
@@ -243,6 +244,7 @@
   let openGroups = $state<string[]>([]);
   let allGroupsOpen = $state(false);
   let collectionsExpanded = $state(false);
+  let similarExpanded = $state(false);
   // A different article is a different graph: nothing stays open across it.
   let openedFor: SembleContextVM | undefined = undefined;
   $effect(() => {
@@ -251,6 +253,7 @@
       openGroups = [];
       allGroupsOpen = false;
       collectionsExpanded = false;
+      similarExpanded = false;
     }
   });
 
@@ -262,6 +265,9 @@
   const foldedCollections = $derived(
     (sembleContext?.collections.length ?? 0) - visibleCollections.length
   );
+  const similar = $derived(sembleContext?.similar ?? []);
+  const visibleSimilar = $derived(similarExpanded ? similar : similar.slice(0, 4));
+  const foldedSimilar = $derived(similar.length - visibleSimilar.length);
 
   const visibleGroups = $derived(
     allGroupsOpen ? connectionGroups : connectionGroups.slice(0, BLOCK_PREVIEW)
@@ -317,6 +323,14 @@
       );
     } catch {
       return connection.other.title || 'Connected article';
+    }
+  }
+
+  function similarLabel(item: NonNullable<SembleContextVM['similar']>[number]): string {
+    try {
+      return item.title || item.siteName || new URL(item.url).hostname;
+    } catch {
+      return item.title || item.siteName || 'Similar article';
     }
   }
 
@@ -628,7 +642,77 @@
           {@render connectCta()}
         {/if}
 
-        {#if sembleContext.cardUrl && (connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
+        {#if similar.length > 0}
+          <div class="semble-similar">
+            <h3>Similar on Semble</h3>
+            <ul class="similar-list">
+              {#each visibleSimilar as item (item.url)}
+                {@const saved = isConnectionSaved?.(item.url) ?? false}
+                {@const busy = savingUrls.includes(item.url)}
+                <li>
+                  <div class="connection-row">
+                    <div class="similar-body">
+                      <a
+                        class="connection-target"
+                        href={safeHref(item.url)}
+                        target="_blank"
+                        rel="noopener"
+                        onclick={(e) => e.stopPropagation()}>{similarLabel(item)}</a
+                      >
+                      {#if (item.title && item.siteName) || item.saveCount > 1}
+                        <span class="similar-meta">
+                          {#if item.title && item.siteName}{item.siteName}{/if}
+                          {#if item.title && item.siteName && item.saveCount > 1}<span
+                              aria-hidden="true"
+                            >
+                              ·
+                            </span>{/if}
+                          {#if item.saveCount > 1}{item.saveCount} saves{/if}
+                        </span>
+                      {/if}
+                    </div>
+                    {#if onSaveConnection}
+                      <button
+                        type="button"
+                        class="connection-save"
+                        class:saved
+                        class:busy
+                        disabled={busy}
+                        aria-busy={busy}
+                        aria-pressed={saved}
+                        title={saved
+                          ? 'In your Saved list. Remove it'
+                          : 'Save to read in Skyreader'}
+                        aria-label={saved
+                          ? `Remove “${similarLabel(item)}” from Saved`
+                          : `Save “${similarLabel(item)}” to read in Skyreader`}
+                        onclick={(e) => {
+                          e.stopPropagation();
+                          toggleSave(item.url);
+                        }}
+                      >
+                        <Icon name="bookmark" size={14} />
+                      </button>
+                    {/if}
+                  </div>
+                </li>
+              {/each}
+            </ul>
+            {#if foldedSimilar > 0}
+              <button
+                type="button"
+                class="semble-disclose"
+                aria-expanded={similarExpanded}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  similarExpanded = true;
+                }}>{foldedSimilar} more</button
+              >
+            {/if}
+          </div>
+        {/if}
+
+        {#if sembleContext.cardUrl && (similar.length > 0 || connectionsBeyond > 0 || collectionsBeyond > 0 || sembleContext.incomplete || sembleTruncated)}
           <p class="semble-foot">
             {#if connectionsBeyond > 0}Showing {connectionsGot} of {connectionsHeld} connections.{/if}
             {#if collectionsBeyond > 0}Showing {collectionsGot} of {collectionsHeld} collections.{/if}
@@ -1189,6 +1273,45 @@
     align-items: flex-start;
     gap: 0.5rem;
     min-width: 0;
+  }
+
+  .semble-similar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .semble-similar h3 {
+    margin: 0;
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--color-text-secondary);
+  }
+
+  .similar-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .similar-body {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .similar-meta {
+    display: block;
+    margin-top: 0.0625rem;
+    font-size: var(--text-xs);
+    line-height: var(--leading-snug);
+    color: var(--color-text-secondary);
+  }
+
+  .similar-list .connection-target {
+    color: var(--color-primary);
   }
 
   /* Quiet at rest and quiet in a column of twenty: the bookmark carries no fill

--- a/frontend/src/lib/hooks/useAtmosphere.svelte.ts
+++ b/frontend/src/lib/hooks/useAtmosphere.svelte.ts
@@ -181,8 +181,8 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
 
   // Resolving people costs a PDS fetch per record, so it stays off until the
   // host says the discussion is actually on screen. Once open, every lane that
-  // has people resolves in parallel — the stream is the whole conversation, so
-  // waiting for a lane to be picked would be waiting for nothing.
+  // has people resolves in parallel. Semble also resolves at zero because its
+  // article recommendations are useful without a human reference count.
   let streamOpen = $state(false);
 
   function openStream() {
@@ -196,6 +196,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     for (const lane of laneRow) {
       if (lane.count > 0) mentionLaneItemsStore.load(url, lane.id);
     }
+    mentionLaneItemsStore.load(url, 'semble');
   });
 
   // Per-lane resolved people, keyed by lane. Reading through the store here (not
@@ -207,6 +208,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     for (const lane of laneRow) {
       if (lane.count > 0) out.set(lane.id, mentionLaneItemsStore.get(url, lane.id));
     }
+    out.set('semble', mentionLaneItemsStore.get(url, 'semble'));
     return out;
   });
 
@@ -348,6 +350,7 @@ export function useAtmosphere(opts: UseAtmosphereOptions): AtmosphereApi {
     for (const lane of laneRow) {
       if (lane.count > 0) mentionLaneItemsStore.load(url, lane.id, { force: true });
     }
+    mentionLaneItemsStore.load(url, 'semble', { force: true });
   }
 
   const total = $derived(laneRow.reduce((sum, l) => sum + l.count, 0));

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -853,6 +853,12 @@ export interface SembleContext {
       imageUrl: string | null;
     };
   }>;
+  similar?: Array<{
+    url: string;
+    title: string | null;
+    siteName: string | null;
+    saveCount: number;
+  }>;
   truncated: { savers: boolean; notes: boolean; collections: boolean; connections: boolean };
   incomplete: boolean;
   source: 'semble-api' | 'constellation-fallback';

--- a/frontend/src/routes/dev/discussion/+page.svelte
+++ b/frontend/src/routes/dev/discussion/+page.svelte
@@ -159,6 +159,7 @@
     notes: [],
     collections: [],
     connections: [],
+    similar: [],
     truncated: { savers: false, notes: false, collections: false, connections: false },
     incomplete: false,
     source: 'semble-api',
@@ -234,7 +235,28 @@
       },
     ],
     connections: [outgoing, incoming, untypedIncoming],
+    similar: [
+      {
+        url: 'https://reading.example/slow-web',
+        title: 'A slower web',
+        siteName: 'Reading Notes',
+        saveCount: 12,
+      },
+      {
+        url: 'https://protocol.example/open-graphs',
+        title: 'Open graphs for readers',
+        siteName: 'Protocol Review',
+        saveCount: 6,
+      },
+    ],
   };
+
+  const similarArticles = Array.from({ length: 8 }, (_, i) => ({
+    url: `https://recommended${i}.example/story`,
+    title: i === 2 ? null : `Recommended article ${i + 1}`,
+    siteName: i === 2 ? null : 'The Reading Review',
+    saveCount: i + 2,
+  }));
 
   // The shape that forced this fold: one curator mapping a topic. Twenty edges
   // come back, all outgoing, all "supplement", all theirs — only the title
@@ -446,6 +468,38 @@
         },
         connections: [outgoing, incoming],
       }}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
+      stream={{ loading: false, entries: [] }}
+    />
+  </Case>
+
+  <Case
+    name="Semble · similar only"
+    note="Algorithmic suggestions remain subordinate to human discussion: a quiet, flat list with clear Semble provenance and the same keep control as connected articles."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={[laneVM('semble', { count: 1 })]}
+      filters={[]}
+      sembleContext={{ ...emptyContext, similar: similarArticles.slice(0, 3) }}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
+      stream={{ loading: false, entries: [] }}
+    />
+  </Case>
+
+  <Case
+    name="Semble · similar fold"
+    note="Four recommendations preview the list; the remaining four stay behind one disclosure."
+    width="800px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={[laneVM('semble', { count: 1 })]}
+      filters={[]}
+      sembleContext={{ ...emptyContext, similar: similarArticles }}
       onSaveConnection={toggleSavedLink}
       isConnectionSaved={isLinkSaved}
       stream={{ loading: false, entries: [] }}

--- a/frontend/src/routes/dev/discussion/+page.svelte
+++ b/frontend/src/routes/dev/discussion/+page.svelte
@@ -371,6 +371,11 @@
   }
   const isLinkSaved = (url: string) => savedLinks.includes(url);
 
+  // Drawing an edge is a real dialog in the app; here it just has to be present,
+  // so the one control the Connections tab owns is visible in the harness.
+  let connectClicks = $state(0);
+  const createConnection = () => connectClicks++;
+
   let activeFilter = $state<DiscussionFilterId>('all');
   const filtered = $derived(
     activeFilter === 'all' ? entries : entries.filter((e) => e.lane === activeFilter)
@@ -383,11 +388,11 @@
 
 <Showcase
   title="Discussion"
-  description="What the Atmosphere said about one article, merged into a single stream ranked by engagement — most-liked first, newest as the tiebreak. Lanes are filters over it, not four lists to click between. The filter chips below are live."
+  description="One article's discussion, split by KIND rather than by network: Conversation (what people said, every network merged and ranked by engagement — most-liked first, newest as the tiebreak), Connections (where Semble has it filed and what it is tied to), and Related (what to read next). The network stays a property of a row — the glyph on each avatar — and survives as a filter inside Conversation, the one tab made of rows. The tabs and the filter chips below are live."
 >
   <Case
     name="Reader · the whole discussion"
-    note="How it reads under a finished article: heading, total, filters, stream, then the ways to answer. Try the chips."
+    note="How it reads under a finished article, with all three kinds populated: heading, the tab row carrying each kind and its count, then the conversation — filters, stream, the ways to answer. Try the tabs, then the chips inside Conversation. Arrow keys move between tabs."
     width="800px"
     pad
   >
@@ -399,13 +404,14 @@
       {sembleContext}
       onSaveConnection={toggleSavedLink}
       isConnectionSaved={isLinkSaved}
+      onCreateConnection={createConnection}
       onSelectFilter={(id) => (activeFilter = id)}
     />
   </Case>
 
   <Case
-    name="Semble · a mapped topic"
-    note="The shape that forced the fold: one curator, twenty outgoing edges of the same type, only the title varying. Unfolded that was sixty lines of the same sentence. Folded on (curator, relation, direction) the sentence is said once and the titles are the only thing left. Semble held twenty-seven and returned twenty; the foot says so where the reader can act on it."
+    name="Connections · a mapped topic"
+    note="The shape that forced the fold: one curator, twenty outgoing edges of the same type, only the title varying. Unfolded that was sixty lines of the same sentence. Folded on (curator, relation, direction) the sentence is said once and the titles are the only thing left. Semble held twenty-seven and returned twenty; the tab count carries a + and the foot says how many. Open the Connections tab."
     width="800px"
     pad
   >
@@ -420,8 +426,8 @@
   </Case>
 
   <Case
-    name="Semble · filed everywhere"
-    note="A URL every mapper has filed. Twenty collections came back and unfolded they were a wall of pills between the reader and the discussion they introduce; six read as a set, the rest open on request. A name long enough to eat the panel gives up its tail and keeps it in the title. Semble holds forty-seven, and the foot says so."
+    name="Connections · filed everywhere"
+    note="A URL every mapper has filed. Twenty collections came back and unfolded they were a wall of pills between the reader and the discussion they introduce; six read as a set, the rest open on request. A name long enough to eat the panel gives up its tail and keeps it in the title. Semble holds forty-seven, and the foot says so. A URL with no edges but plenty of shelves still earns the tab: a collection membership is an edge too."
     width="800px"
     pad
   >
@@ -434,8 +440,8 @@
   </Case>
 
   <Case
-    name="Semble · everything it knows"
-    note="What Semble holds about this URL that isn't a person in the stream: the counts, where it's filed, notes nobody attached to a save, and the typed edges. Outbound reads this → type → other; inbound reads other → type → this, so the arrow never lies about which way the claim points. Shown under All and Semble only — switch the chips above to watch it leave."
+    name="Connections · everything it knows"
+    note="What Semble holds about this URL: where it's filed and the typed edges. Outbound reads this → type → other; inbound reads other → type → this, so the arrow never lies about which way the claim points. The standalone notes are NOT here — they are somebody's words about the article, so they lead the Conversation stream with everyone else's."
     width="800px"
     pad
   >
@@ -450,8 +456,8 @@
   </Case>
 
   <Case
-    name="Semble · connections only"
-    note="Nobody said anything and nobody saved it — the URL exists in Semble purely as the endpoint of other people's edges. That still counts as readable content, so the panel must not claim nothing came back."
+    name="Connections · edges only"
+    note="Nobody said anything and nobody saved it — the URL exists in Semble purely as the endpoint of other people's edges. Conversation opens empty and says so plainly, which is now honest: the Connections tab's own count says where the rest of it went."
     width="800px"
     pad
   >
@@ -475,8 +481,8 @@
   </Case>
 
   <Case
-    name="Semble · similar only"
-    note="Algorithmic suggestions remain subordinate to human discussion: a quiet, flat list with clear Semble provenance and the same keep control as connected articles."
+    name="Related · recommendations only"
+    note="What to read next is not discussion at all, which is why it kept reading as a wall bolted onto the end of one. Behind its own tab it is a quiet, flat list with clear Semble provenance and the same keep control as a connected article — subordinate to the conversation by position, not by styling."
     width="800px"
     pad
   >
@@ -491,7 +497,7 @@
   </Case>
 
   <Case
-    name="Semble · similar fold"
+    name="Related · the fold"
     note="Four recommendations preview the list; the remaining four stay behind one disclosure."
     width="800px"
     pad
@@ -507,7 +513,7 @@
   </Case>
 
   <Case
-    name="Semble · partial and truncated"
+    name="Connections · partial and truncated"
     note="One category timed out and another had more than one page. Both are disclosed in a line rather than silently rounded off — what returned still renders."
     width="800px"
     pad
@@ -526,7 +532,7 @@
   </Case>
 
   <Case
-    name="Semble · saver fallback"
+    name="Conversation · saver fallback"
     note="The API was unreachable and the Constellation/PDS resolver answered instead: the people it found still read normally, and no aggregate is invented to fill the space."
     width="800px"
     pad
@@ -541,7 +547,7 @@
 
   <Case
     name="Card · no heading"
-    note="Inside the feed card's sticky footer the Discussion button already names the section, so the panel drops its heading."
+    note="Inside the feed card's sticky footer the Discussion button already names the section, so the panel drops its heading — and at this width the tab row tightens rather than wrapping."
     width="620px"
     pad
   >
@@ -550,7 +556,30 @@
       {filters}
       activeFilter="all"
       stream={{ loading: false, ...allStream }}
+      {sembleContext}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
+      onCreateConnection={createConnection}
       showHeading={false}
+    />
+  </Case>
+
+  <Case
+    name="Tabs · a phone-width column"
+    note="Three labels and three counts in 360px. The strip scrolls rather than wrapping: a second row of navigation over a reading surface is the thing this whole change was undoing."
+    width="360px"
+    pad
+  >
+    <AtmospherePanel
+      laneRow={lanes}
+      {filters}
+      {activeFilter}
+      {stream}
+      {sembleContext}
+      onSaveConnection={toggleSavedLink}
+      isConnectionSaved={isLinkSaved}
+      onCreateConnection={createConnection}
+      onSelectFilter={(id) => (activeFilter = id)}
     />
   </Case>
 
@@ -616,8 +645,8 @@
   </Case>
 
   <Case
-    name="One source only"
-    note="A single populated lane needs no filter row — there is nothing to filter to."
+    name="One kind, one source"
+    note="A single populated lane needs no filter row, and a single kind needs no tab row: with nothing from Semble there is only the conversation, so neither strip renders. One tab is not a tab strip."
     width="800px"
     pad
   >


### PR DESCRIPTION
## Summary

- fetch and defensively normalize Semble similar URLs alongside existing human context
- render a quiet, foldable Similar on Semble list with existing save controls
- load Semble recommendations when Discussion opens even at zero human mentions
- preserve deploy/cache compatibility and keep recommendation failures silent

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-cuv4iezdow6yahhedm6yux5y)

## Checks

- feed-proxy TypeScript and focused formatting passed
- frontend TypeScript passed with pre-existing warnings
- AtmospherePanel component suite passed (26 tests)
- frontend focused formatting passed
- Bun-only proxy tests unavailable because Bun is not installed
- backend type check blocked by absent generated `worker-configuration.d.ts`
