### PR TITLE
Put the open article in the URL (?read=) so links and history work

### DIFF
--- a/e2e-pwa/offline.spec.ts
+++ b/e2e-pwa/offline.spec.ts
@@ -48,4 +48,29 @@ test.describe('offline resilience', () => {
       await context.setOffline(false);
     }
   });
+
+  // An open article is a `?read=` query on a normal surface (see `readerLink.ts`),
+  // and the app-shell handler answers navigations regardless of query — so a link
+  // into the reader must survive offline exactly like any other deep link. This
+  // suite runs without a backend or a signed-in user, so it pins the shell half of
+  // that; reopening the article itself from Dexie is covered in the main E2E suite.
+  test('a reader deep link while offline serves the precached shell', async ({
+    browserName,
+    context,
+    page,
+  }) => {
+    test.skip(browserName === 'webkit', 'Playwright webkit cannot navigate while offline');
+    await page.goto('/');
+    await waitForControl(page);
+
+    await context.setOffline(true);
+    try {
+      await page.goto('/saved?read=https%3A%2F%2Fexample.com%2Fa', {
+        waitUntil: 'domcontentloaded',
+      });
+      expect(await shellRendered(page), 'reader deep link should render offline').toBe(true);
+    } finally {
+      await context.setOffline(false);
+    }
+  });
 });

--- a/e2e/reader-url.spec.ts
+++ b/e2e/reader-url.spec.ts
@@ -35,6 +35,16 @@ function readParam(page: Page): string | null {
   return new URL(page.url()).searchParams.get('read');
 }
 
