### PR TITLE
Repair stale document publication caches

### DIFF
--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -128,7 +128,7 @@ describe('ops tiles', () => {
 
   it('renders a full set of tiles before the cron has ever run', () => {
     const metrics = opsMetricsFrom({ cron: null, poller: null, proxy: null }, NOW);
-    expect(metrics).toHaveLength(6);
+    expect(metrics).toHaveLength(7);
     expect(metrics.every((m) => m.status === 'error')).toBe(true);
   });
 });

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -113,12 +113,21 @@ function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
 
 function proxyMetrics(status: OpsStatus, now: number): MetricValue[] {
   const proxy = status.proxy;
-  if (!proxy) return [unknown('Proxy Cache Fresh'), unknown('Proxy Feeds in Error')];
+  if (!proxy)
+    return [
+      unknown('Proxy Cache Fresh'),
+      unknown('Proxy Feeds in Error'),
+      unknown('Document Sync'),
+    ];
 
   // Nobody refreshed these, so don't dress them up as current.
   const rowAge = now - proxy.updatedAt;
   if (rowAge > PROXY_STALE_MS) {
-    return [stale('Proxy Cache Fresh', rowAge), stale('Proxy Feeds in Error', rowAge)];
+    return [
+      stale('Proxy Cache Fresh', rowAge),
+      stale('Proxy Feeds in Error', rowAge),
+      stale('Document Sync', rowAge),
+    ];
   }
 
   const { freshPct, total, feedsInError, feedsPermanentlyFailed } = proxy.value;
@@ -141,6 +150,17 @@ function proxyMetrics(status: OpsStatus, now: number): MetricValue[] {
       value: feedsInError,
       unit: feedsPermanentlyFailed > 0 ? `${feedsPermanentlyFailed} permanent` : undefined,
       status: feedsPermanentlyFailed > 0 ? 'error' : feedsInError > 0 ? 'warning' : 'healthy',
+    },
+    {
+      label: 'Document Sync',
+      value: proxy.value.documentAuthorsFrozen ?? 0,
+      unit: `${proxy.value.documentAuthorsActive ?? 0} active · ${proxy.value.documentAuthorsInBackoff ?? 0} retrying`,
+      status:
+        (proxy.value.documentAuthorsFrozen ?? 0) > 0
+          ? 'error'
+          : proxy.value.documentFirehoseHealthy === false
+            ? 'warning'
+            : 'healthy',
     },
   ];
 }

