### PR TITLE
Window the Discover view with stable filter controls

### DIFF
--- a/frontend/src/lib/components/DiscoveryToolbar.svelte
+++ b/frontend/src/lib/components/DiscoveryToolbar.svelte
@@ -31,11 +31,10 @@
 
 <style>
   .discovery-toolbar {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: space-between;
     gap: 0.75rem;
-    flex-wrap: wrap;
     margin-bottom: 0.25rem;
   }
 
@@ -48,6 +47,7 @@
   .controls {
     display: flex;
     align-items: center;
+    justify-self: end;
     gap: 0.75rem;
     flex-wrap: wrap;
   }
@@ -105,8 +105,13 @@
   }
 
   @media (max-width: 520px) {
+    .discovery-toolbar {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
     .controls {
       width: 100%;
+      justify-self: stretch;
     }
 
     .search {

--- a/frontend/src/lib/components/DiscoveryToolbar.svelte
+++ b/frontend/src/lib/components/DiscoveryToolbar.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    /** Free-text filter, owned by the parent so it can drive its own predicates. */
+    query: string;
+    /** "Hide added": drop rows the user already subscribes to. Off by default. */
+    hideAdded: boolean;
+    /** Placeholder + aria-label for the search input. */
+    searchLabel: string;
+    /** The count line — each surface phrases its own totals. */
+    count: Snippet;
+  }
+  let { query = $bindable(''), hideAdded = $bindable(false), searchLabel, count }: Props = $props();
+</script>
+
+<div class="discovery-toolbar">
+  <p class="count">{@render count()}</p>
+  <div class="controls">
+    <label class="hide-added">
+      <input type="checkbox" bind:checked={hideAdded} />
+      Hide added
+    </label>
+    <div class="search">
+      <Icon name="search" size={15} />
+      <input type="search" placeholder={searchLabel} aria-label={searchLabel} bind:value={query} />
+    </div>
+  </div>
+</div>
+
+<style>
+  .discovery-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.25rem;
+  }
+
+  .count {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .hide-added {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .hide-added:hover {
+    color: var(--color-text);
+  }
+
+  .hide-added input {
+    margin: 0;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+
+  .search {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    color: var(--color-text-secondary);
+    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md, 6px);
+    transition: border-color 0.15s;
+  }
+
+  .search:focus-within {
+    border-color: var(--color-primary);
+  }
+
+  .search input {
+    width: 14rem;
+    max-width: 100%;
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: transparent;
+    border: none;
+    outline: none;
+    padding: 0;
+  }
+
+  .search input::placeholder {
+    color: var(--color-text-secondary);
+  }
+
+  @media (max-width: 520px) {
+    .controls {
+      width: 100%;
+    }
+
+    .search {
+      flex: 1;
+    }
+
+    .search input {
+      width: 100%;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/DiscoveryToolbar.svelte
+++ b/frontend/src/lib/components/DiscoveryToolbar.svelte
@@ -116,5 +116,9 @@
     .search input {
       width: 100%;
     }
+
+    .hide-added {
+      min-height: 44px;
+    }
   }
 </style>

--- a/frontend/src/lib/components/FollowingPublications.component.test.ts
+++ b/frontend/src/lib/components/FollowingPublications.component.test.ts
@@ -1,0 +1,178 @@
+// Mounted component test (jsdom) — see the "component" project in vitest.config.ts.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { FollowingPublication } from '$lib/types';
+import FollowingPublications from './FollowingPublications.svelte';
+
+const store = {
+  publications: [] as FollowingPublication[],
+  loaded: true,
+  loading: false,
+  scanning: false,
+  error: null,
+  hiddenAccounts: [] as Array<Record<string, unknown>>,
+  load: vi.fn(),
+  subscribe: vi.fn(),
+  hide: vi.fn(),
+  unhide: vi.fn(),
+};
+
+const subs = { subscriptions: [] as Array<Record<string, unknown>> };
+
+vi.mock('$lib/stores/followingPublications.svelte', () => ({
+  get followingPublicationsStore() {
+    return store;
+  },
+}));
+
+vi.mock('$lib/stores/subscriptions.svelte', () => ({
+  get subscriptionsStore() {
+    return subs;
+  },
+}));
+
+// One publication per account, so account groups and publication rows count 1:1
+// except where a test says otherwise.
+function pub(i: number): FollowingPublication {
+  return {
+    did: `did:plc:acct${i}`,
+    handle: `acct${i}.bsky.social`,
+    displayName: `Account ${i}`,
+    publicationUri: `at://did:plc:acct${i}/site.standard.publication/pub`,
+    name: `Publication ${i}`,
+    description: `About publication ${i}`,
+    url: `https://pub${i}.example.com`,
+  };
+}
+
+let component: Record<string, any> | undefined;
+let target: HTMLElement;
+
+function render(props: Record<string, unknown> = {}) {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(FollowingPublications, { target, props });
+  flushSync();
+}
+
+function accounts(): HTMLElement[] {
+  return [...target.querySelectorAll<HTMLElement>('.account')];
+}
+
+function showMore(): HTMLButtonElement[] {
+  return [...target.querySelectorAll<HTMLButtonElement>('.show-more')];
+}
+
+function countText(): string {
+  return target.querySelector('.count')!.textContent!.replace(/\s+/g, ' ').trim();
+}
+
+function type(value: string) {
+  const input = target.querySelector<HTMLInputElement>('input[type="search"]')!;
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+describe('FollowingPublications full variant windowing', () => {
+  beforeEach(() => {
+    store.publications = Array.from({ length: 30 }, (_, i) => pub(i));
+    store.hiddenAccounts = [];
+    store.scanning = false;
+    subs.subscriptions = [];
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('caps the list at 10 account groups and reveals the rest on Show more', () => {
+    render();
+    expect(accounts()).toHaveLength(10);
+    expect(showMore()[0].textContent).toContain('Show 20 more');
+
+    showMore()[0].click();
+    flushSync();
+    expect(accounts()).toHaveLength(30);
+    expect(showMore()).toHaveLength(0);
+  });
+
+  it('keeps the count line reporting what the scan found, not what is on screen', () => {
+    render();
+    expect(countText()).toContain('30 publications from 30 accounts you follow');
+  });
+
+  it('filters on search and resets the window so late matches are visible', () => {
+    render();
+    // "Publication 29" is the last group, far past the initial window.
+    type('Publication 29');
+    expect(accounts()).toHaveLength(1);
+    expect(showMore()).toHaveLength(0);
+    expect(target.textContent).toContain('Publication 29');
+    expect(countText()).toContain('1 of 30 accounts');
+
+    type('');
+    expect(accounts()).toHaveLength(10);
+  });
+
+  it('re-caps the window when the query changes after an expansion', () => {
+    render();
+    showMore()[0].click();
+    flushSync();
+    expect(accounts()).toHaveLength(30);
+
+    type('Account');
+    expect(accounts()).toHaveLength(10);
+    expect(showMore()[0].textContent).toContain('Show 20 more');
+  });
+
+  it('reports no matches for a query that hits nothing', () => {
+    render();
+    type('nothing here');
+    expect(accounts()).toHaveLength(0);
+    expect(target.textContent).toContain('No publications match');
+  });
+
+  it('drops already-added accounts when Hide added is on, and resets the window', () => {
+    subs.subscriptions = store.publications
+      .slice(0, 8)
+      .map((p) => ({ sourceType: 'atproto.documents', feedUrl: p.publicationUri }));
+    render();
+    showMore()[0].click();
+    flushSync();
+    expect(accounts()).toHaveLength(30);
+
+    const toggle = target.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    toggle.click();
+    flushSync();
+    // 22 accounts left, re-windowed to 10.
+    expect(accounts()).toHaveLength(10);
+    expect(showMore()[0].textContent).toContain('Show 12 more');
+    expect(countText()).toContain('22 of 30 accounts');
+  });
+});
+
+describe('FollowingPublications suggestions variant', () => {
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('still honours the limit, with no toolbar or Show more', () => {
+    store.publications = Array.from({ length: 30 }, (_, i) => pub(i));
+    subs.subscriptions = [];
+    render({
+      variant: 'suggestions',
+      limit: 3,
+      heading: 'Publications from people you follow',
+    });
+
+    expect(target.querySelectorAll('.suggestion')).toHaveLength(3);
+    expect(accounts()).toHaveLength(0);
+    expect(showMore()).toHaveLength(0);
+    expect(target.querySelector('.discovery-toolbar')).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/FollowingPublications.component.test.ts
+++ b/frontend/src/lib/components/FollowingPublications.component.test.ts
@@ -99,6 +99,17 @@ describe('FollowingPublications full variant windowing', () => {
     expect(showMore()).toHaveLength(0);
   });
 
+  it('labels each click with no more than the 25 groups it will reveal', () => {
+    store.publications = Array.from({ length: 100 }, (_, i) => pub(i));
+    render();
+
+    expect(showMore()[0].textContent).toContain('Show 25 more');
+    showMore()[0].click();
+    flushSync();
+    expect(accounts()).toHaveLength(35);
+    expect(showMore()[0].textContent).toContain('Show 25 more');
+  });
+
   it('keeps the count line reporting what the scan found, not what is on screen', () => {
     render();
     expect(countText()).toContain('30 publications from 30 accounts you follow');

--- a/frontend/src/lib/components/FollowingPublications.svelte
+++ b/frontend/src/lib/components/FollowingPublications.svelte
@@ -4,7 +4,14 @@
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import type { FollowingPublication } from '$lib/types';
   import { safeHref } from '$lib/utils/sanitize';
+  import DiscoveryToolbar from './DiscoveryToolbar.svelte';
   import Icon from './Icon.svelte';
+  import ShowMoreButton from './ShowMoreButton.svelte';
+
+  // The scan keeps appending accounts for minutes on a large follow graph; the
+  // window is what keeps that out of the DOM until the reader asks for it.
+  const INITIAL_WINDOW = 10;
+  const WINDOW_STEP = 25;
 
   interface Props {
     /**
@@ -67,13 +74,22 @@
     return [...map.values()];
   }
 
-  // Full view: every account, grouped.
-  let groups = $derived(groupByAccount(followingPublicationsStore.publications, false));
-
-  // Full-view counts (total scanned so far) and free-text filter.
-  let pubCount = $derived(followingPublicationsStore.publications.length);
-  let accountCount = $derived(groups.length);
+  // Full view: every account, grouped. "Hide added" drops publications the user
+  // already subscribes to, then any account left with nothing to offer.
   let query = $state('');
+  let hideAdded = $state(false);
+  let allGroups = $derived(groupByAccount(followingPublicationsStore.publications, false));
+  let groups = $derived(
+    hideAdded
+      ? groupByAccount(followingPublicationsStore.publications, true).filter(
+          (g) => g.publications.length > 0
+        )
+      : allGroups
+  );
+
+  // Full-view counts — what the scan has found so far, not what's on screen.
+  let pubCount = $derived(followingPublicationsStore.publications.length);
+  let accountCount = $derived(allGroups.length);
 
   // Filter the grouped list by query, matching the account (name/handle) or any
   // of its publications (name/description). An account match keeps all its pubs.
@@ -92,6 +108,21 @@
       if (pubs.length) out.push({ ...g, publications: pubs });
     }
     return out;
+  });
+
+  let filtering = $derived(query.trim().length > 0 || hideAdded);
+
+  // Windowing runs after filtering, so a match beyond the initial window is
+  // never hidden behind an unexpanded list. New accounts from the background
+  // scan append, so they grow the "Show N more" count instead of reshuffling.
+  let visibleAccounts = $state(INITIAL_WINDOW);
+
+  // Reset the window whenever the filter changes — and *only* then. Depending on
+  // the publications array here would collapse an expanded list mid-scan.
+  $effect(() => {
+    void query;
+    void hideAdded;
+    visibleAccounts = INITIAL_WINDOW;
   });
 
   // Suggestions: accounts with at least one not-yet-subscribed publication.
@@ -319,37 +350,39 @@
     {/if}
   {:else if loading && !loaded}
     <p class="status">Looking for publications…</p>
-  {:else if groups.length === 0 && loaded && !scanning}
+  {:else if allGroups.length === 0 && loaded && !scanning}
     <p class="status">No publications found among the people you follow.</p>
-  {:else if groups.length > 0}
-    <div class="discovery-toolbar">
-      <p class="count">
-        {pubCount}
-        {pubCount === 1 ? 'publication' : 'publications'} from {accountCount}
-        {accountCount === 1 ? 'account' : 'accounts'} you follow
+  {:else if allGroups.length > 0}
+    <DiscoveryToolbar bind:query bind:hideAdded searchLabel="Search publications">
+      {#snippet count()}
+        {#if filtering}
+          {filteredGroups.length} of {accountCount}
+          {accountCount === 1 ? 'account' : 'accounts'} you follow
+        {:else}
+          {pubCount}
+          {pubCount === 1 ? 'publication' : 'publications'} from {accountCount}
+          {accountCount === 1 ? 'account' : 'accounts'} you follow
+        {/if}
         {#if scanning}<span class="count-scanning"
             ><span class="spinner dark"></span> finding more…</span
           >{/if}
-      </p>
-      <div class="search">
-        <Icon name="search" size={15} />
-        <input
-          type="search"
-          placeholder="Search publications"
-          aria-label="Search publications"
-          bind:value={query}
-        />
-      </div>
-    </div>
+      {/snippet}
+    </DiscoveryToolbar>
 
     {#if filteredGroups.length > 0}
       <ul class="account-list">
-        {#each filteredGroups as g (g.did)}
+        {#each filteredGroups.slice(0, visibleAccounts) as g (g.did)}
           {@render accountBlock(g, true)}
         {/each}
       </ul>
-    {:else}
+      <ShowMoreButton
+        remaining={filteredGroups.length - visibleAccounts}
+        onclick={() => (visibleAccounts += WINDOW_STEP)}
+      />
+    {:else if query.trim()}
       <p class="status">No publications match “{query.trim()}”.</p>
+    {:else}
+      <p class="status">You've already added every publication here.</p>
     {/if}
   {:else if scanning}
     <p class="status"><span class="spinner dark"></span> Searching the people you follow…</p>
@@ -414,60 +447,6 @@
     font-weight: var(--weight-semibold);
     color: var(--color-text-secondary);
     margin: 0 0 0.375rem;
-  }
-
-  .discovery-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    margin-bottom: 0.25rem;
-  }
-
-  .count {
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-    margin: 0;
-  }
-
-  .search {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.625rem;
-    color: var(--color-text-secondary);
-    background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md, 6px);
-    transition: border-color 0.15s;
-  }
-
-  .search:focus-within {
-    border-color: var(--color-primary);
-  }
-
-  .search input {
-    width: 14rem;
-    max-width: 100%;
-    font: inherit;
-    font-size: var(--text-sm);
-    color: var(--color-text);
-    background: transparent;
-    border: none;
-    outline: none;
-    padding: 0;
-  }
-
-  .search input::placeholder {
-    color: var(--color-text-secondary);
-  }
-
-  @media (max-width: 520px) {
-    .search,
-    .search input {
-      width: 100%;
-    }
   }
 
   .account-list {

--- a/frontend/src/lib/components/FollowingPublications.svelte
+++ b/frontend/src/lib/components/FollowingPublications.svelte
@@ -377,6 +377,7 @@
       </ul>
       <ShowMoreButton
         remaining={filteredGroups.length - visibleAccounts}
+        batchSize={WINDOW_STEP}
         onclick={() => (visibleAccounts += WINDOW_STEP)}
       />
     {:else if query.trim()}

--- a/frontend/src/lib/components/LinkblogDiscovery.component.test.ts
+++ b/frontend/src/lib/components/LinkblogDiscovery.component.test.ts
@@ -1,0 +1,184 @@
+// Mounted component test (jsdom) — see the "component" project in vitest.config.ts.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { LinkblogPerson } from '$lib/types';
+import LinkblogDiscovery from './LinkblogDiscovery.svelte';
+
+const store = {
+  friends: [] as LinkblogPerson[],
+  people: [] as LinkblogPerson[],
+  friendsLoaded: true,
+  peopleLoaded: true,
+  loadingFriends: false,
+  loadingPeople: false,
+  error: null,
+  loadFriends: vi.fn(),
+  loadDiscover: vi.fn(),
+  subscribe: vi.fn(),
+};
+
+const subs = { subscriptions: [] as Array<Record<string, unknown>> };
+
+vi.mock('$lib/stores/linkblogDiscovery.svelte', () => ({
+  get linkblogDiscoveryStore() {
+    return store;
+  },
+}));
+
+vi.mock('$lib/stores/subscriptions.svelte', () => ({
+  get subscriptionsStore() {
+    return subs;
+  },
+}));
+
+function person(i: number, isFollow: boolean): LinkblogPerson {
+  return {
+    did: `did:plc:${isFollow ? 'f' : 'o'}${i}`,
+    handle: `${isFollow ? 'friend' : 'other'}${i}.bsky.social`,
+    displayName: `${isFollow ? 'Friend' : 'Other'} ${i}`,
+    publicationUri: `at://did:plc:${isFollow ? 'f' : 'o'}${i}/site.standard.publication/skyreader-links`,
+    blogUrl: `https://linkblogs.skyreader.app/${i}`,
+    isFollow,
+  };
+}
+
+let component: Record<string, any> | undefined;
+let target: HTMLElement;
+
+function render(props: Record<string, unknown> = { variant: 'full' }) {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(LinkblogDiscovery, { target, props });
+  flushSync();
+}
+
+function rows(): HTMLElement[] {
+  return [...target.querySelectorAll<HTMLElement>('.person')];
+}
+
+function showMore(): HTMLButtonElement[] {
+  return [...target.querySelectorAll<HTMLButtonElement>('.show-more')];
+}
+
+function type(value: string) {
+  const input = target.querySelector<HTMLInputElement>('input[type="search"]')!;
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+describe('LinkblogDiscovery full variant windowing', () => {
+  beforeEach(() => {
+    store.friends = [];
+    // 12 friends + 18 others = 30 people in the registry.
+    store.people = [
+      ...Array.from({ length: 12 }, (_, i) => person(i, true)),
+      ...Array.from({ length: 18 }, (_, i) => person(i, false)),
+    ];
+    subs.subscriptions = [];
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('caps each group at 10 rows and reveals the rest on Show more', () => {
+    render();
+    // 10 of 12 friends + 10 of 18 others.
+    expect(rows()).toHaveLength(20);
+
+    const buttons = showMore();
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].textContent).toContain('Show 2 more');
+    expect(buttons[1].textContent).toContain('Show 8 more');
+
+    // A step of 25 exhausts both groups, so both buttons go away.
+    buttons[0].click();
+    flushSync();
+    buttons[1].click();
+    flushSync();
+    expect(rows()).toHaveLength(30);
+    expect(showMore()).toHaveLength(0);
+  });
+
+  it('filters on search and resets the window so late matches are visible', () => {
+    render();
+    // "Other 17" sits well past the initial window of its group.
+    type('Other 1');
+    expect(rows().map((r) => r.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining('Other 17')])
+    );
+    // Others 1, 10–17 = 9 matches, all within one window; friends drop out.
+    expect(rows()).toHaveLength(9);
+    expect(showMore()).toHaveLength(0);
+
+    type('');
+    expect(rows()).toHaveLength(20);
+  });
+
+  it('re-caps the window when the query changes after an expansion', () => {
+    render();
+    // Expand "More on Skyreader" only: 10 friends + all 18 others.
+    showMore()[1].click();
+    flushSync();
+    expect(rows()).toHaveLength(28);
+
+    type('Other');
+    expect(rows()).toHaveLength(10);
+    expect(showMore()[0].textContent).toContain('Show 8 more');
+  });
+
+  it('reports no matches for a query that hits nothing', () => {
+    render();
+    type('nobody at all');
+    expect(rows()).toHaveLength(0);
+    expect(target.textContent).toContain('No linkblogs match');
+  });
+
+  it('drops already-added rows when Hide added is on', () => {
+    subs.subscriptions = store.people
+      .slice(0, 5)
+      .map((p) => ({ sourceType: 'atproto.documents', feedUrl: p.publicationUri }));
+    render();
+    expect(rows()).toHaveLength(20);
+
+    const toggle = target.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    toggle.click();
+    flushSync();
+    // 7 friends left (5 of 12 hidden) + 10 of 18 others.
+    expect(rows()).toHaveLength(17);
+    expect(showMore()[0].textContent).toContain('Show 8 more');
+  });
+});
+
+describe('LinkblogDiscovery other variants', () => {
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('still honours the suggestions limit, with no toolbar or Show more', () => {
+    store.friends = [];
+    store.people = Array.from({ length: 30 }, (_, i) => person(i, false));
+    subs.subscriptions = [];
+    render({ variant: 'suggestions', limit: 3, heading: 'More Skyreader linkblogs' });
+
+    expect(rows()).toHaveLength(3);
+    expect(showMore()).toHaveLength(0);
+    expect(target.querySelector('.discovery-toolbar')).toBeNull();
+  });
+
+  it('renders the friends variant uncapped', () => {
+    store.friends = Array.from({ length: 14 }, (_, i) => person(i, true));
+    store.people = [];
+    subs.subscriptions = [];
+    render({ variant: 'friends' });
+
+    expect(rows()).toHaveLength(14);
+    expect(showMore()).toHaveLength(0);
+    expect(target.querySelector('.discovery-toolbar')).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/LinkblogDiscovery.svelte
+++ b/frontend/src/lib/components/LinkblogDiscovery.svelte
@@ -231,6 +231,7 @@
       </ul>
       <ShowMoreButton
         remaining={filteredFriends.length - visibleFriends}
+        batchSize={WINDOW_STEP}
         onclick={() => (visibleFriends += WINDOW_STEP)}
       />
     {/if}
@@ -244,6 +245,7 @@
       </ul>
       <ShowMoreButton
         remaining={filteredOthers.length - visibleOthers}
+        batchSize={WINDOW_STEP}
         onclick={() => (visibleOthers += WINDOW_STEP)}
       />
     {/if}

--- a/frontend/src/lib/components/LinkblogDiscovery.svelte
+++ b/frontend/src/lib/components/LinkblogDiscovery.svelte
@@ -3,7 +3,14 @@
   import { linkblogDiscoveryStore } from '$lib/stores/linkblogDiscovery.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import type { LinkblogPerson } from '$lib/types';
+  import DiscoveryToolbar from './DiscoveryToolbar.svelte';
   import Icon from './Icon.svelte';
+  import ShowMoreButton from './ShowMoreButton.svelte';
+
+  // The registry arrives whole, so windowing is purely about what we put in the
+  // DOM: show a screenful, reveal the rest a batch at a time.
+  const INITIAL_WINDOW = 10;
+  const WINDOW_STEP = 25;
 
   interface Props {
     /**
@@ -55,6 +62,42 @@
   $effect(() => {
     totalAvailable = eligible.length;
   });
+
+  // Full-view filters. Both are inert outside `full` — the suggestions and
+  // friends variants never render the toolbar that drives them.
+  let query = $state('');
+  let hideAdded = $state(false);
+
+  function matches(p: LinkblogPerson, q: string): boolean {
+    if (hideAdded && subscribedPubUris.has(p.publicationUri)) return false;
+    if (!q) return true;
+    return (
+      (p.displayName?.toLowerCase().includes(q) ?? false) ||
+      (p.handle?.toLowerCase().includes(q) ?? false)
+    );
+  }
+
+  let normalizedQuery = $derived(query.trim().toLowerCase());
+  let filteredFriends = $derived(friends.filter((p) => matches(p, normalizedQuery)));
+  let filteredOthers = $derived(others.filter((p) => matches(p, normalizedQuery)));
+  let totalPeople = $derived(friends.length + others.length);
+  let shownPeople = $derived(filteredFriends.length + filteredOthers.length);
+  let filtering = $derived(normalizedQuery.length > 0 || hideAdded);
+
+  // Windowing runs after filtering, so a match beyond the initial window is
+  // never hidden behind an unexpanded list.
+  let visibleFriends = $state(INITIAL_WINDOW);
+  let visibleOthers = $state(INITIAL_WINDOW);
+
+  // Reset both windows whenever the filter changes — and *only* then. A broader
+  // dependency (the people array) would collapse an expanded list on refresh.
+  $effect(() => {
+    void query;
+    void hideAdded;
+    visibleFriends = INITIAL_WINDOW;
+    visibleOthers = INITIAL_WINDOW;
+  });
+
   let loading = $derived(
     variant === 'friends'
       ? linkblogDiscoveryStore.loadingFriends
@@ -164,31 +207,67 @@
     {/if}
   {:else if loading && !loaded}
     <p class="status">Looking for linkblogs…</p>
+  {:else if variant === 'full'}
+    {#if totalPeople > 0}
+      <DiscoveryToolbar bind:query bind:hideAdded searchLabel="Search linkblogs">
+        {#snippet count()}
+          {#if filtering}
+            {shownPeople} of {totalPeople}
+            {totalPeople === 1 ? 'linkblog' : 'linkblogs'}
+          {:else}
+            {totalPeople}
+            {totalPeople === 1 ? 'linkblog' : 'linkblogs'} · {friends.length} from people you follow
+          {/if}
+        {/snippet}
+      </DiscoveryToolbar>
+    {/if}
+
+    {#if filteredFriends.length > 0}
+      <h3 class="group-title">People you follow</h3>
+      <ul class="person-list">
+        {#each filteredFriends.slice(0, visibleFriends) as p (p.did)}
+          {@render personRow(p)}
+        {/each}
+      </ul>
+      <ShowMoreButton
+        remaining={filteredFriends.length - visibleFriends}
+        onclick={() => (visibleFriends += WINDOW_STEP)}
+      />
+    {/if}
+
+    {#if filteredOthers.length > 0}
+      <h3 class="group-title">More on Skyreader</h3>
+      <ul class="person-list">
+        {#each filteredOthers.slice(0, visibleOthers) as p (p.did)}
+          {@render personRow(p)}
+        {/each}
+      </ul>
+      <ShowMoreButton
+        remaining={filteredOthers.length - visibleOthers}
+        onclick={() => (visibleOthers += WINDOW_STEP)}
+      />
+    {/if}
+
+    {#if shownPeople === 0}
+      {#if totalPeople === 0}
+        {#if loaded}
+          <p class="status">No linkblogs to show yet — check back as more people start one.</p>
+        {/if}
+      {:else if normalizedQuery}
+        <p class="status">No linkblogs match “{query.trim()}”.</p>
+      {:else}
+        <p class="status">You've already added every linkblog here.</p>
+      {/if}
+    {/if}
   {:else}
     {#if friends.length > 0}
-      {#if variant === 'full'}
-        <h3 class="group-title">People you follow</h3>
-      {/if}
       <ul class="person-list">
         {#each friends as p (p.did)}
           {@render personRow(p)}
         {/each}
       </ul>
-    {:else if variant === 'friends' && loaded}
+    {:else if loaded}
       <p class="status">None of the people you follow have a linkblog yet.</p>
-    {/if}
-
-    {#if variant === 'full' && others.length > 0}
-      <h3 class="group-title">More on Skyreader</h3>
-      <ul class="person-list">
-        {#each others as p (p.did)}
-          {@render personRow(p)}
-        {/each}
-      </ul>
-    {/if}
-
-    {#if variant === 'full' && loaded && friends.length === 0 && others.length === 0}
-      <p class="status">No linkblogs to show yet — check back as more people start one.</p>
     {/if}
   {/if}
 </div>

--- a/frontend/src/lib/components/ShowMoreButton.svelte
+++ b/frontend/src/lib/components/ShowMoreButton.svelte
@@ -4,9 +4,11 @@
   interface Props {
     /** How many rows are still hidden behind the current window. */
     remaining: number;
+    /** Maximum number of rows the next click reveals. */
+    batchSize: number;
     onclick: () => void;
   }
-  let { remaining, onclick }: Props = $props();
+  let { remaining, batchSize, onclick }: Props = $props();
 </script>
 
 <!-- Progressive disclosure, not a call to action: quiet text button, same
@@ -14,7 +16,7 @@
 {#if remaining > 0}
   <button class="show-more" type="button" {onclick}>
     <Icon name="chevron-down" size={14} />
-    Show {remaining} more
+    Show {Math.min(remaining, batchSize)} more
   </button>
 {/if}
 
@@ -38,5 +40,11 @@
 
   .show-more:hover {
     color: var(--color-text);
+  }
+
+  @media (max-width: 520px) {
+    .show-more {
+      min-height: 44px;
+    }
   }
 </style>

--- a/frontend/src/lib/components/ShowMoreButton.svelte
+++ b/frontend/src/lib/components/ShowMoreButton.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    /** How many rows are still hidden behind the current window. */
+    remaining: number;
+    onclick: () => void;
+  }
+  let { remaining, onclick }: Props = $props();
+</script>
+
+<!-- Progressive disclosure, not a call to action: quiet text button, same
+     weight as the "N hidden accounts" toggle it sits near. -->
+{#if remaining > 0}
+  <button class="show-more" type="button" {onclick}>
+    <Icon name="chevron-down" size={14} />
+    Show {remaining} more
+  </button>
+{/if}
+
+<style>
+  .show-more {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-top: 0.5rem;
+    padding: 0.375rem 0;
+    font: inherit;
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    color: var(--color-text-secondary);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: color 0.15s;
+  }
+
+  .show-more:hover {
+    color: var(--color-text);
+  }
+</style>


### PR DESCRIPTION
The Discover view now keeps both large result sets behind display windows, with shared search and “Hide added” filters.

This follow-up resolves the remaining review feedback:

- “Show more” labels name the next batch actually revealed (up to 25).
- Show more and Hide added have 44px minimum touch targets on narrow screens.
- The filter toolbar uses a stable two-column grid, so changing the count via “Hide added” no longer moves the controls between rows; mobile retains the intentional stacked layout.
- A 100-account regression case verifies repeated large remainders.

Checks:

- `cd frontend && npm run check` — 0 errors, 18 pre-existing warnings; formatting clean.
- `cd frontend && npm run test` — 45 files, 624 tests passing.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-e3t2brq7udlkylxjol4hefcc)