+/**
+ * The reader's Save control, by its title. The overlay mounts both chromes —
+ * the desktop header row and the mobile bottom bar — and hides the one the
+ * viewport isn't using, so two buttons carry the title but only one is on
+ * screen. Match the one the reader is actually showing.
+ */
+function saveControl(page: Page, title: 'Unsave' | 'Save (s)') {
+  return reader(page).getByTitle(title).filter({ visible: true });
+}
+
 test.describe('Reader URLs', () => {
   test('opening an article puts it in the URL, and a reload reopens it', async ({
     authedPage,
@@ -146,10 +156,10 @@ test.describe('Reader URLs', () => {
 
     // Restored from a URL the item is the save it already is, not the feed
     // article — the reader's Save control has to know that and still act.
-    const unsave = authedPage.locator('.reader-overlay').getByTitle('Unsave');
+    const unsave = saveControl(authedPage, 'Unsave');
     await expect(unsave).toBeVisible();
     await unsave.click();
-    await expect(authedPage.locator('.reader-overlay').getByTitle('Save (s)')).toBeVisible();
+    await expect(saveControl(authedPage, 'Save (s)')).toBeVisible();
   });
 
   test('an unresolvable link on an empty surface says so and restores the empty state', async ({

--- a/e2e/reader-url.spec.ts
+++ b/e2e/reader-url.spec.ts
@@ -129,6 +129,40 @@ test.describe('Reader URLs', () => {
     await expect(authedPage).toHaveURL('/saved?view=nonexistent-channel');
   });
 
+  test('a link still opens on a surface whose list is empty, and Save works there', async ({
+    authedPage,
+    testUser,
+  }) => {
+    // A save made from a feed article: it carries the article's guid, which is
+    // how a `?read=` restore finds it — and why it comes back typed 'saved'.
+    const rkey = await seedArticle(testUser, { source: 'feed', itemGuid: URL_ });
+    const key = `at://${testUser.did}/app.skyreader.feed.saved/${rkey}`;
+
+    // This user has no subscriptions, so /feeds would render an empty state —
+    // and an empty state hosts no reader stack for the link to land in.
+    await authedPage.goto(`/feeds?read=${encodeURIComponent(key)}`);
+    await expect(reader(authedPage)).toBeVisible({ timeout: 20_000 });
+    await expect(authedPage.locator('.reader-overlay').getByText(TITLE).first()).toBeVisible();
+
+    // Restored from a URL the item is the save it already is, not the feed
+    // article — the reader's Save control has to know that and still act.
+    const unsave = authedPage.locator('.reader-overlay').getByTitle('Unsave');
+    await expect(unsave).toBeVisible();
+    await unsave.click();
+    await expect(authedPage.locator('.reader-overlay').getByTitle('Save (s)')).toBeVisible();
+  });
+
+  test('an unresolvable link on an empty surface says so and restores the empty state', async ({
+    authedPage,
+  }) => {
+    await authedPage.goto('/feeds?read=https%3A%2F%2Fexample.com%2Fnever-seen-here');
+
+    await expect(authedPage.getByText('Article unavailable')).toBeVisible({ timeout: 20_000 });
+    await expect(authedPage).toHaveURL(/\/feeds$/);
+    await expect(reader(authedPage)).toBeHidden();
+    await expect(authedPage.getByText('Your library is empty')).toBeVisible();
+  });
+
   test('the list under the reader keeps its scroll position on close', async ({
     authedPage,
     testUser,

--- a/e2e/reader-url.spec.ts
+++ b/e2e/reader-url.spec.ts
@@ -1,0 +1,169 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { seedSavedArticle, type SeedSavedArticleOpts, type TestUser } from './seed';
+
+// The reader is an overlay stack, not a route — but every level now rides a
+// shallow-routed `?read=<item key>` URL, so a reading session survives a reload,
+// can be linked, and Forward reopens what Back closed. These walk that contract
+// through the history stack on the surface it matters most: Saved.
+
+const TITLE = 'An Addressable Article';
+const URL_ = 'https://example.com/addressable-article';
+const BODY = Array.from(
+  { length: 12 },
+  (_, i) => `<p>Paragraph ${i} of an article you should be able to link to.</p>`
+).join('');
+
+async function seedArticle(user: TestUser, overrides: Partial<SeedSavedArticleOpts> = {}) {
+  return seedSavedArticle(user, {
+    url: URL_,
+    title: TITLE,
+    domain: 'example.com',
+    contentType: 'article',
+    content: BODY,
+    wordCount: 400,
+    ...overrides,
+  });
+}
+
+/** The reader overlay, identified by the article body it renders full-screen. */
+function reader(page: Page) {
+  return page.locator('.reader-overlay');
+}
+
+function readParam(page: Page): string | null {
+  return new URL(page.url()).searchParams.get('read');
+}
+
+test.describe('Reader URLs', () => {
+  test('opening an article puts it in the URL, and a reload reopens it', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedArticle(testUser);
+
+    await authedPage.goto('/saved');
+    await authedPage.getByText(TITLE).first().click({ timeout: 15_000 });
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+
+    // The key is the save's record uri; the surface (path) is unchanged.
+    await expect(authedPage).toHaveURL(/\/saved\?read=/);
+    const key = readParam(authedPage);
+    expect(key).toContain('app.skyreader.feed.saved');
+    // Exactly one read param, at every depth.
+    expect(new URL(authedPage.url()).searchParams.getAll('read')).toHaveLength(1);
+    // The tab (and so the history entry, and any shared link) is named after it.
+    await expect(authedPage).toHaveTitle(new RegExp(TITLE));
+
+    await authedPage.reload();
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+    expect(readParam(authedPage)).toBe(key);
+  });
+
+  test('Back closes the reader and drops the param; Forward reopens it', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedArticle(testUser);
+
+    await authedPage.goto('/saved');
+    await authedPage.getByText(TITLE).first().click({ timeout: 15_000 });
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+
+    await authedPage.goBack();
+    await expect(reader(authedPage)).toBeHidden();
+    await expect(authedPage).toHaveURL(/\/saved$/);
+
+    await authedPage.goForward();
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage).toHaveURL(/\/saved\?read=/);
+  });
+
+  test('a deep link opens the reader, and Back lands on the list it belongs to', async ({
+    authedPage,
+    testUser,
+  }) => {
+    const rkey = await seedArticle(testUser);
+    const key = `at://${testUser.did}/app.skyreader.feed.saved/${rkey}`;
+
+    await authedPage.goto(`/saved?read=${encodeURIComponent(key)}`);
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.locator('.reader-overlay').getByText(TITLE).first()).toBeVisible();
+
+    // The base entry is synthesized, so the single close path still works and
+    // lands on the container list rather than leaving the app.
+    await authedPage.goBack();
+    await expect(reader(authedPage)).toBeHidden();
+    await expect(authedPage).toHaveURL(/\/saved$/);
+    await expect(authedPage.getByText(TITLE).first()).toBeVisible();
+  });
+
+  test('a link to an item this reader does not have says so and strips the param', async ({
+    authedPage,
+  }) => {
+    await authedPage.goto('/saved?read=https%3A%2F%2Fexample.com%2Fnever-saved-here');
+
+    await expect(authedPage.getByText('Article unavailable')).toBeVisible({ timeout: 20_000 });
+    await expect(authedPage).toHaveURL(/\/saved$/);
+    await expect(reader(authedPage)).toBeHidden();
+  });
+
+  test('opening a reader keeps the surface it was opened from', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedArticle(testUser);
+
+    // A channel view: the reader must not drop the ?view= that selects it.
+    await authedPage.goto('/saved?view=nonexistent-channel');
+    await authedPage.getByText(TITLE).first().click({ timeout: 15_000 });
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+
+    const url = new URL(authedPage.url());
+    expect(url.pathname).toBe('/saved');
+    expect(url.searchParams.get('view')).toBe('nonexistent-channel');
+    expect(url.searchParams.get('read')).toBeTruthy();
+
+    await authedPage.goBack();
+    await expect(reader(authedPage)).toBeHidden();
+    await expect(authedPage).toHaveURL('/saved?view=nonexistent-channel');
+  });
+
+  test('the list under the reader keeps its scroll position on close', async ({
+    authedPage,
+    testUser,
+  }) => {
+    // Enough saves that the list scrolls, so a pagination reset triggered by the
+    // reader's own URL write would be visible as a jump back to the top.
+    for (let i = 0; i < 20; i++) {
+      await seedSavedArticle(testUser, {
+        url: `https://example.com/scroll/${i}`,
+        title: `Scroll fixture ${i}`,
+        domain: 'example.com',
+        contentType: 'article',
+        content: BODY,
+        savedAt: Date.now() - i * 60_000,
+      });
+    }
+
+    await authedPage.goto('/saved');
+    await expect(authedPage.getByText('Scroll fixture 0').first()).toBeVisible({ timeout: 15_000 });
+
+    await authedPage.evaluate(() => window.scrollTo(0, 600));
+    await expect
+      .poll(() => authedPage.evaluate(() => Math.round(window.scrollY)))
+      .toBeGreaterThan(400);
+    const before = await authedPage.evaluate(() => Math.round(window.scrollY));
+
+    await authedPage.getByText('Scroll fixture 8').first().click();
+    await expect(reader(authedPage)).toBeVisible({ timeout: 15_000 });
+    await authedPage.goBack();
+    await expect(reader(authedPage)).toBeHidden();
+
+    await expect
+      .poll(() => authedPage.evaluate(() => Math.round(window.scrollY)))
+      .toBeGreaterThan(before - 50);
+    // The whole list is still rendered — the URL write must not have reset paging.
+    await expect(authedPage.getByText('Scroll fixture 19').first()).toBeAttached();
+  });
+});

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -101,12 +101,27 @@ param is what makes a reload, a bookmark, a shared link and Forward-reopen work 
 on a cold load the hook rewrites the current entry to the bare list URL and pushes
 the reader's, so closing always lands on the container list. Resolution
 (`src/lib/utils/readerLink.ts`) goes saves → articles → documents, with an
-`at://` network fallback; an unresolvable key toasts and strips the param.
+`at://` network fallback; an unresolvable key toasts and strips the param. The
+hook only gives up (network fallback, then toast) once `appManager.phase` reaches
+`ready`/`error` — `isInitialized` is already true all through `refreshing`, which
+is exactly when the sync that supplies a feed article is still running.
+
+Because saves are matched first, an article you saved comes back typed `'saved'`
+rather than `'article'` when the _URL_ is what opened it. Anything a reader host
+does per item type needs a `'saved'` branch: `src/lib/utils/readerSave.ts` is the
+shared one for Save/Unsave, and it keys off the save's guid/url, never its display
+key (usually the save's `at://` record uri, which the saves store doesn't index).
 
 Consequence for anything that reads the URL: an effect on `$page.url` now re-runs
 when a reader opens or closes. Keep such effects idempotent under an added or
 removed `read` param — `feedViewStore.setFilters` is the precedent (it no-ops when
-the filter set is unchanged; see `src/lib/utils/urlFilters.ts`).
+the filter set is unchanged; see `src/lib/utils/urlFilters.ts`). The deliberate
+trade there: re-selecting the channel you are already in no longer re-applies that
+channel's persisted toolbar configuration (leaving and coming back still does).
+
+A surface renders its list, not an empty state, while a `read` param is present
+(`FeedPage`) — otherwise a shared link landing on a feed-less or filtered-empty
+page would have no reader stack to receive it and would sit there inert.
 
 ## Common Tasks
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -89,6 +89,25 @@ See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) for sampling and recovery details.
 | `/auth/login`    | Bluesky handle input                           |
 | `/auth/callback` | OAuth callback handler                         |
 
+#### The `?read=` contract
+
+Any surface that hosts the fullscreen reader (`/feeds`, `/saved`, `/home`,
+`/linkblog`, `/highlights`, plus channel views under `?view=`) carries the open
+article as `?read=<FeedDisplayItem.key>`, percent-encoded. It is **shallow
+routing, not a route**: `useReaderStack` pushes a history entry per reader level
+with the URL and a `page.state.readerDepth` tag, so the list underneath never
+unmounts and Back still closes the reader and restores its scroll position. The
+param is what makes a reload, a bookmark, a shared link and Forward-reopen work —
+on a cold load the hook rewrites the current entry to the bare list URL and pushes
+the reader's, so closing always lands on the container list. Resolution
+(`src/lib/utils/readerLink.ts`) goes saves → articles → documents, with an
+`at://` network fallback; an unresolvable key toasts and strips the param.
+
+Consequence for anything that reads the URL: an effect on `$page.url` now re-runs
+when a reader opens or closes. Keep such effects idempotent under an added or
+removed `read` param — `feedViewStore.setFilters` is the precedent (it no-ops when
+the filter set is unchanged; see `src/lib/utils/urlFilters.ts`).
+
 ## Common Tasks
 
 ### Adding a New Lexicon Field

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -8,9 +8,11 @@ declare global {
     // interface Locals {}
     // interface PageData {}
     interface PageState {
-      readerOpen?: boolean;
-      // Reader-stack depth for the main feed (FeedListView): each open pushes a
-      // history entry; Back regresses the depth, popping the stack to match.
+      // Reader-stack depth (every surface that opens the fullscreen reader): each
+      // open pushes a history entry; Back regresses the depth, popping the stack
+      // to match. The entry's URL carries the open item's key as `?read=`, so a
+      // cold load (where no state exists) can restore the same reader from the URL
+      // alone. See `useReaderStack` for the full contract.
       readerDepth?: number;
     }
     // interface Platform {}

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -27,6 +27,10 @@
   let { children }: { children: Snippet } = $props();
 
   let pageTitle = $derived.by(() => {
+    // An open article names the tab (and so the history entry and any link
+    // preview) on its own — no unread count in front of what you're reading.
+    const override = viewTitleStore.override;
+    if (override) return `${override} - Skyreader`;
     const count = viewTitleStore.unreadCount;
     const view = viewTitleStore.current;
     const suffix = view ? `${view} - Skyreader` : 'Skyreader';

--- a/frontend/src/lib/components/feed/FeedListView.svelte
+++ b/frontend/src/lib/components/feed/FeedListView.svelte
@@ -9,6 +9,7 @@
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
   import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
+  import { toggleSavedItemSave } from '$lib/utils/readerSave';
   import type { Article, SocialDocument } from '$lib/types';
   import { getDocumentEffectiveUrl } from '$lib/utils/linkPost';
 
@@ -182,6 +183,10 @@
     if (!readerItem) return;
     if (readerItem.type === 'article') {
       onToggleSave(readerItem.item);
+    } else if (readerItem.type === 'saved') {
+      // An article opened from its `?read=` URL (reload, Forward, a link) comes
+      // back as the save it already is, not as the feed article — see readerSave.
+      void toggleSavedItemSave(readerItem.item);
     } else if (readerItem.type === 'document') {
       const doc = readerItem.item;
       itemLabelsStore.toggleSave(

--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy, tick, untrack } from 'svelte';
   import { page } from '$app/stores';
+  import { browser } from '$app/environment';
+  import { READ_PARAM } from '$lib/utils/readerLink';
   import { auth } from '$lib/stores/auth.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
@@ -464,6 +466,22 @@
   // an empty published set is not an empty page.
   let hasLinkblogDrafts = $derived(mode === 'linkblog' && shareDraftsStore.list.length > 0);
 
+  // Is a `?read=` link waiting to be honoured? The reader stack lives inside the
+  // list views, so a surface that swaps its list for an empty state would
+  // swallow the link — a shared or bookmarked article landing on a feed-less or
+  // filtered-empty page would show a bare empty state with an unexplained param
+  // still in the address bar. While the param is there the list mounts instead
+  // (empty, and covered by the reader anyway); the hook then either opens the
+  // article or toasts and strips the param, which brings the empty state back.
+  let readerLinkPending = $derived.by(() => {
+    // `$page` notifies on every push, pop and navigation and is the trigger; the
+    // live location is the truth, because shallow routing moves the address bar
+    // without touching `$page.url` (see `useReaderStack`).
+    void $page.state;
+    if (!browser) return false;
+    return new URL(location.href).searchParams.has(READ_PARAM);
+  });
+
   // Reset selection when any filter changes
   $effect(() => {
     const _ = [
@@ -556,7 +574,7 @@
       >
         {#if (appManager.isHydrating || appManager.isRefreshing || (mode === 'linkblog' && myLinkblogStore.loading && !myLinkblogStore.loaded)) && feedViewStore.currentItems.length === 0 && !hasLinkblogDrafts}
           <LoadingState />
-        {:else if !isSavedView && feedViewStore.currentItems.length === 0 && !hasLinkblogDrafts}
+        {:else if !isSavedView && feedViewStore.currentItems.length === 0 && !hasLinkblogDrafts && !readerLinkPending}
           {#if mode === 'linkblog'}
             <!-- Linkblog always shows all shares, so there's no "no unread" case. -->
             <EmptyState

--- a/frontend/src/lib/components/feed/HighlightsPage.svelte
+++ b/frontend/src/lib/components/feed/HighlightsPage.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { pushState } from '$app/navigation';
-  import { page } from '$app/state';
   import NavigationDropdown from '$lib/components/NavigationDropdown.svelte';
   import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
@@ -21,6 +19,7 @@
   import { notificationsStore } from '$lib/stores/notifications.svelte';
   import { mobileStore } from '$lib/stores/mediaQuery.svelte';
   import { useScrollDirection } from '$lib/hooks/useScrollDirection.svelte';
+  import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
   import {
     saveHighlightToMargin,
     deleteHighlight,
@@ -177,32 +176,17 @@
   let displayed = $derived(groups.slice(0, loadedCount));
   let hasMore = $derived(loadedCount < groups.length);
 
-  // Reader overlay — mirrors FeedListView: page.state.readerOpen drives the back
-  // button, readerItem holds the data.
-  let readerItem = $state<FeedDisplayItem | null>(null);
-  let savedScrollY = 0;
-
-  $effect(() => {
-    if (!page.state.readerOpen && readerItem) {
-      readerItem = null;
-      requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
-    }
-  });
+  // Reader overlay — the same stack every other surface uses, so /highlights gets
+  // Back-to-close, scroll restore and a `?read=` URL for free.
+  const reader = useReaderStack();
+  let readerItem = $derived(reader.readerItem);
 
   function openGroup(group: HighlightGroup) {
     if (group.displayItem) {
-      savedScrollY = window.scrollY;
-      readerItem = group.displayItem;
-      pushState('', { readerOpen: true });
+      reader.openReader(group.displayItem);
     } else if (group.url) {
       window.open(group.url, '_blank', 'noopener,noreferrer');
     }
-  }
-
-  function closeReader() {
-    readerItem = null;
-    history.back();
-    requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
   }
 
   function handleRemove(group: HighlightGroup, row: HighlightRow) {
@@ -400,7 +384,7 @@
 </div>
 
 {#if readerItem}
-  <SavedReader {readerItem} onClose={closeReader} />
+  <SavedReader {readerItem} onClose={reader.closeReader} />
 {/if}
 
 {#if noteEditor}

--- a/frontend/src/lib/components/feed/LinkblogListView.svelte
+++ b/frontend/src/lib/components/feed/LinkblogListView.svelte
@@ -12,6 +12,7 @@
   import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
+  import { toggleSavedItemSave } from '$lib/utils/readerSave';
   import { getDocumentEffectiveUrl } from '$lib/utils/linkPost';
   import type { ShareDraft } from '$lib/types';
 
@@ -72,7 +73,14 @@
   });
 
   function handleReaderSave() {
-    if (!readerItem || readerItem.type !== 'document') return;
+    if (!readerItem) return;
+    if (readerItem.type === 'saved') {
+      // A post opened from its `?read=` URL (reload, Forward, a link) comes back
+      // as the save it already is, not as the document — see readerSave.
+      void toggleSavedItemSave(readerItem.item);
+      return;
+    }
+    if (readerItem.type !== 'document') return;
     const doc = readerItem.item;
     itemLabelsStore.toggleSave(doc.recordUri, 'document', getDocumentEffectiveUrl(doc), doc.title, {
       type: 'document',

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -39,6 +39,7 @@
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
   import { shareComposerStore } from '$lib/stores/shareComposer.svelte';
   import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
+  import { toastStore } from '$lib/stores/toast.svelte';
   import { shareTargetForDisplayItem } from '$lib/utils/shareTarget';
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
   import CommunityHighlightPopover from '$lib/components/feed/CommunityHighlightPopover.svelte';
@@ -615,6 +616,12 @@
       onclick: handleOpenUrl,
     });
 
+    items.push({
+      label: 'Copy link',
+      icon: 'link',
+      onclick: handleCopyLink,
+    });
+
     return items;
   });
 
@@ -822,6 +829,18 @@
 
   function handleOpenUrl() {
     if (itemUrl) window.open(itemUrl, '_blank', 'noopener');
+  }
+
+  // The address bar already names what's open (the reader is shallow-routed, see
+  // `useReaderStack`), so a link back into Skyreader is just the current location.
+  async function handleCopyLink() {
+    const toastId = toastStore.add('Copying link…');
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toastStore.update(toastId, 'success', 'Link copied');
+    } catch {
+      toastStore.update(toastId, 'error', 'Could not copy link');
+    }
   }
 </script>
 

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -41,6 +41,7 @@
   import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
   import { toastStore } from '$lib/stores/toast.svelte';
   import { shareTargetForDisplayItem } from '$lib/utils/shareTarget';
+  import { isSavedItemSaved } from '$lib/utils/readerSave';
   import HighlightPopover from '$lib/components/feed/HighlightPopover.svelte';
   import CommunityHighlightPopover from '$lib/components/feed/CommunityHighlightPopover.svelte';
   import NotePeek from '$lib/components/feed/NotePeek.svelte';
@@ -415,7 +416,14 @@
   });
 
   let isArchived = $derived(itemLabelsStore.isArchived(itemKey));
-  let isSaved = $derived(itemLabelsStore.isSaved(itemKey));
+  // A `'saved'` item is keyed by the save's `at://` record uri, which the saves
+  // store indexes by neither guid nor url — asking about that key would answer
+  // "Save" for something plainly already saved. Ask about the save itself.
+  let isSaved = $derived(
+    readerItem.type === 'saved'
+      ? isSavedItemSaved(readerItem.item)
+      : itemLabelsStore.isSaved(itemKey)
+  );
 
   // ── Share from the reader chrome ────────────────────────────────────────────
   // A share control lives in the bar (desktop and mobile) so sharing is in

--- a/frontend/src/lib/hooks/useReaderStack.svelte.ts
+++ b/frontend/src/lib/hooks/useReaderStack.svelte.ts
@@ -113,7 +113,14 @@ export function useReaderStack(config: { onReaderChange?: (open: boolean) => voi
 
     // Nothing local yet. Hydration is still the likely explanation, so only reach
     // for the network (and only then give up) once the stores have settled.
-    if (!appManager.isInitialized) return;
+    //
+    // Settled means the *refresh* finished, not `isInitialized` — that flag is
+    // already true throughout `phase === 'refreshing'`, which is exactly the
+    // window in which the backend sync fills `articlesStore`. Giving up there
+    // would abandon a feed article's key seconds before the sync that supplies
+    // it, on precisely the devices that need the wait: a newly signed-in one, or
+    // one whose IndexedDB was evicted.
+    if (appManager.phase !== 'ready' && appManager.phase !== 'error') return;
     resolvingKey = key;
     void fetchReaderDocument(key, fetchCollectionDoc).then((fetched) => {
       resolvingKey = null;

--- a/frontend/src/lib/hooks/useReaderStack.svelte.ts
+++ b/frontend/src/lib/hooks/useReaderStack.svelte.ts
@@ -1,25 +1,62 @@
-// The fullscreen reader as a navigation stack, shared by the feed and saved-list
-// views so both behave identically — including opening a curated Collection
-// piece on top of the edition reader.
+// The fullscreen reader as a navigation stack, shared by the feed, saved, home,
+// linkblog and highlights surfaces so they all behave identically — including
+// opening a curated Collection piece on top of the edition reader.
 //
 // A piece opened from an edition pushes onto the stack, so Back returns to the
 // edition (not the list). Each level pushes a history entry tagged with its depth
 // (`page.state.readerDepth`); Back regresses the depth and the effect pops the
 // stack to match, restoring the list scroll position once it empties.
 //
+// **The URL contract.** Each level is shallow-routed: the pushed entry keeps the
+// host surface's path and query and adds `?read=<item key>` (see `readerLink.ts`).
+// It is still an overlay, not a route — nothing navigates, the list never
+// unmounts — but the address bar now names what you're reading, so a reload,
+// bookmark or shared link reopens it and Forward reopens what Back closed.
+// Within a session `page.state.readerDepth` remains the single driver; the `read`
+// param is only read on a cold load (no depth state at all) and on Forward, where
+// state alone can't rebuild the stack. On a cold load the current entry is first
+// rewritten to the bare list URL, so the one close path (`history.back()`) still
+// lands on the container list.
+//
 // Call once at the top of a component's <script> (during init, so the internal
 // $effect binds to that component's lifecycle). Read `readerItem` in markup; it's
 // reactive. Selection-driven opens read `feedViewStore`, which both views share.
-import { pushState } from '$app/navigation';
+import { pushState, replaceState } from '$app/navigation';
 import { page } from '$app/state';
+import { appManager } from '$lib/stores/app.svelte';
+import { articlesStore } from '$lib/stores/articles.svelte';
+import { savesStore } from '$lib/stores/saves.svelte';
+import { socialStore } from '$lib/stores/social.svelte';
+import { toastStore } from '$lib/stores/toast.svelte';
+import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
 import { feedViewStore, type FeedDisplayItem } from '$lib/stores/feedView.svelte';
 import { fetchCollectionDoc } from '$lib/utils/collectionPiece';
+import { getItemTitle } from '$lib/utils/displayItem';
+import {
+  READ_PARAM,
+  fetchReaderDocument,
+  readerUrl,
+  resolveReaderItem,
+} from '$lib/utils/readerLink';
 import type { ReaderCollectionItem } from '$lib/types';
 
 export function useReaderStack(config: { onReaderChange?: (open: boolean) => void } = {}) {
   let readerStack = $state<FeedDisplayItem[]>([]);
   let savedScrollY = 0;
   let readerItem = $derived(readerStack.length ? readerStack[readerStack.length - 1] : null);
+
+  // A key we've given up on: the stores were hydrated and the network fallback
+  // came back empty. Without it, a permanently unknown key would re-enter the
+  // restore effect on every store tick.
+  let abandonedKey: string | null = null;
+  // The key an async resolution is in flight for, so the effect doesn't start a
+  // second one while it waits.
+  let resolvingKey: string | null = null;
+
+  /** What the address bar actually says right now — see the restore effect. */
+  function currentUrl(): URL {
+    return new URL(location.href);
+  }
 
   $effect(() => {
     const depth = page.state.readerDepth ?? 0;
@@ -34,15 +71,100 @@ export function useReaderStack(config: { onReaderChange?: (open: boolean) => voi
     }
   });
 
+  // Name the history entry (and any shared link's preview) after what's open, and
+  // hand the tab title back to the host page on close. An override rather than a
+  // plain set: the host's own title effect re-runs on unrelated changes (unread
+  // counts), and must not win while the reader is up.
+  $effect(() => {
+    const item = readerItem;
+    if (!item) return;
+    viewTitleStore.setOverride(getItemTitle(item));
+    return () => viewTitleStore.setOverride(null);
+  });
+
+  // Restore the reader from the URL. Runs on a cold load (`?read=` with no depth
+  // state — a reload, bookmark or shared link) and on Forward-reopen (a
+  // depth-tagged entry whose stack we already popped). Reading the stores here is
+  // what makes it re-run as Dexie hydration fills them, so it waits out a slow
+  // cold start rather than racing it.
+  $effect(() => {
+    // `page.state` is the reactive trigger — SvelteKit replaces it on every
+    // push, pop and real navigation — while the live location is the truth.
+    // `page.url` is neither: a shallow push moves the address bar without
+    // touching it, and a pop back to an entry we rewrote restores a `page.url`
+    // still carrying the param the address bar no longer shows, so reading it
+    // here would reopen a reader the user just closed.
+    const depth = page.state.readerDepth ?? 0;
+    const key = currentUrl().searchParams.get(READ_PARAM);
+    if (!key || key === abandonedKey || key === resolvingKey) return;
+
+    const isColdLoad = depth === 0 && readerStack.length === 0;
+    if (!isColdLoad && depth <= readerStack.length) return;
+
+    const item = resolveReaderItem(key, {
+      saves: savesStore.articles,
+      getArticle: (guid) => articlesStore.getByGuid(guid),
+      documents: socialStore.documents,
+    });
+    if (item) {
+      restoreItem(item, isColdLoad);
+      return;
+    }
+
+    // Nothing local yet. Hydration is still the likely explanation, so only reach
+    // for the network (and only then give up) once the stores have settled.
+    if (!appManager.isInitialized) return;
+    resolvingKey = key;
+    void fetchReaderDocument(key, fetchCollectionDoc).then((fetched) => {
+      resolvingKey = null;
+      // The user can close, navigate or open something else while the fetch is out.
+      if (currentUrl().searchParams.get(READ_PARAM) !== key) return;
+      const currentDepth = page.state.readerDepth ?? 0;
+      const stillColdLoad = currentDepth === 0 && readerStack.length === 0;
+      if (!stillColdLoad && currentDepth <= readerStack.length) return;
+      if (fetched) {
+        restoreItem(fetched, stillColdLoad);
+        return;
+      }
+      // A save or feed item that's personal to someone else, or one that aged out
+      // of this reader's cache. Say so once and drop the param — no failure state.
+      abandonedKey = key;
+      toastStore.update(toastStore.add('Article unavailable'), 'error');
+      replaceState(readerUrl(currentUrl(), null), {});
+    });
+  });
+
+  // Put `item` on the stack for a URL that already names it. A cold load has no
+  // entry beneath to go back to, so synthesize one: rewrite the current entry to
+  // the bare list URL, then push the reader's. Back then closes the reader and
+  // lands on the list — from an external link that costs a second press to leave
+  // the app, which beats Back exiting mid-read.
+  function restoreItem(item: FeedDisplayItem, synthesizeBase: boolean) {
+    if (synthesizeBase) {
+      const here = currentUrl();
+      const bare = readerUrl(here, null);
+      const withItem = readerUrl(here, item.key);
+      savedScrollY = 0;
+      replaceState(bare, {});
+      readerStack = [item];
+      pushState(withItem, { readerDepth: 1 });
+    } else {
+      readerStack = [...readerStack, item];
+    }
+    config.onReaderChange?.(true);
+  }
+
   function openReader(item: FeedDisplayItem) {
     if (readerStack.length === 0) savedScrollY = window.scrollY;
+    const url = readerUrl(currentUrl(), item.key);
     readerStack = [...readerStack, item];
-    pushState('', { readerDepth: readerStack.length });
+    pushState(url, { readerDepth: readerStack.length });
     config.onReaderChange?.(true);
   }
 
   // Pop one level; the popstate-driven effect updates the stack (and restores the
-  // list scroll position once it empties).
+  // list scroll position once it empties). Back also restores the entry beneath's
+  // URL, so the `read` param follows the stack for free.
   function closeReader() {
     history.back();
   }

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -1533,6 +1533,14 @@ function createFeedViewStore() {
       // would truncate the list under an open reader and lose the scroll position
       // restored on close, so an unchanged filter set is a no-op. The linkblog
       // view isn't URL-driven, so leaving it always counts as a change.
+      //
+      // The deliberate trade: re-selecting the channel you are already in no
+      // longer re-applies that channel's persisted configuration (sort order,
+      // read filter, tag/type/source filters, the inbox-vs-archive tab below),
+      // so it can't be used to discard unsaved toolbar tweaks. Leaving the
+      // channel and coming back does re-apply it — that path changes the filter
+      // set and runs the whole body. A stable list under an open reader is worth
+      // more than an undocumented reset gesture.
       if (!myLinkblogFilter) {
         const current: UrlFilters = {
           feed: feedFilter,

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -20,6 +20,7 @@ import type {
   SortOrder,
 } from '$lib/types';
 import { htmlToText, normalize, searchRank } from '$lib/services/savedSearch';
+import { sameUrlFilters, type UrlFilters } from '$lib/utils/urlFilters';
 import {
   isRssSource,
   isDocumentsSource,
@@ -1525,16 +1526,26 @@ function createFeedViewStore() {
     closeTagMenu() {
       tagMenuItemKey = null;
     },
-    setFilters(filters: {
-      feed: string | null;
-      saved: string | null;
-      sharer: string | null;
-      following: string | null;
-      feeds: string | null;
-      contentType?: 'documents' | null;
-      view?: string | null;
-      category?: string | null;
-    }) {
+    setFilters(filters: UrlFilters) {
+      // Every URL change re-runs this, including ones that don't move the view —
+      // the reader's `?read=` param, a canonicalizing `goto`, re-clicking the
+      // surface you're already on. Resetting pagination and toolbar state there
+      // would truncate the list under an open reader and lose the scroll position
+      // restored on close, so an unchanged filter set is a no-op. The linkblog
+      // view isn't URL-driven, so leaving it always counts as a change.
+      if (!myLinkblogFilter) {
+        const current: UrlFilters = {
+          feed: feedFilter,
+          saved: savedFilter,
+          sharer: sharerFilter,
+          following: followingFilter,
+          feeds: feedsFilter,
+          contentType: contentTypeFilter,
+          view: viewFilter,
+          category: categoryFilter,
+        };
+        if (sameUrlFilters(filters, current)) return;
+      }
       // Any URL-driven filter change exits the "Your Linkblog" view.
       myLinkblogFilter = false;
       // Search is ephemeral session state, scoped to one saved surface, so

--- a/frontend/src/lib/stores/viewTitle.svelte.ts
+++ b/frontend/src/lib/stores/viewTitle.svelte.ts
@@ -1,10 +1,19 @@
 class ViewTitleStore {
   current = $state('');
   unreadCount = $state(0);
+  // What's open in the reader, which outranks the host page's own title for as
+  // long as it's up. Kept separate because the page sets `current` on unrelated
+  // changes (a new unread count), which would otherwise clobber the article title
+  // mid-read. See `useReaderStack`.
+  override = $state<string | null>(null);
 
   set(title: string, count: number = 0) {
     this.current = title;
     this.unreadCount = count;
+  }
+
+  setOverride(title: string | null) {
+    this.override = title;
   }
 }
 

--- a/frontend/src/lib/utils/displayItem.ts
+++ b/frontend/src/lib/utils/displayItem.ts
@@ -40,7 +40,7 @@ export function normalizeDisplayItem(
   sub?: Subscription
 ): NormalizedDisplayItem {
   return {
-    title: getTitle(item),
+    title: getItemTitle(item),
     url: getUrl(item),
     publishedAt: getPublishedAt(item),
     displayContent: getDisplayContent(item),
@@ -50,7 +50,8 @@ export function normalizeDisplayItem(
   };
 }
 
-function getTitle(item: FeedDisplayItem): string {
+/** The item's display title, decoded — its headline in a list, reader or tab title. */
+export function getItemTitle(item: FeedDisplayItem): string {
   if (item.type === 'article') return decodeEntities(item.item.title) || item.item.url;
   if (item.type === 'document') return decodeEntities(item.item.title) || item.item.recordUri;
   if (item.type === 'saved') return decodeEntities(item.item.title) || item.item.url;

--- a/frontend/src/lib/utils/readerLink.test.ts
+++ b/frontend/src/lib/utils/readerLink.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { readerUrl, resolveReaderItem, fetchReaderDocument } from './readerLink';
+import type { Article, SavedItem, SocialDocument } from '$lib/types';
+
+function save(partial: Partial<SavedItem>): SavedItem {
+  return {
+    rkey: '3kaaaaaaaaaaa',
+    uri: 'at://did:plc:me/app.skyreader.feed.saved/3kaaaaaaaaaaa',
+    url: 'https://example.com/piece',
+    title: 'A Piece',
+    author: null,
+    description: null,
+    content: null,
+    contentType: 'article',
+    domain: 'example.com',
+    image: null,
+    wordCount: null,
+    publishedAt: null,
+    savedAt: '2026-08-01T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+function article(partial: Partial<Article> = {}): Article {
+  return {
+    guid: 'https://example.com/feed-item',
+    subscriptionId: 1,
+    title: 'A Feed Item',
+    url: 'https://example.com/feed-item',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    ...partial,
+  } as Article;
+}
+
+function doc(partial: Partial<SocialDocument> = {}): SocialDocument {
+  return {
+    authorDid: 'did:plc:author',
+    recordUri: 'at://did:plc:author/com.example.doc/abc',
+    siteUri: 'at://did:plc:author/com.example.site/self',
+    title: 'A Document',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+const empty = { saves: [], getArticle: () => undefined, documents: [] };
+
+describe('readerUrl', () => {
+  it('adds read to the current path and query', () => {
+    const url = new URL('https://app.test/feeds?feed=12&view=abc');
+    expect(readerUrl(url, 'https://example.com/a?b=c')).toBe(
+      '/feeds?feed=12&view=abc&read=https%3A%2F%2Fexample.com%2Fa%3Fb%3Dc'
+    );
+  });
+
+  it('replaces an existing read rather than appending a second one', () => {
+    const url = new URL('https://app.test/saved?read=one');
+    expect(readerUrl(url, 'two')).toBe('/saved?read=two');
+  });
+
+  it('removes read for null, leaving the other params intact', () => {
+    const url = new URL('https://app.test/feeds?feed=12&read=one');
+    expect(readerUrl(url, null)).toBe('/feeds?feed=12');
+  });
+
+  it('keeps a bare path bare on close', () => {
+    expect(readerUrl(new URL('https://app.test/saved?read=one'), null)).toBe('/saved');
+  });
+});
+
+describe('resolveReaderItem', () => {
+  it('matches a save by any of its keys and re-keys it to the current one', () => {
+    const item = save({ itemGuid: 'guid-1' });
+    const sources = { ...empty, saves: [item] };
+
+    for (const key of [item.uri, 'guid-1', item.rkey]) {
+      const resolved = resolveReaderItem(key, sources);
+      expect(resolved).toEqual({ type: 'saved', item, key: item.uri });
+    }
+  });
+
+  it('falls back to itemGuid when a save has no uri yet', () => {
+    const item = save({ uri: '', itemGuid: 'guid-1' });
+    expect(resolveReaderItem('guid-1', { ...empty, saves: [item] })).toEqual({
+      type: 'saved',
+      item,
+      key: 'guid-1',
+    });
+  });
+
+  it('prefers a save over a feed article with the same key', () => {
+    const saved = save({ itemGuid: 'https://example.com/feed-item' });
+    const feedItem = article();
+    const resolved = resolveReaderItem('https://example.com/feed-item', {
+      saves: [saved],
+      getArticle: () => feedItem,
+      documents: [],
+    });
+    expect(resolved?.type).toBe('saved');
+  });
+
+  it('resolves a feed article by guid', () => {
+    const feedItem = article();
+    const resolved = resolveReaderItem(feedItem.guid, {
+      ...empty,
+      getArticle: (guid) => (guid === feedItem.guid ? feedItem : undefined),
+    });
+    expect(resolved).toEqual({ type: 'article', item: feedItem, key: feedItem.guid });
+  });
+
+  it('resolves a loaded document by record uri', () => {
+    const document = doc();
+    const resolved = resolveReaderItem(document.recordUri, { ...empty, documents: [document] });
+    expect(resolved).toEqual({ type: 'document', item: document, key: document.recordUri });
+  });
+
+  it('returns null for a key nothing knows', () => {
+    expect(resolveReaderItem('https://example.com/never-seen', empty)).toBeNull();
+  });
+});
+
+describe('fetchReaderDocument', () => {
+  it('fetches an at:// key that no store had', async () => {
+    const document = doc();
+    const resolved = await fetchReaderDocument(document.recordUri, async () => document);
+    expect(resolved).toEqual({ type: 'document', item: document, key: document.recordUri });
+  });
+
+  it('does not go to the network for a non-at:// key', async () => {
+    let called = false;
+    const resolved = await fetchReaderDocument('https://example.com/a', async () => {
+      called = true;
+      return doc();
+    });
+    expect(resolved).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it('treats a missing document as unresolved', async () => {
+    expect(await fetchReaderDocument('at://did:plc:x/c/1', async () => null)).toBeNull();
+  });
+
+  it('treats a failed fetch as unresolved rather than throwing', async () => {
+    const resolved = await fetchReaderDocument('at://did:plc:x/c/1', async () => {
+      throw new Error('offline');
+    });
+    expect(resolved).toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/readerLink.ts
+++ b/frontend/src/lib/utils/readerLink.ts
@@ -1,0 +1,84 @@
+// The open article, as a URL.
+//
+// The reader stays an overlay stack rather than a route (see the Reader FDR and
+// `useReaderStack`), but each level now rides a shallow-routed URL: the current
+// path and query, plus `?read=<item key>`. That makes a reading session
+// reloadable, linkable and bookmarkable — and lets Forward reopen what Back
+// closed — without unmounting the list underneath or losing its scroll position.
+//
+// The key in the URL is exactly `FeedDisplayItem.key` (article → guid, document →
+// at:// record uri, save → uri/itemGuid/rkey), the same key `item_labels_cache`
+// and the highlight aliases use. Resolution matches every alias of a save, so a
+// link written before an external backing engine attached a `uri` still opens.
+import { savedItemDisplayKey } from '$lib/utils/dailyMagazine';
+import type { FeedDisplayItem } from '$lib/stores/feedView.svelte';
+import type { Article, SavedItem, SocialDocument } from '$lib/types';
+
+/** The query parameter carrying the open article's key. */
+export const READ_PARAM = 'read';
+
+/**
+ * `url` with `read` set to `key` (or removed when null), as a path+query string
+ * suitable for `pushState`/`replaceState`. Every other parameter is preserved,
+ * so the surface (`?feed=`, `?view=`, `?category=`) survives an open and a close.
+ */
+export function readerUrl(url: URL, key: string | null): string {
+  const next = new URL(url);
+  if (key === null) next.searchParams.delete(READ_PARAM);
+  else next.searchParams.set(READ_PARAM, key);
+  return next.pathname + next.search + next.hash;
+}
+
+/** The stores a reader key is resolved against, in the order they're consulted. */
+export interface ReaderKeySources {
+  /** Saved items (`savesStore.articles`). */
+  saves: SavedItem[];
+  /** Article lookup by guid (`articlesStore.getByGuid`). */
+  getArticle: (guid: string) => Article | undefined;
+  /** Loaded documents (`socialStore.documents`). */
+  documents: SocialDocument[];
+}
+
+/**
+ * Resolve a `read` key against the local stores, saves first.
+ *
+ * Deliberately bypasses `feedViewStore.currentItems`: that list is filter- and
+ * pagination-dependent, so a link to an item outside the current filter (or below
+ * the loaded page) would not resolve. The reader opens over the list either way;
+ * the list underneath simply won't contain the item, and closing lands on its top.
+ */
+export function resolveReaderItem(key: string, sources: ReaderKeySources): FeedDisplayItem | null {
+  const save = sources.saves.find(
+    (item) => item.uri === key || item.itemGuid === key || item.rkey === key
+  );
+  // The item is re-keyed to the save's *current* preferred key, so a link written
+  // under a stale alias reopens under (and rewrites to) the canonical one.
+  if (save) return { type: 'saved', item: save, key: savedItemDisplayKey(save) };
+
+  const article = sources.getArticle(key);
+  if (article) return { type: 'article', item: article, key: article.guid };
+
+  const doc = sources.documents.find((item) => item.recordUri === key);
+  if (doc) return { type: 'document', item: doc, key: doc.recordUri };
+
+  return null;
+}
+
+/**
+ * Network fallback for a key no store knows: documents are public, so a shared
+ * `at://` link opens even when the recipient has never loaded that document.
+ * Everything else (feed items, saves) is personal to its owner and can only come
+ * from the local stores, so those keys resolve to null and the caller gives up.
+ */
+export async function fetchReaderDocument(
+  key: string,
+  fetchDoc: (uri: string) => Promise<SocialDocument | null>
+): Promise<FeedDisplayItem | null> {
+  if (!key.startsWith('at://')) return null;
+  try {
+    const doc = await fetchDoc(key);
+    return doc ? { type: 'document', item: doc, key: doc.recordUri } : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/utils/readerSave.test.ts
+++ b/frontend/src/lib/utils/readerSave.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SavedItem } from '$lib/types';
+
+// A stand-in saves store: the real one drags in Dexie, the API client and the
+// sync queue. What's under test is the identity logic on top of it — which key a
+// save is looked up by, and which rkey an unsave targets.
+const saves: SavedItem[] = [];
+
+vi.mock('$lib/stores/saves.svelte', () => ({
+  savesStore: {
+    getByGuid: (guid: string) => saves.find((s) => s.itemGuid === guid),
+    getByUrl: (url: string) => saves.find((s) => s.url === url),
+    remove: vi.fn(async (rkey: string) => {
+      const i = saves.findIndex((s) => s.rkey === rkey);
+      if (i >= 0) saves.splice(i, 1);
+    }),
+    saveArticle: vi.fn(async (a: { url: string; guid: string; title?: string }) => {
+      const item = save({ rkey: 'fresh-rkey', uri: '', url: a.url, itemGuid: a.guid });
+      saves.push(item);
+      return item;
+    }),
+    saveDocument: vi.fn(async (d: { recordUri: string; url: string; content?: string }) => {
+      const item = save({
+        rkey: 'fresh-rkey',
+        uri: '',
+        url: d.url,
+        itemGuid: d.recordUri,
+        source: 'document',
+        content: d.content ?? null,
+      });
+      saves.push(item);
+      return item;
+    }),
+    // Bodies are stripped from the in-memory copies; the full row lives in Dexie.
+    getContent: vi.fn(async (rkey: string) => (rkey === '3kaaaaaaaaaaa' ? '<p>A body</p>' : null)),
+  },
+}));
+
+const { savesStore } = await import('$lib/stores/saves.svelte');
+const { isSavedItemSaved, toggleSavedItemSave } = await import('./readerSave');
+
+function save(partial: Partial<SavedItem> = {}): SavedItem {
+  return {
+    rkey: '3kaaaaaaaaaaa',
+    uri: 'at://did:plc:me/app.skyreader.feed.saved/3kaaaaaaaaaaa',
+    url: 'https://example.com/piece',
+    title: 'A Piece',
+    author: null,
+    description: null,
+    content: null,
+    contentType: 'article',
+    domain: 'example.com',
+    image: null,
+    wordCount: null,
+    publishedAt: null,
+    savedAt: '2026-08-01T00:00:00.000Z',
+    itemGuid: 'guid-1',
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  saves.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('isSavedItemSaved', () => {
+  it('reports a save as saved even though its display key is unindexed', () => {
+    const item = save();
+    saves.push(item);
+    // The display key is the record uri — neither the guid nor the url map holds
+    // it, which is why the reader can't ask about that key.
+    expect(savesStore.getByGuid(item.uri)).toBeUndefined();
+    expect(isSavedItemSaved(item)).toBe(true);
+  });
+
+  it('matches by url when the save carries no guid', () => {
+    const item = save({ itemGuid: undefined });
+    saves.push(item);
+    expect(isSavedItemSaved(item)).toBe(true);
+  });
+
+  it('reports false once the save is gone', () => {
+    expect(isSavedItemSaved(save())).toBe(false);
+  });
+});
+
+describe('toggleSavedItemSave', () => {
+  it('unsaves the save behind the reader item', async () => {
+    const item = save();
+    saves.push(item);
+    await toggleSavedItemSave(item);
+    expect(savesStore.remove).toHaveBeenCalledWith(item.rkey);
+    expect(isSavedItemSaved(item)).toBe(false);
+  });
+
+  it('re-saves under the same guid, so the feed article lights up again', async () => {
+    const item = save();
+    await toggleSavedItemSave(item);
+    expect(savesStore.saveArticle).toHaveBeenCalledWith(
+      expect.objectContaining({ url: item.url, guid: 'guid-1', title: 'A Piece' })
+    );
+    expect(isSavedItemSaved(item)).toBe(true);
+  });
+
+  it('re-saves a document save as a document, body and all', async () => {
+    const item = save({
+      source: 'document',
+      itemGuid: 'at://did:plc:me/site.doc/abc',
+      content: null,
+    });
+    saves.push(item);
+
+    await toggleSavedItemSave(item); // unsave — the body goes with the row
+    await toggleSavedItemSave(item); // undo
+
+    expect(savesStore.saveArticle).not.toHaveBeenCalled();
+    expect(savesStore.saveDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordUri: 'at://did:plc:me/site.doc/abc',
+        url: item.url,
+        content: '<p>A body</p>',
+      })
+    );
+  });
+
+  it('targets the live rkey across a save → unsave → save → unsave round trip', async () => {
+    const item = save();
+    saves.push(item);
+
+    await toggleSavedItemSave(item); // unsave
+    await toggleSavedItemSave(item); // re-save, minting a new rkey
+    await toggleSavedItemSave(item); // unsave again — the reader still holds the old rkey
+
+    expect(savesStore.remove).toHaveBeenLastCalledWith('fresh-rkey');
+    expect(saves).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/utils/readerSave.ts
+++ b/frontend/src/lib/utils/readerSave.ts
@@ -1,0 +1,82 @@
+// Save/Unsave for a reader item that *is* a save.
+//
+// A `?read=` restore resolves saves first (`readerLink.ts`), so an article you
+// saved on `/feeds` — or a linkblog post you saved — comes back typed `'saved'`
+// rather than `'article'`/`'document'` whenever the URL is what opened it: a
+// reload, a Forward-reopen, a link from another device. The reader's Save
+// control has to keep working on those surfaces, and the save row is the only
+// handle it has, so it acts on the save directly instead of on the feed article
+// or document behind it.
+//
+// Identity is the save's guid or URL, never its display key: that key is usually
+// the save's `at://` record uri (`savedItemDisplayKey`), which the store's
+// lookup maps don't index — asking `savesStore.isSaved` about it answers "not
+// saved" for an item that plainly is.
+import { savesStore } from '$lib/stores/saves.svelte';
+import type { SavedItem } from '$lib/types';
+
+/**
+ * The live row for `save`, or undefined once it's been unsaved. Reactive: it
+ * reads the store's lookup maps, which are rebuilt on every mutation.
+ */
+function liveSave(save: SavedItem): SavedItem | undefined {
+  const byGuid = save.itemGuid ? savesStore.getByGuid(save.itemGuid) : undefined;
+  return byGuid ?? (save.url ? savesStore.getByUrl(save.url) : undefined);
+}
+
+/** Whether a `'saved'` reader item is still saved — the reader's button label. */
+export function isSavedItemSaved(save: SavedItem): boolean {
+  return liveSave(save) !== undefined;
+}
+
+// The body of the last save unsaved through here. A document save stores its
+// rendered body and has no URL to re-extract from, so undoing a mis-tapped
+// Unsave would otherwise bring the item back empty. One slot: only the undo of
+// the thing you just did needs it.
+let lastUnsavedBody: { guid: string; content: string | null } | null = null;
+
+/**
+ * Toggle the save behind a `'saved'` reader item. Unsaves the *live* row rather
+ * than the one the reader is holding, so a save → unsave → save round trip in a
+ * single reading session still removes the right record (re-saving mints a new
+ * rkey, and the reader's copy keeps the old one).
+ */
+export async function toggleSavedItemSave(save: SavedItem): Promise<void> {
+  const live = liveSave(save);
+  if (live) {
+    const guid = live.itemGuid || live.url;
+    const content = live.source === 'document' ? await savesStore.getContent(live.rkey) : null;
+    await savesStore.remove(live.rkey);
+    lastUnsavedBody = { guid, content };
+    return;
+  }
+
+  // A standard.site document renders from its record, not from URL extraction —
+  // re-save it as one, under the record uri its guid already is.
+  if (save.source === 'document' && save.itemGuid) {
+    const guid = save.itemGuid;
+    await savesStore.saveDocument({
+      recordUri: guid,
+      url: save.url,
+      title: save.title ?? undefined,
+      description: save.description ?? undefined,
+      publishedAt: save.publishedAt ?? undefined,
+      content:
+        save.content ??
+        (lastUnsavedBody?.guid === guid ? (lastUnsavedBody.content ?? undefined) : undefined),
+    });
+    return;
+  }
+
+  await savesStore.saveArticle({
+    url: save.url,
+    // Re-save under the same guid the original carried, so the feed article it
+    // came from lights up as saved again (the list matches on guid).
+    guid: save.itemGuid || save.url,
+    title: save.title ?? undefined,
+    author: save.author ?? undefined,
+    summary: save.description ?? undefined,
+    imageUrl: save.image ?? undefined,
+    publishedAt: save.publishedAt ?? undefined,
+  });
+}

--- a/frontend/src/lib/utils/urlFilters.test.ts
+++ b/frontend/src/lib/utils/urlFilters.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { sameUrlFilters, type UrlFilters } from './urlFilters';
+
+const base: UrlFilters = {
+  feed: null,
+  saved: 'true',
+  sharer: null,
+  following: null,
+  feeds: null,
+  contentType: null,
+  view: null,
+  category: null,
+};
+
+describe('sameUrlFilters', () => {
+  it('sees an added ?read= as no view change (the reader must not reset the list)', () => {
+    // The reader adds `read` to the URL; setFilters gets the same filter set back.
+    expect(sameUrlFilters(base, { ...base })).toBe(true);
+  });
+
+  it('treats an absent optional field as null', () => {
+    const withoutOptionals: UrlFilters = {
+      feed: null,
+      saved: 'true',
+      sharer: null,
+      following: null,
+      feeds: null,
+    };
+    expect(sameUrlFilters(withoutOptionals, base)).toBe(true);
+    expect(sameUrlFilters(base, withoutOptionals)).toBe(true);
+  });
+
+  it('detects every filter that does move the view', () => {
+    const changes: Partial<UrlFilters>[] = [
+      { feed: '12' },
+      { saved: null },
+      { sharer: 'did:plc:someone' },
+      { following: 'true' },
+      { feeds: '1,2' },
+      { contentType: 'documents' },
+      { view: 'channel-uuid' },
+      { category: 'News' },
+    ];
+    for (const change of changes) {
+      expect(sameUrlFilters({ ...base, ...change }, base)).toBe(false);
+    }
+  });
+});

--- a/frontend/src/lib/utils/urlFilters.ts
+++ b/frontend/src/lib/utils/urlFilters.ts
@@ -1,0 +1,34 @@
+// The set of feed filters that live in the URL, and the comparison that decides
+// whether an incoming URL actually moves the view.
+//
+// `feedViewStore.setFilters` runs on *every* URL change while FeedPage is mounted
+// and unconditionally resets pagination, toolbar state and the saved search. The
+// reader now writes `?read=` into the same URL (see `readerLink.ts`), so a URL
+// change no longer implies a view change: without this comparison, opening an
+// article would truncate the list back to one page under the open reader and
+// corrupt the scroll position restored on close.
+
+export interface UrlFilters {
+  feed: string | null;
+  saved: string | null;
+  sharer: string | null;
+  following: string | null;
+  feeds: string | null;
+  contentType?: 'documents' | null;
+  view?: string | null;
+  category?: string | null;
+}
+
+/** True when both filter sets select the same view (absent and null are equal). */
+export function sameUrlFilters(a: UrlFilters, b: UrlFilters): boolean {
+  return (
+    a.feed === b.feed &&
+    a.saved === b.saved &&
+    a.sharer === b.sharer &&
+    a.following === b.following &&
+    a.feeds === b.feeds &&
+    (a.contentType ?? null) === (b.contentType ?? null) &&
+    (a.view ?? null) === (b.view ?? null) &&
+    (a.category ?? null) === (b.category ?? null)
+  );
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -21,6 +21,11 @@
     saved: '/saved',
   };
 
+  // Every branch below carries the remaining params through, which is what keeps
+  // an old link that also names an open article (`?saved=true&read=…`) working:
+  // `read` must survive to the new surface for the reader to restore there. The
+  // bare-`?view=` channel branch is the one that drops params, and it only fires
+  // when `view` is the *only* one — `?view=…&read=…` falls to the generic branch.
   function targetFor(url: URL): string {
     const sp = new URLSearchParams(url.search);
     if (sp.get('saved')) {


### PR DESCRIPTION
Puts the open article in the URL so navigation and linking work: every reader level is now shallow-routed as `?read=<item key>` on top of whatever surface it was opened from (`/feeds`, `/saved`, `/home`, `/linkblog`, `/highlights`, channel views). Reloading while reading reopens the article, a reading session can be linked or bookmarked, and Forward reopens what Back closed — while the reader stays an overlay stack (the list underneath never unmounts, and still gets its scroll position back on close).

Implements [Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-dyodc4lw4b6um4u7ergehzyy).

## What changed

- **`frontend/src/lib/utils/readerLink.ts`** (new) — the URL shape (`readerUrl`) and key resolution: saves first (matching `uri`/`itemGuid`/`rkey`, so a link written under a stale alias still opens, and re-keyed to the current one), then feed articles by guid, then loaded documents, with an `at://` network fallback so a shared document link opens for a recipient who never loaded it. Deliberately bypasses `feedViewStore.currentItems`, which is filter- and page-dependent.
- **`useReaderStack`** — writes the URL on open (`pushState(url, {readerDepth})`), restores from it on a cold load and on Forward-reopen, and on a terminal miss toasts "Article unavailable" and strips the param. A cold load first rewrites the current entry to the bare list URL, so the single close path (`history.back()`) still lands on the container list. It reads the **live location**, not `page.url`: SvelteKit's shallow `pushState` doesn't update `page.url`, and a pop back to a rewritten entry restores a `page.url` still carrying the param the address bar no longer shows — reading it there would reopen a reader the user just closed.
- **`feedViewStore.setFilters`** — no-ops when the incoming filter set matches current state (`urlFilters.ts`), so the reader's own URL write can no longer reset pagination/toolbar state and corrupt the scroll restore. This also hardens the pre-existing `?feed=` canonicalization `goto`.
- **`/highlights`** — drops its hand-rolled `readerOpen` page state for the shared stack (and `readerOpen` leaves `app.d.ts`).
- **Polish** — the tab title names the open article while it's up (a `viewTitleStore` override, so the host page's own title effect can't clobber it mid-read), and the reader's ⋯ menu gains **Copy link**.
- **Docs** — the `?read=` contract in `frontend/CLAUDE.md`'s routes section, plus the comment blocks in `useReaderStack` / `readerLink`.

## Checks

- `npm run check` (frontend): 0 errors, prettier clean.
- `npx vitest run --project unit`: 30 files / 445 tests pass, including new units for `readerLink` (resolution order, save aliases, `at://` fallback, not-found) and `sameUrlFilters`.
- **Not run here:** the new Playwright specs (`e2e/reader-url.spec.ts` — open→URL→reload, Back/Forward, deep link + synthesized base entry, unknown key, params preserved, scroll restore) and the new offline assertion in `e2e-pwa/offline.spec.ts`. This container has no browser and can't install one (`headless_shell` needs `libglib-2.0`, no root); the dev servers start, the browser does not. They need a CI run.

## Risks

- The history bookkeeping (base-entry synthesis, Forward-reopen) was reasoned against SvelteKit 2.70's client source rather than exercised in a browser here — the E2E specs above are the check that matters.
- `setFilters` no longer resets toolbar filters when you re-select the surface you're already on. That's the intended trade for a stable list under the reader.
- A surface that renders an empty state instead of its list (e.g. `/feeds` with no items) never mounts a reader stack, so a `?read=` link there is inert rather than toasting. `/saved`, `/home` and `/highlights` mount unconditionally.
- The Reader FDR's "overlay stack, not a route" bullet now needs a revision through the artifact process; only the in-repo comments were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-ups (round 2)

Addresses the five findings on the first round. See [Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-d6nsw63qlqgaowngbsrjckvx).

- **Cold-load restore gave up before the refresh that supplies the item.** `appManager.isInitialized` is already true throughout `phase === 'refreshing'` — the exact window in which the backend sync fills `articlesStore`. A `?read=` link to a feed article on a device with a cold or evicted cache was latched as unresolvable seconds before its item arrived. The give-up now waits for `phase` to reach `ready` (or `error`); store resolution still runs on every tick, so a hydrating device opens as soon as the item lands.
- **A restored save silently killed the reader's Save control.** Resolution matches saves first, so an article you saved comes back typed `'saved'` when a URL is what opened it; `handleReaderSave` in `FeedListView`/`LinkblogListView` only branched on `'article'`/`'document'`. New `frontend/src/lib/utils/readerSave.ts` is the shared `'saved'` branch: identity by the save's guid/url rather than its display key (usually the save's `at://` record uri, which the store indexes under neither — so the label read "Save" for something plainly saved), unsave targets the *live* row rather than the stale rkey the reader holds, and a document save is re-saved as a document with its body carried across the round trip. Unit-tested (`readerSave.test.ts`).
- **A `?read=` link was inert on a surface that renders an empty state.** `FeedPage` now renders its list — not the empty state — while a `read` param is present, so the link reaches a reader stack. The hook either opens the article or toasts and strips the param, which brings the empty state back.
- **The `setFilters` no-op trade is now documented** as a deliberate call, in the store and in `frontend/CLAUDE.md`: re-selecting the channel you are already in no longer re-applies its persisted toolbar configuration (leaving and coming back still does).
- **Doc drift (unchanged):** the Reader FDR's "overlay stack, not a route" bullet still needs a revision through the artifact process; the repo-side docs are current.

Checks: `npm run check` 0 errors + prettier clean, `vitest` unit 466 / component 52 pass, `npm run build` succeeds. Two new Playwright specs cover the empty-surface link and the restored-save Save control; as before, no browser can run here (`headless_shell` needs `libglib-2.0`, no root), so the E2E suite still needs a CI run.



---

## CI fix

The E2E job failed on `e2e/reader-url.spec.ts:132` — a Playwright strict-mode violation, not a product bug. The reader overlay mounts both chromes (desktop header action row, mobile bottom bar) and hides the one the viewport isn't using, so `.reader-overlay` scoped to `title="Unsave"` resolved to two buttons. The spec now matches the control the reader is actually showing. See [Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-zo3w6pefudx5p7mhaejlyj2o).

Also, the behavior the earlier round could not verify here is now verified: the full Playwright suite ran locally (chromium installed by hand against the sandbox's read-only root), `e2e/reader-url.spec.ts` passes 8/8, including the restored-save Save control round trip.
