### PR TITLE
Move community highlights toggle to settings

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -45,6 +45,20 @@ test.describe('Settings', () => {
     await expect(readout).toHaveText(`${before + 2}px`);
   });
 
+  test('community highlights are enabled by default and can be turned off', async ({
+    authedPage,
+  }) => {
+    await authedPage.goto('/settings');
+    const toggle = authedPage.getByRole('checkbox', { name: 'Show community highlights' });
+
+    await expect(toggle).toBeChecked();
+    await toggle.uncheck();
+    await expect(toggle).not.toBeChecked();
+
+    await authedPage.reload();
+    await expect(toggle).not.toBeChecked();
+  });
+
   test('logout shows confirm dialog', async ({ authedPage }) => {
     await authedPage.goto('/settings');
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -59,6 +59,23 @@ test.describe('Settings', () => {
     await expect(toggle).not.toBeChecked();
   });
 
+  test('migrates the former implicit community highlights default to on', async ({
+    authedPage,
+  }) => {
+    await authedPage.goto('/settings');
+    await authedPage.evaluate(() => {
+      localStorage.setItem(
+        'skyreader-preferences',
+        JSON.stringify({ communityHighlights: false, articleFont: 'serif' })
+      );
+    });
+    await authedPage.reload();
+
+    await expect(
+      authedPage.getByRole('checkbox', { name: 'Show community highlights' })
+    ).toBeChecked();
+  });
+
   test('logout shows confirm dialog', async ({ authedPage }) => {
     await authedPage.goto('/settings');
 

--- a/frontend/src/lib/components/feed/ReaderBottomBar.svelte
+++ b/frontend/src/lib/components/feed/ReaderBottomBar.svelte
@@ -34,11 +34,6 @@
     isSaved = false,
     onShare,
     shareActive = false,
-    onCommunity,
-    communityCount,
-    communityCapped = false,
-    communityActive = false,
-    communityButtonEl = $bindable(null),
     onTag,
     tagCount = 0,
     tagActive = false,
@@ -61,13 +56,6 @@
     onShare?: () => void;
     /** The item is already shared to the linkblog. */
     shareActive?: boolean;
-    /** Toggle passages highlighted by other readers on Margin. */
-    onCommunity?: () => void;
-    /** Number of fetched community highlights; undefined while loading. */
-    communityCount?: number;
-    communityCapped?: boolean;
-    communityActive?: boolean;
-    communityButtonEl?: HTMLButtonElement | null;
     onTag?: () => void;
     tagCount?: number;
     tagActive?: boolean;
@@ -143,25 +131,6 @@
         title={shareActive ? 'Shared — edit your note' : 'Share to your linkblog'}
       >
         <Icon name="share" size={20} />
-      </button>
-    {/if}
-
-    {#if onCommunity}
-      <button
-        class="bar-btn"
-        class:active={communityActive}
-        bind:this={communityButtonEl}
-        onclick={onCommunity}
-        aria-pressed={communityActive}
-        aria-label={communityCount === undefined
-          ? 'Community highlights'
-          : `${communityCount}${communityCapped ? ' or more' : ''} community highlight${communityCount === 1 ? '' : 's'}`}
-        title="Passages highlighted by readers on margin.at"
-      >
-        <Icon name="users" size={20} />
-        {#if communityCount !== undefined}
-          <span class="bar-btn-count">{communityCount}{communityCapped ? '+' : ''}</span>
-        {/if}
       </button>
     {/if}
 

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -750,7 +750,6 @@
     contentEl: () => readerBodyEl,
     itemUrl: () => itemUrl,
     enabled: () => readerItem.type === 'saved' && preferences.communityHighlights,
-    load: () => readerItem.type === 'saved',
   });
 
   // Set up observer when the reader body is mounted — and re-run it whenever the

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -99,15 +99,8 @@
   let tagMenuOpen = $state(false);
   let overflowMenuOpen = $state(false);
   let overflowRef = $state<HTMLDivElement | null>(null);
-  // The mobile Tag popover normally anchors to its bottom-bar button. Saved
-  // articles use that slot for Community instead, so Tag (reached from the
-  // actions sheet) anchors to that stable slot after the sheet closes.
   let tagBtnRef = $state<HTMLButtonElement | null>(null);
   let mobileTagBtnRef = $state<HTMLButtonElement | null>(null);
-  let mobileCommunityBtnRef = $state<HTMLButtonElement | null>(null);
-  let mobileTagAnchorRef = $derived(
-    readerItem.type === 'saved' ? mobileCommunityBtnRef : mobileTagBtnRef
-  );
   let controlsVisible = $state(true);
   // Desktop header hides on scroll-down, but stays put while a header-anchored
   // menu (Style/Tag/overflow ⋯) is open so its popover doesn't slide off-screen.
@@ -760,11 +753,6 @@
     load: () => readerItem.type === 'saved',
   });
 
-  function toggleCommunityHighlights() {
-    if (!preferences.communityHighlights) communityHighlightsHook.retry();
-    preferences.setCommunityHighlights(!preferences.communityHighlights);
-  }
-
   // Set up observer when the reader body is mounted — and re-run it whenever the
   // rendered content changes. Saved/article bodies load lazily (see the lazy*
   // effects above), so the first frame shows only the short description fallback;
@@ -908,27 +896,6 @@
 
         <span class="action-separator"></span>
 
-        {#if readerItem.type === 'saved'}
-          <button
-            class="action-btn"
-            class:active={preferences.communityHighlights}
-            aria-pressed={preferences.communityHighlights}
-            aria-label={communityHighlightsHook.count === undefined
-              ? 'Community highlights'
-              : `${communityHighlightsHook.count}${communityHighlightsHook.capped ? ' or more' : ''} community highlight${communityHighlightsHook.count === 1 ? '' : 's'}`}
-            onclick={toggleCommunityHighlights}
-            title="Passages highlighted by readers on margin.at"
-          >
-            <Icon name="users" size={16} />
-            <span class="action-label">Community</span>
-            {#if communityHighlightsHook.count !== undefined}
-              <span class="action-count">
-                ({communityHighlightsHook.count}{communityHighlightsHook.capped ? '+' : ''})
-              </span>
-            {/if}
-          </button>
-        {/if}
-
         {#if canShareLinkblog}
           <button
             class="action-btn"
@@ -1030,12 +997,7 @@
     {isSaved}
     onShare={canShareLinkblog ? openShareComposer : undefined}
     shareActive={sharedNow}
-    onCommunity={readerItem.type === 'saved' ? toggleCommunityHighlights : undefined}
-    communityCount={communityHighlightsHook.count}
-    communityCapped={communityHighlightsHook.capped}
-    communityActive={preferences.communityHighlights}
-    bind:communityButtonEl={mobileCommunityBtnRef}
-    onTag={readerItem.type !== 'saved' ? () => (tagMenuOpen = !tagMenuOpen) : undefined}
+    onTag={() => (tagMenuOpen = !tagMenuOpen)}
     tagCount={itemTags.length}
     tagActive={tagMenuOpen}
     bind:tagButtonEl={mobileTagBtnRef}
@@ -1155,7 +1117,7 @@
         <TagMenu
           {itemKey}
           itemType={labelItemType}
-          anchorEl={mobileTagAnchorRef}
+          anchorEl={mobileTagBtnRef}
           onClose={() => (tagMenuOpen = false)}
         />
       {/if}
@@ -1577,11 +1539,6 @@
   .action-label {
     font-size: var(--text-sm);
     font-weight: var(--weight-medium);
-  }
-
-  .action-count {
-    font-size: var(--text-sm);
-    font-variant-numeric: tabular-nums;
   }
 
   .action-btn:hover:not(.active) {

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -15,9 +15,7 @@ export function useCommunityHighlights(params: {
   /** Whether community marks should be drawn in the article. */
   enabled: () => boolean;
   /**
-   * Whether to fetch the Margin highlights. This can stay true while drawing is
-   * off so the toolbar can show how many highlights are available before the
-   * reader turns them on.
+   * Whether to fetch the Margin highlights independently of drawing them.
    */
   load?: () => boolean;
 }) {

--- a/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
+++ b/frontend/src/lib/hooks/useCommunityHighlights.svelte.ts
@@ -14,10 +14,6 @@ export function useCommunityHighlights(params: {
   itemUrl: () => string;
   /** Whether community marks should be drawn in the article. */
   enabled: () => boolean;
-  /**
-   * Whether to fetch the Margin highlights independently of drawing them.
-   */
-  load?: () => boolean;
 }) {
   let marks: HTMLElement[] = [];
   let noteMarkers: HTMLElement[] = [];
@@ -30,12 +26,11 @@ export function useCommunityHighlights(params: {
   $effect(() => {
     const url = params.itemUrl();
     const enabled = params.enabled();
-    const shouldLoad = params.load?.() ?? enabled;
     const state = communityHighlightsStore.get(url);
-    if (shouldLoad && url && (!state || (!wasLoadEnabled && state.failed))) {
+    if (enabled && url && (!state || (!wasLoadEnabled && state.failed))) {
       communityHighlightsStore.load(url, { force: state?.failed });
     }
-    wasLoadEnabled = shouldLoad;
+    wasLoadEnabled = enabled;
     // Reading groups here makes the decoration react when the lazy request
     // settles. Defer until Svelte has committed the current article body.
     void state?.groups;
@@ -161,12 +156,6 @@ export function useCommunityHighlights(params: {
     get capped() {
       return communityHighlightsStore.get(params.itemUrl())?.capped ?? false;
     },
-    get count(): number | undefined {
-      const state = communityHighlightsStore.get(params.itemUrl());
-      if (!state?.loaded) return undefined;
-      return state.groups.reduce((total, group) => total + group.people.length, 0);
-    },
     closePopover: () => (popoverState = null),
-    retry: () => communityHighlightsStore.load(params.itemUrl(), { force: true }),
   };
 }

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -99,7 +99,7 @@ function createPreferencesStore() {
     cardDensity: 'cozy',
     dailyMagazineMinutes: 20,
     dailyMagazineOrder: 'shuffle',
-    communityHighlights: false,
+    communityHighlights: true,
   });
 
   // Restore from localStorage on init

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -75,6 +75,9 @@ interface PreferencesState {
   dailyMagazineMinutes: DailyMagazineMinutes;
   dailyMagazineOrder: DailyMagazineOrder;
   communityHighlights: boolean;
+  // Distinguishes an explicit opt-out from the former default-off value that
+  // was written whenever any preference was saved.
+  communityHighlightsConfigured: boolean;
 }
 
 const STORAGE_KEY = 'skyreader-preferences';
@@ -100,6 +103,7 @@ function createPreferencesStore() {
     dailyMagazineMinutes: 20,
     dailyMagazineOrder: 'shuffle',
     communityHighlights: true,
+    communityHighlightsConfigured: false,
   });
 
   // Restore from localStorage on init
@@ -154,8 +158,13 @@ function createPreferencesStore() {
         if (DAILY_MAGAZINE_ORDER_OPTIONS.some((o) => o.value === parsed.dailyMagazineOrder)) {
           state.dailyMagazineOrder = parsed.dailyMagazineOrder;
         }
-        if (typeof parsed.communityHighlights === 'boolean')
+        if (
+          parsed.communityHighlightsConfigured === true &&
+          typeof parsed.communityHighlights === 'boolean'
+        ) {
           state.communityHighlights = parsed.communityHighlights;
+          state.communityHighlightsConfigured = true;
+        }
       } catch {
         localStorage.removeItem(STORAGE_KEY);
       }
@@ -268,6 +277,7 @@ function createPreferencesStore() {
   }
   function setCommunityHighlights(enabled: boolean) {
     state.communityHighlights = enabled;
+    state.communityHighlightsConfigured = true;
     save();
   }
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -867,6 +867,17 @@
     <p class="setting-description">
       Automatically mark articles as read when you scroll past them in the feed.
     </p>
+    <label class="toggle-setting">
+      <input
+        type="checkbox"
+        checked={preferences.communityHighlights}
+        onchange={(e) => preferences.setCommunityHighlights(e.currentTarget.checked)}
+      />
+      <span>Show community highlights</span>
+    </label>
+    <p class="setting-description">
+      Show passages highlighted by other readers on Margin while reading saved articles.
+    </p>
   </section>
 
   <section class="card">


### PR DESCRIPTION
Moves the community-highlights preference out of reader chrome and into Reading settings. Community highlights default on, while explicit opt-outs persist and suppress Margin requests.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-qk6ksxn4bzrzutl3rsjxrloq)

Checks:
- npm run check (0 errors; 20 existing warnings)
- npm run test (35 files, 494 tests)
- Focused Playwright coverage added; local execution unavailable because Bun is not installed.