### PR TITLE
Drop the per-feed refresh spinner that could never settle

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -68,6 +68,13 @@ clears an error**, so `applyHealthSnapshot` runs after the per-feed `markReady` 
 it. The payload is sent on every cold start and whenever the echoed `health_rev` is stale, so a
 steady-state poll pays nothing for it.
 
+There is deliberately **no per-feed loading state** to go with it — `feedStatus.svelte.ts` has no
+`'pending'`, and the sidebar renders a source's favicon or its error badge, nothing in between. A
+refresh is one archive-wide request, so nothing per-feed ever arrives to settle a per-feed spinner;
+seeding one at boot left it spinning for the life of the tab. Sync progress belongs to the
+app-level indicators (`RefreshProgressBar`, the header ↻, the mobile bottom-bar rail), which key off
+`appManager.isRefreshing`.
+
 The legacy per-feed `/api/v2/feeds/batch` path (`fetchAllFeedsViaBatch`, with per-subscription
 `feedCursors`) is kept for one release as a fallback: it runs when the timeline 404s and whenever
 the server reports `ingestActive: false` (this environment's crawler isn't pushing into D1). See

--- a/frontend/docs/STATE_ARCHITECTURE.md
+++ b/frontend/docs/STATE_ARCHITECTURE.md
@@ -139,10 +139,12 @@ function createAppManager() {
 
 ### 3. Feed Status Store (`feedStatus.svelte.ts`)
 
-Tracks per-feed status for error display and circuit breaker awareness.
+Tracks per-feed status for error display and circuit breaker awareness. There is
+no 'pending' state: a refresh is one archive-wide timeline request, not a per-feed
+fetch, so a feed is healthy until the crawler's health report says otherwise.
 
 ```typescript
-type FeedStatusType = 'ready' | 'pending' | 'error' | 'circuit-open';
+type FeedStatusType = 'ready' | 'error' | 'circuit-open';
 
 interface FeedStatus {
   status: FeedStatusType;
@@ -279,8 +281,8 @@ function createSubscriptionsStore() {
     // 2. Store locally after success
     await liveDb.addSubscription(subscription);
 
-    // 3. Mark feed as pending
-    feedStatusStore.markPending(feedUrl);
+    // No feed status is written: a feed is healthy until the crawler's health
+    // report says otherwise (feedStatusStore has no 'pending' state).
   }
 
   async function remove(id: number) {
@@ -414,11 +416,6 @@ function createFeedViewStore() {
 ┌──────────────────────────────┐
 │  liveDb.addSubscription()    │
 │  subscriptionsVersion++      │  → Sidebar re-renders
-└────────┬─────────────────────┘
-         │
-         ▼
-┌──────────────────────────────┐
-│  feedStatusStore.markPending │
 └────────┬─────────────────────┘
          │
          ▼ (background)

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -570,20 +570,15 @@
                 {#each cat.subscriptions as sub (sub.rkey)}
                   {@const feedUrl = sub.feedUrl ?? ''}
                   {@const status = feedStatusStore.getStatus(feedUrl)}
-                  {@const loadingState = !feedUrl
-                    ? 'ready'
-                    : status?.status === 'error' || status?.status === 'circuit-open'
-                      ? 'error'
-                      : status?.status === 'pending'
-                        ? 'loading'
-                        : 'ready'}
+                  {@const hasError =
+                    status?.status === 'error' || status?.status === 'circuit-open'}
                   {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
                   {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
                     <FeedItem
                       subscription={sub}
                       unreadCount={subUnread}
                       isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
-                      {loadingState}
+                      {hasError}
                       errorMessage={status?.errorMessage ?? ''}
                       errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
                       onSelect={() => sub.id && selectFilter('feed', sub.id)}
@@ -603,20 +598,14 @@
         {#each uncategorizedSources as sub (sub.rkey)}
           {@const feedUrl = sub.feedUrl ?? ''}
           {@const status = feedStatusStore.getStatus(feedUrl)}
-          {@const loadingState = !feedUrl
-            ? 'ready'
-            : status?.status === 'error' || status?.status === 'circuit-open'
-              ? 'error'
-              : status?.status === 'pending'
-                ? 'loading'
-                : 'ready'}
+          {@const hasError = status?.status === 'error' || status?.status === 'circuit-open'}
           {@const subUnread = sub.id ? (unreadCounts.feedCounts.get(sub.id) ?? 0) : 0}
           {#if !sidebarStore.showOnlyUnread.feeds || subUnread > 0}
             <FeedItem
               subscription={sub}
               unreadCount={subUnread}
               isActive={currentFilter().type === 'feed' && currentFilter().id === sub.id}
-              {loadingState}
+              {hasError}
               errorMessage={status?.errorMessage ?? ''}
               errorDetails={feedStatusStore.getErrorDetails(feedUrl)}
               onSelect={() => sub.id && selectFilter('feed', sub.id)}

--- a/frontend/src/lib/components/sidebar/FeedItem.component.test.ts
+++ b/frontend/src/lib/components/sidebar/FeedItem.component.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import FeedItem from './FeedItem.svelte';
+import type { Subscription } from '$lib/types';
+
+const subscription: Subscription = {
+  id: 1,
+  rkey: 'abcdefghijklm',
+  feedUrl: 'https://example.com/feed.xml',
+  siteUrl: 'https://example.com',
+  title: 'Example',
+  tags: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  localUpdatedAt: 0,
+};
+
+function render(props: Record<string, unknown>) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  return mount(FeedItem, {
+    target,
+    props: {
+      subscription,
+      unreadCount: 0,
+      isActive: false,
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+      onTouchStart: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onTouchMove: vi.fn(),
+      onRetry: vi.fn(),
+      onMoreClick: vi.fn(),
+      ...props,
+    },
+  });
+}
+
+describe('FeedItem', () => {
+  let component: Record<string, any> | undefined;
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = '';
+  });
+
+  // A refresh is one archive-wide timeline request, so nothing per-feed ever
+  // arrives to settle a per-feed spinner. A source with no error must render its
+  // favicon, not an indicator that spins for the life of the tab.
+  it('renders the favicon and no spinner for a healthy feed', () => {
+    component = render({ hasError: false });
+
+    expect(document.querySelector('.feed-favicon')).not.toBeNull();
+    expect(document.querySelector('[class*="spinner"]')).toBeNull();
+  });
+
+  it('renders the error badge and a retry control for a broken feed', () => {
+    component = render({
+      hasError: true,
+      errorMessage: 'HTTP 404',
+      errorDetails: {
+        title: 'Feed Not Found',
+        description: 'This feed could not be found.',
+        isPermanent: true,
+        errorCount: 3,
+      },
+    });
+
+    expect(document.querySelector('.feed-error-icon')).not.toBeNull();
+    expect(document.querySelector('.feed-favicon')).toBeNull();
+    expect(document.querySelector('.retry-btn')).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/components/sidebar/FeedItem.svelte
+++ b/frontend/src/lib/components/sidebar/FeedItem.svelte
@@ -6,13 +6,14 @@
   import Icon from '../Icon.svelte';
   import { getSourceDisplay } from '$lib/utils/sourceDisplay';
 
-  type LoadingState = 'loading' | 'error' | 'ready';
-
   interface Props {
     subscription: Subscription;
     unreadCount: number;
     isActive: boolean;
-    loadingState?: LoadingState;
+    // Per-feed state is binary: the crawler either reports this feed as broken or
+    // it doesn't. There is no per-feed "loading" — a refresh is one archive-wide
+    // timeline request, not a fetch of this feed. See feedStatus.svelte.ts.
+    hasError?: boolean;
     errorMessage?: string;
     errorDetails?: ErrorDetails | null;
     onSelect: () => void;
@@ -30,7 +31,7 @@
     subscription,
     unreadCount,
     isActive,
-    loadingState = 'ready',
+    hasError = false,
     errorMessage = '',
     errorDetails = null,
     onSelect,
@@ -122,16 +123,14 @@
   <button
     class="nav-item sub-item feed-item {sourceDisplay.pillClass}"
     class:active={isActive}
-    class:has-error={loadingState === 'error'}
+    class:has-error={hasError}
     onclick={onSelect}
     oncontextmenu={onContextMenu}
     ontouchstart={onTouchStart}
     ontouchend={onTouchEnd}
     ontouchmove={onTouchMove}
   >
-    {#if loadingState === 'loading'}
-      <span class="feed-loading-spinner"></span>
-    {:else if loadingState === 'error'}
+    {#if hasError}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <span
         bind:this={errorIconRef}
@@ -172,7 +171,7 @@
     >
       <Icon name="more-horizontal" size={14} />
     </span>
-    {#if loadingState === 'error'}
+    {#if hasError}
       <span
         class="retry-btn"
         class:retrying
@@ -338,16 +337,6 @@
     flex-shrink: 0;
     background: var(--color-border);
     border-radius: 2px;
-  }
-
-  .feed-loading-spinner {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-    border: 2px solid var(--color-border);
-    border-top-color: var(--color-primary);
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
   }
 
   @keyframes spin {

--- a/frontend/src/lib/services/timelineSync.test.ts
+++ b/frontend/src/lib/services/timelineSync.test.ts
@@ -200,7 +200,7 @@ describe('reconcileFeedHealth', () => {
     expect(decisions).toEqual([{ feedUrl: 'https://a.example/f', kind: 'recovered' }]);
   });
 
-  it('leaves a healthy feed with no error alone, so pending never becomes a fake success', () => {
+  it('leaves a healthy feed with no error alone, so absence never becomes a fake success', () => {
     expect(reconcileFeedHealth({}, ['https://a.example/f'], () => false)).toEqual([]);
   });
 

--- a/frontend/src/lib/services/timelineSync.ts
+++ b/frontend/src/lib/services/timelineSync.ts
@@ -180,9 +180,9 @@ export type FeedHealthDecision =
  * omission. That omission is what clears an error, including one left over from
  * the batch path.
  *
- * A feed with no status yet (never fetched, or still 'pending') is left alone
- * when it isn't in the report: absence means "not broken", not "confirmed
- * fetched", and inventing a success would show a fetch that never happened.
+ * A feed with no status yet (never fetched in this session) is left alone when it
+ * isn't in the report: absence means "not broken", not "confirmed fetched", and
+ * inventing a success would show a fetch that never happened.
  */
 export function reconcileFeedHealth(
   unhealthy: Record<string, TimelineFeedHealth>,

--- a/frontend/src/lib/stores/app.svelte.ts
+++ b/frontend/src/lib/stores/app.svelte.ts
@@ -78,12 +78,10 @@ function createAppManager() {
         magazineStore.load(),
       ]);
 
-      // Initialize feed statuses for existing subscriptions
-      const feedUrls = liveDb.subscriptions
-        .filter((s) => !s.sourceType?.startsWith('atproto.'))
-        .map((s) => s.feedUrl)
-        .filter((u): u is string => !!u);
-      feedStatusStore.initializeFeeds(feedUrls);
+      // Feed statuses are NOT seeded here. A feed is healthy until the crawler's
+      // health report says otherwise, and that report is the only thing that can
+      // ever change a feed's status under the timeline path — see
+      // feedStatus.svelte.ts.
 
       // Initialize pending count and process queue if online
       await syncStore.updatePendingCount();
@@ -260,7 +258,6 @@ function createAppManager() {
           const id = await liveDb.addSubscription(subscription);
           result.added.push(subscription.feedUrl || '');
           result.addedSubs.push({ ...subscription, id });
-          if (subscription.feedUrl && !isAtProto) feedStatusStore.markPending(subscription.feedUrl);
         }
       }
 

--- a/frontend/src/lib/stores/feedStatus.component.test.ts
+++ b/frontend/src/lib/stores/feedStatus.component.test.ts
@@ -1,0 +1,44 @@
+// Named `.component.test.ts` so it runs in the project that compiles runes —
+// the store is a `.svelte.ts` module and `$state` needs the Svelte plugin.
+import { beforeEach, describe, expect, it } from 'vitest';
+import { feedStatusStore } from './feedStatus.svelte';
+
+const FEED = 'https://example.com/feed.xml';
+const OTHER = 'https://other.example/feed.xml';
+
+describe('feedStatusStore under the timeline path', () => {
+  beforeEach(() => {
+    feedStatusStore.clearAll();
+  });
+
+  // The regression: boot used to seed every subscription with a 'pending' status
+  // that rendered a spinner in the sidebar. Under the timeline path nothing
+  // per-feed ever arrives to settle it — reads are served from the archive — so
+  // a feed carries no status at all until the crawler's health report says it is
+  // broken.
+  it('reports no status for a subscribed feed nobody has fetched', () => {
+    expect(feedStatusStore.getStatus(FEED)).toBeUndefined();
+    expect(feedStatusStore.getStatusMessage(FEED)).toBe('');
+    expect(feedStatusStore.canFetch(FEED)).toBe(true);
+  });
+
+  it('leaves a feed clean when a steady-state poll reports nothing broken', () => {
+    feedStatusStore.applyHealthSnapshot({}, [FEED, OTHER]);
+
+    expect(feedStatusStore.getStatus(FEED)).toBeUndefined();
+    expect(feedStatusStore.errorFeeds).toEqual([]);
+  });
+
+  it('flags a feed the crawler reports broken, and clears it when it drops out', () => {
+    feedStatusStore.applyHealthSnapshot({ [FEED]: { errorCount: 2, error: 'HTTP 404' } }, [
+      FEED,
+      OTHER,
+    ]);
+    expect(feedStatusStore.getStatus(FEED)?.status).toBe('error');
+    expect(feedStatusStore.getStatus(OTHER)).toBeUndefined();
+
+    feedStatusStore.applyHealthSnapshot({}, [FEED, OTHER]);
+    expect(feedStatusStore.getStatus(FEED)?.status).toBe('ready');
+    expect(feedStatusStore.errorFeeds).toEqual([]);
+  });
+});

--- a/frontend/src/lib/stores/feedStatus.svelte.ts
+++ b/frontend/src/lib/stores/feedStatus.svelte.ts
@@ -14,7 +14,15 @@ import {
   type TimelineFeedHealth,
 } from '$lib/services/timelineSync';
 
-export type FeedStatusType = 'ready' | 'pending' | 'error' | 'circuit-open';
+/**
+ * There is deliberately no 'pending' state. A refresh is one archive-wide
+ * `GET /api/v2/timeline` request, not a per-feed fetch, so nothing ever arrives
+ * to settle a per-feed "loading": the crawler's health report is the only
+ * per-feed signal, and it says either "broken" or — by omission — "not broken".
+ * Seeding every subscription 'pending' at boot therefore left a spinner next to
+ * every source in the sidebar that never settled.
+ */
+export type FeedStatusType = 'ready' | 'error' | 'circuit-open';
 export type ErrorType = 'transient' | 'permanent';
 
 export interface ErrorDetails {
@@ -242,18 +250,6 @@ function createFeedStatusStore() {
   }
 
   /**
-   * Mark a feed as pending (initial state for new subscriptions)
-   */
-  function markPending(feedUrl: string): void {
-    statuses.set(feedUrl, {
-      status: 'pending',
-      errorCount: 0,
-      lastCheckedAt: Date.now(),
-    });
-    statuses = new Map(statuses);
-  }
-
-  /**
    * Mark a feed as ready
    */
   function markReady(feedUrl: string): void {
@@ -330,8 +326,6 @@ function createFeedStatusStore() {
     switch (status.status) {
       case 'ready':
         return '';
-      case 'pending':
-        return 'Loading...';
       case 'error':
         if (status.errorMessage?.toLowerCase().includes('blocking automated access')) {
           return 'Blocked by site';
@@ -445,22 +439,6 @@ function createFeedStatusStore() {
     };
   }
 
-  /**
-   * Initialize statuses for a list of feed URLs (mark as pending)
-   */
-  function initializeFeeds(feedUrls: string[]): void {
-    for (const url of feedUrls) {
-      if (!statuses.has(url)) {
-        statuses.set(url, {
-          status: 'pending',
-          errorCount: 0,
-          lastCheckedAt: Date.now(),
-        });
-      }
-    }
-    statuses = new Map(statuses);
-  }
-
   return {
     get statuses() {
       return statuses;
@@ -476,7 +454,6 @@ function createFeedStatusStore() {
     },
     updateFromV2Result,
     applyHealthSnapshot,
-    markPending,
     markReady,
     markError,
     clearStatus,
@@ -485,7 +462,6 @@ function createFeedStatusStore() {
     canFetch,
     getStatusMessage,
     getErrorDetails,
-    initializeFeeds,
   };
 }
 

--- a/frontend/src/lib/stores/subscriptions.svelte.ts
+++ b/frontend/src/lib/stores/subscriptions.svelte.ts
@@ -134,9 +134,6 @@ function createSubscriptionsStore() {
       };
 
       const id = await liveDb.addSubscription(subscription);
-      if (!isAtProto && feedUrl) {
-        feedStatusStore.markPending(feedUrl);
-      }
 
       return id;
     });
@@ -251,7 +248,6 @@ function createSubscriptionsStore() {
         try {
           const id = await liveDb.addSubscription(subscription);
           added.push(id);
-          feedStatusStore.markPending(feed.feedUrl);
         } catch (e) {
           failed.push({
             url: feed.feedUrl,


### PR DESCRIPTION
## The bug

The spinner next to every source in the sidebar never settled.

`appManager.initialize()` seeded every RSS subscription with `feedStatusStore` status `'pending'` at boot, and `FeedItem` rendered `'pending'` as a spinner. Under the timeline path nothing per-feed can clear that:

- a refresh is one archive-wide `GET /api/v2/timeline`, so only feeds that happened to deliver **new** items in a drain get `markReady`;
- `applyHealthSnapshot` deliberately leaves a statusless feed alone (absence from the health report means "not broken", not "confirmed fetched").

So a quiet feed spun for the life of the tab. An OPML import marked all 200 feeds pending at once, and the ≤10-per-sync backfill was the only thing that could ever chip away at them.

## The change

Per-feed state is binary now: the crawler reports a feed broken, or it doesn't. There is no per-feed loading state, because there is no per-feed fetch to be loading.

- `feedStatus.svelte.ts` — `'pending'` is gone from `FeedStatusType`, along with `markPending`, `initializeFeeds`, and the `"Loading..."` status message.
- `FeedItem.svelte` — `loadingState: 'loading' | 'error' | 'ready'` → `hasError: boolean`; the spinner markup and `.feed-loading-spinner` CSS are removed.
- `Sidebar.svelte`, `app.svelte.ts`, `subscriptions.svelte.ts` — updated to match; nothing seeds a status at boot, on add, or on bulk import.

Sync progress is still shown, just where it belongs: the app-level indicators (`RefreshProgressBar`, the header ↻, the mobile bottom-bar rail) that key off `appManager.isRefreshing`. Error badges, the error popover and the per-feed retry are untouched — they're driven by the crawler's `feedHealth`, which still works.

`/sources` (Manage Sources) never had the spinner; its `SourceRow` only shows the error badge, so it's unaffected beyond the shared store change.

## Checks

- `npx vitest run` — 47 files, 629 tests passing (includes 5 new)
- `npm run check` (svelte-check + prettier) — 0 errors, warnings all pre-existing
- `npm run build` — clean

New tests: `FeedItem.component.test.ts` pins that a healthy source renders its favicon and no spinner and a broken one renders the badge + retry; `feedStatus.component.test.ts` pins that a subscribed-but-unfetched feed carries no status at all and that a steady-state health report leaves it that way.

## Risk

Adding a feed no longer shows a per-feed spinner while its first items land — the add modal's own spinner and the app-level refresh indicator cover that window. Behavioural, deliberate, and the reason it's called out here.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-5c7j4csyyr3c42qitofprvfn)
