### PR TITLE
Preserve Bluesky handles in discussion notes

### DIFF
--- a/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
+++ b/frontend/src/lib/components/feed/AtmospherePanel.component.test.ts
@@ -507,6 +507,14 @@ describe('AtmospherePanel entry engagement', () => {
       '2 likes',
     ]);
   });
+
+  it('renders dotted handles in Bluesky post text verbatim', () => {
+    const post = entry('did:plc:handles', null);
+    post.cleanNote = 'Fascinating that @alice.example.com and @bob.example.com published this';
+    const target = render({ stream: { loading: false, entries: [post] } });
+
+    expect(target.querySelector('.entry-note')?.textContent).toBe(post.cleanNote);
+  });
 });
 
 // Three different kinds of thing had piled up in one column with no boundary

--- a/frontend/src/lib/utils/discussionNote.test.ts
+++ b/frontend/src/lib/utils/discussionNote.test.ts
@@ -103,6 +103,33 @@ describe('cleanDiscussionNote', () => {
     ).toBe('Some weekend thoughts on how LLMs change the way we start new projects.');
   });
 
+  it('keeps dotted Bluesky handles while stripping an article URL', () => {
+    expect(
+      cleanDiscussionNote(
+        'Fascinating that @alice.example.com and @bob.example.com published these thoughts https://example.com/article',
+        TITLE
+      )
+    ).toBe('Fascinating that @alice.example.com and @bob.example.com published these thoughts');
+  });
+
+  it('keeps dotted handles at the edges of a note', () => {
+    expect(cleanDiscussionNote('@alice.example.com said it first', TITLE)).toBe(
+      '@alice.example.com said it first'
+    );
+    expect(cleanDiscussionNote('Credit to @bob.example.com', TITLE)).toBe(
+      'Credit to @bob.example.com'
+    );
+  });
+
+  it('still strips bare and truncated URLs beside a handle', () => {
+    expect(
+      cleanDiscussionNote(
+        '@alice.example.com shared example.com/story and example.org/another…',
+        TITLE
+      )
+    ).toBe('@alice.example.com shared and');
+  });
+
   it('strips the publication name as well as the headline', () => {
     // The real case: a bridge leads with the FEED title, not the article's.
     expect(

--- a/frontend/src/lib/utils/discussionNote.ts
+++ b/frontend/src/lib/utils/discussionNote.ts
@@ -152,6 +152,15 @@ function looksLikeLink(match: string): boolean {
   return LINK_TLDS.has(tld);
 }
 
+// A Bluesky handle is domain-shaped, but it is prose rather than a display URL.
+// Check the source boundary for the whole regex match so the matcher cannot
+// consume either the full handle or a suffix of it after starting past `@`.
+function belongsToMentionToken(source: string, offset: number): boolean {
+  let cursor = offset - 1;
+  while (cursor >= 0 && /[a-z0-9.-]/i.test(source[cursor])) cursor -= 1;
+  return cursor >= 0 && source[cursor] === '@';
+}
+
 // The words that remain once a leading run matching `key` is consumed, or null
 // when the text doesn't open with that title. Matching walks the ORIGINAL words
 // and compares their normalized form, so a title whose punctuation splits into a
@@ -254,7 +263,9 @@ function cleanPass(
   const replacement = gated ? ` ${BOUNDARY} ` : ' ';
   let text = note
     .replace(URL_PATTERN, replacement)
-    .replace(BARE_URL_PATTERN, (match) => (looksLikeLink(match) ? replacement : match));
+    .replace(BARE_URL_PATTERN, (match, offset, source) =>
+      belongsToMentionToken(source, offset) || !looksLikeLink(match) ? match : replacement
+    );
   if (gated) text = text.replace(/[\r\n]+/g, replacement);
 
   for (const title of titles) {


### PR DESCRIPTION
Preserves dotted @handles in Bluesky discussion notes while continuing to remove genuine bare and full URLs.

Adds sanitizer boundary coverage and a mounted AtmospherePanel rendering regression.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-spg2usrunyd3ign3yygemvc6)