--- a/admin/src/lib/queries/ops.ts
+++ b/admin/src/lib/queries/ops.ts
@@ -35,6 +35,11 @@ export interface ProxyStatsValue {
   feedsInBackoff: number;
   feedsPermanentlyFailed: number;
   cacheTtlSeconds: number | null;
+  documentFirehoseHealthy?: boolean | null;
+  documentFirehoseConnected?: boolean | null;
+  documentAuthorsActive?: number;
+  documentAuthorsFrozen?: number;
+  documentAuthorsInBackoff?: number;
 }
 
 export interface StatusRow<T> {

--- a/backend/src/observability/ops-metrics.ts
+++ b/backend/src/observability/ops-metrics.ts
@@ -80,6 +80,13 @@ export interface ProxyStatsValue {
   feedsInBackoff: number;
   feedsPermanentlyFailed: number;
   cacheTtlSeconds: number | null;
+  documentFirehoseHealthy: boolean | null;
+  documentFirehoseConnected: boolean | null;
+  documentAuthorsActive: number;
+  documentAuthorsFrozen: number;
+  documentAuthorsInBackoff: number;
+  /** Alert dedupe state; not displayed. */
+  documentFrozenAlertAt: number | null;
 }
 
 export async function writeSystemStatus(
@@ -212,6 +219,8 @@ interface ProxyStatsResponse {
   inFlight?: number;
   cacheTtlSeconds?: number;
   errors?: { total?: number; inBackoff?: number; permanent?: number };
+  firehose?: { healthy?: boolean; connected?: boolean };
+  documents?: { active?: number; frozen?: number; inBackoff?: number };
 }
 
 /**
@@ -237,6 +246,7 @@ export async function recordProxyStats(env: Env, now = Date.now()): Promise<Prox
 
   const total = stats.total ?? 0;
   const fresh = stats.fresh ?? 0;
+  const previous = await readSystemStatus<ProxyStatsValue>(env, 'proxy_stats');
   const value: ProxyStatsValue = {
     total,
     fresh,
@@ -248,9 +258,34 @@ export async function recordProxyStats(env: Env, now = Date.now()): Promise<Prox
     feedsInBackoff: stats.errors?.inBackoff ?? 0,
     feedsPermanentlyFailed: stats.errors?.permanent ?? 0,
     cacheTtlSeconds: stats.cacheTtlSeconds ?? null,
+    documentFirehoseHealthy: stats.firehose?.healthy ?? null,
+    documentFirehoseConnected: stats.firehose?.connected ?? null,
+    documentAuthorsActive: stats.documents?.active ?? 0,
+    documentAuthorsFrozen: stats.documents?.frozen ?? 0,
+    documentAuthorsInBackoff: stats.documents?.inBackoff ?? 0,
+    documentFrozenAlertAt: previous?.value.documentFrozenAlertAt ?? null,
   };
 
+  const frozenStayedHigh =
+    value.documentAuthorsFrozen > 0 && (previous?.value.documentAuthorsFrozen ?? 0) > 0;
+  const shouldAlert =
+    frozenStayedHigh &&
+    (!value.documentFrozenAlertAt || now - value.documentFrozenAlertAt >= FIREHOSE_LAG_REALERT_MS);
+  if (value.documentAuthorsFrozen === 0) value.documentFrozenAlertAt = null;
+  else if (shouldAlert) value.documentFrozenAlertAt = now;
+
   await writeSystemStatus(env, 'proxy_stats', value, now);
+  if (shouldAlert) {
+    reportMessage('Actively read document authors are past the re-list floor', {
+      level: 'warning',
+      fingerprint: ['proxy-document-cache-frozen'],
+      extra: {
+        frozen: value.documentAuthorsFrozen,
+        active: value.documentAuthorsActive,
+        inBackoff: value.documentAuthorsInBackoff,
+      },
+    });
+  }
   return value;
 }
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -464,6 +464,35 @@ Fix, once you know which one it is: a wedged warm loop or push loop is
 `fly machine restart <id>` (never `fly scale count` — see §4's proxy-warmer entry);
 a heartbeat that never arrives is configuration, not a restart.
 
+### Document publication feed goes quiet
+
+The admin's **Document Sync** tile and proxy `/stats` → `documents` cover the
+Jetstream lane used by standard.site/Leaflet publications. `frozen > 0` means an
+actively read author has not had a full PDS re-list for more than twice the
+24-hour floor; `inBackoff > 0` explains why a repair is waiting. A persistent
+frozen count emits the `proxy-document-cache-frozen` alert.
+
+On the production proxy, inspect the affected author before changing it:
+
+```sql
+SELECT fetched_at, listed_at, error_count, last_error, last_error_at,
+       next_retry_at, last_requested_at
+FROM document_cache WHERE did = 'did:plc:...';
+```
+
+Confirm the record exists on the author's PDS, then schedule a safe re-list:
+
+```sql
+UPDATE document_cache
+SET listed_at = 0, error_count = 0, next_retry_at = NULL
+WHERE did = 'did:plc:...';
+```
+
+The next client poll serves the existing cache and refreshes it in the
+background; a changed scope digest replaces the stale list without user action.
+For multiple victims, update small batches of recently requested rows so the
+upstream PDSes are not hit in a stampede.
+
 ### The timeline rollout gate
 
 `ingestActive` is the AND of two things: a fresh crawler heartbeat and

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -2211,7 +2211,7 @@ export function createApp(db: Database, config: AppConfig) {
     const frozenDocuments = db
       .query<{ count: number }, [number, number]>(
         `SELECT COUNT(*) as count FROM document_cache
-         WHERE last_requested_at > ? AND listed_at < ?`
+         WHERE last_requested_at > ? AND listed_at > 0 AND listed_at < ?`
       )
       .get(activeDocumentCutoff, now - 2 * firehoseRelistMs);
     const documentBackoff = db
@@ -2935,6 +2935,20 @@ export function createApp(db: Database, config: AppConfig) {
         let listedAge = Number.POSITIVE_INFINITY;
 
         if (cached && cached.documents_json) {
+          // Polling is the activity signal for an error placeholder, and this
+          // branch otherwise returns before fetchAndCacheDocuments can shorten
+          // a legacy seven-day backoff. Persist the active-reader cap first.
+          if (
+            cached.next_retry_at &&
+            now < cached.next_retry_at &&
+            cached.next_retry_at > now + ACTIVE_DOCUMENT_BACKOFF_MAX_MS
+          ) {
+            cached.next_retry_at = now + ACTIVE_DOCUMENT_BACKOFF_MAX_MS;
+            db.run('UPDATE document_cache SET next_retry_at = ? WHERE did = ?', [
+              cached.next_retry_at,
+              did,
+            ]);
+          }
           const age = now - cached.fetched_at;
           // Age since the last real PDS list. Splices bump `fetched_at` but not
           // `listed_at`, so this is the only measure that reflects whether we

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -316,6 +316,7 @@ const DEFAULT_WARM_TARGET_CYCLE_MS = 60 * 60 * 1000;
 // a record that predates the cache row). One list per author per day is a
 // rounding error against the warm loop's ordinary volume.
 const FIREHOSE_RELIST_MS = 24 * 60 * 60 * 1000; // 24 hours
+const ACTIVE_DOCUMENT_BACKOFF_MAX_MS = 6 * 60 * 60 * 1000;
 const MAX_RESPONSE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 // Extracted article content is effectively immutable per URL; cache it for a long
 // time so repeat (and cross-user) saves of the same article are free.
@@ -1123,6 +1124,10 @@ export function initDatabase(db: Database): void {
   if (!new Set(docColumns.map((c) => c.name)).has('listed_at')) {
     db.run(`ALTER TABLE document_cache ADD COLUMN listed_at INTEGER`);
   }
+  // Preserve the pre-migration freshness rather than forcing every cached
+  // author to re-list at once. From here on listed_at is the sole list clock;
+  // firehose splices may safely continue bumping fetched_at.
+  db.run(`UPDATE document_cache SET listed_at = fetched_at WHERE listed_at IS NULL`);
 
   // Small key/value store for sync bookkeeping (e.g. the Jetstream document
   // firehose cursor), so the stream resumes across restarts without replaying
@@ -1305,7 +1310,16 @@ export function createApp(db: Database, config: AppConfig) {
   // Default: firehose absent → unhealthy, nothing subscribed (serve path keeps
   // its existing age-based refresh behavior).
   const getFirehoseStatus =
-    config.getFirehoseStatus ?? (() => ({ healthy: false, isSubscribed: () => false }));
+    config.getFirehoseStatus ??
+    (() => ({
+      healthy: false,
+      connected: false,
+      subscribedDids: 0,
+      lastEventAt: null,
+      reconnectAttempts: 0,
+      cursor: null,
+      isSubscribed: () => false,
+    }));
 
   // Track in-flight fetches to avoid duplicate requests
   const inFlight = new Map<string, Promise<ParsedFeed | null>>();
@@ -1902,6 +1916,20 @@ export function createApp(db: Database, config: AppConfig) {
 
     // Circuit breaker: respect backoff window.
     if (cached?.next_retry_at && now < cached.next_retry_at) {
+      // Rows may already carry the old seven-day tier from before this guard
+      // shipped. A current reader is itself the signal to shorten that freeze;
+      // persist the clamp so a later poll can retry even if this process exits.
+      if (
+        cached.last_requested_at &&
+        cached.last_requested_at > now - warmActiveWindowMs &&
+        cached.next_retry_at > now + ACTIVE_DOCUMENT_BACKOFF_MAX_MS
+      ) {
+        cached.next_retry_at = now + ACTIVE_DOCUMENT_BACKOFF_MAX_MS;
+        db.run('UPDATE document_cache SET next_retry_at = ? WHERE did = ?', [
+          cached.next_retry_at,
+          did,
+        ]);
+      }
       return cached.documents_json ? (JSON.parse(cached.documents_json) as ProxyDocument[]) : null;
     }
 
@@ -1930,10 +1958,13 @@ export function createApp(db: Database, config: AppConfig) {
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
       const newErrorCount = (cached?.error_count || 0) + 1;
-      const nextRetryAt =
+      let nextRetryAt =
         newErrorCount >= MAX_RECOVERABLE_ERRORS
           ? now + PERMANENT_ERROR_DELAY_MS
           : now + calculateBackoff(newErrorCount);
+      if (cached?.last_requested_at && cached.last_requested_at > now - warmActiveWindowMs) {
+        nextRetryAt = Math.min(nextRetryAt, now + ACTIVE_DOCUMENT_BACKOFF_MAX_MS);
+      }
       console.error(
         `[Proxy] documents ${did}: ${msg} (retry at ${new Date(nextRetryAt).toISOString()})`
       );
@@ -1945,9 +1976,9 @@ export function createApp(db: Database, config: AppConfig) {
         );
       } else {
         db.run(
-          `INSERT INTO document_cache (did, documents_json, cached_at, fetched_at, error_count, last_error, last_error_at, next_retry_at, last_requested_at)
-					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          [did, '[]', now, now, newErrorCount, msg, now, nextRetryAt, now]
+          `INSERT INTO document_cache (did, documents_json, cached_at, fetched_at, listed_at, error_count, last_error, last_error_at, next_retry_at, last_requested_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [did, '[]', now, now, now, newErrorCount, msg, now, nextRetryAt, now]
         );
       }
 
@@ -2171,6 +2202,26 @@ export function createApp(db: Database, config: AppConfig) {
       )
       .get(now + 6 * 24 * 60 * 60 * 1000); // More than 6 days means it's a permanent error
 
+    const activeDocumentCutoff = now - warmActiveWindowMs;
+    const activeDocuments = db
+      .query<{ count: number }, [number]>(
+        'SELECT COUNT(*) as count FROM document_cache WHERE last_requested_at > ?'
+      )
+      .get(activeDocumentCutoff);
+    const frozenDocuments = db
+      .query<{ count: number }, [number, number]>(
+        `SELECT COUNT(*) as count FROM document_cache
+         WHERE last_requested_at > ? AND listed_at < ?`
+      )
+      .get(activeDocumentCutoff, now - 2 * firehoseRelistMs);
+    const documentBackoff = db
+      .query<{ count: number }, [number, number]>(
+        `SELECT COUNT(*) as count FROM document_cache
+         WHERE last_requested_at > ? AND error_count > 0 AND next_retry_at > ?`
+      )
+      .get(activeDocumentCutoff, now);
+    const firehose = getFirehoseStatus();
+
     // Ingest push (see ingest-push.ts). `pending` is the outbox backlog — the
     // number that should hover near zero once a push cycle keeps up.
     const itemCount = db
@@ -2248,6 +2299,25 @@ export function createApp(db: Database, config: AppConfig) {
         total: inError?.count || 0,
         inBackoff: inBackoff?.count || 0,
         permanent: permanentErrors?.count || 0,
+      },
+      firehose: {
+        healthy: firehose.healthy,
+        connected: firehose.connected ?? false,
+        subscribedDids: firehose.subscribedDids ?? 0,
+        lastEventAt: firehose.lastEventAt ?? null,
+        lastEventAgeSeconds: firehose.lastEventAt
+          ? Math.max(0, Math.round((now - firehose.lastEventAt) / 1000))
+          : null,
+        reconnectAttempts: firehose.reconnectAttempts ?? 0,
+        cursorAgeSeconds: firehose.cursor
+          ? Math.max(0, Math.round((now - Number(firehose.cursor) / 1000) / 1000))
+          : null,
+      },
+      documents: {
+        active: activeDocuments?.count || 0,
+        frozen: frozenDocuments?.count || 0,
+        inBackoff: documentBackoff?.count || 0,
+        relistFloorSeconds: firehoseRelistMs / 1000,
       },
     });
   });
@@ -2857,6 +2927,7 @@ export function createApp(db: Database, config: AppConfig) {
           .query<DocumentCacheRow, [string]>('SELECT * FROM document_cache WHERE did = ?')
           .get(did);
         recordDocumentRequest(did, now);
+        if (cached) cached.last_requested_at = now;
 
         let documents: ProxyDocument[] | null = null;
         // Infinity when there is no cache row at all: nothing has been listed, so
@@ -2868,7 +2939,7 @@ export function createApp(db: Database, config: AppConfig) {
           // Age since the last real PDS list. Splices bump `fetched_at` but not
           // `listed_at`, so this is the only measure that reflects whether we
           // have actually looked for documents we never saw written.
-          listedAge = now - (cached.listed_at ?? cached.fetched_at);
+          listedAge = now - cached.listed_at!;
           const inErrorBackoff =
             cached.error_count > 0 && cached.next_retry_at && now < cached.next_retry_at;
           const stale = JSON.parse(cached.documents_json) as ProxyDocument[];

--- a/feed-proxy/src/documents.test.ts
+++ b/feed-proxy/src/documents.test.ts
@@ -844,6 +844,51 @@ describe('POST /documents firehose-covered re-list floor', () => {
   });
 });
 
+describe('document cache repair guards', () => {
+  it('backfills a pre-migration NULL listed_at from fetched_at', () => {
+    const db = new Database(':memory:');
+    initDatabase(db);
+    const fetchedAt = Date.now() - 123_000;
+    db.run(
+      `INSERT INTO document_cache
+       (did, documents_json, cached_at, fetched_at, listed_at, last_requested_at)
+       VALUES (?, '[]', ?, ?, NULL, ?)`,
+      [AUTHOR, fetchedAt, fetchedAt, fetchedAt]
+    );
+
+    initDatabase(db);
+
+    const row = db
+      .query<{ listed_at: number }, [string]>('SELECT listed_at FROM document_cache WHERE did = ?')
+      .get(AUTHOR);
+    expect(row?.listed_at).toBe(fetchedAt);
+  });
+
+  it('caps permanent-error backoff for an actively requested author', async () => {
+    const { db, app } = createTestApp({ cacheTtlMs: 1, staleTtlMs: 2 });
+    const now = Date.now();
+    insertDocCache(db, {
+      documents: [proxyDoc({ recordUri: 'real' })],
+      fetchedAt: now - 10_000,
+      listedAt: now - 10_000,
+      lastRequestedAt: now,
+      errorCount: 4,
+    });
+    const fetchMock = mockAtprotoFetch({ listStatus: 500 });
+
+    await postDocuments(app, [{ did: AUTHOR }]);
+
+    const row = db
+      .query<{ error_count: number; next_retry_at: number }, [string]>(
+        'SELECT error_count, next_retry_at FROM document_cache WHERE did = ?'
+      )
+      .get(AUTHOR);
+    expect(row?.error_count).toBe(5);
+    expect(row!.next_retry_at).toBeLessThanOrEqual(Date.now() + 6 * 60 * 60 * 1000);
+    fetchMock.mockRestore();
+  });
+});
+
 describe('resolveSiteMeta caching', () => {
   let fetchMock: ReturnType<typeof spyOn> | undefined;
   afterEach(() => {

--- a/feed-proxy/src/documents.test.ts
+++ b/feed-proxy/src/documents.test.ts
@@ -362,6 +362,32 @@ describe('POST /documents', () => {
     expect(json.authors[0].status).toBe('error');
   });
 
+  it('shortens a legacy error-placeholder backoff when the author is requested', async () => {
+    const { db, app } = createTestApp();
+    const now = Date.now();
+    insertDocCache(db, {
+      documents: [],
+      fetchedAt: now,
+      listedAt: now,
+      lastRequestedAt: now - 1000,
+      errorCount: 5,
+      nextRetryAt: now + 7 * 24 * 60 * 60 * 1000,
+    });
+
+    const json = (await (await postDocuments(app, [{ did: AUTHOR }])).json()) as {
+      authors: Array<{ status: string; nextRetryAt?: number }>;
+    };
+    const row = db
+      .query<{ next_retry_at: number }, [string]>(
+        'SELECT next_retry_at FROM document_cache WHERE did = ?'
+      )
+      .get(AUTHOR);
+
+    expect(json.authors[0].status).toBe('error');
+    expect(row!.next_retry_at).toBeLessThanOrEqual(Date.now() + 6 * 60 * 60 * 1000);
+    expect(json.authors[0].nextRetryAt).toBe(row!.next_retry_at);
+  });
+
   it('rejects an empty authors array', async () => {
     const { app } = createTestApp();
     const res = await postDocuments(app, []);

--- a/feed-proxy/src/index.ts
+++ b/feed-proxy/src/index.ts
@@ -141,7 +141,16 @@ const { app, warmStaleFeeds, warmStaleDocuments } = createApp(db, {
   extractQueueMax: EXTRACT_QUEUE_MAX,
   feedFetchConcurrency: FEED_FETCH_CONCURRENCY,
   feedFetchQueueMax: FEED_FETCH_QUEUE_MAX,
-  getFirehoseStatus: () => firehose?.status() ?? { healthy: false, isSubscribed: () => false },
+  getFirehoseStatus: () =>
+    firehose?.status() ?? {
+      healthy: false,
+      connected: false,
+      subscribedDids: 0,
+      lastEventAt: null,
+      reconnectAttempts: 0,
+      cursor: null,
+      isSubscribed: () => false,
+    },
   ingestEnabled: INGEST_ENABLED,
 });
 

--- a/feed-proxy/src/integration.test.ts
+++ b/feed-proxy/src/integration.test.ts
@@ -1345,6 +1345,25 @@ describe('Integration Tests', () => {
 				VALUES (?, ?, ?, ?, ?, ?)`,
         ['healthy', 'https://example.com/ok', '{}', Date.now(), Date.now(), 0]
       );
+      // listed_at=0 means a splice repair is pending, not that the author has
+      // genuinely gone 48h without a list. Only the latter belongs in frozen.
+      const activeAt = Date.now();
+      db.run(
+        `INSERT INTO document_cache
+          (did, documents_json, cached_at, fetched_at, listed_at, error_count, last_requested_at)
+         VALUES (?, '[]', ?, ?, 0, 0, ?), (?, '[]', ?, ?, ?, 0, ?)`,
+        [
+          'did:plc:repairpending',
+          activeAt,
+          activeAt,
+          activeAt,
+          'did:plc:genuinelyfrozen',
+          activeAt,
+          activeAt,
+          activeAt - 3 * 24 * 60 * 60 * 1000,
+          activeAt,
+        ]
+      );
 
       const res = await app.request('/stats', {
         headers: { 'X-Proxy-Secret': 'test-secret' },
@@ -1354,6 +1373,7 @@ describe('Integration Tests', () => {
       expect(json.errors).toBeDefined();
       expect(json.errors.total).toBe(2); // Both error feeds
       expect(json.errors.inBackoff).toBe(2); // Both in backoff
+      expect(json.documents.frozen).toBe(1);
     });
 
     it('returns error info in bulk feed response for real content with errors', async () => {

--- a/feed-proxy/src/jetstream.test.ts
+++ b/feed-proxy/src/jetstream.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeEach } from 'bun:test';
+import { test, expect, describe, beforeEach, jest } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { initDatabase } from './app';
 import { DocumentFirehose } from './jetstream';
@@ -205,7 +205,8 @@ describe('DocumentFirehose reconcile / active-author set', () => {
 
     fh.reconcile(); // not running → updates the set without connecting
 
-    expect(fh.isSubscribed('did:plc:fresh')).toBe(true);
+    // Desired authors are not trusted until their filter reaches Jetstream.
+    expect(fh.isSubscribed('did:plc:fresh')).toBe(false);
     expect(fh.isSubscribed('did:plc:stale')).toBe(false);
   });
 
@@ -284,16 +285,19 @@ describe('DocumentFirehose.isHealthy', () => {
 });
 
 describe('DocumentFirehose repair scheduling', () => {
-  test('keeps the desired filter dirty and reconnects when options_update throws', () => {
+  test('keeps the desired filter dirty and backs off repeated options_update failures', () => {
+    jest.useFakeTimers();
     const db = makeDb();
     const fh = new DocumentFirehose(db, { enabled: false });
     const internals = fh as unknown as {
+      running: boolean;
       subscribedDids: Set<string>;
       sentDids: Set<string>;
       ws: WebSocket;
-      reconnect: () => void;
+      connect: () => void;
       sendOptionsUpdate: (ws: WebSocket) => boolean;
     };
+    internals.running = true;
     internals.subscribedDids = new Set([DID]);
     const ws = {
       send: () => {
@@ -301,14 +305,26 @@ describe('DocumentFirehose repair scheduling', () => {
       },
     } as unknown as WebSocket;
     internals.ws = ws;
-    let reconnects = 0;
-    internals.reconnect = () => {
-      reconnects++;
-    };
+    let connects = 0;
+    internals.connect = () => connects++;
 
     expect(internals.sendOptionsUpdate(ws)).toBe(false);
     expect(internals.sentDids.size).toBe(0);
-    expect(reconnects).toBe(1);
+    expect(fh.isSubscribed(DID)).toBe(false);
+    expect(connects).toBe(0);
+    jest.advanceTimersByTime(999);
+    expect(connects).toBe(0);
+    jest.advanceTimersByTime(1);
+    expect(connects).toBe(1);
+
+    // A second failed connection uses the next exponential-backoff tier.
+    internals.ws = ws;
+    expect(internals.sendOptionsUpdate(ws)).toBe(false);
+    jest.advanceTimersByTime(1999);
+    expect(connects).toBe(1);
+    jest.advanceTimersByTime(1);
+    expect(connects).toBe(2);
+    jest.useRealTimers();
   });
 
   test('marks an author for re-list when applying an event throws', async () => {

--- a/feed-proxy/src/jetstream.test.ts
+++ b/feed-proxy/src/jetstream.test.ts
@@ -282,3 +282,54 @@ describe('DocumentFirehose.isHealthy', () => {
     expect(fh.isHealthy()).toBe(false);
   });
 });
+
+describe('DocumentFirehose repair scheduling', () => {
+  test('keeps the desired filter dirty and reconnects when options_update throws', () => {
+    const db = makeDb();
+    const fh = new DocumentFirehose(db, { enabled: false });
+    const internals = fh as unknown as {
+      subscribedDids: Set<string>;
+      sentDids: Set<string>;
+      ws: WebSocket;
+      reconnect: () => void;
+      sendOptionsUpdate: (ws: WebSocket) => boolean;
+    };
+    internals.subscribedDids = new Set([DID]);
+    const ws = {
+      send: () => {
+        throw new Error('closed');
+      },
+    } as unknown as WebSocket;
+    internals.ws = ws;
+    let reconnects = 0;
+    internals.reconnect = () => {
+      reconnects++;
+    };
+
+    expect(internals.sendOptionsUpdate(ws)).toBe(false);
+    expect(internals.sentDids.size).toBe(0);
+    expect(reconnects).toBe(1);
+  });
+
+  test('marks an author for re-list when applying an event throws', async () => {
+    const db = makeDb();
+    const now = Date.now();
+    seedAuthor(db, DID, [], now);
+    db.run('UPDATE document_cache SET listed_at = ? WHERE did = ?', [now, DID]);
+    const fh = new DocumentFirehose(db, { enabled: false });
+    const internals = fh as unknown as {
+      applyDocumentEvent: () => Promise<boolean>;
+      handleMessage: (data: string) => Promise<void>;
+    };
+    internals.applyDocumentEvent = async () => {
+      throw new Error('splice failed');
+    };
+
+    await internals.handleMessage(JSON.stringify(event(DID, 'p1', 'delete')));
+
+    const row = db
+      .query<{ listed_at: number }, [string]>('SELECT listed_at FROM document_cache WHERE did = ?')
+      .get(DID);
+    expect(row?.listed_at).toBe(0);
+  });
+});

--- a/feed-proxy/src/jetstream.ts
+++ b/feed-proxy/src/jetstream.ts
@@ -54,6 +54,11 @@ const STABLE_CONNECTION_MS = 60_000;
  *  authors the firehose is actively keeping fresh. */
 export interface FirehoseStatus {
   healthy: boolean;
+  connected?: boolean;
+  subscribedDids?: number;
+  lastEventAt?: number | null;
+  reconnectAttempts?: number;
+  cursor?: string | null;
   isSubscribed: (did: string) => boolean;
 }
 
@@ -99,6 +104,10 @@ export class DocumentFirehose {
   private connected = false;
   private ws: WebSocket | null = null;
   private subscribedDids = new Set<string>();
+  // The filter the server has actually accepted for the current socket. Keep it
+  // separate from the desired set: a failed options_update must remain dirty so
+  // reconcile retries it instead of trusting a filter the server never saw.
+  private sentDids = new Set<string>();
   private lastCursor: string | null = null;
   private lastEventAt = 0;
   // Timestamp of the last frame of *any* kind (message/ping/pong) on the live
@@ -174,7 +183,15 @@ export class DocumentFirehose {
   }
 
   status(): FirehoseStatus {
-    return { healthy: this.isHealthy(), isSubscribed: (did) => this.isSubscribed(did) };
+    return {
+      healthy: this.isHealthy(),
+      connected: this.connected,
+      subscribedDids: this.subscribedDids.size,
+      lastEventAt: this.lastEventAt || null,
+      reconnectAttempts: this.reconnectAttempts,
+      cursor: this.lastCursor,
+      isSubscribed: (did) => this.isSubscribed(did),
+    };
   }
 
   // --- Active-author set ------------------------------------------------------
@@ -230,12 +247,13 @@ export class DocumentFirehose {
    *  wantedDids filter is fixed per-connection). Public for tests. */
   reconcile(): void {
     const next = new Set(this.computeActiveDids(Date.now()));
-    if (setsEqual(next, this.subscribedDids)) {
+    const desiredChanged = !setsEqual(next, this.subscribedDids);
+    if (!desiredChanged && setsEqual(next, this.sentDids)) {
       this.flushCursor();
       return;
     }
     this.subscribedDids = next;
-    console.log(`[Firehose] active author set changed → ${next.size}`);
+    if (desiredChanged) console.log(`[Firehose] active author set changed → ${next.size}`);
     this.flushCursor();
     if (!this.running) return;
     if (next.size === 0) {
@@ -256,7 +274,7 @@ export class DocumentFirehose {
    *  message. Used both on `open` (the URL carries no DIDs) and on reconcile to
    *  narrow/widen the watched set without reconnecting. The message replaces the
    *  connection's whole filter, so it must carry both fields. */
-  private sendOptionsUpdate(ws: WebSocket): void {
+  private sendOptionsUpdate(ws: WebSocket): boolean {
     const message = {
       type: 'options_update',
       payload: {
@@ -266,8 +284,16 @@ export class DocumentFirehose {
     };
     try {
       ws.send(JSON.stringify(message));
+      this.sentDids = new Set(this.subscribedDids);
+      return true;
     } catch (err) {
       console.error('[Firehose] options_update send failed:', err);
+      this.sentDids.clear();
+      // The socket's server-side filter is now unknowable. Reconnect so the
+      // next open sends the complete desired set, and retain the dirty sent set
+      // so a later reconcile also retries if reconnect cannot start.
+      if (this.ws === ws) this.reconnect();
+      return false;
     }
   }
 
@@ -380,7 +406,7 @@ export class DocumentFirehose {
       this.lastEventAt = now;
       this.lastActivityAt = now;
       console.log(`[Firehose] connected, watching ${this.subscribedDids.size} author(s)`);
-      this.sendOptionsUpdate(ws);
+      if (!this.sendOptionsUpdate(ws)) return;
       this.startPingTimer(ws);
       // Clear the backoff only once the connection has *held*. Resetting on
       // `open` alone turns any instant-close condition (a rejected
@@ -451,8 +477,13 @@ export class DocumentFirehose {
         await this.applyDocumentEvent(event);
       } catch (err) {
         console.error(`[Firehose] failed to apply event for ${event.did}:`, err);
+        this.markAuthorForRelist(event.did);
       }
     }
+  }
+
+  private markAuthorForRelist(did: string): void {
+    this.db.run('UPDATE document_cache SET listed_at = 0 WHERE did = ?', [did]);
   }
 
   /** Ping the server every PING_INTERVAL_MS and force a reconnect if no frame
@@ -518,6 +549,7 @@ export class DocumentFirehose {
         /* ignore */
       }
     }
+    this.sentDids.clear();
     this.connected = false;
   }
 

--- a/feed-proxy/src/jetstream.ts
+++ b/feed-proxy/src/jetstream.ts
@@ -179,7 +179,10 @@ export class DocumentFirehose {
   }
 
   isSubscribed(did: string): boolean {
-    return this.subscribedDids.has(did);
+    // The serve path uses this as permission to trust the spliced cache. Only
+    // report filters successfully sent on the current socket, not desired DIDs
+    // still waiting for an options_update/reconnect.
+    return this.sentDids.has(did);
   }
 
   status(): FirehoseStatus {
@@ -289,10 +292,13 @@ export class DocumentFirehose {
     } catch (err) {
       console.error('[Firehose] options_update send failed:', err);
       this.sentDids.clear();
-      // The socket's server-side filter is now unknowable. Reconnect so the
-      // next open sends the complete desired set, and retain the dirty sent set
-      // so a later reconcile also retries if reconnect cannot start.
-      if (this.ws === ws) this.reconnect();
+      // The socket's server-side filter is now unknowable. Close it and use the
+      // normal capped reconnect backoff; reconnecting immediately here creates
+      // a handshake-rate loop when every open socket rejects send().
+      if (this.ws === ws) {
+        this.closeSocket();
+        this.scheduleReconnect();
+      }
       return false;
     }
   }


### PR DESCRIPTION
Repairs frozen standard.site/Leaflet document caches by making firehose filter failures retryable, scheduling full re-lists after splice failures, bounding active-reader backoff, and using a durable list freshness clock.

Follow-up fixes route failed filter sends through exponential reconnect backoff, trust only successfully sent DID filters, clamp legacy error-placeholder backoffs on the request path, and keep repair sentinels out of the frozen-author alert.

Adds proxy document-lane health stats, backend alerting, an admin Document Sync tile, focused recovery tests, and an incident runbook.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-sikwkxl5hzc5h3bw25fn3zp3)
