### PR TITLE
Move standard.site documents from the Fly proxy into D1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,8 @@ AT Protocol (Bluesky PDS) + Fly.io Feed Proxy + Jetstream Firehose
 - **Framework:** SvelteKit 2.x with Svelte 5 runes
 - **Runtime:** Cloudflare Pages
 - **Database:** D1 (SQLite) - reads the same database as the backend
-- **Features:** Ops panel (cron liveness, firehose lag, proxy cache health) with 30-day trend
+- **Features:** Ops panel (cron liveness, firehose lag, document-stream lag + ingest saturation,
+  proxy cache health) with 30-day trend
   sparklines, system metrics, user management, feed health monitoring, search/sort/pagination
 - **Pages:** Dashboard (ops + metrics + trends), Users (list + detail), Feeds (health + error tracking).
   Feed health is the crawler's own verdict from `feeds.error_count` / `feeds.crawl_stale`, not an
@@ -234,6 +235,11 @@ AT Protocol (Bluesky PDS) + Fly.io Feed Proxy + Jetstream Firehose
    frontend refreshes with one `GET /api/v2/timeline` query that joins subscriptions and read
    state. Reads never touch Fly — see `docs/plans/D1_FEED_TIMELINE.md`
 4. **Social:** Jetstream firehose → D1 shares table → frontend polls for updates
+5. **Documents:** the JetstreamPoller DO drains `site.standard.document` (filtered to
+   subscribed authors) into D1, backfilling an author's back catalogue from their PDS at
+   subscribe time; `/api/v2/documents/batch` serves from D1 behind the
+   `documents_v2_enabled` gate, from the Fly proxy until it's flipped — see
+   `docs/plans/DOCUMENTS_TO_D1.md`
 
 ## AT Protocol Integration
 

--- a/admin/src/lib/metrics/ops.test.ts
+++ b/admin/src/lib/metrics/ops.test.ts
@@ -28,6 +28,12 @@ const status = (overrides: Partial<OpsStatus> = {}): OpsStatus => ({
       processed: 12,
       errors: 0,
       alarmScheduled: true,
+      documentsLagMs: 30_000,
+      documentsProcessed: 3,
+      documentsErrors: 0,
+      documentsCapStreak: 0,
+      documentsAuthors: 42,
+      documentsIngestPaused: false,
     },
   },
   proxy: {
@@ -126,6 +132,42 @@ describe('ops tiles', () => {
     expect(fresh(null)).toBe('warning');
   });
 
+  it('grades the document stream separately from subscriptions', () => {
+    const s = status();
+    s.poller!.value.documentsLagMs = 20 * MINUTE;
+    const metrics = opsMetricsFrom(s, NOW);
+    expect(tile(metrics, 'Document Stream Lag').status).toBe('error');
+    // One stream stuck while the other is fine is exactly what a shared number
+    // would hide.
+    expect(tile(metrics, 'Firehose Lag').status).toBe('healthy');
+  });
+
+  it('escalates as capped cycles pile up, and says so when ingest is paused', () => {
+    const streak = (n: number) => {
+      const s = status();
+      s.poller!.value.documentsCapStreak = n;
+      return tile(opsMetricsFrom(s, NOW), 'Document Ingest');
+    };
+    // A burst draining across a couple of cycles is the design working.
+    expect(streak(0).value).toBe('Draining');
+    expect(streak(1).status).toBe('healthy');
+    expect(streak(4).status).toBe('warning');
+    expect(streak(12).status).toBe('error');
+
+    const paused = status();
+    paused.poller!.value.documentsIngestPaused = true;
+    const metrics = opsMetricsFrom(paused, NOW);
+    expect(tile(metrics, 'Document Ingest').value).toBe('Disabled');
+    // A paused stream's lag climbs by construction; don't render it as a stall.
+    expect(tile(metrics, 'Document Stream Lag').value).toBe('Paused');
+  });
+
+  it('says "no data" for a backend that predates the document stream', () => {
+    const s = status();
+    delete s.poller!.value.documentsLagMs;
+    expect(tile(opsMetricsFrom(s, NOW), 'Document Stream Lag').value).toBe('No data');
+  });
+
   it('grades frozen document authors by whether re-listing looks broken', () => {
     // The tile is graded the way the backend's alert is graded: a straggler is
     // visible without being an emergency, so the red keeps meaning something.
@@ -144,7 +186,7 @@ describe('ops tiles', () => {
 
   it('renders a full set of tiles before the cron has ever run', () => {
     const metrics = opsMetricsFrom({ cron: null, poller: null, proxy: null }, NOW);
-    expect(metrics).toHaveLength(7);
+    expect(metrics).toHaveLength(9);
     expect(metrics.every((m) => m.status === 'error')).toBe(true);
   });
 });

--- a/admin/src/lib/metrics/ops.ts
+++ b/admin/src/lib/metrics/ops.ts
@@ -83,7 +83,22 @@ function cronMetric(status: OpsStatus, now: number): MetricValue {
   };
 }
 
-const POLLER_LABELS = ['Firehose Lag', 'Last Poll', 'Poll Errors (last cycle)'] as const;
+const POLLER_LABELS = [
+  'Firehose Lag',
+  'Last Poll',
+  'Poll Errors (last cycle)',
+  'Document Stream Lag',
+  'Document Ingest',
+] as const;
+
+/**
+ * Consecutive capped document cycles before the tile goes red. Mirrors the
+ * backend's `DOCUMENT_CAP_SATURATION_ALERT_STREAK`: one or two capped cycles is a
+ * burst draining exactly as designed, ten in a row is a flood that wants the
+ * `documents_ingest_enabled` switch.
+ */
+const CAP_STREAK_ERROR = 10;
+const CAP_STREAK_WARN = 3;
 
 function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
   const poller = status.poller;
@@ -116,6 +131,50 @@ function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
           status: pollAge > POLL_STALE_MS ? 'error' : 'healthy',
         };
 
+  const {
+    documentsLagMs,
+    documentsCapStreak = 0,
+    documentsAuthors = 0,
+    documentsIngestPaused = false,
+  } = poller.value;
+
+  // The two streams fail independently — one stuck while the other is healthy is
+  // exactly what a single "firehose lag" number hides — so documents get their own
+  // tile, graded on the same thresholds.
+  const documentsLag: MetricValue =
+    documentsLagMs === undefined
+      ? unknown(POLLER_LABELS[3])
+      : documentsIngestPaused
+        ? { label: POLLER_LABELS[3], value: 'Paused', status: 'warning' }
+        : documentsLagMs === null
+          ? { label: POLLER_LABELS[3], value: '—', status: 'warning' }
+          : {
+              label: POLLER_LABELS[3],
+              value: formatAge(documentsLagMs),
+              status:
+                documentsLagMs >= LAG_ERROR_MS
+                  ? 'error'
+                  : documentsLagMs >= LAG_WARN_MS
+                    ? 'warning'
+                    : 'healthy',
+            };
+
+  // Cap saturation: how many cycles in a row the drain stopped early. This is the
+  // number an operator reads before deciding a burst has become a flood.
+  const documentIngest: MetricValue = documentsIngestPaused
+    ? { label: POLLER_LABELS[4], value: 'Disabled', status: 'error' }
+    : {
+        label: POLLER_LABELS[4],
+        value: documentsCapStreak === 0 ? 'Draining' : `${documentsCapStreak} capped cycles`,
+        unit: `${documentsAuthors} authors`,
+        status:
+          documentsCapStreak >= CAP_STREAK_ERROR
+            ? 'error'
+            : documentsCapStreak >= CAP_STREAK_WARN
+              ? 'warning'
+              : 'healthy',
+      };
+
   return [
     lag,
     lastPoll,
@@ -124,6 +183,8 @@ function pollerMetrics(status: OpsStatus, now: number): MetricValue[] {
       value: errors,
       status: errors > 0 ? 'warning' : 'healthy',
     },
+    documentsLag,
+    documentIngest,
   ];
 }
 

--- a/admin/src/lib/queries/ops.ts
+++ b/admin/src/lib/queries/ops.ts
@@ -15,6 +15,17 @@ export interface PollerStatusValue {
   processed: number;
   errors: number;
   alarmScheduled: boolean;
+  // The document stream (site.standard.document + reader collections), which the
+  // poller drains alongside subscriptions. Optional: a backend that predates it
+  // writes rows without these, and the tiles say "no data" rather than "0".
+  documentsLagMs?: number | null;
+  documentsProcessed?: number;
+  documentsErrors?: number;
+  /** Consecutive cycles that stopped on the per-cycle apply cap. */
+  documentsCapStreak?: number;
+  documentsAuthors?: number;
+  /** `documents_ingest_enabled` is off — a deliberate pause, not a stall. */
+  documentsIngestPaused?: boolean;
 }
 
 export interface CronLastRunValue {

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -50,7 +50,12 @@ Each fan-out asks `canAffordBackfill` before starting an author and leaves the r
 reconcile queue rather than throwing halfway through a walk that has already written rows.
 `BACKFILL_QUERY_COST` is a true worst case — every per-row term is either one statement (the
 prune is a single `updated_at`-scoped DELETE; the sidecars are one read plus one capped batch) or
-capped (`MAX_SITE_RESOLVES_PER_BACKFILL`, `MAX_COLLECTION_WRITES_PER_BACKFILL`). The same ceiling
+capped (`MAX_SITE_RESOLVES_PER_BACKFILL`, `MAX_COLLECTION_WRITES_PER_BACKFILL`). A walk resolves
+the author's DID once for both of its listings (`PdsMemo`) — `resolvePdsUrl` is an uncached fetch,
+and the second one is a subrequest the listing term does not budget. The sidecar cap is the floor
+that arithmetic leaves at every other cap at once, not a flat limit: a walk spends its unspent
+headroom on sidecars and records what it still couldn't afford as `collections_pending`, which
+keeps the author in the reconcile queue instead of parking them for an interval. The same ceiling
 is why an applied event costs a single statement: the cap eviction and bookkeeping settle once per
 author at the end of a cycle. **Still unbounded:** the PDS→local subscription pull's insert batch
 is one statement per restored row, capped only by the plan's mirror limit (1000/5000), so a very

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -30,7 +30,11 @@ and the subscription-gated pull-through in `/api/v2/feeds/fetch`.
 and `/api/v2/documents/get` serve from D1 once `sync_state.documents_v2_enabled` is `'1'` and from
 the proxy until then, wire-identical either way. Writes have their own switch
 (`documents_ingest_enabled`) so a flood can be paused without touching reads or the subscriptions
-stream. See `docs/plans/DOCUMENTS_TO_D1.md` and RUNBOOK §4e.
+stream. Every path that creates an `atproto.documents` subscription — the API, the Atmosphere
+subscribe button, the PDS→local sync, and a subscription mirrored in by the poller — goes through
+`ensureAuthorDocuments`, because a subscription whose author was never listed serves
+`status:'error'` on every poll until something lists them. See `docs/plans/DOCUMENTS_TO_D1.md` and
+RUNBOOK §4e.
 
 ## Key Concepts
 
@@ -207,7 +211,9 @@ Key tables:
   negative TTL. Replaces 0031's `publications_cache`, whose `base_url` is NOT NULL and so can't
   hold a negative entry
 - `document_authors` - Per-author ingest bookkeeping: last successful list (drives the reconcile
-  queue), whether the stored set is the author's complete repo, and the last backfill error
+  queue), whether the last list saw the author's whole repo, and the last backfill error with its
+  timestamp — a failed list holds that author out of the reconcile queue for a doubling backoff, so
+  an author nobody can list (deleted account, dead PDS) can't monopolise the only self-heal there is
 - `documents` / `publications_cache` - orphaned from the pre-proxy era; still not read or written.
   They stay until the proxy document path is decommissioned
 - `item_labels_cache` - Unified labels (read/starred/archived/tags)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -35,13 +35,28 @@ reconcile — leaving only the operator backfill endpoint. Every path that creat
 `atproto.documents` subscription — the API, the Atmosphere subscribe button, the Atmosphere graph
 import, the PDS→local subscription pull, and a subscription mirrored in by the poller — goes
 through `ensureAuthorDocuments`, because a subscription whose author was never listed serves
-`status:'error'` on every poll until something lists them. The two sync paths bound their fan-out
-at `MAX_SYNC_BACKFILLS` and leave the tail to the reconcile (a never-listed author sorts to the
-front of that queue, drained one a minute plus three an hour): every walk they schedule runs in
-the same invocation, and D1 allows `D1_QUERIES_PER_INVOCATION` queries per one. That ceiling is
-what the drain budgets against too, and why an applied event costs a single statement — the cap
-eviction and bookkeeping settle once per author at the end of a cycle. See
-`docs/plans/DOCUMENTS_TO_D1.md` and RUNBOOK §4e.
+`status:'error'` on every poll until something lists them. (Those subscribe/sync paths are
+deliberately **not** gated by `documents_ingest_enabled`: a reader subscribing during an incident
+should still see their linkblog, and each walk is one author, deduped to one an hour. The switch
+governs the background loops — the drain, the poller's queue, the cron's reconcile.)
+
+**The budget everything here is sized against** is `D1_QUERIES_PER_INVOCATION`: 1,000 per Worker
+invocation, counting each statement inside a `batch` separately _and_ sharing that ceiling with
+outbound `fetch()`es (it is the read-subrequest limit), so `document-store.ts` counts both as
+subrequests. A `QueryLedger` is per invocation, not per loop: the cron's two reconcile passes
+share one, the operator endpoint's batch shares one, and `/api/sync` threads one through both of
+its halves so the walks it schedules are admitted against what the request has already spent.
+Each fan-out asks `canAffordBackfill` before starting an author and leaves the rest in the
+reconcile queue rather than throwing halfway through a walk that has already written rows.
+`BACKFILL_QUERY_COST` is a true worst case — every per-row term is either one statement (the
+prune is a single `updated_at`-scoped DELETE; the sidecars are one read plus one capped batch) or
+capped (`MAX_SITE_RESOLVES_PER_BACKFILL`, `MAX_COLLECTION_WRITES_PER_BACKFILL`). The same ceiling
+is why an applied event costs a single statement: the cap eviction and bookkeeping settle once per
+author at the end of a cycle. **Still unbounded:** the PDS→local subscription pull's insert batch
+is one statement per restored row, capped only by the plan's mirror limit (1000/5000), so a very
+large restore can exhaust the invocation on its own — it charges the ledger (which is what stops
+walks being scheduled on top of it) and logs `subscription_pull_batch_large`, but nothing chunks
+it. See `docs/plans/DOCUMENTS_TO_D1.md` and RUNBOOK §4e.
 
 ## Key Concepts
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -30,11 +30,18 @@ and the subscription-gated pull-through in `/api/v2/feeds/fetch`.
 and `/api/v2/documents/get` serve from D1 once `sync_state.documents_v2_enabled` is `'1'` and from
 the proxy until then, wire-identical either way. Writes have their own switch
 (`documents_ingest_enabled`) so a flood can be paused without touching reads or the subscriptions
-stream. Every path that creates an `atproto.documents` subscription — the API, the Atmosphere
-subscribe button, the PDS→local sync, and a subscription mirrored in by the poller — goes through
-`ensureAuthorDocuments`, because a subscription whose author was never listed serves
-`status:'error'` on every poll until something lists them. See `docs/plans/DOCUMENTS_TO_D1.md` and
-RUNBOOK §4e.
+stream; it stops every background write — the drain, the poller's back catalogues and the cron's
+reconcile — leaving only the operator backfill endpoint. Every path that creates an
+`atproto.documents` subscription — the API, the Atmosphere subscribe button, the Atmosphere graph
+import, the PDS→local subscription pull, and a subscription mirrored in by the poller — goes
+through `ensureAuthorDocuments`, because a subscription whose author was never listed serves
+`status:'error'` on every poll until something lists them. The two sync paths bound their fan-out
+at `MAX_SYNC_BACKFILLS` and leave the tail to the reconcile (a never-listed author sorts to the
+front of that queue, drained one a minute plus three an hour): every walk they schedule runs in
+the same invocation, and D1 allows `D1_QUERIES_PER_INVOCATION` queries per one. That ceiling is
+what the drain budgets against too, and why an applied event costs a single statement — the cap
+eviction and bookkeeping settle once per author at the end of a cycle. See
+`docs/plans/DOCUMENTS_TO_D1.md` and RUNBOOK §4e.
 
 ## Key Concepts
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -21,8 +21,16 @@ the gate is what actually admits readers to the archive (and, set back to `'0'`,
 rollback that returns every client to the legacy batch path with no deploy). Either half false and
 clients stay on `/batch`; the request short-circuits rather than building a page they will discard.
 See `docs/plans/D1_FEED_TIMELINE.md`. The proxy is still on the path for `/api/extract`, feed
-discovery, standard.site documents, and social context — plus the one crawl per new subscription
-(`warmFeedIntoArchive`) and the subscription-gated pull-through in `/api/v2/feeds/fetch`.
+discovery, and social context — plus the one crawl per new subscription (`warmFeedIntoArchive`)
+and the subscription-gated pull-through in `/api/v2/feeds/fetch`.
+
+**standard.site documents are following feeds into D1.** The JetstreamPoller DO now drains
+`site.standard.document` (+ its `app.standard-reader.collection` sidecar) straight into
+`documents_v2`, filtered server-side to the subscribed-author DID set; `/api/v2/documents/batch`
+and `/api/v2/documents/get` serve from D1 once `sync_state.documents_v2_enabled` is `'1'` and from
+the proxy until then, wire-identical either way. Writes have their own switch
+(`documents_ingest_enabled`) so a flood can be paused without touching reads or the subscriptions
+stream. See `docs/plans/DOCUMENTS_TO_D1.md` and RUNBOOK §4e.
 
 ## Key Concepts
 
@@ -61,26 +69,27 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 
 ### Routes
 
-| File                          | Purpose                                                |
-| ----------------------------- | ------------------------------------------------------ |
-| `src/routes/auth.ts`          | OAuth flow (login, callback, logout, client metadata)  |
-| `src/routes/timeline.ts`      | `GET /api/v2/timeline` — the whole refresh, one query  |
-| `src/routes/ingest.ts`        | Crawler endpoints: item ingest, crawl set, feed health |
-| `src/routes/feeds-v2.ts`      | Single-feed read (D1 + pull-through), discover, docs   |
-| `src/routes/social.ts`        | Social feed, popular, grouped, detect-content          |
-| `src/routes/shares.ts`        | User shares CRUD (with PDS sync)                       |
-| `src/routes/subscriptions.ts` | Subscription CRUD (with PDS sync)                      |
-| `src/routes/records.ts`       | PDS record listing                                     |
-| `src/routes/reading.ts`       | Article + document read positions (forward delta)      |
-| `src/routes/labels.ts`        | Unified item labels (read/starred/archived/tags)       |
-| `src/routes/saved.ts`         | Saved articles CRUD                                    |
-| `src/routes/integrations.ts`  | Semble/Margin writes to the user's PDS                 |
-| `src/routes/settings.ts`      | User settings                                          |
-| `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status          |
-| `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons         |
-| `src/routes/health.ts`        | `/api/health` (shallow) + `/api/health/deep` (gated)   |
-| `src/routes/telemetry.ts`     | `/api/telemetry/error` — sampled client error reports  |
-| `src/routes/guest.ts`         | `/api/guest/*` — the unauthenticated reading surface   |
+| File                          | Purpose                                                   |
+| ----------------------------- | --------------------------------------------------------- |
+| `src/routes/auth.ts`          | OAuth flow (login, callback, logout, client metadata)     |
+| `src/routes/timeline.ts`      | `GET /api/v2/timeline` — the whole refresh, one query     |
+| `src/routes/ingest.ts`        | Crawler endpoints: item ingest, crawl set, feed health    |
+| `src/routes/documents.ts`     | Document backfill + proxy-vs-D1 shadow compare (internal) |
+| `src/routes/feeds-v2.ts`      | Single-feed read (D1 + pull-through), discover, docs      |
+| `src/routes/social.ts`        | Social feed, popular, grouped, detect-content             |
+| `src/routes/shares.ts`        | User shares CRUD (with PDS sync)                          |
+| `src/routes/subscriptions.ts` | Subscription CRUD (with PDS sync)                         |
+| `src/routes/records.ts`       | PDS record listing                                        |
+| `src/routes/reading.ts`       | Article + document read positions (forward delta)         |
+| `src/routes/labels.ts`        | Unified item labels (read/starred/archived/tags)          |
+| `src/routes/saved.ts`         | Saved articles CRUD                                       |
+| `src/routes/integrations.ts`  | Semble/Margin writes to the user's PDS                    |
+| `src/routes/settings.ts`      | User settings                                             |
+| `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status             |
+| `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons            |
+| `src/routes/health.ts`        | `/api/health` (shallow) + `/api/health/deep` (gated)      |
+| `src/routes/telemetry.ts`     | `/api/telemetry/error` — sampled client error reports     |
+| `src/routes/guest.ts`         | `/api/guest/*` — the unauthenticated reading surface      |
 
 Guest reading mode is the only unauthenticated surface that reads the archive,
 and it is **read-only**. `POST /api/guest/timeline` is a query over
@@ -94,7 +103,7 @@ unauthenticated path can steer a fetch at a caller-chosen URL and nothing
 relaxes the `callerSubscribes` rule in `feeds-v2.ts`. Preserve that if you ever
 reopen guest adds — an earlier version had a bounded warm endpoint, and its
 bounds (per-IP rate, a per-feed freshness claim, a global daily ceiling, and an
-orphan reaper) all existed to contain exactly that one write path. See §4e of
+orphan reaper) all existed to contain exactly that one write path. See §4f of
 [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 Integration writes are gated per-capability, not per-app: `POST /api/integrations/semble/connections`
@@ -106,17 +115,20 @@ saves until they re-authed. `GET /api/integrations/status` reports the two separ
 
 ### Services
 
-| File                                | Purpose                                           |
-| ----------------------------------- | ------------------------------------------------- |
-| `src/services/oauth.ts`             | PKCE, DPoP, handle resolution, session management |
-| `src/services/feed-parser.ts`       | RSS/Atom/RDF parsing                              |
-| `src/services/feed-proxy-client.ts` | Client for Fly.io feed proxy                      |
-| `src/services/pds-client.ts`        | PDS API client                                    |
-| `src/services/client-auth.ts`       | Confidential client auth helpers                  |
-| `src/services/share-sync.ts`        | Push/delete shares to/from PDS                    |
-| `src/services/subscription-sync.ts` | Sync subscriptions to/from PDS                    |
-| `src/services/rate-limit.ts`        | Per-user per-endpoint rate limiting (D1-backed)   |
-| `src/services/user-tier.ts`         | Tier lookup (free/supporter)                      |
+| File                                | Purpose                                                      |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `src/services/oauth.ts`             | PKCE, DPoP, handle resolution, session management            |
+| `src/services/feed-parser.ts`       | RSS/Atom/RDF parsing                                         |
+| `src/services/feed-proxy-client.ts` | Client for Fly.io feed proxy                                 |
+| `src/services/standard-site.ts`     | standard.site record mapping, digest, publication cache      |
+| `src/services/document-store.ts`    | The D1 document store: apply, backfill, reconcile, serve     |
+| `src/services/document-flags.ts`    | `documents_v2_enabled` / `documents_ingest_enabled` switches |
+| `src/services/pds-client.ts`        | PDS API client                                               |
+| `src/services/client-auth.ts`       | Confidential client auth helpers                             |
+| `src/services/share-sync.ts`        | Push/delete shares to/from PDS                               |
+| `src/services/subscription-sync.ts` | Sync subscriptions to/from PDS                               |
+| `src/services/rate-limit.ts`        | Per-user per-endpoint rate limiting (D1-backed)              |
+| `src/services/user-tier.ts`         | Tier lookup (free/supporter)                                 |
 
 ### Observability
 
@@ -164,9 +176,9 @@ procedures: [`docs/RUNBOOK.md`](../docs/RUNBOOK.md).
 
 ### Durable Objects
 
-| File                                      | Purpose                                               |
-| ----------------------------------------- | ----------------------------------------------------- |
-| `src/durable-objects/jetstream-poller.ts` | Long-running Jetstream firehose connection via alarms |
+| File                                      | Purpose                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `src/durable-objects/jetstream-poller.ts` | Two Jetstream streams (subscriptions, documents) drained per alarm |
 
 ### Storage
 
@@ -186,16 +198,29 @@ Key tables:
 - `feed_items` - The feed archive the timeline serves: every item the crawler has ever pushed,
   keyed `(feed_url, guid)` with a monotonic `seq`. Never pruned in ordinary operation — see
   `docs/plans/D1_FEED_TIMELINE.md`
-- `documents` / `publications_cache` - orphaned after standard.site document reads moved to the
-  feed proxy; retained in place but no longer read or written
+- `documents_v2` - One row per `site.standard.document` record: the raw record (`record_json`)
+  plus the scalars the serve path queries on. Written by the poller and by backfill, capped at 100
+  rows per author
+- `collections_v2` - `app.standard-reader.collection` sidecars (curated magazine editions), paired
+  to their document by rkey, with the resolved item previews persisted after the first read
+- `publications_cache_v2` - Publication base URL / icon / name / theme / fonts, 24h TTL and a 5m
+  negative TTL. Replaces 0031's `publications_cache`, whose `base_url` is NOT NULL and so can't
+  hold a negative entry
+- `document_authors` - Per-author ingest bookkeeping: last successful list (drives the reconcile
+  queue), whether the stored set is the author's complete repo, and the last backfill error
+- `documents` / `publications_cache` - orphaned from the pre-proxy era; still not read or written.
+  They stay until the proxy document path is decommissioned
 - `item_labels_cache` - Unified labels (read/starred/archived/tags)
 - `saved_articles` - Saved/bookmarked articles
 - `social_read_positions_cache` - Legacy social read tracking (superseded; document
   reads now live in `item_labels_cache` as `item_type='document'`/`label='read'`)
 - `user_settings` - User preferences
 - `rate_limits` - Per-user rate limiting
-- `sync_state` - Jetstream cursor, the archive generation token, the crawler heartbeat, and
-  `timeline_enabled` (the rollout gate: only an explicit `'0'` holds clients on the batch path)
+- `sync_state` - Jetstream cursor, the archive generation token, the crawler heartbeat,
+  `timeline_enabled` (the rollout gate: only an explicit `'0'` holds clients on the batch path),
+  and the document switches: `documents_v2_enabled` (reads from D1; only an explicit `'1'`),
+  `documents_ingest_enabled` (the poller's document stream; only an explicit `'0'` stops it) and
+  the `documents_apply_cap` override
 - `system_status` - Cron-written health board (cron liveness, poller lag, proxy stats)
 - `metrics_snapshots` - Hourly trend points behind the admin's sparklines (90-day retention)
 

--- a/backend/migrations/0073_documents_v2.sql
+++ b/backend/migrations/0073_documents_v2.sql
@@ -1,0 +1,83 @@
+-- standard.site documents move from the Fly proxy's SQLite blob cache into D1.
+--
+-- The 0030 `documents` table predates `content`, `links`, `skyreaderLinkblog` and
+-- reader collections, and stored a flattened projection of the record. These
+-- tables keep the raw record instead (`record_json`) plus the scalars we query on,
+-- so a lexicon that grows a field needs no migration — the mapper reads it out of
+-- the stored record. 0030/0031 stay orphaned until the proxy path is decommissioned.
+
+-- One row per `site.standard.document` record. `record_uri` is the natural key:
+-- Jetstream gives us create/update/delete keyed by (did, collection, rkey), which
+-- is exactly the URI, so an upsert is a single statement with no read first.
+CREATE TABLE IF NOT EXISTS documents_v2 (
+    record_uri TEXT PRIMARY KEY,
+    author_did TEXT NOT NULL,
+    rkey TEXT NOT NULL,
+    record_cid TEXT NOT NULL,
+    -- The `site` field verbatim: an at:// publication URI, a loose https:// site,
+    -- or '' for a freestanding document. Publication scoping filters on it.
+    site_uri TEXT NOT NULL DEFAULT '',
+    -- ms epoch, resolved from the record's publishedAt (falling back to ingest
+    -- time). Drives both the serve order and the per-author cap eviction.
+    published_at INTEGER NOT NULL,
+    -- Resolved at write time from the publication's base URL. Re-derived at read
+    -- time when publication meta is fresher, so a repaired publication cache fixes
+    -- served URLs without rewriting rows; this column is the durable fallback and
+    -- the lookup key for URL-keyed joins.
+    canonical_url TEXT,
+    record_json TEXT NOT NULL,
+    indexed_at INTEGER NOT NULL,
+    updated_at INTEGER
+);
+
+-- The serve path is always "this author, newest first" (then scoped by site).
+CREATE INDEX IF NOT EXISTS idx_documents_v2_author_published
+    ON documents_v2(author_did, published_at DESC);
+CREATE INDEX IF NOT EXISTS idx_documents_v2_canonical ON documents_v2(canonical_url);
+
+-- `app.standard-reader.collection` sidecars: a curated magazine edition, paired to
+-- its `site.standard.document` by shared rkey. Item previews (cross-PDS getRecord
+-- fan-out) are resolved lazily in a request context and persisted here, so the
+-- fan-out happens once per edition rather than inside the poller's alarm.
+CREATE TABLE IF NOT EXISTS collections_v2 (
+    author_did TEXT NOT NULL,
+    rkey TEXT NOT NULL,
+    record_json TEXT NOT NULL,
+    preview_json TEXT,
+    preview_at INTEGER,
+    indexed_at INTEGER NOT NULL,
+    PRIMARY KEY (author_did, rkey)
+);
+
+-- Publication metadata (base URL / icon / name / theme / fonts) resolved from
+-- `site.standard.publication` + its `app.standard-reader.publicationTheme` sidecar.
+-- Replaces the 0031 table, which cannot hold a negative cache entry (its base_url
+-- is NOT NULL) and has no theme/fonts columns.
+CREATE TABLE IF NOT EXISTS publications_cache_v2 (
+    publication_uri TEXT PRIMARY KEY,
+    base_url TEXT,
+    icon TEXT,
+    name TEXT,
+    theme TEXT,
+    fonts TEXT,
+    cached_at INTEGER NOT NULL
+);
+
+-- Per-author ingest bookkeeping: when we last listed the author's repo (the
+-- self-heal reconcile picks the stalest), and the last backfill error so the serve
+-- path can report `status:'error'` for an author we have never successfully read
+-- instead of silently serving an empty list.
+CREATE TABLE IF NOT EXISTS document_authors (
+    author_did TEXT PRIMARY KEY,
+    last_listed_at INTEGER,
+    last_event_at INTEGER,
+    -- 1 when the last successful list returned fewer than the per-author cap, i.e.
+    -- the stored set is the author's complete repo (what the batch response's
+    -- `complete` flag reports).
+    complete INTEGER NOT NULL DEFAULT 0,
+    error_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    last_error_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_authors_listed ON document_authors(last_listed_at);

--- a/backend/migrations/0073_documents_v2.sql
+++ b/backend/migrations/0073_documents_v2.sql
@@ -75,6 +75,11 @@ CREATE TABLE IF NOT EXISTS document_authors (
     -- the stored set is the author's complete repo (what the batch response's
     -- `complete` flag reports).
     complete INTEGER NOT NULL DEFAULT 0,
+    -- Curated editions the last walk could not afford to write. Non-zero keeps the
+    -- author in the reconcile queue despite a fresh `last_listed_at`, so a back
+    -- catalogue's sidecars land over the next passes rather than one walk's worth
+    -- per reconcile interval.
+    collections_pending INTEGER NOT NULL DEFAULT 0,
     error_count INTEGER NOT NULL DEFAULT 0,
     last_error TEXT,
     last_error_at INTEGER

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -3,6 +3,7 @@ import type { Env } from '../types';
 import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
 import {
   createDocumentDrain,
+  ensureAuthorDocuments,
   subscribedDocumentAuthors,
   type DocumentCommitEvent,
 } from '../services/document-store';
@@ -83,6 +84,17 @@ export const CAP_SATURATION_ALERT_STREAK = 10;
 export const JETSTREAM_MAX_WANTED_DIDS = 10_000;
 
 const CAP_STREAK_KEY = 'documents_cap_streak';
+
+// Back catalogues pulled per cycle for subscriptions mirrored in from a PDS. Each
+// is up to five `listRecords` pages against a foreign PDS, so this is deliberately
+// small: the alarm's job is draining streams, and the queue survives to next cycle.
+const MAX_CYCLE_BACKFILLS = 3;
+
+// Ceiling on that queue. A device syncing a very long subscription list can enqueue
+// faster than three a cycle drains, and this is in-memory state on a long-lived
+// object; past the ceiling the surplus authors are left to the hourly reconcile,
+// which is where they would have been before any of this existed.
+const MAX_PENDING_BACKFILLS = 200;
 
 // How long after an alarm *started* we still consider the poller alive without a
 // scheduled alarm. `getAlarm()` returns null while the handler runs, so both
@@ -201,6 +213,15 @@ export function buildDocumentSubscribeUrl(
 class JetstreamPollerBase implements DurableObject {
   private state: DurableObjectState;
   private env: Env;
+
+  /**
+   * Authors whose documents this cycle's subscription events asked for. A
+   * subscription created on another device arrives here rather than through the
+   * API, so this is the fourth path that has to pull a back catalogue — but a
+   * `listRecords` walk must not happen inside the drain, where it would stall the
+   * socket, so the DIDs are collected and worked after both streams are closed.
+   */
+  private pendingDocumentBackfills = new Set<string>();
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -346,6 +367,15 @@ class JetstreamPollerBase implements DurableObject {
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'documents' } });
       }
 
+      // Back catalogues for subscriptions this cycle mirrored in from a PDS. Both
+      // sockets are closed by now, and the count is bounded, so a slow PDS costs
+      // this cycle's tail rather than the drain window.
+      try {
+        await this.backfillPendingAuthors();
+      } catch (error) {
+        log.error('jetstream_documents_backfill_failed', { ...serializeError(error) });
+      }
+
       stats.duration = Date.now() - startTime;
 
       // Save stats (best effort)
@@ -388,6 +418,32 @@ class JetstreamPollerBase implements DurableObject {
         // this one is worth a page rather than a log line.
         console.error('[JetstreamPoller] CRITICAL: Error scheduling next alarm:', error);
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm-scheduling' } });
+      }
+    }
+  }
+
+  /**
+   * Pull back catalogues for the authors this cycle's mirrored subscriptions
+   * introduced. `ensureAuthorDocuments` skips an author we listed recently or one
+   * inside their retry backoff, so a burst of subscription mirrors for a popular
+   * linkblog is still one walk; the per-cycle bound keeps the tail short when a
+   * device syncs a long subscription list at once — the rest are picked up by the
+   * next cycle's queue or, failing that, by the hourly reconcile.
+   */
+  private async backfillPendingAuthors(): Promise<void> {
+    if (this.pendingDocumentBackfills.size === 0) return;
+    const dids = [...this.pendingDocumentBackfills].slice(0, MAX_CYCLE_BACKFILLS);
+    // Only the ones being worked leave the queue; the remainder wait for the next
+    // cycle rather than being dropped.
+    for (const did of dids) this.pendingDocumentBackfills.delete(did);
+    for (const did of dids) {
+      try {
+        await ensureAuthorDocuments(this.env, did);
+      } catch (error) {
+        log.warn('documents_backfill_failed', {
+          authorDid: did,
+          ...serializeError(error),
+        });
       }
     }
   }
@@ -735,6 +791,16 @@ class JetstreamPollerBase implements DurableObject {
       }
 
       const recAny = record as Record<string, unknown>;
+      // A mirrored `atproto.*` subscription needs the same back-catalogue pull the
+      // API path does; queued, not run, so the drain stays a D1-only loop.
+      if (
+        typeof recAny.sourceType === 'string' &&
+        recAny.sourceType.startsWith('atproto.') &&
+        typeof recAny.subjectDid === 'string' &&
+        this.pendingDocumentBackfills.size < MAX_PENDING_BACKFILLS
+      ) {
+        this.pendingDocumentBackfills.add(recAny.subjectDid);
+      }
       console.log(
         `[JetstreamPoller] ${did} ${operation}d subscription: ${
           record.feedUrl || `${recAny.sourceType}:${recAny.subjectDid}`

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -1,6 +1,13 @@
 import * as Sentry from '@sentry/cloudflare';
 import type { Env } from '../types';
 import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
+import {
+  createDocumentDrain,
+  subscribedDocumentAuthors,
+  type DocumentCommitEvent,
+} from '../services/document-store';
+import { readDocumentFlags } from '../services/document-flags';
+import { DOCUMENT_COLLECTION, READER_COLLECTION } from '../services/standard-site';
 import { sentryOptions, reportError } from '../observability/sentry';
 import { log, serializeError } from '../utils/logger';
 import { runWithRequestContext } from '../utils/request-context';
@@ -15,7 +22,9 @@ interface JetstreamEvent {
     operation: 'create' | 'update' | 'delete';
     collection: string;
     rkey: string;
-    // Only `app.skyreader.feed.subscription` records reach this DO now.
+    // Subscription records are read field-by-field here; document and
+    // reader-collection records are handed to the document store whole, which owns
+    // their shapes (`DocumentRecord` / `CollectionRecord`).
     record?: {
       $type: string;
       feedUrl?: string;
@@ -29,8 +38,22 @@ interface JetstreamEvent {
   };
 }
 
+interface DocumentPollStats {
+  processed: number;
+  errors: number;
+  /** The cycle stopped on the apply cap rather than on an empty stream. */
+  capped: boolean;
+  /** Consecutive capped cycles — a burst is 1–2, a flood keeps climbing. */
+  capStreak: number;
+  /** Authors in the connect-time `wantedDids` filter. */
+  authors: number;
+  /** The `documents_ingest_enabled` kill switch is off. */
+  skipped: boolean;
+}
+
 interface PollStats {
   subscriptions: { processed: number; errors: number };
+  documents: DocumentPollStats;
   duration: number;
   lastPollAt: number;
 }
@@ -40,6 +63,27 @@ const POLL_TIMEOUT_MS = 8000; // 8 seconds per stream
 const IDLE_TIMEOUT_MS = 2000; // 2 seconds without events = caught up
 const ALARM_INTERVAL_MS = 60000; // 60 seconds between polls
 
+/**
+ * Above this many subscribed authors the DID filter is sent as an `options_update`
+ * frame after `open` instead of as `wantedDids` URL params. A few hundred DIDs is
+ * already several kilobytes of query string, and an over-long upgrade request is
+ * rejected by the server (the proxy's own comment recorded the same hazard) — which
+ * would take the whole cycle's drain down. Well under any conservative URL ceiling.
+ */
+export const DID_URL_PARAM_LIMIT = 150;
+
+/** Consecutive capped cycles that mean a sustained flood rather than a burst. */
+export const CAP_SATURATION_ALERT_STREAK = 10;
+
+/**
+ * Jetstream's hard cap on `wantedDids`. Reaching it means the subscribed-author
+ * set has outgrown a single subscription and wants sharding across alternating
+ * cycles (or collection-only operation, justified by then-current volume).
+ */
+export const JETSTREAM_MAX_WANTED_DIDS = 10_000;
+
+const CAP_STREAK_KEY = 'documents_cap_streak';
+
 // How long after an alarm *started* we still consider the poller alive without a
 // scheduled alarm. `getAlarm()` returns null while the handler runs, so both
 // `/start` (don't double-start) and `/status` consumers (don't cry wedged) need
@@ -47,16 +91,21 @@ const ALARM_INTERVAL_MS = 60000; // 60 seconds between polls
 // enough that a genuinely dead poller is caught within a couple of minutes.
 export const ALARM_ACTIVE_WINDOW_MS = 2 * ALARM_INTERVAL_MS;
 
-// One stream today (`app.skyreader.feed.subscription`). The plumbing stays keyed
-// by name because the `site.standard.document` stream lived here until documents
-// moved to on-demand proxy fetch, and a second stream is a plausible future.
-type StreamName = 'subscriptions';
+// Two streams: `app.skyreader.feed.subscription`, and the standard.site document
+// pair (`site.standard.document` + its `app.standard-reader.collection` sidecar),
+// which lived here before it moved to the proxy and has now come back. Everything
+// stayed keyed by stream name for exactly this return.
+type StreamName = 'subscriptions' | 'documents';
 
-/** Why a poll cycle stopped reading. Only `idle` means "Jetstream had nothing left". */
-type PollExit = 'idle' | 'poll-timeout' | 'closed' | 'socket-error';
+/**
+ * Why a poll cycle stopped reading. Only `idle` means "Jetstream had nothing left";
+ * `apply-cap` means we deliberately stopped early and carried the cursor.
+ */
+type PollExit = 'idle' | 'poll-timeout' | 'closed' | 'socket-error' | 'apply-cap';
 
 const CURSOR_KEY = {
   subscriptions: 'cursor_subscriptions',
+  documents: 'cursor_documents',
 } as const;
 
 // When each stream was last *confirmed current* — a cycle that opened the socket
@@ -64,6 +113,7 @@ const CURSOR_KEY = {
 // nothing more for us.
 const CAUGHT_UP_KEY = {
   subscriptions: 'caughtup_subscriptions',
+  documents: 'caughtup_documents',
 } as const;
 
 /**
@@ -115,6 +165,39 @@ export function streamLagMs(
   return Math.min(sinceDrain, sinceEvent);
 }
 
+const JETSTREAM_ENDPOINT = 'wss://jetstream2.us-east.bsky.network/subscribe';
+
+/**
+ * The document stream's connect-time subscription: both document collections, the
+ * cursor, and the subscribed-author DID filter when it is small enough to ride the
+ * URL.
+ *
+ * The filter is nearly free here, and that is the whole reason documents belong in
+ * this DO rather than in a persistent socket. A long-lived connection has to *mutate*
+ * its filter in place as subscriptions come and go — the machinery that cost the
+ * proxy hundreds of lines of `options_update` reconciliation. This socket is torn
+ * down and rebuilt every cycle, so the filter is just connect-time state read from
+ * D1: at most one alarm interval stale, by construction, with no reconcile loop.
+ *
+ * Returns `viaFrame: true` when the set is too large for the URL, in which case the
+ * caller sends one `options_update` frame on `open` instead (see `pollDocumentsStream`).
+ */
+export function buildDocumentSubscribeUrl(
+  dids: string[],
+  cursor?: string
+): { url: string; viaFrame: boolean } {
+  const wsUrl = new URL(JETSTREAM_ENDPOINT);
+  wsUrl.searchParams.append('wantedCollections', DOCUMENT_COLLECTION);
+  wsUrl.searchParams.append('wantedCollections', READER_COLLECTION);
+  if (cursor) wsUrl.searchParams.set('cursor', cursor);
+
+  const viaFrame = dids.length > DID_URL_PARAM_LIMIT;
+  if (!viaFrame) {
+    for (const did of dids) wsUrl.searchParams.append('wantedDids', did);
+  }
+  return { url: wsUrl.toString(), viaFrame };
+}
+
 class JetstreamPollerBase implements DurableObject {
   private state: DurableObjectState;
   private env: Env;
@@ -159,25 +242,36 @@ class JetstreamPollerBase implements DurableObject {
     }
 
     if (url.pathname === '/status') {
-      const [subscriptionsCursor, lastStats, alarmTime, lastAlarmStart, subscriptionsLagMs] =
-        await Promise.all([
-          this.state.storage.get<string>('cursor_subscriptions'),
-          this.state.storage.get<PollStats>('last_stats'),
-          this.state.storage.getAlarm(),
-          this.state.storage.get<number>('last_alarm_start'),
-          this.streamLag('subscriptions'),
-        ]);
+      const [
+        subscriptionsCursor,
+        documentsCursor,
+        lastStats,
+        alarmTime,
+        lastAlarmStart,
+        subscriptionsLagMs,
+        documentsLagMs,
+      ] = await Promise.all([
+        this.state.storage.get<string>('cursor_subscriptions'),
+        this.state.storage.get<string>('cursor_documents'),
+        this.state.storage.get<PollStats>('last_stats'),
+        this.state.storage.getAlarm(),
+        this.state.storage.get<number>('last_alarm_start'),
+        this.streamLag('subscriptions'),
+        this.streamLag('documents'),
+      ]);
 
       return new Response(
         JSON.stringify({
           cursors: {
             subscriptions: subscriptionsCursor,
+            documents: documentsCursor,
           },
           // Lag is derived here rather than by each caller: knowing what "behind"
           // means for a filtered Jetstream stream (see `streamLagMs`) should live
           // in exactly one place. Null means "unknown", not "zero lag".
           lag: {
             subscriptionsMs: subscriptionsLagMs,
+            documentsMs: documentsLagMs,
           },
           lastStats,
           nextPoll: alarmTime,
@@ -220,6 +314,14 @@ class JetstreamPollerBase implements DurableObject {
 
       const stats: PollStats = {
         subscriptions: { processed: 0, errors: 0 },
+        documents: {
+          processed: 0,
+          errors: 0,
+          capped: false,
+          capStreak: 0,
+          authors: 0,
+          skipped: false,
+        },
         duration: 0,
         lastPollAt: startTime,
       };
@@ -231,6 +333,17 @@ class JetstreamPollerBase implements DurableObject {
       } catch (error) {
         log.error('jetstream_poll_failed', { ...serializeError(error) });
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'poll-cycle' } });
+      }
+
+      // Documents (site.standard.document + its reader-collection sidecar). Its own
+      // try/catch: a failing document drain must not cost the subscriptions stream
+      // its cycle, which is the same isolation the ingest kill switch gives an
+      // operator during a flood.
+      try {
+        stats.documents = await this.pollDocumentsStream();
+      } catch (error) {
+        log.error('jetstream_documents_poll_failed', { ...serializeError(error) });
+        reportError(error, { tags: { source: 'jetstream-poller', phase: 'documents' } });
       }
 
       stats.duration = Date.now() - startTime;
@@ -245,12 +358,21 @@ class JetstreamPollerBase implements DurableObject {
       // Time since the stream last showed evidence of being current. Logging it
       // every cycle turns "the firehose is stalled" from something you notice when
       // subscriptions stop syncing into a number with a history.
-      const subscriptionsLagMs = await this.streamLag('subscriptions');
+      const [subscriptionsLagMs, documentsLagMs] = await Promise.all([
+        this.streamLag('subscriptions'),
+        this.streamLag('documents'),
+      ]);
 
       log.info('jetstream_poll', {
         subscriptionsProcessed: stats.subscriptions.processed,
         subscriptionsErrors: stats.subscriptions.errors,
         subscriptionsLagMs,
+        documentsProcessed: stats.documents.processed,
+        documentsErrors: stats.documents.errors,
+        documentsCapped: stats.documents.capped,
+        documentsCapStreak: stats.documents.capStreak,
+        documentsAuthors: stats.documents.authors,
+        documentsLagMs,
         durationMs: stats.duration,
       });
     } catch (error) {
@@ -398,6 +520,184 @@ class JetstreamPollerBase implements DurableObject {
             console.error('[JetstreamPoller] Error processing subscription event:', error);
             errors++;
           }
+        });
+
+        ws.addEventListener('close', () => cleanupWithCatch('closed'));
+        ws.addEventListener('error', () => cleanupWithCatch('socket-error'));
+      } catch {
+        cleanupWithCatch('socket-error');
+      }
+    });
+  }
+
+  // --- Documents Stream ---
+  // `site.standard.document` + `app.standard-reader.collection`, filtered
+  // server-side to the DIDs someone actually subscribes to, then re-checked
+  // per event before any write. See §3a of the plan for why the filter is the
+  // first of five layers and what each of the others bounds.
+  private async pollDocumentsStream(): Promise<DocumentPollStats> {
+    const empty: DocumentPollStats = {
+      processed: 0,
+      errors: 0,
+      capped: false,
+      capStreak: 0,
+      authors: 0,
+      skipped: false,
+    };
+
+    const flags = await readDocumentFlags(this.env);
+    if (!flags.ingestEnabled) {
+      // The flood switch. Reads keep serving whatever D1 holds, the subscriptions
+      // stream is untouched, and the cursor stays exactly where it was — so
+      // flipping the flag back resumes the drain rather than skipping the backlog.
+      log.info('documents_ingest_disabled');
+      return { ...empty, skipped: true };
+    }
+
+    // The true active-author set, straight from the subscription table. No
+    // read-traffic inference, and one alarm interval is the most it can be stale.
+    const allAuthors = await subscribedDocumentAuthors(this.env);
+    // Jetstream's hard cap on `wantedDids`. Past it the filter would be rejected
+    // outright, so watch the first 10k rather than nothing; the per-event re-check
+    // still keeps writes correct, and this line is the alert that the set needs
+    // sharding across cycles.
+    const dids = allAuthors.slice(0, JETSTREAM_MAX_WANTED_DIDS);
+    if (allAuthors.length > dids.length) {
+      log.warn('documents_did_filter_truncated', {
+        authors: allAuthors.length,
+        watching: dids.length,
+      });
+    }
+    const allowed = new Set(dids);
+    if (dids.length === 0) {
+      // Nobody subscribes to any author's documents, so there is no stream to be
+      // behind on. Mark caught up rather than letting the lag metric climb toward
+      // an alert about an empty subscription set.
+      await this.markCaughtUp('documents');
+      return empty;
+    }
+
+    const cursor = await this.state.storage.get<string>(CURSOR_KEY.documents);
+    const { url, viaFrame } = buildDocumentSubscribeUrl(dids, cursor);
+    const priorStreak = (await this.state.storage.get<number>(CAP_STREAK_KEY)) ?? 0;
+
+    return new Promise<DocumentPollStats>((resolve) => {
+      let cleanedUp = false;
+      let opened = false;
+      let lastEventTime = Date.now();
+      // Owns the cap, the error count and the cursor — which it only ever advances
+      // past an event it finished, so a capped cycle resumes at the first event it
+      // skipped rather than stepping over the rest of the burst.
+      const drain = createDocumentDrain(this.env, { allowed, cap: flags.applyCap, cursor });
+      // Jetstream delivers faster than D1 accepts writes, so handling has to be
+      // serialized: concurrent handlers would both race the cap and reorder two
+      // edits of the same rkey.
+      let queue: Promise<void> = Promise.resolve();
+
+      const cleanupWithCatch = (exit: PollExit) =>
+        cleanup(exit).catch((e) => console.error('[JetstreamPoller] documents cleanup error:', e));
+
+      const pollTimeout = setTimeout(() => cleanupWithCatch('poll-timeout'), POLL_TIMEOUT_MS);
+      const idleCheck = setInterval(() => {
+        if (Date.now() - lastEventTime > IDLE_TIMEOUT_MS) cleanupWithCatch('idle');
+      }, 500);
+
+      let ws: WebSocket | null = null;
+
+      const cleanup = async (exit: PollExit) => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+
+        clearTimeout(pollTimeout);
+        clearInterval(idleCheck);
+
+        if (ws) {
+          try {
+            ws.close();
+          } catch {
+            /* ignore */
+          }
+          ws = null;
+        }
+
+        // Let in-flight writes finish before the cursor is persisted, or a cycle
+        // could record progress past an event it never applied.
+        await queue.catch(() => {});
+
+        await this.state.storage.put(CURSOR_KEY.documents, drain.cursor);
+
+        const capStreak = drain.capped ? priorStreak + 1 : 0;
+        await this.state.storage.put(CAP_STREAK_KEY, capStreak);
+
+        // A drain is the only evidence the stream is current (see `streamLagMs`);
+        // a capped cycle is the opposite of caught up, so it must not mark one.
+        if (opened && exit === 'idle') await this.markCaughtUp('documents');
+
+        if (drain.capped) {
+          log.warn('documents_apply_cap_hit', {
+            applied: drain.applied,
+            cap: flags.applyCap,
+            capStreak,
+          });
+        }
+
+        resolve({
+          processed: drain.applied,
+          errors: drain.errors,
+          capped: drain.capped,
+          capStreak,
+          authors: dids.length,
+          skipped: false,
+        });
+      };
+
+      const handle = async (data: JetstreamEvent) => {
+        if (cleanedUp) return;
+        if (data.kind !== 'commit' || !data.commit) return;
+        const outcome = await drain.handle(data as DocumentCommitEvent & { time_us?: number });
+        // Cap reached: stop reading now, with the cursor parked at the last event
+        // this cycle finished. The rest of the burst is the next cycle's work.
+        if (outcome === 'capped') cleanupWithCatch('apply-cap');
+      };
+
+      try {
+        ws = new WebSocket(url);
+
+        ws.addEventListener('open', () => {
+          opened = true;
+          lastEventTime = Date.now();
+          if (viaFrame && ws) {
+            // Too many DIDs for the URL. One frame, sent before anything can be
+            // delivered; every DID in it was validated by `subscribedDocumentAuthors`,
+            // because Jetstream rejects the whole frame on one malformed entry and
+            // closes the socket.
+            try {
+              ws.send(
+                JSON.stringify({
+                  type: 'options_update',
+                  payload: {
+                    wantedCollections: [DOCUMENT_COLLECTION, READER_COLLECTION],
+                    wantedDids: dids,
+                  },
+                })
+              );
+            } catch (error) {
+              console.error('[JetstreamPoller] documents options_update failed:', error);
+            }
+          }
+        });
+
+        ws.addEventListener('message', (event) => {
+          let data: JetstreamEvent;
+          try {
+            data = JSON.parse(event.data as string) as JetstreamEvent;
+          } catch {
+            // Unparseable frame: nothing to apply and nothing to advance past.
+            console.error('[JetstreamPoller] documents: unparseable frame');
+            return;
+          }
+          if (data.kind === 'commit') lastEventTime = Date.now();
+          queue = queue.then(() => handle(data)).catch(() => {});
         });
 
         ws.addEventListener('close', () => cleanupWithCatch('closed'));

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -2,9 +2,13 @@ import * as Sentry from '@sentry/cloudflare';
 import type { Env } from '../types';
 import { upsertSubscriptionFromFirehose } from '../services/firehose-subscription';
 import {
+  createDocumentApplyContext,
   createDocumentDrain,
+  createQueryLedger,
   ensureAuthorDocuments,
   subscribedDocumentAuthors,
+  CYCLE_BACKFILL_QUERY_BUDGET,
+  MAX_CYCLE_BACKFILLS,
   type DocumentCommitEvent,
 } from '../services/document-store';
 import { readDocumentFlags, type DocumentFlags } from '../services/document-flags';
@@ -85,15 +89,13 @@ export const JETSTREAM_MAX_WANTED_DIDS = 10_000;
 
 const CAP_STREAK_KEY = 'documents_cap_streak';
 
-// Back catalogues pulled per cycle for subscriptions mirrored in from a PDS. Each
-// is up to five `listRecords` pages against a foreign PDS and up to
-// `BACKFILL_QUERY_COST` D1 queries, so this is deliberately small: the alarm's job
-// is draining streams, the drain's budget already reserves
-// `DOCUMENT_CYCLE_QUERY_RESERVE` for this and the subscriptions stream, and the
-// queue survives to the next cycle.
-const MAX_CYCLE_BACKFILLS = 2;
-
-// Ceiling on that queue. A device syncing a very long subscription list can enqueue
+// `MAX_CYCLE_BACKFILLS` — how many back catalogues a cycle pulls for subscriptions
+// mirrored in from a PDS — lives in `document-store` next to the budget it is sized
+// against: each walk is up to `BACKFILL_QUERY_COST` subrequests, and
+// `DOCUMENT_CYCLE_QUERY_RESERVE` is what the drain leaves the rest of the cycle.
+//
+// Ceiling on the queue those walks come from. A device syncing a very long
+// subscription list can enqueue
 // faster than a couple a cycle drains, and this is in-memory state on a long-lived
 // object; past the ceiling the surplus authors are left to the cron's reconcile,
 // which is where they would have been before any of this existed.
@@ -450,9 +452,12 @@ class JetstreamPollerBase implements DurableObject {
     // Only the ones being worked leave the queue; the remainder wait for the next
     // cycle rather than being dropped.
     for (const did of dids) this.pendingDocumentBackfills.delete(did);
+    // These share the alarm's invocation with the drain that just ran, so they draw
+    // on the reserve that drain left rather than on a budget of their own.
+    const ctx = createDocumentApplyContext(createQueryLedger(CYCLE_BACKFILL_QUERY_BUDGET));
     for (const did of dids) {
       try {
-        await ensureAuthorDocuments(this.env, did);
+        await ensureAuthorDocuments(this.env, did, Date.now(), ctx);
       } catch (error) {
         log.warn('documents_backfill_failed', {
           authorDid: did,

--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -7,7 +7,7 @@ import {
   subscribedDocumentAuthors,
   type DocumentCommitEvent,
 } from '../services/document-store';
-import { readDocumentFlags } from '../services/document-flags';
+import { readDocumentFlags, type DocumentFlags } from '../services/document-flags';
 import { DOCUMENT_COLLECTION, READER_COLLECTION } from '../services/standard-site';
 import { sentryOptions, reportError } from '../observability/sentry';
 import { log, serializeError } from '../utils/logger';
@@ -86,13 +86,16 @@ export const JETSTREAM_MAX_WANTED_DIDS = 10_000;
 const CAP_STREAK_KEY = 'documents_cap_streak';
 
 // Back catalogues pulled per cycle for subscriptions mirrored in from a PDS. Each
-// is up to five `listRecords` pages against a foreign PDS, so this is deliberately
-// small: the alarm's job is draining streams, and the queue survives to next cycle.
-const MAX_CYCLE_BACKFILLS = 3;
+// is up to five `listRecords` pages against a foreign PDS and up to
+// `BACKFILL_QUERY_COST` D1 queries, so this is deliberately small: the alarm's job
+// is draining streams, the drain's budget already reserves
+// `DOCUMENT_CYCLE_QUERY_RESERVE` for this and the subscriptions stream, and the
+// queue survives to the next cycle.
+const MAX_CYCLE_BACKFILLS = 2;
 
 // Ceiling on that queue. A device syncing a very long subscription list can enqueue
-// faster than three a cycle drains, and this is in-memory state on a long-lived
-// object; past the ceiling the surplus authors are left to the hourly reconcile,
+// faster than a couple a cycle drains, and this is in-memory state on a long-lived
+// object; past the ceiling the surplus authors are left to the cron's reconcile,
 // which is where they would have been before any of this existed.
 const MAX_PENDING_BACKFILLS = 200;
 
@@ -347,6 +350,11 @@ class JetstreamPollerBase implements DurableObject {
         lastPollAt: startTime,
       };
 
+      // One read for the whole cycle: the document stream and the back-catalogue
+      // walks below are both "the poller writing documents", and the kill switch
+      // has to mean the same thing to both of them.
+      const flags = await readDocumentFlags(this.env);
+
       try {
         // Subscriptions (app.skyreader.feed.subscription) - global watch, filter by sync-enabled
         const subscriptionsResult = await this.pollSubscriptionsStream();
@@ -361,7 +369,7 @@ class JetstreamPollerBase implements DurableObject {
       // its cycle, which is the same isolation the ingest kill switch gives an
       // operator during a flood.
       try {
-        stats.documents = await this.pollDocumentsStream();
+        stats.documents = await this.pollDocumentsStream(flags);
       } catch (error) {
         log.error('jetstream_documents_poll_failed', { ...serializeError(error) });
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'documents' } });
@@ -371,7 +379,7 @@ class JetstreamPollerBase implements DurableObject {
       // sockets are closed by now, and the count is bounded, so a slow PDS costs
       // this cycle's tail rather than the drain window.
       try {
-        await this.backfillPendingAuthors();
+        await this.backfillPendingAuthors(flags);
       } catch (error) {
         log.error('jetstream_documents_backfill_failed', { ...serializeError(error) });
       }
@@ -430,8 +438,14 @@ class JetstreamPollerBase implements DurableObject {
    * device syncs a long subscription list at once — the rest are picked up by the
    * next cycle's queue or, failing that, by the hourly reconcile.
    */
-  private async backfillPendingAuthors(): Promise<void> {
+  private async backfillPendingAuthors(flags: DocumentFlags): Promise<void> {
     if (this.pendingDocumentBackfills.size === 0) return;
+    // A backfill writes documents, so the ingest kill switch stops it too —
+    // otherwise "pause writes" would still let the poller write up to
+    // MAX_CYCLE_BACKFILLS × the per-author cap every minute, because the
+    // subscriptions stream keeps enqueuing DIDs while the switch is off. The queue
+    // is kept, not dropped: flipping the switch back resumes it.
+    if (!flags.ingestEnabled) return;
     const dids = [...this.pendingDocumentBackfills].slice(0, MAX_CYCLE_BACKFILLS);
     // Only the ones being worked leave the queue; the remainder wait for the next
     // cycle rather than being dropped.
@@ -591,7 +605,7 @@ class JetstreamPollerBase implements DurableObject {
   // server-side to the DIDs someone actually subscribes to, then re-checked
   // per event before any write. See §3a of the plan for why the filter is the
   // first of five layers and what each of the others bounds.
-  private async pollDocumentsStream(): Promise<DocumentPollStats> {
+  private async pollDocumentsStream(flags: DocumentFlags): Promise<DocumentPollStats> {
     const empty: DocumentPollStats = {
       processed: 0,
       errors: 0,
@@ -601,7 +615,6 @@ class JetstreamPollerBase implements DurableObject {
       skipped: false,
     };
 
-    const flags = await readDocumentFlags(this.env);
     if (!flags.ingestEnabled) {
       // The flood switch. Reads keep serving whatever D1 holds, the subscriptions
       // stream is untouched, and the cursor stays exactly where it was — so
@@ -679,6 +692,9 @@ class JetstreamPollerBase implements DurableObject {
         // Let in-flight writes finish before the cursor is persisted, or a cycle
         // could record progress past an event it never applied.
         await queue.catch(() => {});
+        // Then settle what the drain deferred: one cap eviction and one bookkeeping
+        // row per author written this cycle, rather than a pair per event.
+        await drain.flush().catch((e) => console.error('[JetstreamPoller] documents flush:', e));
 
         await this.state.storage.put(CURSOR_KEY.documents, drain.cursor);
 
@@ -693,6 +709,11 @@ class JetstreamPollerBase implements DurableObject {
           log.warn('documents_apply_cap_hit', {
             applied: drain.applied,
             cap: flags.applyCap,
+            // Which bound stopped the cycle. `query-budget` means the events were
+            // costlier than the common one-query case (many distinct authors or
+            // cold publications), not that the cap is set too low.
+            cappedBy: drain.cappedBy,
+            queries: drain.queries,
             capStreak,
           });
         }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,7 +19,14 @@ import {
 } from './routes/feeds-v2';
 import { handleIngest, handleCrawlSet, handleFeedHealth } from './routes/ingest';
 import { handleDocumentBackfill, handleDocumentShadowCompare } from './routes/documents';
-import { reconcileStaleAuthors } from './services/document-store';
+import {
+  createDocumentApplyContext,
+  createQueryLedger,
+  reconcileStaleAuthors,
+  CRON_DOCUMENT_QUERY_BUDGET,
+  CRON_HOURLY_RECONCILE_AUTHORS,
+  CRON_MINUTE_RECONCILE_AUTHORS,
+} from './services/document-store';
 import { readDocumentFlags } from './services/document-flags';
 import { handleTimeline } from './routes/timeline';
 import {
@@ -966,8 +973,14 @@ async function runScheduled(
     // the hourly tick's afternoon. This writes documents, so the ingest kill switch
     // stops it like every other background write.
     const documentFlags = await readDocumentFlags(env);
+    // One ledger for both reconcile passes: on the hour they run in the same
+    // invocation, so a budget held per pass would let the pair add up past D1's
+    // per-invocation ceiling and fail the later walks mid-write.
+    const documentCtx = createDocumentApplyContext(createQueryLedger(CRON_DOCUMENT_QUERY_BUDGET));
     try {
-      const reconciled = documentFlags.ingestEnabled ? await reconcileStaleAuthors(env, 1) : [];
+      const reconciled = documentFlags.ingestEnabled
+        ? await reconcileStaleAuthors(env, CRON_MINUTE_RECONCILE_AUTHORS, documentCtx)
+        : [];
       if (reconciled.length > 0) {
         log.info('cron_documents_cold_start', {
           authors: reconciled.length,
@@ -1103,7 +1116,9 @@ async function runScheduled(
       // author. The operator backfill endpoint stays available regardless — that
       // one is a deliberate repair, not a background loop.
       try {
-        const reconciled = documentFlags.ingestEnabled ? await reconcileStaleAuthors(env, 3) : [];
+        const reconciled = documentFlags.ingestEnabled
+          ? await reconcileStaleAuthors(env, CRON_HOURLY_RECONCILE_AUTHORS, documentCtx)
+          : [];
         if (reconciled.length > 0) {
           log.info('cron_documents_reconcile', {
             authors: reconciled.length,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import {
 import { handleIngest, handleCrawlSet, handleFeedHealth } from './routes/ingest';
 import { handleDocumentBackfill, handleDocumentShadowCompare } from './routes/documents';
 import { reconcileStaleAuthors } from './services/document-store';
+import { readDocumentFlags } from './services/document-flags';
 import { handleTimeline } from './routes/timeline';
 import {
   handleGuestMarginHighlights,
@@ -819,7 +820,7 @@ async function route(
       break;
     case url.pathname === '/api/sync/subscriptions':
       if (!session) return unauthorizedResponse(headers);
-      response = await handleSyncSubscriptions(request, env);
+      response = await handleSyncSubscriptions(request, env, ctx);
       break;
     case url.pathname === '/api/sync/status':
       if (!session) return unauthorizedResponse(headers);
@@ -958,6 +959,26 @@ async function runScheduled(
       await runRecordingStep('proxy-stats', () => recordProxyStats(env));
     }
 
+    // Phase 1c: one document author per minute, which is what makes "the rest is
+    // the reconcile's job" an honest thing for the bounded sync paths to say. The
+    // queue takes never-listed authors first, so a restore that brought back more
+    // linkblogs than one request may warm is served in minutes rather than across
+    // the hourly tick's afternoon. This writes documents, so the ingest kill switch
+    // stops it like every other background write.
+    const documentFlags = await readDocumentFlags(env);
+    try {
+      const reconciled = documentFlags.ingestEnabled ? await reconcileStaleAuthors(env, 1) : [];
+      if (reconciled.length > 0) {
+        log.info('cron_documents_cold_start', {
+          authors: reconciled.length,
+          failed: reconciled.filter((r) => !r.ok).length,
+        });
+      }
+    } catch (error) {
+      log.error('cron_phase_failed', { phase: 'documents-cold-start', ...serializeError(error) });
+      reportError(error, { tags: { source: 'cron', phase: 'documents-cold-start' } });
+    }
+
     // Phase 2: Clean up rate limit records
     let rateLimitDuration = 0;
     let rateLimitDeleted = 0;
@@ -1077,8 +1098,12 @@ async function runScheduled(
       // nothing else fills — the proxy closed those by full-replacing its blob on
       // every refresh. A few of the stalest authors per hour re-lists everyone
       // inside the reconcile interval without ever making the cron the bottleneck.
+      // Paused with ingest, like every other background write of documents: the
+      // kill switch is a flood response, and this writes up to a hundred rows an
+      // author. The operator backfill endpoint stays available regardless — that
+      // one is a deliberate repair, not a background loop.
       try {
-        const reconciled = await reconcileStaleAuthors(env, 3);
+        const reconciled = documentFlags.ingestEnabled ? await reconcileStaleAuthors(env, 3) : [];
         if (reconciled.length > 0) {
           log.info('cron_documents_reconcile', {
             authors: reconciled.length,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,8 @@ import {
   handleV2MarginHighlights,
 } from './routes/feeds-v2';
 import { handleIngest, handleCrawlSet, handleFeedHealth } from './routes/ingest';
+import { handleDocumentBackfill, handleDocumentShadowCompare } from './routes/documents';
+import { reconcileStaleAuthors } from './services/document-store';
 import { handleTimeline } from './routes/timeline';
 import {
   handleGuestMarginHighlights,
@@ -376,6 +378,14 @@ async function route(
       break;
     case url.pathname === '/api/internal/feed-health':
       response = await handleFeedHealth(request, env);
+      break;
+    // Document store operator endpoints: the one-time (and ongoing) backfill, and
+    // the proxy-vs-D1 shadow compare that gates the read cutover.
+    case url.pathname === '/api/internal/documents/backfill':
+      response = await handleDocumentBackfill(request, env);
+      break;
+    case url.pathname === '/api/internal/documents/shadow-compare':
+      response = await handleDocumentShadowCompare(request, env);
       break;
 
     // The reader's whole refresh, served from the D1 archive in one query.
@@ -1061,6 +1071,24 @@ async function runScheduled(
       // a multiple of 5), so the snapshot reads fresh values rather than
       // five-minute-old ones. Prunes its own tail at 90 days.
       await runRecordingStep('metrics-snapshot', () => writeMetricsSnapshot(env));
+
+      // Document self-heal. The firehose only carries writes made while we were
+      // watching, so a gap (reconnect, cursor reset, a paused ingest) leaves a hole
+      // nothing else fills — the proxy closed those by full-replacing its blob on
+      // every refresh. A few of the stalest authors per hour re-lists everyone
+      // inside the reconcile interval without ever making the cron the bottleneck.
+      try {
+        const reconciled = await reconcileStaleAuthors(env, 3);
+        if (reconciled.length > 0) {
+          log.info('cron_documents_reconcile', {
+            authors: reconciled.length,
+            failed: reconciled.filter((r) => !r.ok).length,
+          });
+        }
+      } catch (error) {
+        log.error('cron_phase_failed', { phase: 'documents-reconcile', ...serializeError(error) });
+        reportError(error, { tags: { source: 'cron', phase: 'documents-reconcile' } });
+      }
     }
 
     // The run summary. `durationMs` is the number to watch as the cron takes on

--- a/backend/src/observability/ops-metrics.ts
+++ b/backend/src/observability/ops-metrics.ts
@@ -90,6 +90,25 @@ export interface PollerStatusValue {
   alarmScheduled: boolean;
   /** When the lag alert last fired. Dedupe state, not a display value. */
   lagAlertAt: number | null;
+  // --- The document stream (site.standard.document + reader collections) ---
+  /** Its own lag: the two streams fail independently, so they're measured apart. */
+  documentsLagMs: number | null;
+  documentsProcessed: number;
+  documentsErrors: number;
+  /**
+   * Consecutive cycles that stopped on the per-cycle apply cap. One or two is a
+   * burst draining as designed; a climbing streak is a flood, and the number an
+   * operator reads before flipping `documents_ingest_enabled`.
+   */
+  documentsCapStreak: number;
+  /** Authors in the connect-time DID filter — how much of the stream we ask for. */
+  documentsAuthors: number;
+  /** Ingest is paused by the kill switch. Not an alert; a deliberate state. */
+  documentsIngestPaused: boolean;
+  /** Cap-saturation alert dedupe stamp; not displayed. */
+  documentsCapAlertAt: number | null;
+  /** Document-lag alert dedupe stamp, separate from the subscriptions one. */
+  documentsLagAlertAt: number | null;
 }
 
 export interface CronLastRunValue {
@@ -152,15 +171,30 @@ export async function readSystemStatus<T>(
 }
 
 interface PollerStatusResponse {
-  lag?: { subscriptionsMs?: number | null };
+  lag?: { subscriptionsMs?: number | null; documentsMs?: number | null };
   lastStats?: {
     subscriptions?: { processed?: number; errors?: number };
+    documents?: {
+      processed?: number;
+      errors?: number;
+      capped?: boolean;
+      capStreak?: number;
+      authors?: number;
+      skipped?: boolean;
+    };
     duration?: number;
     lastPollAt?: number;
   };
   nextPoll?: number | null;
   isRunning?: boolean;
 }
+
+/**
+ * Consecutive capped document cycles that mean a sustained flood rather than a
+ * burst draining as designed. Mirrors `CAP_SATURATION_ALERT_STREAK` in the poller;
+ * ~10 minutes of every cycle hitting the cap is not a spike any more.
+ */
+export const DOCUMENT_CAP_SATURATION_ALERT_STREAK = 10;
 
 export interface LagAlertDecision {
   /** Send an event now. */
@@ -262,9 +296,27 @@ export async function recordPollerStatus(env: Env, now = Date.now()): Promise<Po
   const status = (await response.json()) as PollerStatusResponse;
 
   const lagMs = status.lag?.subscriptionsMs ?? null;
+  const documentsLagMs = status.lag?.documentsMs ?? null;
+  const documents = status.lastStats?.documents;
+  const capStreak = documents?.capStreak ?? 0;
 
   const previous = await readSystemStatus<PollerStatusValue>(env, 'poller_status');
   const decision = decideLagAlert(lagMs, previous?.value.lagAlertAt ?? null, now);
+  // The document stream gets the same threshold and the same "alert once, remind
+  // at the re-alert interval" behaviour, decided independently: one stream stuck
+  // while the other is healthy is exactly the case a shared number would hide.
+  const documentsDecision = decideLagAlert(
+    // A paused ingest is a deliberate state, not a stalled stream. Its lag climbs
+    // by construction while the switch is off, so don't page on it.
+    documents?.skipped ? null : documentsLagMs,
+    previous?.value.documentsLagAlertAt ?? null,
+    now
+  );
+
+  const capSaturated = capStreak >= DOCUMENT_CAP_SATURATION_ALERT_STREAK;
+  const previousCapAlertAt = previous?.value.documentsCapAlertAt ?? null;
+  const capAlert =
+    capSaturated && (!previousCapAlertAt || now - previousCapAlertAt >= FIREHOSE_LAG_REALERT_MS);
 
   const value: PollerStatusValue = {
     lagMs,
@@ -274,9 +326,45 @@ export async function recordPollerStatus(env: Env, now = Date.now()): Promise<Po
     errors: status.lastStats?.subscriptions?.errors ?? 0,
     alarmScheduled: Boolean(status.isRunning),
     lagAlertAt: decision.lagAlertAt,
+    documentsLagMs,
+    documentsProcessed: documents?.processed ?? 0,
+    documentsErrors: documents?.errors ?? 0,
+    documentsCapStreak: capStreak,
+    documentsAuthors: documents?.authors ?? 0,
+    documentsIngestPaused: Boolean(documents?.skipped),
+    documentsCapAlertAt: capSaturated ? (capAlert ? now : previousCapAlertAt) : null,
+    documentsLagAlertAt: documentsDecision.lagAlertAt,
   };
 
   await writeSystemStatus(env, 'poller_status', value, now);
+
+  if (documentsDecision.alert) {
+    log.error('documents_stream_lag_high', {
+      lagMs: documentsLagMs,
+      thresholdMs: FIREHOSE_LAG_ALERT_MS,
+    });
+    reportMessage(`Document stream lag above ${Math.round(FIREHOSE_LAG_ALERT_MS / 60000)}m`, {
+      level: 'error',
+      fingerprint: ['documents-stream-lag-high'],
+      tags: { source: 'cron', check: 'documents-lag' },
+      extra: { lagMs: documentsLagMs, authors: value.documentsAuthors },
+    });
+  } else if (documentsDecision.recovered) {
+    log.info('documents_stream_lag_recovered', {
+      lagMs: documentsLagMs,
+      thresholdMs: FIREHOSE_LAG_ALERT_MS,
+    });
+  }
+
+  if (capAlert) {
+    log.error('documents_cap_saturated', { capStreak, processed: value.documentsProcessed });
+    reportMessage('Document ingest has hit its per-cycle apply cap for 10 cycles', {
+      level: 'error',
+      fingerprint: ['documents-cap-saturated'],
+      tags: { source: 'cron', check: 'documents-cap' },
+      extra: { capStreak, processed: value.documentsProcessed, authors: value.documentsAuthors },
+    });
+  }
 
   if (decision.alert) {
     log.error('firehose_lag_high', {

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -17,9 +17,14 @@ import {
 } from '../services/feed-proxy-client';
 import {
   backfillAuthorDocuments,
+  canAffordBackfill,
+  createDocumentApplyContext,
+  createQueryLedger,
   loadAuthorDocuments,
   staleDocumentAuthors,
   subscribedDocumentAuthorPage,
+  BACKFILL_QUERY_COST,
+  D1_QUERIES_PER_INVOCATION,
   type BackfillResult,
 } from '../services/document-store';
 import { digestScope } from '../services/standard-site';
@@ -27,12 +32,26 @@ import { log } from '../utils/logger';
 
 /**
  * Authors backfilled per call. A backfill is a `listRecords` walk plus a write per
- * document — up to `BACKFILL_QUERY_COST` D1 queries — so the operator drives the
+ * document — up to `BACKFILL_QUERY_COST` subrequests — so the operator drives the
  * migration as a loop of bounded calls rather than one request that would outlive
  * its CPU budget or run into `D1_QUERIES_PER_INVOCATION` partway through and lose
- * the walks it hadn't reached. Five authors is ~560 queries, well under.
+ * the walks it hadn't reached.
  */
 const MAX_BACKFILL_BATCH = 5;
+
+/** What the endpoint's own queries (the stale-author picks) may spend. */
+const ENDPOINT_QUERY_RESERVE = 50;
+
+/**
+ * What one call may spend on walks. Sized so the batch fits with room to spare, and
+ * enforced per author rather than assumed: the loop stops at the author it can no
+ * longer afford and reports the rest as still queued, instead of throwing partway
+ * through a walk that has already written rows.
+ */
+const BACKFILL_QUERY_BUDGET = Math.min(
+  MAX_BACKFILL_BATCH * BACKFILL_QUERY_COST,
+  D1_QUERIES_PER_INVOCATION - ENDPOINT_QUERY_RESERVE
+);
 
 function unauthorized(): Response {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -75,9 +94,17 @@ export async function handleDocumentBackfill(request: Request, env: Env): Promis
     ? body.dids.slice(0, limit)
     : await staleDocumentAuthors(env, limit);
 
+  // One ledger for the whole call: the ceiling is per invocation, so the walks have
+  // to be admitted against their shared spend rather than against a per-walk rule.
+  const ctx = createDocumentApplyContext(createQueryLedger(BACKFILL_QUERY_BUDGET));
   const results: BackfillResult[] = [];
+  let deferred = 0;
   for (const did of dids) {
-    results.push(await backfillAuthorDocuments(env, did));
+    if (!canAffordBackfill(ctx.ledger)) {
+      deferred = dids.length - results.length;
+      break;
+    }
+    results.push(await backfillAuthorDocuments(env, did, ctx));
   }
 
   // Authors still queued after this chunk. An author whose PDS can't be listed at
@@ -90,11 +117,17 @@ export async function handleDocumentBackfill(request: Request, env: Env): Promis
     requested: dids.length,
     ok: results.filter((r) => r.ok).length,
     failed: results.filter((r) => !r.ok).length,
+    deferred,
+    queries: ctx.ledger.spent,
   });
 
   return json({
     backfilled: results.length,
     results,
+    // Walks this call declined to start because the invocation's budget was spent.
+    // They are still in the queue; call again. Silence here would read as "all five
+    // were done" when the request stopped at three.
+    deferred,
     // Non-null only for the "next chunk" form: how many of this chunk's size still
     // need work, so a driving loop knows when to stop. 0 means the migration is done.
     remaining,

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -1,0 +1,207 @@
+/**
+ * Operator endpoints for the standard.site document store: the one-time backfill of
+ * everyone's already-subscribed authors, and the shadow-compare that has to come
+ * back clean before `documents_v2_enabled` is flipped in production.
+ *
+ * Both authenticate with `FEED_PROXY_SECRET` — the same shared secret the crawler
+ * endpoints use, so no new secret exists to manage — and are fail-closed when it is
+ * unset.
+ */
+
+import type { Env } from '../types';
+import { isAuthorizedProxyRequest } from './ingest';
+import { FeedProxyClient, type ProxyDocument } from '../services/feed-proxy-client';
+import {
+  backfillAuthorDocuments,
+  loadAuthorDocuments,
+  staleDocumentAuthors,
+  subscribedDocumentAuthors,
+  type BackfillResult,
+} from '../services/document-store';
+import { digestScope } from '../services/standard-site';
+import { log } from '../utils/logger';
+
+/**
+ * Authors backfilled per call. A backfill is a `listRecords` walk plus a write per
+ * document, so the operator drives the migration as a loop of bounded calls rather
+ * than one request that would outlive its own CPU budget.
+ */
+const MAX_BACKFILL_BATCH = 20;
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * POST /api/internal/documents/backfill
+ *
+ * Body: `{ dids?: string[], limit?: number }`. With `dids`, backfills exactly those
+ * authors. Without, takes the stalest subscribed authors that need one — which is
+ * both the one-time migration (nobody has been listed yet, so every author is
+ * stale) and the ongoing self-heal, run one bounded chunk at a time.
+ */
+export async function handleDocumentBackfill(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+  if (!isAuthorizedProxyRequest(request, env)) return unauthorized();
+
+  let body: { dids?: string[]; limit?: number } = {};
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    // An empty body is the common case (backfill the next chunk).
+  }
+
+  const limit = Math.min(
+    Math.max(1, Math.floor(body.limit ?? MAX_BACKFILL_BATCH)),
+    MAX_BACKFILL_BATCH
+  );
+  const dids = Array.isArray(body.dids)
+    ? body.dids.slice(0, limit)
+    : await staleDocumentAuthors(env, limit);
+
+  const results: BackfillResult[] = [];
+  for (const did of dids) {
+    results.push(await backfillAuthorDocuments(env, did));
+  }
+
+  const remaining = Array.isArray(body.dids)
+    ? null
+    : (await staleDocumentAuthors(env, limit)).length;
+  log.info('documents_backfill_batch', {
+    requested: dids.length,
+    ok: results.filter((r) => r.ok).length,
+    failed: results.filter((r) => !r.ok).length,
+  });
+
+  return json({
+    backfilled: results.length,
+    results,
+    // Non-null only for the "next chunk" form: how many of this chunk's size still
+    // need work, so a driving loop knows when to stop. 0 means the migration is done.
+    remaining,
+  });
+}
+
+interface ScopeDrift {
+  did: string;
+  siteUri?: string;
+  proxyCount: number;
+  d1Count: number;
+  /** In the proxy's set, missing from D1 — the drift that loses a reader content. */
+  missingInD1: string[];
+  /** In D1, absent upstream — a delete we never applied. */
+  extraInD1: string[];
+  /** Same record, different cid: an edit one side didn't see. */
+  cidMismatches: string[];
+  /** Same record, different canonical URL: a publication-cache divergence. */
+  canonicalMismatches: string[];
+  proxyDigest: string | null;
+  d1Digest: string;
+  /** True when nothing above differs — the bar for flipping the read gate. */
+  clean: boolean;
+  error?: string;
+}
+
+function byUri(documents: ProxyDocument[]): Map<string, ProxyDocument> {
+  return new Map(documents.map((d) => [d.recordUri, d]));
+}
+
+/**
+ * POST /api/internal/documents/shadow-compare
+ *
+ * Body: `{ dids?: string[], limit?: number }`. Serves each author both ways — proxy
+ * blob and D1 rows — and reports the difference. This is Phase 3's gate: the flip to
+ * `documents_v2_enabled` waits on a clean report, because a silent hole in the store
+ * looks exactly like an author who stopped publishing.
+ */
+export async function handleDocumentShadowCompare(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+  if (!isAuthorizedProxyRequest(request, env)) return unauthorized();
+
+  let body: { dids?: string[]; limit?: number } = {};
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    /* empty body → compare the first chunk of subscribed authors */
+  }
+
+  const limit = Math.min(Math.max(1, Math.floor(body.limit ?? 10)), 50);
+  const dids = Array.isArray(body.dids)
+    ? body.dids.slice(0, limit)
+    : (await subscribedDocumentAuthors(env)).slice(0, limit);
+
+  if (dids.length === 0) return json({ compared: 0, clean: true, scopes: [] });
+
+  const client = new FeedProxyClient(env);
+  let proxyEntries;
+  try {
+    proxyEntries = await client.fetchDocumentsBatch(dids.map((did) => ({ did })));
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : 'Proxy fetch failed' }, 502);
+  }
+
+  const scopes: ScopeDrift[] = [];
+  for (const entry of proxyEntries) {
+    const proxyDocs = entry.documents ?? [];
+    const d1Docs = await loadAuthorDocuments(env, entry.did, {
+      // Comparison is about which records exist, not about warming magazine
+      // previews; resolving them here would fan out across foreign PDSes.
+      collectionBudget: { remaining: 0 },
+    });
+    const proxyByUri = byUri(proxyDocs);
+    const d1ByUri = byUri(d1Docs);
+
+    const cidMismatches: string[] = [];
+    const canonicalMismatches: string[] = [];
+    for (const [uri, proxyDoc] of proxyByUri) {
+      const d1Doc = d1ByUri.get(uri);
+      if (!d1Doc) continue;
+      if (proxyDoc.recordCid !== d1Doc.recordCid) cidMismatches.push(uri);
+      if ((proxyDoc.canonicalUrl || '') !== (d1Doc.canonicalUrl || ''))
+        canonicalMismatches.push(uri);
+    }
+
+    const missingInD1 = [...proxyByUri.keys()].filter((uri) => !d1ByUri.has(uri));
+    const extraInD1 = [...d1ByUri.keys()].filter((uri) => !proxyByUri.has(uri));
+    const d1Digest = await digestScope(d1Docs);
+
+    scopes.push({
+      did: entry.did,
+      siteUri: entry.siteUri,
+      proxyCount: proxyDocs.length,
+      d1Count: d1Docs.length,
+      missingInD1,
+      extraInD1,
+      cidMismatches,
+      canonicalMismatches,
+      proxyDigest: entry.digest ?? null,
+      d1Digest,
+      clean:
+        entry.status !== 'error' &&
+        missingInD1.length === 0 &&
+        extraInD1.length === 0 &&
+        cidMismatches.length === 0 &&
+        canonicalMismatches.length === 0,
+      error: entry.status === 'error' ? entry.error : undefined,
+    });
+  }
+
+  const clean = scopes.every((s) => s.clean);
+  log.info('documents_shadow_compare', {
+    compared: scopes.length,
+    clean,
+    drifted: scopes.filter((s) => !s.clean).length,
+  });
+
+  return json({ compared: scopes.length, clean, scopes });
+}

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -10,12 +10,16 @@
 
 import type { Env } from '../types';
 import { isAuthorizedProxyRequest } from './ingest';
-import { FeedProxyClient, type ProxyDocument } from '../services/feed-proxy-client';
+import {
+  FeedProxyClient,
+  type ProxyDocument,
+  type ProxyDocumentEntry,
+} from '../services/feed-proxy-client';
 import {
   backfillAuthorDocuments,
   loadAuthorDocuments,
   staleDocumentAuthors,
-  subscribedDocumentAuthors,
+  subscribedDocumentAuthorPage,
   type BackfillResult,
 } from '../services/document-store';
 import { digestScope } from '../services/standard-site';
@@ -74,6 +78,9 @@ export async function handleDocumentBackfill(request: Request, env: Env): Promis
     results.push(await backfillAuthorDocuments(env, did));
   }
 
+  // Authors still queued after this chunk. An author whose PDS can't be listed at
+  // all drops out for a backoff window rather than pinning this above 0 forever,
+  // so the driving loop terminates on a repo we will never be able to read.
   const remaining = Array.isArray(body.dids)
     ? null
     : (await staleDocumentAuthors(env, limit)).length;
@@ -119,28 +126,46 @@ function byUri(documents: ProxyDocument[]): Map<string, ProxyDocument> {
 /**
  * POST /api/internal/documents/shadow-compare
  *
- * Body: `{ dids?: string[], limit?: number }`. Serves each author both ways — proxy
- * blob and D1 rows — and reports the difference. This is Phase 3's gate: the flip to
- * `documents_v2_enabled` waits on a clean report, because a silent hole in the store
- * looks exactly like an author who stopped publishing.
+ * Body: `{ dids?: string[], limit?: number, cursor?: string }`. Serves each author
+ * both ways — proxy blob and D1 rows — and reports the difference. This is Phase 3's
+ * gate: the flip to `documents_v2_enabled` waits on a clean report, because a silent
+ * hole in the store looks exactly like an author who stopped publishing.
+ *
+ * Without `dids` the endpoint walks the whole subscribed-author set one page at a
+ * time: pass the returned `cursor` back to get the next page, and keep going until
+ * it comes back null. Only "every page clean" is the gate — a single call compares
+ * the page it was given and says nothing about the authors behind it.
  */
 export async function handleDocumentShadowCompare(request: Request, env: Env): Promise<Response> {
   if (request.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
   if (!isAuthorizedProxyRequest(request, env)) return unauthorized();
 
-  let body: { dids?: string[]; limit?: number } = {};
+  let body: { dids?: string[]; limit?: number; cursor?: string } = {};
   try {
     body = (await request.json()) as typeof body;
   } catch {
-    /* empty body → compare the first chunk of subscribed authors */
+    /* empty body → compare the first page of subscribed authors */
   }
 
   const limit = Math.min(Math.max(1, Math.floor(body.limit ?? 10)), 50);
-  const dids = Array.isArray(body.dids)
-    ? body.dids.slice(0, limit)
-    : (await subscribedDocumentAuthors(env)).slice(0, limit);
+  const explicit = Array.isArray(body.dids);
+  const page = explicit
+    ? { dids: body.dids!.slice(0, limit), cursor: null, remaining: 0 }
+    : await subscribedDocumentAuthorPage(env, {
+        limit,
+        after: typeof body.cursor === 'string' ? body.cursor : undefined,
+      });
+  const dids = page.dids;
 
-  if (dids.length === 0) return json({ compared: 0, clean: true, scopes: [] });
+  if (dids.length === 0) {
+    return json({
+      compared: 0,
+      clean: true,
+      cursor: page.cursor,
+      remaining: page.remaining,
+      scopes: [],
+    });
+  }
 
   const client = new FeedProxyClient(env);
   let proxyEntries;
@@ -150,8 +175,18 @@ export async function handleDocumentShadowCompare(request: Request, env: Env): P
     return json({ error: error instanceof Error ? error.message : 'Proxy fetch failed' }, 502);
   }
 
+  const byDid = new Map(proxyEntries.map((entry) => [entry.did, entry]));
   const scopes: ScopeDrift[] = [];
-  for (const entry of proxyEntries) {
+  for (const did of dids) {
+    // An author the proxy answered nothing for is drift too: the compare has to
+    // account for every author it was asked about, or the walk's coverage is a
+    // claim rather than a fact.
+    const entry: ProxyDocumentEntry = byDid.get(did) ?? {
+      did,
+      status: 'error',
+      error: 'No proxy entry returned',
+      documents: [],
+    };
     const proxyDocs = entry.documents ?? [];
     const d1Docs = await loadAuthorDocuments(env, entry.did, {
       // Comparison is about which records exist, not about warming magazine
@@ -201,7 +236,16 @@ export async function handleDocumentShadowCompare(request: Request, env: Env): P
     compared: scopes.length,
     clean,
     drifted: scopes.filter((s) => !s.clean).length,
+    remaining: page.remaining,
   });
 
-  return json({ compared: scopes.length, clean, scopes });
+  return json({
+    compared: scopes.length,
+    // This page only. The cutover gate is every page of the walk clean, which the
+    // caller establishes by following `cursor` to the end.
+    clean,
+    cursor: page.cursor,
+    remaining: page.remaining,
+    scopes,
+  });
 }

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -27,10 +27,12 @@ import { log } from '../utils/logger';
 
 /**
  * Authors backfilled per call. A backfill is a `listRecords` walk plus a write per
- * document, so the operator drives the migration as a loop of bounded calls rather
- * than one request that would outlive its own CPU budget.
+ * document — up to `BACKFILL_QUERY_COST` D1 queries — so the operator drives the
+ * migration as a loop of bounded calls rather than one request that would outlive
+ * its CPU budget or run into `D1_QUERIES_PER_INVOCATION` partway through and lose
+ * the walks it hadn't reached. Five authors is ~560 queries, well under.
  */
-const MAX_BACKFILL_BATCH = 20;
+const MAX_BACKFILL_BATCH = 5;
 
 function unauthorized(): Response {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {

--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -7,6 +7,12 @@ import type {
   ArticleMentionsResult,
 } from '../services/feed-proxy-client';
 import { resolveStandardSite } from '../utils/canonical-url';
+import { readDocumentFlags } from '../services/document-flags';
+import {
+  MAX_COLLECTION_RESOLVES_PER_REQUEST,
+  serveDocumentScope,
+  serveSingleDocument,
+} from '../services/document-store';
 import { log, serializeError } from '../utils/logger';
 import { chunkArray, getReadKeys } from './reading';
 import { clearFeedHealth, ingestProxyFeed } from './ingest';
@@ -546,9 +552,11 @@ async function correctLinkblogScopes(
 /**
  * POST /api/v2/documents/batch
  *
- * Batch fetch standard.site documents for multiple authors via the Fly.io proxy.
- * Thin pass-through — no D1 reads/writes. Documents come back already resolved
- * (canonical URL + site icon) in the frontend's SocialDocument shape.
+ * Batch fetch standard.site documents for multiple authors. Served from D1 once
+ * `documents_v2_enabled` is on, from the Fly.io proxy until then; the response is
+ * byte-compatible either way (same statuses, same digest algorithm, same
+ * `complete` semantics), so the frontend is unaware of the cutover. Documents come
+ * back already resolved (canonical URL + site icon) in the SocialDocument shape.
  *
  * Request body:
  * {
@@ -643,13 +651,18 @@ export async function handleV2BatchDocumentFetch(
       console.error('Linkblog scope correction failed; forwarding scopes as-is:', e);
     }
 
-    const client = new FeedProxyClient(env);
-    const proxyEntries = await client.fetchDocumentsBatch(requests);
-    for (const entry of proxyEntries) {
+    // The rollout gate. Both paths produce the same wire shape (status, digest,
+    // `complete`), so this is a per-request choice of *source*, not of contract —
+    // and flipping `documents_v2_enabled` back is a full rollback with no deploy.
+    const { serveFromD1 } = await readDocumentFlags(env);
+    const sourceEntries = serveFromD1
+      ? await serveDocumentsFromD1(env, requests)
+      : await new FeedProxyClient(env).fetchDocumentsBatch(requests);
+    for (const entry of sourceEntries) {
       const requestedScope = entry.siteUri && restore.get(`${entry.did}\n${entry.siteUri}`);
       if (requestedScope) entry.siteUri = requestedScope;
     }
-    authors.push(...proxyEntries);
+    authors.push(...sourceEntries);
 
     // Inline read annotation, identical to the feed path but keyed by recordUri
     // and item_type='document' (decision 3: documents share the unified read
@@ -687,12 +700,46 @@ export async function handleV2BatchDocumentFetch(
 }
 
 /**
+ * Serve every requested scope from D1. One curated-edition resolve budget is shared
+ * across the whole batch: each edition costs up to 50 cross-PDS getRecords, and a
+ * batch is up to 50 scopes, so a per-scope budget would multiply into the
+ * subrequest ceiling. Editions past the budget serve their last resolved preview
+ * (or none) and resolve on a later read.
+ */
+async function serveDocumentsFromD1(
+  env: Env,
+  requests: Array<{ did: string; siteUri?: string; since_digest?: string }>
+): Promise<ProxyDocumentEntry[]> {
+  const collectionBudget = { remaining: MAX_COLLECTION_RESOLVES_PER_REQUEST };
+  return Promise.all(
+    requests.map(async (entry): Promise<ProxyDocumentEntry> => {
+      try {
+        return await serveDocumentScope(env, entry, collectionBudget);
+      } catch (error) {
+        // One author's bad row must not fail the batch: the client keeps what it
+        // holds for this scope and retries next poll.
+        console.error(`D1 document serve failed for ${entry.did}:`, error);
+        return {
+          did: entry.did,
+          siteUri: entry.siteUri,
+          documents: [],
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Document read failed',
+        };
+      }
+    })
+  );
+}
+
+/**
  * GET /api/v2/documents/get?uri=at://...
  *
  * On-demand fetch of a single standard.site document — the in-app reader path
  * for a curated Collection piece whose author the user doesn't subscribe to (so
- * it's in no batch response). Thin pass-through to the proxy, then the same
- * per-user read annotation the batch path applies (item_type 'document').
+ * it's in no batch response). D1 first (falling back to a live getRecord for an
+ * author nobody subscribes to) once `documents_v2_enabled` is on, the proxy until
+ * then, followed by the same per-user read annotation the batch path applies
+ * (item_type 'document').
  */
 export async function handleV2GetDocument(
   request: Request,
@@ -715,8 +762,10 @@ export async function handleV2GetDocument(
   }
 
   try {
-    const client = new FeedProxyClient(env);
-    const document = await client.fetchDocument(uri);
+    const { serveFromD1 } = await readDocumentFlags(env);
+    const document = serveFromD1
+      ? await serveSingleDocument(env, uri)
+      : await new FeedProxyClient(env).fetchDocument(uri);
     if (!document) {
       return new Response(JSON.stringify({ error: 'Document not found' }), {
         status: 404,

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -14,6 +14,7 @@ import {
   deleteAtmosphereSubscription,
 } from '../services/atmosphere-subscription';
 import { createPDSClient, type WriteOp } from '../services/pds-client';
+import { backfillAuthorDocuments } from '../services/document-store';
 import { isValidRkey, invalidRkeyResponse } from '../utils/validation';
 import { generateTid } from '../utils/tid';
 import { fetchProfiles } from '../services/bsky-appview';
@@ -1021,6 +1022,19 @@ export async function handleCreateSubscription(
         settings.pdsSyncEnabled ? 1 : 0
       )
       .run();
+
+    // The documents equivalent of `warmFeedIntoArchive`: pull the author's back
+    // catalogue into D1 so the first read of a brand-new subscription isn't empty.
+    // The firehose only carries writes made while we were watching, so nothing else
+    // would ever supply it. In the background — a listRecords walk is several PDS
+    // round-trips and the subscribe response shouldn't wait on them.
+    if (isAtProto && subjectDid) {
+      ctx.waitUntil(
+        backfillAuthorDocuments(env, subjectDid).catch((error) => {
+          console.error(`Document backfill failed for ${subjectDid}:`, error);
+        })
+      );
+    }
 
     // Crawl the feed once and ingest it into the archive, so the client's first
     // read of this brand-new subscription is a plain D1 query (RSS only).

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -14,7 +14,7 @@ import {
   deleteAtmosphereSubscription,
 } from '../services/atmosphere-subscription';
 import { createPDSClient, type WriteOp } from '../services/pds-client';
-import { backfillAuthorDocuments } from '../services/document-store';
+import { scheduleAuthorDocuments } from '../services/document-store';
 import { isValidRkey, invalidRkeyResponse } from '../utils/validation';
 import { generateTid } from '../utils/tid';
 import { fetchProfiles } from '../services/bsky-appview';
@@ -608,6 +608,11 @@ export async function ensureLocalDocumentSubscription(
     )
     .run();
 
+  // Same back-catalogue pull the API subscribe does. Without it this row exists with
+  // nothing behind it, and every poll of the new linkblog serves `status:'error'`
+  // until the hourly reconcile reaches that author.
+  scheduleAuthorDocuments(env, (p) => ctx.waitUntil(p), subjectDid);
+
   // Mirror to the user's PDS subscription list when Atmospheric sync is on, so the
   // reader follow behaves exactly like an in-app one (best-effort, background).
   ctx.waitUntil(
@@ -1026,14 +1031,9 @@ export async function handleCreateSubscription(
     // The documents equivalent of `warmFeedIntoArchive`: pull the author's back
     // catalogue into D1 so the first read of a brand-new subscription isn't empty.
     // The firehose only carries writes made while we were watching, so nothing else
-    // would ever supply it. In the background — a listRecords walk is several PDS
-    // round-trips and the subscribe response shouldn't wait on them.
+    // would ever supply it.
     if (isAtProto && subjectDid) {
-      ctx.waitUntil(
-        backfillAuthorDocuments(env, subjectDid).catch((error) => {
-          console.error(`Document backfill failed for ${subjectDid}:`, error);
-        })
-      );
+      scheduleAuthorDocuments(env, (p) => ctx.waitUntil(p), subjectDid);
     }
 
     // Crawl the feed once and ingest it into the archive, so the client's first

--- a/backend/src/routes/sync.ts
+++ b/backend/src/routes/sync.ts
@@ -79,7 +79,7 @@ export async function handleFullSync(
     // Sync subscriptions. Pass the session id so the PDS client can self-heal a
     // stale host after a PDS migration (re-resolve + persist + retry).
     const sessionId = getSessionIdFromRequest(request) ?? undefined;
-    const subResult = await syncSubscriptions(session, env, sessionId);
+    const subResult = await syncSubscriptions(session, env, sessionId, (p) => ctx.waitUntil(p));
     result.subscriptions = subResult;
 
     if (subResult.success) {
@@ -127,7 +127,11 @@ export async function handleFullSync(
 }
 
 // POST /api/sync/subscriptions - Sync subscriptions only
-export async function handleSyncSubscriptions(request: Request, env: Env): Promise<Response> {
+export async function handleSyncSubscriptions(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<Response> {
   if (request.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), {
       status: 405,
@@ -160,7 +164,7 @@ export async function handleSyncSubscriptions(request: Request, env: Env): Promi
 
   try {
     const sessionId = getSessionIdFromRequest(request) ?? undefined;
-    const result = await syncSubscriptions(session, env, sessionId);
+    const result = await syncSubscriptions(session, env, sessionId, (p) => ctx.waitUntil(p));
 
     if (result.success) {
       await updateSyncTimestamp(env, session.did, 'subscriptions');

--- a/backend/src/routes/sync.ts
+++ b/backend/src/routes/sync.ts
@@ -15,8 +15,10 @@ import { createQueryLedger, D1_QUERIES_PER_INVOCATION } from '../services/docume
 /**
  * What a sync request keeps back from the ledger for the D1 work it does outside the
  * terms it charges: the tier and count reads, the PDS-push bookkeeping, the settings
- * and session rows. The pull's insert batch — the one term big enough to matter — is
- * charged for real.
+ * and session rows. The terms big enough to matter are charged for real — the pull's
+ * insert batch, and the Atmosphere reconcile's graph listing plus its `MAX_OPS`
+ * cross-PDS operations, which on their own could account for the whole of this
+ * reserve if they were left inside it.
  */
 const SYNC_QUERY_RESERVE = 100;
 

--- a/backend/src/routes/sync.ts
+++ b/backend/src/routes/sync.ts
@@ -10,6 +10,15 @@ import {
   reconcileAtmosphereSubscriptions,
   type AtmosphereSyncResult,
 } from '../services/atmosphere-subscription-sync';
+import { createQueryLedger, D1_QUERIES_PER_INVOCATION } from '../services/document-store';
+
+/**
+ * What a sync request keeps back from the ledger for the D1 work it does outside the
+ * terms it charges: the tier and count reads, the PDS-push bookkeeping, the settings
+ * and session rows. The pull's insert batch — the one term big enough to matter — is
+ * charged for real.
+ */
+const SYNC_QUERY_RESERVE = 100;
 
 export interface FullSyncResult {
   success: boolean;
@@ -79,7 +88,19 @@ export async function handleFullSync(
     // Sync subscriptions. Pass the session id so the PDS client can self-heal a
     // stale host after a PDS migration (re-resolve + persist + retry).
     const sessionId = getSessionIdFromRequest(request) ?? undefined;
-    const subResult = await syncSubscriptions(session, env, sessionId, (p) => ctx.waitUntil(p));
+    // One ledger for the whole request. Both halves of this route write
+    // subscriptions and both schedule back-catalogue walks into the same
+    // invocation, so they have to be admitted against one another's spend —
+    // sized apart, a large restore plus a graph import would go over D1's
+    // per-invocation ceiling and take the walks down with it.
+    const ledger = createQueryLedger(D1_QUERIES_PER_INVOCATION - SYNC_QUERY_RESERVE);
+    const subResult = await syncSubscriptions(
+      session,
+      env,
+      sessionId,
+      (p) => ctx.waitUntil(p),
+      ledger
+    );
     result.subscriptions = subResult;
 
     if (subResult.success) {
@@ -99,7 +120,7 @@ export async function handleFullSync(
     // Reconcile standard.site follows ↔ Skyreader. This rides the same
     // Atmospheric-sync switch (the graph edges are the public mirror), so it
     // always runs while PDS sync is on — no separate opt-in.
-    const atmoResult = await reconcileAtmosphereSubscriptions(session, env, ctx);
+    const atmoResult = await reconcileAtmosphereSubscriptions(session, env, ctx, ledger);
     result.atmosphere = atmoResult;
     if (atmoResult.hasMore) {
       result.hasMore = true;
@@ -164,7 +185,13 @@ export async function handleSyncSubscriptions(
 
   try {
     const sessionId = getSessionIdFromRequest(request) ?? undefined;
-    const result = await syncSubscriptions(session, env, sessionId, (p) => ctx.waitUntil(p));
+    const result = await syncSubscriptions(
+      session,
+      env,
+      sessionId,
+      (p) => ctx.waitUntil(p),
+      createQueryLedger(D1_QUERIES_PER_INVOCATION - SYNC_QUERY_RESERVE)
+    );
 
     if (result.success) {
       await updateSyncTimestamp(env, session.did, 'subscriptions');

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -37,8 +37,11 @@ import {
   isPublicationUri,
   writeAtmosphereSubscription,
 } from './atmosphere-subscription';
-import { pushSubscriptionToPds, deleteSubscriptionFromPds } from './subscription-sync';
-import type { LimitNotice } from './subscription-sync';
+import {
+  pushSubscriptionToPds,
+  deleteSubscriptionFromPds,
+  type LimitNotice,
+} from './subscription-sync';
 import { log } from '../utils/logger';
 import {
   chargeQueries,

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -44,6 +44,7 @@ import {
   chargeQueries,
   createBackfillScheduler,
   MAX_SYNC_BACKFILLS,
+  tryChargeQueries,
   type QueryLedger,
 } from './document-store';
 
@@ -201,8 +202,9 @@ export async function reconcileAtmosphereSubscriptions(
   // Every op this reconcile performs comes out of the same invocation as the
   // subscription pull and the back-catalogue walks. Charging them is what lets
   // `/api/sync` reserve for what it does *not* charge rather than for this.
-  const charge = (subrequests: number) => {
-    if (ledger) chargeQueries(ledger, subrequests);
+  const charge = (subrequests: number): boolean => {
+    if (!ledger) return true;
+    return tryChargeQueries(ledger, subrequests);
   };
   const chargeOp = () => charge(SUBREQUESTS_PER_ATMOSPHERE_OP);
   // Imports fan out into this one invocation, so the back-catalogue walks they
@@ -219,7 +221,14 @@ export async function reconcileAtmosphereSubscriptions(
     if (!graphResult.success) {
       return { ...result, success: false, error: `Failed to list graph: ${graphResult.error}` };
     }
-    charge(graphListSubrequests(graphResult.data.length, graphResult.truncated === true));
+    // The listing has already happened, so this charge is accounting rather than
+    // admission. Later work will defer if the listing consumed the headroom.
+    if (ledger) {
+      chargeQueries(
+        ledger,
+        graphListSubrequests(graphResult.data.length, graphResult.truncated === true)
+      );
+    }
     const graphPubs = new Set<string>();
     for (const rec of graphResult.data) {
       if (isPublicationUri(rec.value.publication)) graphPubs.add(rec.value.publication);
@@ -299,7 +308,10 @@ export async function reconcileAtmosphereSubscriptions(
       // Charged before the work, not after: an import that bails part way (an
       // unparseable URI, a concurrent reconcile that inserted the row first) has
       // still spent the fetches it made by then.
-      chargeOp();
+      if (!chargeOp()) {
+        result.hasMore = true;
+        break;
+      }
       const meta = await resolvePublicationMeta(pubUri);
       if (!meta) continue; // unparseable URI — skip
       const title = await titleFor(meta);
@@ -402,7 +414,10 @@ export async function reconcileAtmosphereSubscriptions(
             result.hasMore = true;
             break;
           }
-          chargeOp();
+          if (!chargeOp()) {
+            result.hasMore = true;
+            break;
+          }
           const removeOld = await deleteAtmosphereSubscription(session, previousPubUri);
           if (!removeOld.success) {
             result.warnings.push(
@@ -419,7 +434,10 @@ export async function reconcileAtmosphereSubscriptions(
             result.hasMore = true;
             break;
           }
-          chargeOp();
+          if (!chargeOp()) {
+            result.hasMore = true;
+            break;
+          }
           const writeNew = await writeAtmosphereSubscription(session, pubUri);
           if (!writeNew.success) {
             result.warnings.push(
@@ -434,7 +452,10 @@ export async function reconcileAtmosphereSubscriptions(
 
         // Not gated by `MAX_OPS` — it is one statement per local row, so the loop
         // as a whole is bounded only by the mirror cap. Charged for that reason.
-        charge(1);
+        if (!charge(1)) {
+          result.hasMore = true;
+          break;
+        }
         await env.DB.prepare(
           `UPDATE subscriptions_cache
            SET atmosphere_synced = unixepoch(), atmosphere_previous_feed_url = NULL
@@ -448,7 +469,10 @@ export async function reconcileAtmosphereSubscriptions(
       if (graphPubs.has(pubUri)) {
         // Present both places — claim it if not yet marked (e.g. an in-app follow).
         if (sub.atmosphere_synced === null) {
-          charge(1);
+          if (!charge(1)) {
+            result.hasMore = true;
+            break;
+          }
           await env.DB.prepare(
             `UPDATE subscriptions_cache SET atmosphere_synced = unixepoch() WHERE record_uri = ?`
           )
@@ -471,7 +495,10 @@ export async function reconcileAtmosphereSubscriptions(
         if (graphTruncated) continue;
         // Delete the PDS record first (so a subscription sync can't re-import it),
         // then the local row.
-        chargeOp();
+        if (!chargeOp()) {
+          result.hasMore = true;
+          break;
+        }
         const rkey = extractRkey(sub.record_uri);
         const del = await deleteSubscriptionFromPds(session, rkey);
         if (!del.success) {
@@ -485,7 +512,10 @@ export async function reconcileAtmosphereSubscriptions(
         ops++;
       } else {
         // Local-only (edge write hasn't landed) → write it back, then mark synced.
-        chargeOp();
+        if (!chargeOp()) {
+          result.hasMore = true;
+          break;
+        }
         const write = await writeAtmosphereSubscription(session, pubUri);
         if (!write.success) {
           result.warnings.push(`Failed to push edge for ${pubUri}: ${write.error}`);

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -57,6 +57,31 @@ const MAX_LIST_PAGES = 20;
 // `hasMore` is set so the caller loops — exactly like syncSubscriptions batching.
 const MAX_OPS = 20;
 
+/**
+ * Subrequests one reconcile op costs, charged flat against the invocation's ledger.
+ * Sized on the largest of them — an import: the publication's DID document and its
+ * record, the owner's profile for a fallback title, the local insert, and the mirror
+ * record pushed to the user's PDS. A delete or an edge write is a PDS write plus a
+ * statement, comfortably under it.
+ *
+ * `MAX_OPS` of these is the dominant term of this half of a sync request, and until
+ * it was charged it was hidden inside `/api/sync`'s flat reserve — where it could
+ * quietly account for the whole of it, leaving the reserve to cover nothing.
+ */
+const SUBREQUESTS_PER_ATMOSPHERE_OP = 8;
+
+/**
+ * Subrequests the graph listing spent, derived from what it returned: a page is 100
+ * records, and a listing that stopped on the page cap spent every page it was
+ * allowed. A server that returns short pages costs more calls than this counts, so
+ * treat it as the listing's floor — it exists so the term is present in the ledger
+ * at all, which for a full graph is the difference between 1 and 20.
+ */
+function graphListSubrequests(records: number, truncated: boolean): number {
+  if (truncated) return MAX_LIST_PAGES;
+  return Math.max(1, Math.ceil(records / 100));
+}
+
 export interface AtmosphereSyncResult {
   success: boolean;
   error?: string;
@@ -173,6 +198,13 @@ export async function reconcileAtmosphereSubscriptions(
 
   const pdsClient = createPDSClient(session);
   let ops = 0;
+  // Every op this reconcile performs comes out of the same invocation as the
+  // subscription pull and the back-catalogue walks. Charging them is what lets
+  // `/api/sync` reserve for what it does *not* charge rather than for this.
+  const charge = (subrequests: number) => {
+    if (ledger) chargeQueries(ledger, subrequests);
+  };
+  const chargeOp = () => charge(SUBREQUESTS_PER_ATMOSPHERE_OP);
   // Imports fan out into this one invocation, so the back-catalogue walks they
   // trigger are bounded the way the poller's are (see `MAX_SYNC_BACKFILLS`).
   const scheduleBackfill = createBackfillScheduler(env, (p) => ctx.waitUntil(p), { ledger });
@@ -187,6 +219,7 @@ export async function reconcileAtmosphereSubscriptions(
     if (!graphResult.success) {
       return { ...result, success: false, error: `Failed to list graph: ${graphResult.error}` };
     }
+    charge(graphListSubrequests(graphResult.data.length, graphResult.truncated === true));
     const graphPubs = new Set<string>();
     for (const rec of graphResult.data) {
       if (isPublicationUri(rec.value.publication)) graphPubs.add(rec.value.publication);
@@ -263,6 +296,10 @@ export async function reconcileAtmosphereSubscriptions(
         continue;
       }
 
+      // Charged before the work, not after: an import that bails part way (an
+      // unparseable URI, a concurrent reconcile that inserted the row first) has
+      // still spent the fetches it made by then.
+      chargeOp();
       const meta = await resolvePublicationMeta(pubUri);
       if (!meta) continue; // unparseable URI — skip
       const title = await titleFor(meta);
@@ -287,7 +324,6 @@ export async function reconcileAtmosphereSubscriptions(
       // publication first; the unique (user, source_type, feed_url) index makes
       // our insert a no-op. Skip the follow-up work so we don't double-count or
       // write a second, orphaned PDS record under our throwaway rkey.
-      if (ledger) chargeQueries(ledger, 1);
       if (insert.meta && insert.meta.changes === 0) continue;
 
       // An imported follow needs the author's back catalogue pulled in like any
@@ -366,6 +402,7 @@ export async function reconcileAtmosphereSubscriptions(
             result.hasMore = true;
             break;
           }
+          chargeOp();
           const removeOld = await deleteAtmosphereSubscription(session, previousPubUri);
           if (!removeOld.success) {
             result.warnings.push(
@@ -382,6 +419,7 @@ export async function reconcileAtmosphereSubscriptions(
             result.hasMore = true;
             break;
           }
+          chargeOp();
           const writeNew = await writeAtmosphereSubscription(session, pubUri);
           if (!writeNew.success) {
             result.warnings.push(
@@ -394,6 +432,9 @@ export async function reconcileAtmosphereSubscriptions(
           ops++;
         }
 
+        // Not gated by `MAX_OPS` — it is one statement per local row, so the loop
+        // as a whole is bounded only by the mirror cap. Charged for that reason.
+        charge(1);
         await env.DB.prepare(
           `UPDATE subscriptions_cache
            SET atmosphere_synced = unixepoch(), atmosphere_previous_feed_url = NULL
@@ -407,6 +448,7 @@ export async function reconcileAtmosphereSubscriptions(
       if (graphPubs.has(pubUri)) {
         // Present both places — claim it if not yet marked (e.g. an in-app follow).
         if (sub.atmosphere_synced === null) {
+          charge(1);
           await env.DB.prepare(
             `UPDATE subscriptions_cache SET atmosphere_synced = unixepoch() WHERE record_uri = ?`
           )
@@ -429,6 +471,7 @@ export async function reconcileAtmosphereSubscriptions(
         if (graphTruncated) continue;
         // Delete the PDS record first (so a subscription sync can't re-import it),
         // then the local row.
+        chargeOp();
         const rkey = extractRkey(sub.record_uri);
         const del = await deleteSubscriptionFromPds(session, rkey);
         if (!del.success) {
@@ -442,6 +485,7 @@ export async function reconcileAtmosphereSubscriptions(
         ops++;
       } else {
         // Local-only (edge write hasn't landed) → write it back, then mark synced.
+        chargeOp();
         const write = await writeAtmosphereSubscription(session, pubUri);
         if (!write.success) {
           result.warnings.push(`Failed to push edge for ${pubUri}: ${write.error}`);

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -39,6 +39,7 @@ import {
 } from './atmosphere-subscription';
 import { pushSubscriptionToPds, deleteSubscriptionFromPds } from './subscription-sync';
 import type { LimitNotice } from './subscription-sync';
+import { scheduleAuthorDocuments } from './document-store';
 
 const SUBSCRIPTION_NSID = 'app.skyreader.feed.subscription';
 
@@ -273,6 +274,11 @@ export async function reconcileAtmosphereSubscriptions(
       // our insert a no-op. Skip the follow-up work so we don't double-count or
       // write a second, orphaned PDS record under our throwaway rkey.
       if (insert.meta && insert.meta.changes === 0) continue;
+
+      // An imported follow needs the author's back catalogue pulled in like any
+      // other new subscription — otherwise the reader shows an error for this
+      // linkblog until the hourly reconcile happens to reach that author.
+      scheduleAuthorDocuments(env, (p) => ctx.waitUntil(p), meta.subjectDid);
 
       // Mirror to the user's app.skyreader subscription list on the PDS, so an
       // imported follow looks identical to an in-app one. Best-effort.

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -39,7 +39,8 @@ import {
 } from './atmosphere-subscription';
 import { pushSubscriptionToPds, deleteSubscriptionFromPds } from './subscription-sync';
 import type { LimitNotice } from './subscription-sync';
-import { scheduleAuthorDocuments } from './document-store';
+import { log } from '../utils/logger';
+import { createBackfillScheduler, MAX_SYNC_BACKFILLS } from './document-store';
 
 const SUBSCRIPTION_NSID = 'app.skyreader.feed.subscription';
 
@@ -163,6 +164,10 @@ export async function reconcileAtmosphereSubscriptions(
 
   const pdsClient = createPDSClient(session);
   let ops = 0;
+  // Imports fan out into this one invocation, so the back-catalogue walks they
+  // trigger are bounded the way the poller's are (see `MAX_SYNC_BACKFILLS`).
+  const scheduleBackfill = createBackfillScheduler(env, (p) => ctx.waitUntil(p));
+  let deferredBackfills = 0;
 
   try {
     // Step 1: the user's graph edges → set of followed publication URIs.
@@ -277,8 +282,10 @@ export async function reconcileAtmosphereSubscriptions(
 
       // An imported follow needs the author's back catalogue pulled in like any
       // other new subscription — otherwise the reader shows an error for this
-      // linkblog until the hourly reconcile happens to reach that author.
-      scheduleAuthorDocuments(env, (p) => ctx.waitUntil(p), meta.subjectDid);
+      // linkblog until the reconcile happens to reach that author. Past the bound,
+      // the reconcile is exactly where it goes: an author with no
+      // `document_authors` row sorts to the front of that queue.
+      if (!scheduleBackfill(meta.subjectDid)) deferredBackfills++;
 
       // Mirror to the user's app.skyreader subscription list on the PDS, so an
       // imported follow looks identical to an in-app one. Best-effort.
@@ -330,9 +337,15 @@ export async function reconcileAtmosphereSubscriptions(
       });
     }
 
-    // No backfill step: an imported follow's posts are fetched from the proxy on
-    // first open (POST /api/v2/documents/batch in routes/feeds-v2.ts), so there is
-    // nothing to warm ahead of time.
+    // Imports warm themselves: the loop above schedules up to MAX_SYNC_BACKFILLS
+    // back-catalogue walks (documents are read from D1 now, so an unlisted author
+    // has nothing to serve). Anything past that bound waits for the reconcile.
+    if (deferredBackfills > 0) {
+      log.info('atmosphere_import_backfills_deferred', {
+        deferred: deferredBackfills,
+        scheduled: MAX_SYNC_BACKFILLS,
+      });
+    }
 
     // Step 4: reconcile each local pub-sub against the graph.
     for (const [pubUri, sub] of localByPub) {

--- a/backend/src/services/atmosphere-subscription-sync.ts
+++ b/backend/src/services/atmosphere-subscription-sync.ts
@@ -40,7 +40,12 @@ import {
 import { pushSubscriptionToPds, deleteSubscriptionFromPds } from './subscription-sync';
 import type { LimitNotice } from './subscription-sync';
 import { log } from '../utils/logger';
-import { createBackfillScheduler, MAX_SYNC_BACKFILLS } from './document-store';
+import {
+  chargeQueries,
+  createBackfillScheduler,
+  MAX_SYNC_BACKFILLS,
+  type QueryLedger,
+} from './document-store';
 
 const SUBSCRIPTION_NSID = 'app.skyreader.feed.subscription';
 
@@ -150,7 +155,11 @@ async function titleFor(meta: PublicationMeta): Promise<string> {
 export async function reconcileAtmosphereSubscriptions(
   session: Session,
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  // The invocation's subrequest ledger. On `/api/sync` this is the same one the
+  // subscription sync just charged its pull to, so the walks scheduled here are
+  // admitted against everything the request has spent — both halves of it.
+  ledger?: QueryLedger
 ): Promise<AtmosphereSyncResult> {
   const result: AtmosphereSyncResult = {
     success: true,
@@ -166,7 +175,7 @@ export async function reconcileAtmosphereSubscriptions(
   let ops = 0;
   // Imports fan out into this one invocation, so the back-catalogue walks they
   // trigger are bounded the way the poller's are (see `MAX_SYNC_BACKFILLS`).
-  const scheduleBackfill = createBackfillScheduler(env, (p) => ctx.waitUntil(p));
+  const scheduleBackfill = createBackfillScheduler(env, (p) => ctx.waitUntil(p), { ledger });
   let deferredBackfills = 0;
 
   try {
@@ -278,6 +287,7 @@ export async function reconcileAtmosphereSubscriptions(
       // publication first; the unique (user, source_type, feed_url) index makes
       // our insert a no-op. Skip the follow-up work so we don't double-count or
       // write a second, orphaned PDS record under our throwaway rkey.
+      if (ledger) chargeQueries(ledger, 1);
       if (insert.meta && insert.meta.changes === 0) continue;
 
       // An imported follow needs the author's back catalogue pulled in like any

--- a/backend/src/services/document-flags.ts
+++ b/backend/src/services/document-flags.ts
@@ -1,0 +1,73 @@
+/**
+ * The two operator switches for standard.site documents, both `sync_state` rows so
+ * a flip is a D1 write, not a deploy (same pattern as `timeline_enabled`).
+ *
+ * They are deliberately separate. `documents_ingest_enabled` stops the poller
+ * *writing* — the flood response, which must not touch the subscriptions stream and
+ * must leave reads serving whatever D1 already holds. `documents_v2_enabled` chooses
+ * where reads *come from* — the rollout gate and the one-flip rollback to the proxy.
+ * Sequencing the cutover needs both: ingest on and filling for as long as it takes,
+ * reads flipped only once a shadow-compare says D1 agrees with the proxy.
+ */
+
+import type { Env } from '../types';
+
+/** Reads served from D1 rather than the Fly proxy. Off until explicitly enabled. */
+export const DOCUMENTS_V2_ENABLED_KEY = 'documents_v2_enabled';
+
+/** The poller's document stream. On unless explicitly disabled ('0'). */
+export const DOCUMENTS_INGEST_ENABLED_KEY = 'documents_ingest_enabled';
+
+/**
+ * Per-cycle apply cap override. Sized from measured burst shape; tunable without a
+ * deploy because the number that matters is a property of the network, not the code.
+ */
+export const DOCUMENTS_APPLY_CAP_KEY = 'documents_apply_cap';
+
+/** Applied events per poll cycle before the drain stops and carries its cursor. */
+export const DEFAULT_DOCUMENT_APPLY_CAP = 500;
+
+export interface DocumentFlags {
+  /** Serve reads from D1 (opt-in: only an explicit '1'). */
+  serveFromD1: boolean;
+  /** Run the poller's document stream (opt-out: only an explicit '0' stops it). */
+  ingestEnabled: boolean;
+  applyCap: number;
+}
+
+export async function readDocumentFlags(env: Env): Promise<DocumentFlags> {
+  const defaults: DocumentFlags = {
+    serveFromD1: false,
+    ingestEnabled: true,
+    applyCap: DEFAULT_DOCUMENT_APPLY_CAP,
+  };
+  try {
+    const result = await env.DB.prepare(`SELECT key, value FROM sync_state WHERE key IN (?, ?, ?)`)
+      .bind(DOCUMENTS_V2_ENABLED_KEY, DOCUMENTS_INGEST_ENABLED_KEY, DOCUMENTS_APPLY_CAP_KEY)
+      .all<{ key: string; value: string }>();
+    const flags = { ...defaults };
+    for (const row of result.results ?? []) {
+      if (row.key === DOCUMENTS_V2_ENABLED_KEY) flags.serveFromD1 = row.value === '1';
+      else if (row.key === DOCUMENTS_INGEST_ENABLED_KEY) flags.ingestEnabled = row.value !== '0';
+      else if (row.key === DOCUMENTS_APPLY_CAP_KEY) {
+        const cap = Number(row.value);
+        if (Number.isFinite(cap) && cap > 0) flags.applyCap = Math.floor(cap);
+      }
+    }
+    return flags;
+  } catch (error) {
+    // A flag read that fails must not change behaviour: keep serving from the
+    // proxy and keep ingesting.
+    console.error('[document-flags] read failed:', error);
+    return defaults;
+  }
+}
+
+export async function setDocumentFlag(env: Env, key: string, value: string): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO sync_state (key, value, updated_at) VALUES (?, ?, unixepoch())
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+  )
+    .bind(key, value)
+    .run();
+}

--- a/backend/src/services/document-flags.ts
+++ b/backend/src/services/document-flags.ts
@@ -27,6 +27,21 @@ export const DOCUMENTS_APPLY_CAP_KEY = 'documents_apply_cap';
 /** Applied events per poll cycle before the drain stops and carries its cursor. */
 export const DEFAULT_DOCUMENT_APPLY_CAP = 500;
 
+/**
+ * Hard ceiling on the cap, whatever the override says.
+ *
+ * Burst shape is not the only constraint on this number: every D1 call inside the
+ * alarm counts against the Worker's per-invocation subrequest budget (1000 on the
+ * paid plan), and hitting that ceiling is quiet — each throw is caught per event,
+ * counted as an error, and the cursor advances past it, so the case the cap exists
+ * to make safe would be the one most likely to drop events. `applyDocumentEvent`
+ * batches its writes into a single call, so an applied event costs ~1 subrequest
+ * (plus, on a cold publication, its metadata resolve); 900 leaves headroom for the
+ * cycle's own reads and those resolves. Phase 0's measurement sizes the cap under
+ * this, never over it.
+ */
+export const MAX_DOCUMENT_APPLY_CAP = 900;
+
 export interface DocumentFlags {
   /** Serve reads from D1 (opt-in: only an explicit '1'). */
   serveFromD1: boolean;
@@ -51,7 +66,9 @@ export async function readDocumentFlags(env: Env): Promise<DocumentFlags> {
       else if (row.key === DOCUMENTS_INGEST_ENABLED_KEY) flags.ingestEnabled = row.value !== '0';
       else if (row.key === DOCUMENTS_APPLY_CAP_KEY) {
         const cap = Number(row.value);
-        if (Number.isFinite(cap) && cap > 0) flags.applyCap = Math.floor(cap);
+        if (Number.isFinite(cap) && cap > 0) {
+          flags.applyCap = Math.min(Math.floor(cap), MAX_DOCUMENT_APPLY_CAP);
+        }
       }
     }
     return flags;

--- a/backend/src/services/document-flags.ts
+++ b/backend/src/services/document-flags.ts
@@ -2,15 +2,21 @@
  * The two operator switches for standard.site documents, both `sync_state` rows so
  * a flip is a D1 write, not a deploy (same pattern as `timeline_enabled`).
  *
- * They are deliberately separate. `documents_ingest_enabled` stops the poller
- * *writing* — the flood response, which must not touch the subscriptions stream and
- * must leave reads serving whatever D1 already holds. `documents_v2_enabled` chooses
+ * They are deliberately separate. `documents_ingest_enabled` stops every background
+ * path that *writes* documents — the poller's drain, the back catalogues it pulls
+ * for mirrored subscriptions, and the cron's reconcile — which is the flood
+ * response: it must not touch the subscriptions stream and must leave reads serving
+ * whatever D1 already holds. (The operator backfill endpoint is deliberately exempt:
+ * it is a deliberate repair, not a loop that would keep the flood fed.) The queues
+ * survive the pause, so flipping it back resumes rather than skips.
+ * `documents_v2_enabled` chooses
  * where reads *come from* — the rollout gate and the one-flip rollback to the proxy.
  * Sequencing the cutover needs both: ingest on and filling for as long as it takes,
  * reads flipped only once a shadow-compare says D1 agrees with the proxy.
  */
 
 import type { Env } from '../types';
+import { DOCUMENT_DRAIN_QUERY_BUDGET } from './document-store';
 
 /** Reads served from D1 rather than the Fly proxy. Off until explicitly enabled. */
 export const DOCUMENTS_V2_ENABLED_KEY = 'documents_v2_enabled';
@@ -30,17 +36,16 @@ export const DEFAULT_DOCUMENT_APPLY_CAP = 500;
 /**
  * Hard ceiling on the cap, whatever the override says.
  *
- * Burst shape is not the only constraint on this number: every D1 call inside the
- * alarm counts against the Worker's per-invocation subrequest budget (1000 on the
- * paid plan), and hitting that ceiling is quiet — each throw is caught per event,
- * counted as an error, and the cursor advances past it, so the case the cap exists
- * to make safe would be the one most likely to drop events. `applyDocumentEvent`
- * batches its writes into a single call, so an applied event costs ~1 subrequest
- * (plus, on a cold publication, its metadata resolve); 900 leaves headroom for the
- * cycle's own reads and those resolves. Phase 0's measurement sizes the cap under
- * this, never over it.
+ * Burst shape is not the only constraint on this number, and it is not the binding
+ * one. D1 allows `D1_QUERIES_PER_INVOCATION` queries per invocation — counting each
+ * statement inside a `batch` separately — and the drain budgets against that
+ * directly (`DOCUMENT_DRAIN_QUERY_BUDGET`), stopping while it can still pay for the
+ * events it has already applied. An applied event costs one query in the common
+ * case, so the budget is also the most events any cap could ever buy: clamping here
+ * keeps an override from claiming a number the cycle cannot fund. Phase 0's
+ * measurement sizes the cap under this, never over it.
  */
-export const MAX_DOCUMENT_APPLY_CAP = 900;
+export const MAX_DOCUMENT_APPLY_CAP = DOCUMENT_DRAIN_QUERY_BUDGET;
 
 export interface DocumentFlags {
   /** Serve reads from D1 (opt-in: only an explicit '1'). */

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -58,6 +58,25 @@ export const MAX_COLLECTION_RESOLVES_PER_REQUEST = 3;
  */
 export const AUTHOR_RECONCILE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** First wait after a failed list; doubles per consecutive failure. */
+export const AUTHOR_RETRY_BASE_MS = 60 * 60 * 1000;
+
+/** Ceiling on that wait — a dead author is still retried once a reconcile interval. */
+export const AUTHOR_RETRY_MAX_MS = AUTHOR_RECONCILE_INTERVAL_MS;
+
+/** How long after a failure an author is held out of the reconcile queue. */
+export function authorRetryBackoffMs(errorCount: number): number {
+  const exponent = Math.min(Math.max(Math.floor(errorCount), 1) - 1, 12);
+  return Math.min(AUTHOR_RETRY_BASE_MS * 2 ** exponent, AUTHOR_RETRY_MAX_MS);
+}
+
+/**
+ * `authorRetryBackoffMs` as SQL, so the queue query can apply it per row. Binds, in
+ * order: the ceiling, the base. `1 << n` is SQLite's shift; the exponent is clamped
+ * before shifting so a long-broken author can't overflow it.
+ */
+const RETRY_BACKOFF_SQL = 'MIN(?, ? * (1 << MIN(MAX(COALESCE(a.error_count, 1), 1) - 1, 12)))';
+
 export interface DocumentRow {
   record_uri: string;
   author_did: string;
@@ -97,23 +116,24 @@ function parseRecord<T>(raw: string): T | null {
 // --- Write path --------------------------------------------------------------
 
 /**
- * Upsert one `site.standard.document` record. Idempotent by `record_uri`, so a
- * replayed firehose event or a re-run backfill converges on the same row — which
- * is what makes Jetstream's at-least-once delivery safe here.
+ * The statement that upserts one `site.standard.document` record. Idempotent by
+ * `record_uri`, so a replayed firehose event or a re-run backfill converges on the
+ * same row — which is what makes Jetstream's at-least-once delivery safe here.
  *
- * Publication metadata is resolved (and D1-cached) at write time, so the serve
- * path never blocks on a PDS for a canonical URL.
+ * Publication metadata is resolved (and D1-cached) here, at write time, so the
+ * serve path never blocks on a PDS for a canonical URL. Returns null for a URI we
+ * can't parse an rkey out of, which is not a row we could ever address again.
  */
-export async function upsertDocument(
+async function documentUpsertStatement(
   env: Env,
   authorDid: string,
   recordUri: string,
   recordCid: string,
   record: DocumentRecord,
-  now = Date.now()
-): Promise<void> {
+  now: number
+): Promise<D1PreparedStatement | null> {
   const parsed = parseAtUri(recordUri);
-  if (!parsed) return;
+  if (!parsed) return null;
 
   const siteUri = record.site || '';
   const meta = await resolveSiteMeta(env, siteUri);
@@ -121,7 +141,7 @@ export async function upsertDocument(
     ? buildCanonicalUrl(meta.baseUrl, record.path || '')
     : record.path || '';
 
-  await env.DB.prepare(
+  return env.DB.prepare(
     `INSERT INTO documents_v2
        (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -132,20 +152,38 @@ export async function upsertDocument(
        canonical_url = excluded.canonical_url,
        record_json = excluded.record_json,
        updated_at = excluded.updated_at`
-  )
-    .bind(
-      recordUri,
-      authorDid,
-      parsed.rkey,
-      recordCid,
-      siteUri,
-      publishedAtMs(record, now),
-      canonicalUrl || null,
-      JSON.stringify(record),
-      now,
-      now
-    )
-    .run();
+  ).bind(
+    recordUri,
+    authorDid,
+    parsed.rkey,
+    recordCid,
+    siteUri,
+    publishedAtMs(record, now),
+    canonicalUrl || null,
+    JSON.stringify(record),
+    now,
+    now
+  );
+}
+
+/** Upsert one record on its own (the backfill's per-record write). */
+export async function upsertDocument(
+  env: Env,
+  authorDid: string,
+  recordUri: string,
+  recordCid: string,
+  record: DocumentRecord,
+  now = Date.now()
+): Promise<void> {
+  const statement = await documentUpsertStatement(
+    env,
+    authorDid,
+    recordUri,
+    recordCid,
+    record,
+    now
+  );
+  if (statement) await statement.run();
 }
 
 /**
@@ -155,8 +193,8 @@ export async function upsertDocument(
  * defence no DID filter can provide, because a *subscribed* author's flood passes
  * the filter by design.
  */
-export async function trimAuthorDocuments(env: Env, authorDid: string): Promise<number> {
-  const result = await env.DB.prepare(
+function trimAuthorDocumentsStatement(env: Env, authorDid: string): D1PreparedStatement {
+  return env.DB.prepare(
     `DELETE FROM documents_v2
       WHERE record_uri IN (
         SELECT record_uri FROM documents_v2
@@ -164,9 +202,11 @@ export async function trimAuthorDocuments(env: Env, authorDid: string): Promise<
          ORDER BY published_at DESC, record_uri DESC
          LIMIT -1 OFFSET ?
       )`
-  )
-    .bind(authorDid, MAX_DOCUMENTS_PER_AUTHOR)
-    .run();
+  ).bind(authorDid, MAX_DOCUMENTS_PER_AUTHOR);
+}
+
+export async function trimAuthorDocuments(env: Env, authorDid: string): Promise<number> {
+  const result = await trimAuthorDocumentsStatement(env, authorDid).run();
   return result.meta?.changes ?? 0;
 }
 
@@ -258,7 +298,7 @@ export async function applyDocumentEvent(
   }
 
   if (!commit.record) return false;
-  await upsertDocument(
+  const upsert = await documentUpsertStatement(
     env,
     event.did,
     recordUri,
@@ -266,8 +306,19 @@ export async function applyDocumentEvent(
     commit.record as DocumentRecord,
     now
   );
-  await trimAuthorDocuments(env, event.did);
-  await touchAuthor(env, { authorDid: event.did, lastEventAt: now });
+  if (!upsert) return false;
+
+  // One `batch` rather than three `run`s: D1 calls count against the Worker's
+  // per-invocation subrequest budget, and the drain's whole job is to apply a
+  // burst's worth of events inside one alarm. Three statements per event would put
+  // the apply cap (500) at ~1500 subrequests, over the 1000 ceiling — see the cap's
+  // note in `document-flags.ts`. Batching also makes the write atomic: the cap
+  // eviction and the bookkeeping either land with the document or not at all.
+  await env.DB.batch([
+    upsert,
+    trimAuthorDocumentsStatement(env, event.did),
+    authorBookkeepingStatement(env, { authorDid: event.did, lastEventAt: now }),
+  ]);
   return true;
 }
 
@@ -351,49 +402,54 @@ export function createDocumentDrain(
   };
 }
 
-/** Record ingest bookkeeping for an author (best effort — never fails a write). */
-async function touchAuthor(
+interface AuthorBookkeeping {
+  authorDid: string;
+  lastEventAt?: number;
+  lastListedAt?: number;
+  complete?: boolean;
+  error?: string | null;
+}
+
+/** The statement that records one author's ingest bookkeeping. */
+function authorBookkeepingStatement(
   env: Env,
-  fields: {
-    authorDid: string;
-    lastEventAt?: number;
-    lastListedAt?: number;
-    complete?: boolean;
-    error?: string | null;
-  }
-): Promise<void> {
-  const now = Date.now();
-  try {
-    if (fields.error) {
-      await env.DB.prepare(
-        `INSERT INTO document_authors (author_did, error_count, last_error, last_error_at)
-         VALUES (?, 1, ?, ?)
-         ON CONFLICT(author_did) DO UPDATE SET
-           error_count = document_authors.error_count + 1,
-           last_error = excluded.last_error,
-           last_error_at = excluded.last_error_at`
-      )
-        .bind(fields.authorDid, fields.error.slice(0, 500), now)
-        .run();
-      return;
-    }
-    await env.DB.prepare(
-      `INSERT INTO document_authors (author_did, last_listed_at, last_event_at, complete, error_count, last_error, last_error_at)
-       VALUES (?, ?, ?, ?, 0, NULL, NULL)
+  fields: AuthorBookkeeping,
+  now = Date.now()
+): D1PreparedStatement {
+  if (fields.error) {
+    // A failed list stamps `last_error_at`, which is what the reconcile queue's
+    // backoff reads: an author who can never be listed has to give its slot back.
+    return env.DB.prepare(
+      `INSERT INTO document_authors (author_did, error_count, last_error, last_error_at)
+       VALUES (?, 1, ?, ?)
        ON CONFLICT(author_did) DO UPDATE SET
-         last_listed_at = COALESCE(excluded.last_listed_at, document_authors.last_listed_at),
-         last_event_at = COALESCE(excluded.last_event_at, document_authors.last_event_at),
-         complete = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.complete ELSE excluded.complete END,
-         error_count = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.error_count ELSE 0 END,
-         last_error = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error ELSE NULL END`
-    )
-      .bind(
-        fields.authorDid,
-        fields.lastListedAt ?? null,
-        fields.lastEventAt ?? null,
-        fields.complete ? 1 : 0
-      )
-      .run();
+         error_count = document_authors.error_count + 1,
+         last_error = excluded.last_error,
+         last_error_at = excluded.last_error_at`
+    ).bind(fields.authorDid, fields.error.slice(0, 500), now);
+  }
+  return env.DB.prepare(
+    `INSERT INTO document_authors (author_did, last_listed_at, last_event_at, complete, error_count, last_error, last_error_at)
+     VALUES (?, ?, ?, ?, 0, NULL, NULL)
+     ON CONFLICT(author_did) DO UPDATE SET
+       last_listed_at = COALESCE(excluded.last_listed_at, document_authors.last_listed_at),
+       last_event_at = COALESCE(excluded.last_event_at, document_authors.last_event_at),
+       complete = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.complete ELSE excluded.complete END,
+       error_count = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.error_count ELSE 0 END,
+       last_error = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error ELSE NULL END,
+       last_error_at = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error_at ELSE NULL END`
+  ).bind(
+    fields.authorDid,
+    fields.lastListedAt ?? null,
+    fields.lastEventAt ?? null,
+    fields.complete ? 1 : 0
+  );
+}
+
+/** Record ingest bookkeeping for an author (best effort — never fails a write). */
+async function touchAuthor(env: Env, fields: AuthorBookkeeping): Promise<void> {
+  try {
+    await authorBookkeepingStatement(env, fields).run();
   } catch (error) {
     console.error('[document-store] author bookkeeping failed:', error);
   }
@@ -478,16 +534,43 @@ export async function backfillAuthorDocuments(
   }
 
   const collections = await listAuthorCollections(authorDid);
-  for (const [rkey, record] of collections) {
+  for (const [rkey, record] of collections.byRkey) {
     await upsertCollectionIfChanged(env, authorDid, rkey, record, now);
+  }
+
+  // Sidecars drift the same way documents do — a delete missed during a pause
+  // leaves a curated edition attached to a document the author has since changed.
+  // Only a listing that both succeeded and covered the whole collection can prove
+  // absence, hence `exhaustive`: an empty map from a failed fetch would otherwise
+  // delete every edition we hold.
+  let removedCollections = 0;
+  if (collections.exhaustive) {
+    const storedRkeys = await env.DB.prepare('SELECT rkey FROM collections_v2 WHERE author_did = ?')
+      .bind(authorDid)
+      .all<{ rkey: string }>();
+    const goneRkeys = (storedRkeys.results ?? [])
+      .map((r) => r.rkey)
+      .filter((rkey) => !collections.byRkey.has(rkey));
+    if (goneRkeys.length > 0) {
+      await env.DB.batch(
+        goneRkeys.map((rkey) =>
+          env.DB.prepare('DELETE FROM collections_v2 WHERE author_did = ? AND rkey = ?').bind(
+            authorDid,
+            rkey
+          )
+        )
+      );
+      removedCollections = goneRkeys.length;
+    }
   }
 
   await touchAuthor(env, { authorDid, lastListedAt: now, complete });
   log.info('documents_backfilled', {
     authorDid,
     documents: kept.length,
-    collections: collections.size,
+    collections: collections.byRkey.size,
     removed: stale.length,
+    removedCollections,
     complete,
   });
 
@@ -495,7 +578,7 @@ export async function backfillAuthorDocuments(
     did: authorDid,
     ok: true,
     documents: kept.length,
-    collections: collections.size,
+    collections: collections.byRkey.size,
     complete,
   };
 }
@@ -548,9 +631,71 @@ export async function subscribedDocumentAuthors(env: Env): Promise<string[]> {
   return (result.results ?? []).map((r) => r.did).filter((did): did is string => isValidDid(did));
 }
 
+/** One page of the subscribed-author set, in a stable order. */
+export interface AuthorPage {
+  dids: string[];
+  /** Resume token for the next page; null when this page reached the end. */
+  cursor: string | null;
+  /** Authors still after this page — 0 only when the whole set has been walked. */
+  remaining: number;
+}
+
+/**
+ * A page of {@link subscribedDocumentAuthors}, ordered by DID and resumable.
+ *
+ * The shadow-compare is a gate on the read cutover, so it has to be able to cover
+ * *every* subscribed author: comparing the same first N of them repeatedly says
+ * nothing about author N+1, and a clean verdict from a partial walk would admit a
+ * lossy cutover. Ordering by `subject_did` gives a total order that a concurrent
+ * subscribe can't shuffle a page out of.
+ */
+export async function subscribedDocumentAuthorPage(
+  env: Env,
+  options: { limit: number; after?: string }
+): Promise<AuthorPage> {
+  const after = options.after ?? '';
+  const result = await env.DB.prepare(
+    `SELECT DISTINCT subject_did AS did FROM subscriptions_cache
+      WHERE source_type IN ('atproto.documents', 'atproto.collection')
+        AND subject_did IS NOT NULL AND subject_did > ?
+      ORDER BY subject_did ASC LIMIT ?`
+  )
+    .bind(after, options.limit)
+    .all<{ did: string }>();
+
+  const page = (result.results ?? []).map((r) => r.did);
+  // The cursor is the last DID *examined*, valid or not, so a malformed row can
+  // never stall the walk — it is simply skipped and left behind.
+  const cursor = page.length === options.limit ? page[page.length - 1] : null;
+  const tail = cursor
+    ? await env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM (
+           SELECT DISTINCT subject_did FROM subscriptions_cache
+            WHERE source_type IN ('atproto.documents', 'atproto.collection')
+              AND subject_did IS NOT NULL AND subject_did > ?)`
+      )
+        .bind(cursor)
+        .first<{ n: number }>()
+    : null;
+
+  return {
+    dids: page.filter((did): did is string => isValidDid(did)),
+    cursor,
+    remaining: tail?.n ?? 0,
+  };
+}
+
 /**
  * Authors whose stored set is stalest, for the reconcile loop. Never-listed authors
  * sort first (a subscription created before this shipped, or a failed backfill).
+ *
+ * An author whose last attempt *failed* is held off for a backoff window derived
+ * from their error count, and sorts by that failure rather than by their (still
+ * NULL) `last_listed_at`. Without both halves, an author who can never be listed —
+ * deleted account, unresolvable DID, dead PDS — is re-selected at the front of the
+ * queue on every run, forever: the reconcile is the only self-heal in this design,
+ * and three such authors would starve it silently. It also lets the migration's
+ * `remaining` counter reach 0, which it otherwise never could.
  */
 export async function staleDocumentAuthors(
   env: Env,
@@ -559,16 +704,18 @@ export async function staleDocumentAuthors(
 ): Promise<string[]> {
   const cutoff = now - AUTHOR_RECONCILE_INTERVAL_MS;
   const result = await env.DB.prepare(
-    `SELECT DISTINCT s.subject_did AS did
+    `SELECT DISTINCT s.subject_did AS did,
+            COALESCE(a.last_listed_at, a.last_error_at, 0) AS staleness
        FROM subscriptions_cache s
        LEFT JOIN document_authors a ON a.author_did = s.subject_did
       WHERE s.source_type IN ('atproto.documents', 'atproto.collection')
         AND s.subject_did IS NOT NULL
         AND (a.last_listed_at IS NULL OR a.last_listed_at < ?)
-      ORDER BY COALESCE(a.last_listed_at, 0) ASC
+        AND (a.last_error_at IS NULL OR a.last_error_at + ${RETRY_BACKOFF_SQL} <= ?)
+      ORDER BY staleness ASC
       LIMIT ?`
   )
-    .bind(cutoff, limit)
+    .bind(cutoff, AUTHOR_RETRY_MAX_MS, AUTHOR_RETRY_BASE_MS, now, limit)
     .all<{ did: string }>();
   return (result.results ?? []).map((r) => r.did).filter((did): did is string => isValidDid(did));
 }
@@ -581,6 +728,67 @@ export async function reconcileStaleAuthors(env: Env, limit = 3): Promise<Backfi
     results.push(await backfillAuthorDocuments(env, did));
   }
   return results;
+}
+
+/**
+ * How recently an author must have been listed for a new subscription to skip its
+ * backfill. Ten readers subscribing to the same linkblog in an hour should cost one
+ * `listRecords` walk, not ten.
+ */
+export const BACKFILL_FRESHNESS_MS = 60 * 60 * 1000;
+
+/**
+ * Backfill an author unless we already hold a fresh listing or are inside the retry
+ * backoff for a failing one.
+ *
+ * Every path that creates an `atproto.documents` subscription calls this, because a
+ * subscription whose author was never listed serves `status:'error'` on every poll
+ * until the hourly reconcile happens to reach it — the reader sees an error and an
+ * empty linkblog in the meantime. The proxy had no such window: it listed the author
+ * inline on the first read.
+ */
+export async function ensureAuthorDocuments(
+  env: Env,
+  authorDid: string,
+  now = Date.now()
+): Promise<BackfillResult | null> {
+  if (!isValidDid(authorDid)) return null;
+
+  const author = await env.DB.prepare(
+    'SELECT last_listed_at, last_error_at, error_count FROM document_authors WHERE author_did = ?'
+  )
+    .bind(authorDid)
+    .first<{ last_listed_at: number | null; last_error_at: number | null; error_count: number }>();
+
+  if (author?.last_listed_at && now - author.last_listed_at < BACKFILL_FRESHNESS_MS) return null;
+  if (
+    author?.last_error_at &&
+    now - author.last_error_at < authorRetryBackoffMs(author.error_count)
+  ) {
+    return null;
+  }
+
+  return backfillAuthorDocuments(env, authorDid);
+}
+
+/**
+ * Fire {@link ensureAuthorDocuments} in the background of a request. A `listRecords`
+ * walk is several PDS round-trips and no subscribe response should wait on them; a
+ * failure is recorded on the author row and retried by the reconcile.
+ */
+export function scheduleAuthorDocuments(
+  env: Env,
+  waitUntil: (promise: Promise<unknown>) => void,
+  authorDid: string
+): void {
+  waitUntil(
+    ensureAuthorDocuments(env, authorDid).catch((error) => {
+      log.warn('documents_backfill_schedule_failed', {
+        authorDid,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    })
+  );
 }
 
 // --- Read path ---------------------------------------------------------------
@@ -732,6 +940,11 @@ export async function loadAuthorDocuments(
       meta,
       {
         indexedAt: new Date(row.indexed_at).toISOString(),
+        // The URL resolved when the row was written, used only while the
+        // publication itself won't resolve — otherwise a five-minute negative
+        // cache entry would serve a relative path next to a row holding the
+        // absolute one.
+        canonicalUrlFallback: row.canonical_url,
       }
     );
     const collectionRow = byRkey.get(row.rkey);
@@ -814,9 +1027,24 @@ export async function serveDocumentScope(
     status: 'ready',
     digest,
     // The author's whole repo fits under the cap, so an absent record means
-    // deleted rather than merely beyond the cap.
-    complete: author?.complete === 1,
+    // deleted rather than merely beyond the cap. The stored flag alone can't say
+    // that: it was set at the last successful *list*, and the poller keeps writing
+    // afterwards, so an author listed at 40 documents who has since published past
+    // the cap would still claim completeness while cap eviction drops their oldest.
+    // The proxy recomputed this per serve from the set it was about to return; the
+    // row count reproduces that, and the flag keeps "never listed ⇒ not
+    // authoritative".
+    complete:
+      author?.complete === 1 && (await storedDocumentCount(env, did)) < MAX_DOCUMENTS_PER_AUTHOR,
   };
+}
+
+/** How many documents we hold for an author, across every publication of theirs. */
+async function storedDocumentCount(env: Env, authorDid: string): Promise<number> {
+  const row = await env.DB.prepare('SELECT COUNT(*) AS n FROM documents_v2 WHERE author_did = ?')
+    .bind(authorDid)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
 }
 
 /**
@@ -848,7 +1076,10 @@ export async function serveSingleDocument(env: Env, uri: string): Promise<ProxyD
         row.record_cid,
         record,
         meta,
-        { indexedAt: new Date(row.indexed_at).toISOString() }
+        {
+          indexedAt: new Date(row.indexed_at).toISOString(),
+          canonicalUrlFallback: row.canonical_url,
+        }
       );
       const collectionRow = await env.DB.prepare(
         'SELECT author_did, rkey, record_json, preview_json, preview_at FROM collections_v2 WHERE author_did = ? AND rkey = ?'

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -25,11 +25,13 @@ import {
   EMPTY_SITE_META,
   buildCanonicalUrl,
   cachedSiteMeta,
+  createPdsMemo,
   digestScope,
   getDocumentRecord,
   isValidDid,
   listAuthorCollections,
   listAuthorDocuments,
+  looseSiteMeta,
   publishedAtMs,
   recordToDocument,
   resolveReaderCollection,
@@ -124,7 +126,7 @@ export function chargeQueries(ledger: QueryLedger, subrequests: number): void {
  * a given resolve skips (a warm cache, a loose `https://` site) is not knowable
  * before spending it.
  */
-const SUBREQUESTS_PER_SITE_RESOLVE = 5;
+export const SUBREQUESTS_PER_SITE_RESOLVE = 5;
 
 /**
  * Worst-case subrequests one applied event costs: the record write, plus a
@@ -149,16 +151,28 @@ const QUERIES_PER_FLUSHED_AUTHOR = 2;
 export const MAX_SITE_RESOLVES_PER_BACKFILL = 4;
 
 /**
- * Sidecar statements one backfill may spend: changed curated editions written plus
- * deleted ones pruned. The listing is a page of up to 100, and each one that changed
- * is its own statement, so this is the term that could otherwise rival the document
- * writes. The remainder converges on the next reconcile — each run writes the ones it
- * can afford, so they stop being "changed".
+ * Sidecar statements one backfill is *guaranteed* to be able to spend: changed
+ * curated editions written plus deleted ones pruned. The listing is a page of up to
+ * 100, and each one that changed is its own statement, so this is the term that
+ * could otherwise rival the document writes.
+ *
+ * It is a floor, not the actual allowance: a walk spends whatever is left of its
+ * `BACKFILL_QUERY_COST` reservation once the listing, the upserts, the resolves and
+ * the prune are paid for (see `collectionWriteAllowance`), and this constant is what
+ * that arithmetic leaves in the worst case. A walk that still has to defer sidecars
+ * says so on the author row, and the reconcile picks it back up on its next pass
+ * rather than a reconcile interval later — an author's whole back catalogue landing
+ * 20 curated editions a week is a month of half-rendered magazines.
  */
 export const MAX_COLLECTION_WRITES_PER_BACKFILL = 20;
 
-/** Fetches a backfill's own listing spends: document pages, the DID doc, the sidecar page. */
-const BACKFILL_LIST_SUBREQUESTS = MAX_LIST_PAGES + 2;
+/**
+ * Fetches a backfill's own listing spends: document pages, the DID doc, the sidecar
+ * page. One DID document, not two, because the walk hands the same `PdsMemo` to both
+ * listings — `resolvePdsUrl` is an uncached plc.directory fetch, so without that memo
+ * this term is short by one and a worst-case walk lands a subrequest over the bound.
+ */
+export const BACKFILL_LIST_SUBREQUESTS = MAX_LIST_PAGES + 2;
 
 /**
  * Worst-case subrequests one author's backfill spends, and the unit every fan-out
@@ -183,6 +197,26 @@ export const BACKFILL_QUERY_COST =
 /** Room for one more worst-case backfill, on top of any already reserved. */
 export function canAffordBackfill(ledger: QueryLedger, reserved = 0): boolean {
   return ledger.spent + (reserved + 1) * BACKFILL_QUERY_COST <= ledger.limit;
+}
+
+/** The bookkeeping statement a walk still owes after its sidecar writes. */
+const BACKFILL_QUERIES_AFTER_COLLECTIONS = 1;
+
+/**
+ * Sidecar statements a walk can still afford inside its own `BACKFILL_QUERY_COST`
+ * reservation: the reservation, less what this walk has already spent, less the
+ * bookkeeping it still owes.
+ *
+ * Derived rather than fixed, so the bound enforces itself instead of resting on the
+ * comment above the constant. At every other cap at once it comes out at exactly
+ * `MAX_COLLECTION_WRITES_PER_BACKFILL` (pinned in the budget tests); below them —
+ * the ordinary author, with a handful of documents and one publication — it hands
+ * the unspent headroom to the sidecars, which is what keeps a newly subscribed
+ * author's curated editions from arriving 20 a week.
+ */
+function collectionWriteAllowance(ledger: QueryLedger, spentAtWalkStart: number): number {
+  const spentByWalk = ledger.spent - spentAtWalkStart;
+  return Math.max(0, BACKFILL_QUERY_COST - spentByWalk - BACKFILL_QUERIES_AFTER_COLLECTIONS);
 }
 
 /**
@@ -360,12 +394,26 @@ async function siteMetaForWrite(
   if (memoised) return memoised;
   // A freestanding document has no publication to resolve and costs nothing.
   if (!siteUri) return EMPTY_SITE_META;
+  // Neither does a loose `https://` site: it is its own base URL, with no record to
+  // fetch and no cache row to read. Charging for one would spend a walk's bounded
+  // allowance on no I/O — an author with five loose sites would starve the resolves
+  // their actual publications need. Decide the charge after the free cases, not before.
+  const loose = looseSiteMeta(siteUri);
+  if (loose) {
+    ctx.siteMeta.set(siteUri, loose);
+    return loose;
+  }
   if (ctx.siteResolves <= 0) {
     // Out of resolve budget for this run: store the row without publication
     // metadata rather than spending past the bound. The canonical URL falls back to
     // the record's path, and the serve path resolves the publication from the same
     // cache on the first read, so this costs a fallback URL until then.
-    ctx.siteMeta.set(siteUri, EMPTY_SITE_META);
+    //
+    // Deliberately *not* memoised. The allowance is per author but the context is
+    // shared by a whole fan-out, so a negative entry here would follow a starved
+    // publication into every later author's walk and skip it there too, even though
+    // each of those authors was given a fresh allowance. Re-entering this branch is
+    // free — it is the same comparison, not a re-resolve.
     return EMPTY_SITE_META;
   }
   ctx.siteResolves--;
@@ -753,6 +801,13 @@ interface AuthorBookkeeping {
   lastEventAt?: number;
   lastListedAt?: number;
   complete?: boolean;
+  /**
+   * Curated editions the walk that just listed this author could not afford to
+   * write. Non-zero holds the author in the reconcile queue (see
+   * {@link staleDocumentAuthors}) instead of parking them for a whole interval.
+   * Only meaningful alongside `lastListedAt`; a drain's bookkeeping leaves it alone.
+   */
+  collectionsPending?: number;
   error?: string | null;
 }
 
@@ -775,12 +830,13 @@ function authorBookkeepingStatement(
     ).bind(fields.authorDid, fields.error.slice(0, 500), now);
   }
   return env.DB.prepare(
-    `INSERT INTO document_authors (author_did, last_listed_at, last_event_at, complete, error_count, last_error, last_error_at)
-     VALUES (?, ?, ?, ?, 0, NULL, NULL)
+    `INSERT INTO document_authors (author_did, last_listed_at, last_event_at, complete, collections_pending, error_count, last_error, last_error_at)
+     VALUES (?, ?, ?, ?, ?, 0, NULL, NULL)
      ON CONFLICT(author_did) DO UPDATE SET
        last_listed_at = COALESCE(excluded.last_listed_at, document_authors.last_listed_at),
        last_event_at = COALESCE(excluded.last_event_at, document_authors.last_event_at),
        complete = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.complete ELSE excluded.complete END,
+       collections_pending = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.collections_pending ELSE excluded.collections_pending END,
        error_count = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.error_count ELSE 0 END,
        last_error = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error ELSE NULL END,
        last_error_at = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error_at ELSE NULL END`
@@ -788,7 +844,8 @@ function authorBookkeepingStatement(
     fields.authorDid,
     fields.lastListedAt ?? null,
     fields.lastEventAt ?? null,
-    fields.complete ? 1 : 0
+    fields.complete ? 1 : 0,
+    fields.collectionsPending ?? 0
   );
 }
 
@@ -867,13 +924,21 @@ export async function backfillAuthorDocuments(
   // Resolves are per author, not per invocation: the fan-out bound above is stated
   // per author, so each one has to get the same allowance.
   ctx.siteResolves = MAX_SITE_RESOLVES_PER_BACKFILL;
+  // What this walk may spend is `BACKFILL_QUERY_COST` from here, which is what
+  // `canAffordBackfill` just admitted it against.
+  const spentAtWalkStart = ctx.ledger.spent;
+
+  // Both listings need the author's PDS and `resolvePdsUrl` is an uncached fetch, so
+  // they share one resolution — the difference between the budgeted one DID document
+  // and two.
+  const pds = createPdsMemo();
 
   const now = Date.now();
   let listed: Awaited<ReturnType<typeof listAuthorDocuments>>;
   // The listing's pages are subrequests too, spent whether or not it succeeds.
   chargeQueries(ctx.ledger, BACKFILL_LIST_SUBREQUESTS);
   try {
-    listed = await listAuthorDocuments(authorDid);
+    listed = await listAuthorDocuments(authorDid, pds);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'listRecords failed';
     chargeQueries(ctx.ledger, 1);
@@ -907,7 +972,7 @@ export async function backfillAuthorDocuments(
   chargeQueries(ctx.ledger, 1);
   const removed = pruned.meta?.changes ?? 0;
 
-  const collections = await listAuthorCollections(authorDid);
+  const collections = await listAuthorCollections(authorDid, pds);
 
   // One read of the stored sidecars answers both questions — which listed editions
   // changed, and which stored ones are gone — instead of a SELECT per edition plus
@@ -922,6 +987,12 @@ export async function backfillAuthorDocuments(
     (storedCollections.results ?? []).map((row) => [row.rkey, row.record_json])
   );
 
+  // Whatever is left of this walk's reservation, rather than a flat 20: the terms
+  // above are worst cases, and an author who did not hit them has already paid for
+  // headroom the sidecars can use. Only an author at every cap at once is held to
+  // `MAX_COLLECTION_WRITES_PER_BACKFILL`, which is what this arithmetic leaves there.
+  const collectionAllowance = collectionWriteAllowance(ctx.ledger, spentAtWalkStart);
+
   // Only editions whose record actually changed are rewritten: a re-run over
   // unchanged ones would drop every resolved preview and make the next read pay the
   // whole cross-PDS fan-out again.
@@ -930,7 +1001,7 @@ export async function backfillAuthorDocuments(
   for (const [rkey, record] of collections.byRkey) {
     const next = JSON.stringify(record);
     if (storedByRkey.get(rkey) === next) continue;
-    if (collectionWrites.length >= MAX_COLLECTION_WRITES_PER_BACKFILL) {
+    if (collectionWrites.length >= collectionAllowance) {
       deferredCollections++;
       continue;
     }
@@ -946,7 +1017,7 @@ export async function backfillAuthorDocuments(
   if (collections.exhaustive) {
     for (const rkey of storedByRkey.keys()) {
       if (collections.byRkey.has(rkey)) continue;
-      if (collectionWrites.length >= MAX_COLLECTION_WRITES_PER_BACKFILL) {
+      if (collectionWrites.length >= collectionAllowance) {
         deferredCollections++;
         continue;
       }
@@ -965,17 +1036,29 @@ export async function backfillAuthorDocuments(
     await env.DB.batch(collectionWrites);
   }
 
+  // Sidecar work this walk could not afford is recorded on the author row, so the
+  // reconcile queue picks the author back up on its next pass instead of holding
+  // them for a full `AUTHOR_RECONCILE_INTERVAL_MS` — 20 curated editions a week is
+  // weeks of documents rendering without their item lists, and the back catalogue
+  // at subscribe time is exactly what this walk exists to serve.
+  //
+  // Only when the walk actually wrote some: a walk that wrote none made no progress,
+  // and requeueing it immediately would spin the reconcile on one author forever
+  // rather than converging. Written rows stop being "changed", so each requeued pass
+  // strictly advances.
+  const collectionsPending = collectionWrites.length > 0 ? deferredCollections : 0;
   chargeQueries(ctx.ledger, 1);
-  await touchAuthor(env, { authorDid, lastListedAt: now, complete });
+  await touchAuthor(env, { authorDid, lastListedAt: now, complete, collectionsPending });
   log.info('documents_backfilled', {
     authorDid,
     documents: kept.length,
     collections: collections.byRkey.size,
     removed,
     removedCollections,
-    // Sidecar work past the per-walk cap, picked up by the next reconcile: each run
-    // writes what it can afford, so the remainder shrinks rather than recurring.
+    // Sidecar work past what this walk could afford, left to the next reconcile pass:
+    // each run writes what it can, so the remainder shrinks rather than recurring.
     deferredCollections,
+    collectionAllowance,
     complete,
     queries: ctx.ledger.spent,
   });
@@ -1072,6 +1155,13 @@ export async function subscribedDocumentAuthorPage(
  * queue on every run, forever: the reconcile is the only self-heal in this design,
  * and three such authors would starve it silently. It also lets the migration's
  * `remaining` counter reach 0, which it otherwise never could.
+ *
+ * An author whose last walk ran out of budget for their curated editions
+ * (`collections_pending`) stays eligible even though they were just listed, because
+ * the alternative is a document rendering without its item list until the next
+ * interval. They sort *last* — their `last_listed_at` is fresh — so they take a slot
+ * only when nothing staler wants it, and a walk only sets the flag when it wrote
+ * some, so each pass strictly reduces the remainder.
  */
 export async function staleDocumentAuthors(
   env: Env,
@@ -1086,7 +1176,7 @@ export async function staleDocumentAuthors(
        LEFT JOIN document_authors a ON a.author_did = s.subject_did
       WHERE s.source_type IN ('atproto.documents', 'atproto.collection')
         AND s.subject_did IS NOT NULL
-        AND (a.last_listed_at IS NULL OR a.last_listed_at < ?)
+        AND (a.last_listed_at IS NULL OR a.last_listed_at < ? OR COALESCE(a.collections_pending, 0) > 0)
         AND (a.last_error_at IS NULL OR a.last_error_at + ${RETRY_BACKOFF_SQL} <= ?)
       ORDER BY staleness ASC
       LIMIT ?`

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -17,6 +17,7 @@ import type { ProxyDocument, ProxyDocumentEntry, ProxyReaderCollection } from '.
 import {
   DOCUMENT_COLLECTION,
   MAX_DOCUMENTS_PER_AUTHOR,
+  MAX_LIST_PAGES,
   READER_COLLECTION,
   type CollectionRecord,
   type DocumentRecord,
@@ -71,48 +72,168 @@ export function authorRetryBackoffMs(errorCount: number): number {
 }
 
 /**
- * D1's ceiling on queries per Worker invocation (paid plan), and the number every
- * bounded loop in this file is really sized against.
+ * The per-invocation ceiling every bounded loop in this file is sized against.
  *
- * The unit is the *statement*, not the call: each statement inside a `DB.batch`
- * counts on its own, so "one batch per event" is not one query per event. Hitting
- * the ceiling is quiet in exactly the case the bounds exist for — the drain catches
- * each throw per event, counts it as an error and advances its cursor past it — so
- * the cost of every write here is counted rather than assumed.
+ * Two things share it, and both have bitten this file. D1's limit is *queries per
+ * Worker invocation* where the unit is the **statement**, not the call: each
+ * statement inside a `DB.batch` counts on its own, so "one batch per event" is not
+ * one query per event, and a per-row prune of a hundred rows is a hundred queries.
+ * And the row Cloudflare documents that limit under is the **read subrequest**
+ * limit — a cross-PDS `fetch()` comes out of the same 1,000 — so a budget that
+ * counted only the D1 half would run an invocation into the ceiling while reporting
+ * itself comfortably inside it.
+ *
+ * Everything here is therefore counted in *subrequests*: D1 statements and outbound
+ * fetches alike, actual spend rather than an assumed per-item price. Hitting the
+ * ceiling is quiet in exactly the case the bounds exist for — the drain catches each
+ * throw per event, counts it as an error and advances its cursor past it.
  * https://developers.cloudflare.com/d1/platform/limits/
  */
 export const D1_QUERIES_PER_INVOCATION = 1000;
 
 /**
- * What the drain leaves for the rest of a poll cycle: the subscriptions stream's
- * writes, the flag and author-set reads, and the back-catalogue walks the alarm runs
- * once both sockets are closed (`MAX_CYCLE_BACKFILLS` × `BACKFILL_QUERY_COST`).
+ * One invocation's subrequest ledger.
+ *
+ * The ceiling is per *invocation*, not per loop, so everything that writes documents
+ * in one — a drain, a fan-out of backfills, the walks a sync schedules into
+ * `waitUntil` — charges the same ledger. A caller that fans out admits the next
+ * author only while the ledger can still pay for a worst-case one, which is what
+ * makes "this request fits the budget" a fact about the whole invocation rather than
+ * about one loop in it.
  */
-export const DOCUMENT_CYCLE_QUERY_RESERVE = 300;
+export interface QueryLedger {
+  /** Subrequests spent so far: D1 statements plus cross-PDS fetches. */
+  spent: number;
+  /** What this invocation may spend on document work. */
+  limit: number;
+}
 
-/** Queries one poll cycle's document drain may spend. */
-export const DOCUMENT_DRAIN_QUERY_BUDGET = D1_QUERIES_PER_INVOCATION - DOCUMENT_CYCLE_QUERY_RESERVE;
+export function createQueryLedger(limit = D1_QUERIES_PER_INVOCATION): QueryLedger {
+  return { spent: 0, limit };
+}
+
+/** Record subrequests against the ledger. */
+export function chargeQueries(ledger: QueryLedger, subrequests: number): void {
+  ledger.spent += subrequests;
+}
 
 /**
- * Worst-case queries one applied event costs: the record write, plus a first-seen
- * publication's cache read and its refresh. Every later event for that publication
- * costs the write alone, because the resolved metadata is memoised on the context.
- *
- * Charging every event the cold-publication price is also what keeps the *fetch*
- * subrequest budget in range: a resolve is three cross-PDS fetches, and a cycle of
- * nothing but cold publications stops at a quarter of the query budget.
+ * Subrequests one cold publication resolve costs: the cache read, the author's DID
+ * document, the publication record, its theme sidecar and the cache write — two D1
+ * statements and three fetches. Charged whole on a memo miss, since which half of it
+ * a given resolve skips (a warm cache, a loose `https://` site) is not knowable
+ * before spending it.
  */
-const QUERIES_PER_APPLIED_EVENT = 4;
+const SUBREQUESTS_PER_SITE_RESOLVE = 5;
+
+/**
+ * Worst-case subrequests one applied event costs: the record write, plus a
+ * first-seen publication's whole resolve. Every later event for that publication
+ * costs the write alone, because the resolved metadata is memoised on the context.
+ * This is lookahead only — what the drain must still be able to afford before
+ * handling one more event; the ledger tracks what events actually cost.
+ */
+const QUERIES_PER_APPLIED_EVENT = 1 + SUBREQUESTS_PER_SITE_RESOLVE;
 
 /** Queries the end-of-run flush spends per author written during the run. */
 const QUERIES_PER_FLUSHED_AUTHOR = 2;
 
 /**
- * Worst-case queries one author's backfill spends: a write per document up to the
- * per-author cap, plus the prune, the sidecar reads and the bookkeeping. Callers
- * that fan backfills out inside one invocation size their fan-out against this.
+ * Cold publication resolves one author's backfill may pay for. An author's documents
+ * nearly all share one publication, so this is generous in practice; past it a row is
+ * written without publication metadata (its canonical URL falls back to the record's
+ * path) and the serve path resolves it from the same cache on the first read. Without
+ * the cap, a hundred documents across a hundred publications would be 500 subrequests
+ * of metadata in a walk budgeted for a fraction of that.
  */
-export const BACKFILL_QUERY_COST = MAX_DOCUMENTS_PER_AUTHOR + 12;
+export const MAX_SITE_RESOLVES_PER_BACKFILL = 4;
+
+/**
+ * Sidecar statements one backfill may spend: changed curated editions written plus
+ * deleted ones pruned. The listing is a page of up to 100, and each one that changed
+ * is its own statement, so this is the term that could otherwise rival the document
+ * writes. The remainder converges on the next reconcile — each run writes the ones it
+ * can afford, so they stop being "changed".
+ */
+export const MAX_COLLECTION_WRITES_PER_BACKFILL = 20;
+
+/** Fetches a backfill's own listing spends: document pages, the DID doc, the sidecar page. */
+const BACKFILL_LIST_SUBREQUESTS = MAX_LIST_PAGES + 2;
+
+/**
+ * Worst-case subrequests one author's backfill spends, and the unit every fan-out
+ * here is sized in.
+ *
+ * Every term is bounded by a constant above rather than by what a repo happens to
+ * hold, which is the property the earlier `MAX_DOCUMENTS_PER_AUTHOR + 12` did not
+ * have: it omitted the per-row prune and the per-sidecar reads, so a prune-heavy
+ * author cost around three times the constant its callers were sizing against. Those
+ * are now one statement each (see `backfillAuthorDocuments`), and what is left
+ * per-row is capped.
+ */
+export const BACKFILL_QUERY_COST =
+  // one upsert per document, up to the per-author cap
+  MAX_DOCUMENTS_PER_AUTHOR +
+  MAX_SITE_RESOLVES_PER_BACKFILL * SUBREQUESTS_PER_SITE_RESOLVE +
+  MAX_COLLECTION_WRITES_PER_BACKFILL +
+  BACKFILL_LIST_SUBREQUESTS +
+  // the consolidated prune, the one sidecar read, the bookkeeping
+  3;
+
+/** Room for one more worst-case backfill, on top of any already reserved. */
+export function canAffordBackfill(ledger: QueryLedger, reserved = 0): boolean {
+  return ledger.spent + (reserved + 1) * BACKFILL_QUERY_COST <= ledger.limit;
+}
+
+/**
+ * What one *scheduled* walk reserves: the walk plus the freshness check
+ * `ensureAuthorDocuments` runs first, since a scheduler pays for both.
+ */
+export const SCHEDULED_BACKFILL_QUERY_COST = BACKFILL_QUERY_COST + 1;
+
+/**
+ * Back catalogues one poll cycle pulls for subscriptions mirrored in from a PDS.
+ * Small on purpose: the alarm's job is draining streams, and these come out of the
+ * same invocation as the drain. The queue survives to the next cycle.
+ */
+export const MAX_CYCLE_BACKFILLS = 2;
+
+/**
+ * What a poll cycle's back-catalogue walks may spend. Sized on the *scheduled* cost,
+ * since each one runs through `ensureAuthorDocuments` and pays for its freshness
+ * check too — a budget short by those would refuse the last walk it was sized for.
+ */
+export const CYCLE_BACKFILL_QUERY_BUDGET = MAX_CYCLE_BACKFILLS * SCHEDULED_BACKFILL_QUERY_COST;
+
+/** What the subscriptions stream, the flag read and the author-set read may spend. */
+const SUBSCRIPTIONS_STREAM_QUERY_RESERVE = 100;
+
+/**
+ * What the drain leaves for the rest of a poll cycle. Both halves are named rather
+ * than guessed, because the reserve has to actually cover the walks the alarm runs
+ * once both sockets are closed — an under-sized one puts them past the ceiling, and
+ * they are the part of the cycle that mutates D1 halfway and then throws.
+ */
+export const DOCUMENT_CYCLE_QUERY_RESERVE =
+  CYCLE_BACKFILL_QUERY_BUDGET + SUBSCRIPTIONS_STREAM_QUERY_RESERVE;
+
+/** Queries one poll cycle's document drain may spend. */
+export const DOCUMENT_DRAIN_QUERY_BUDGET = D1_QUERIES_PER_INVOCATION - DOCUMENT_CYCLE_QUERY_RESERVE;
+
+/** Authors the every-minute cron re-lists, and the hourly tick's deeper sweep. */
+export const CRON_MINUTE_RECONCILE_AUTHORS = 1;
+export const CRON_HOURLY_RECONCILE_AUTHORS = 3;
+
+/**
+ * What one cron invocation may spend on document backfills, shared by both reconcile
+ * passes — on the hour they run in the *same* invocation, so sizing them separately
+ * is how the pair quietly adds up past the ceiling. The rest of the ceiling is the
+ * cron's own work (cleanups, the metrics snapshot, the ops rows).
+ */
+export const CRON_DOCUMENT_QUERY_BUDGET =
+  (CRON_MINUTE_RECONCILE_AUTHORS + CRON_HOURLY_RECONCILE_AUTHORS) * BACKFILL_QUERY_COST +
+  // the queue query each pass runs before its walks
+  2;
 
 /**
  * `authorRetryBackoffMs` as SQL, so the queue query can apply it per row. Binds, in
@@ -180,14 +301,19 @@ export interface DocumentApplyContext {
   siteMeta: Map<string, SiteMeta>;
   /** Authors written during this run, trimmed and stamped at the flush. */
   touched: Set<string>;
-  /** D1 queries spent so far — what the drain stops on. */
-  queries: number;
+  /** The invocation's subrequest ledger — what the drain and the fan-outs stop on. */
+  ledger: QueryLedger;
+  /** Cold publication resolves this run may still pay for (`Infinity` = uncapped). */
+  siteResolves: number;
   /** Timestamp of the most recent applied event, for the flush's bookkeeping. */
   lastEventAt: number;
 }
 
-export function createDocumentApplyContext(): DocumentApplyContext {
-  return { siteMeta: new Map(), touched: new Set(), queries: 0, lastEventAt: 0 };
+export function createDocumentApplyContext(
+  ledger: QueryLedger = createQueryLedger(),
+  siteResolves = Infinity
+): DocumentApplyContext {
+  return { siteMeta: new Map(), touched: new Set(), ledger, siteResolves, lastEventAt: 0 };
 }
 
 /**
@@ -207,7 +333,7 @@ export async function flushDocumentApplyContext(
     trimAuthorDocumentsStatement(env, authorDid),
     authorBookkeepingStatement(env, { authorDid, lastEventAt }),
   ]);
-  ctx.queries += statements.length;
+  chargeQueries(ctx.ledger, statements.length);
   try {
     await env.DB.batch(statements);
   } catch (error) {
@@ -219,6 +345,11 @@ export async function flushDocumentApplyContext(
  * Publication metadata for a write, resolved at most once per run. Cheap enough to
  * do at write time — and doing it here is what keeps the serve path from ever
  * blocking on a PDS for a canonical URL.
+ *
+ * The resolve is charged whole (`SUBREQUESTS_PER_SITE_RESOLVE`), fetches included:
+ * the two D1 statements are the smaller half of it, and counting only those is how a
+ * cycle of cold publications used to spend 1,388 subrequests against a budget that
+ * believed it had stopped at 694.
  */
 async function siteMetaForWrite(
   env: Env,
@@ -227,9 +358,18 @@ async function siteMetaForWrite(
 ): Promise<SiteMeta> {
   const memoised = ctx.siteMeta.get(siteUri);
   if (memoised) return memoised;
-  // A cold publication is a cache read plus a refresh write; a warm one is the
-  // read alone. Charged at the worst case, which is what the drain budgets for.
-  ctx.queries += 2;
+  // A freestanding document has no publication to resolve and costs nothing.
+  if (!siteUri) return EMPTY_SITE_META;
+  if (ctx.siteResolves <= 0) {
+    // Out of resolve budget for this run: store the row without publication
+    // metadata rather than spending past the bound. The canonical URL falls back to
+    // the record's path, and the serve path resolves the publication from the same
+    // cache on the first read, so this costs a fallback URL until then.
+    ctx.siteMeta.set(siteUri, EMPTY_SITE_META);
+    return EMPTY_SITE_META;
+  }
+  ctx.siteResolves--;
+  chargeQueries(ctx.ledger, SUBREQUESTS_PER_SITE_RESOLVE);
   const meta = await resolveSiteMeta(env, siteUri);
   ctx.siteMeta.set(siteUri, meta);
   return meta;
@@ -308,7 +448,7 @@ export async function upsertDocument(
     ctx
   );
   if (!statement) return;
-  ctx.queries++;
+  chargeQueries(ctx.ledger, 1);
   await statement.run();
 }
 
@@ -341,18 +481,18 @@ export async function deleteDocument(env: Env, recordUri: string): Promise<void>
 }
 
 /**
- * Upsert a curated-edition sidecar. The stored preview is cleared on every write:
- * the item list may have changed, and a stale preview would render last week's
- * edition under this week's record.
+ * The statement that upserts a curated-edition sidecar. The stored preview is
+ * cleared on every write: the item list may have changed, and a stale preview would
+ * render last week's edition under this week's record.
  */
-export async function upsertCollection(
+function collectionUpsertStatement(
   env: Env,
   authorDid: string,
   rkey: string,
-  record: CollectionRecord,
-  now = Date.now()
-): Promise<void> {
-  await env.DB.prepare(
+  recordJson: string,
+  now: number
+): D1PreparedStatement {
+  return env.DB.prepare(
     `INSERT INTO collections_v2 (author_did, rkey, record_json, preview_json, preview_at, indexed_at)
      VALUES (?, ?, ?, NULL, NULL, ?)
      ON CONFLICT(author_did, rkey) DO UPDATE SET
@@ -360,9 +500,17 @@ export async function upsertCollection(
        preview_json = NULL,
        preview_at = NULL,
        indexed_at = excluded.indexed_at`
-  )
-    .bind(authorDid, rkey, JSON.stringify(record), now)
-    .run();
+  ).bind(authorDid, rkey, recordJson, now);
+}
+
+export async function upsertCollection(
+  env: Env,
+  authorDid: string,
+  rkey: string,
+  record: CollectionRecord,
+  now = Date.now()
+): Promise<void> {
+  await collectionUpsertStatement(env, authorDid, rkey, JSON.stringify(record), now).run();
 }
 
 export async function deleteCollection(env: Env, authorDid: string, rkey: string): Promise<void> {
@@ -420,15 +568,21 @@ async function applyToContext(
   const commit = event.commit!;
   const { collection, operation, rkey } = commit;
 
+  // Every applied event — a delete as much as a write — marks its author, so
+  // `document_authors.last_event_at` means "the last event we applied for them"
+  // rather than "the last write we kept". The trim it also earns is a no-op after a
+  // delete, and costs one statement per author per run, not per event.
   if (collection === READER_COLLECTION) {
     if (operation === 'delete') {
-      ctx.queries++;
+      chargeQueries(ctx.ledger, 1);
       await deleteCollection(env, event.did, rkey);
+      markApplied(ctx, event.did, now);
       return true;
     }
     if (!commit.record) return false;
-    ctx.queries++;
+    chargeQueries(ctx.ledger, 1);
     await upsertCollection(env, event.did, rkey, commit.record as CollectionRecord, now);
+    markApplied(ctx, event.did, now);
     return true;
   }
 
@@ -437,8 +591,9 @@ async function applyToContext(
   const recordUri = `at://${event.did}/${DOCUMENT_COLLECTION}/${rkey}`;
 
   if (operation === 'delete') {
-    ctx.queries++;
+    chargeQueries(ctx.ledger, 1);
     await deleteDocument(env, recordUri);
+    markApplied(ctx, event.did, now);
     return true;
   }
 
@@ -458,11 +613,16 @@ async function applyToContext(
   // write implies are recorded on the context and settled once at the flush — see
   // `DocumentApplyContext` for why, and `D1_QUERIES_PER_INVOCATION` for the ceiling
   // that makes per-event statement count the thing to economise on.
-  ctx.queries++;
+  chargeQueries(ctx.ledger, 1);
   await upsert.run();
-  ctx.touched.add(event.did);
-  ctx.lastEventAt = Math.max(ctx.lastEventAt, now);
+  markApplied(ctx, event.did, now);
   return true;
+}
+
+/** Note an author whose deferred trim + bookkeeping the flush will settle. */
+function markApplied(ctx: DocumentApplyContext, authorDid: string, now: number): void {
+  ctx.touched.add(authorDid);
+  ctx.lastEventAt = Math.max(ctx.lastEventAt, now);
 }
 
 /** What one poll cycle did with an event. */
@@ -479,7 +639,7 @@ export interface DocumentDrain {
   readonly capped: boolean;
   /** Which of the two stopped it, for the log line. */
   readonly cappedBy: 'apply-cap' | 'query-budget' | null;
-  /** D1 queries this cycle's drain has spent, flush included. */
+  /** Subrequests this cycle's drain has spent — D1 statements and PDS fetches, flush included. */
   readonly queries: number;
   /** Cursor to persist: the last event this cycle finished handling, never past it. */
   readonly cursor: string;
@@ -520,13 +680,16 @@ export function createDocumentDrain(
   let errors = 0;
   let cappedBy: 'apply-cap' | 'query-budget' | null = null;
   let cursor = options.cursor ?? String((options.now?.() ?? Date.now()) * 1000);
-  const ctx = createDocumentApplyContext();
-  const queryBudget = options.queryBudget ?? DOCUMENT_DRAIN_QUERY_BUDGET;
+  const ctx = createDocumentApplyContext(
+    createQueryLedger(options.queryBudget ?? DOCUMENT_DRAIN_QUERY_BUDGET)
+  );
 
   /** Room for one more event and for flushing the author it would touch. */
   const affordable = () =>
-    ctx.queries + QUERIES_PER_APPLIED_EVENT + QUERIES_PER_FLUSHED_AUTHOR * (ctx.touched.size + 1) <=
-    queryBudget;
+    ctx.ledger.spent +
+      QUERIES_PER_APPLIED_EVENT +
+      QUERIES_PER_FLUSHED_AUTHOR * (ctx.touched.size + 1) <=
+    ctx.ledger.limit;
 
   return {
     get applied() {
@@ -542,7 +705,7 @@ export function createDocumentDrain(
       return cappedBy;
     },
     get queries() {
-      return ctx.queries;
+      return ctx.ledger.spent;
     },
     get cursor() {
       return cursor;
@@ -647,6 +810,13 @@ export interface BackfillResult {
   collections: number;
   complete: boolean;
   error?: string;
+  /**
+   * The invocation's budget refused this walk before it touched anything. Not a
+   * failure of the author's: nothing was written, nothing was stamped, and the
+   * reconcile picks them up — so it must never be counted as a list error, which
+   * would put a perfectly healthy author into the retry backoff.
+   */
+  deferred?: boolean;
 }
 
 /**
@@ -658,41 +828,58 @@ export interface BackfillResult {
  * author's existing writing, and nothing in the firehose will ever carry it. Pruning
  * to the listed set reproduces what the proxy's full-blob replace did, which is also
  * how a delete missed during an ingest pause finally disappears.
+ *
+ * Every subrequest it spends is charged to `ctx.ledger` and every per-row term is
+ * capped, so `BACKFILL_QUERY_COST` is a real worst case and a caller can decide
+ * *before* starting an author whether the invocation can still afford one. That
+ * matters more than it sounds: a walk that runs out of budget half way has already
+ * upserted rows and not yet pruned, and the throw arrives inside the one loop whose
+ * job is repairing drift.
  */
 export async function backfillAuthorDocuments(
   env: Env,
   authorDid: string,
-  // One context per author: their documents nearly all share one publication, so
-  // the metadata behind every canonical URL is resolved once instead of per record.
+  // Shared with everything else writing documents in this invocation: the ledger is
+  // per invocation, and the publication metadata behind every canonical URL is
+  // resolved once rather than per record.
   ctx: DocumentApplyContext = createDocumentApplyContext()
 ): Promise<BackfillResult> {
-  if (!isValidDid(authorDid)) {
-    return {
-      did: authorDid,
-      ok: false,
-      documents: 0,
-      collections: 0,
-      complete: false,
-      error: 'Invalid DID',
-    };
+  const refused = (error: string, deferred = false): BackfillResult => ({
+    did: authorDid,
+    ok: false,
+    documents: 0,
+    collections: 0,
+    complete: false,
+    error,
+    ...(deferred ? { deferred } : {}),
+  });
+
+  if (!isValidDid(authorDid)) return refused('Invalid DID');
+  if (!canAffordBackfill(ctx.ledger)) {
+    log.info('documents_backfill_deferred', {
+      authorDid,
+      spent: ctx.ledger.spent,
+      limit: ctx.ledger.limit,
+    });
+    return refused('Query budget exhausted', true);
   }
+
+  // Resolves are per author, not per invocation: the fan-out bound above is stated
+  // per author, so each one has to get the same allowance.
+  ctx.siteResolves = MAX_SITE_RESOLVES_PER_BACKFILL;
 
   const now = Date.now();
   let listed: Awaited<ReturnType<typeof listAuthorDocuments>>;
+  // The listing's pages are subrequests too, spent whether or not it succeeds.
+  chargeQueries(ctx.ledger, BACKFILL_LIST_SUBREQUESTS);
   try {
     listed = await listAuthorDocuments(authorDid);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'listRecords failed';
+    chargeQueries(ctx.ledger, 1);
     await touchAuthor(env, { authorDid, error: message });
     log.warn('documents_backfill_failed', { authorDid, error: message });
-    return {
-      did: authorDid,
-      ok: false,
-      documents: 0,
-      collections: 0,
-      complete: false,
-      error: message,
-    };
+    return refused(message);
   }
 
   const complete = listed.length < MAX_DOCUMENTS_PER_AUTHOR;
@@ -704,24 +891,50 @@ export async function backfillAuthorDocuments(
     await upsertDocument(env, authorDid, record.uri, record.cid, record.value, now, ctx);
   }
 
-  // Anything not in the listed set is gone from the repo (or past the cap), which
-  // is the drift the firehose alone can't correct.
-  const keptUris = new Set(kept.map((r) => r.uri));
-  const existing = await env.DB.prepare('SELECT record_uri FROM documents_v2 WHERE author_did = ?')
-    .bind(authorDid)
-    .all<{ record_uri: string }>();
-  const stale = (existing.results ?? [])
-    .map((r) => r.record_uri)
-    .filter((uri) => !keptUris.has(uri));
-  if (stale.length > 0) {
-    await env.DB.batch(
-      stale.map((uri) => env.DB.prepare('DELETE FROM documents_v2 WHERE record_uri = ?').bind(uri))
-    );
-  }
+  // Anything the repo no longer has is gone (or past the cap), which is the drift
+  // the firehose alone can't correct — and every row this walk kept was just
+  // upserted with `updated_at = now`, so "not touched by this walk" identifies the
+  // stale set in one statement. That matters: the read-then-delete-per-row version
+  // was up to 101 statements for one author, which is most of what made the old
+  // per-author constant fiction. It is also safer against a concurrent write — a
+  // row the drain adds while we list carries a later stamp and survives, where a
+  // set difference against the listing would have deleted it.
+  const pruned = await env.DB.prepare(
+    'DELETE FROM documents_v2 WHERE author_did = ? AND (updated_at IS NULL OR updated_at < ?)'
+  )
+    .bind(authorDid, now)
+    .run();
+  chargeQueries(ctx.ledger, 1);
+  const removed = pruned.meta?.changes ?? 0;
 
   const collections = await listAuthorCollections(authorDid);
+
+  // One read of the stored sidecars answers both questions — which listed editions
+  // changed, and which stored ones are gone — instead of a SELECT per edition plus
+  // a second listing query.
+  const storedCollections = await env.DB.prepare(
+    'SELECT rkey, record_json FROM collections_v2 WHERE author_did = ?'
+  )
+    .bind(authorDid)
+    .all<{ rkey: string; record_json: string }>();
+  chargeQueries(ctx.ledger, 1);
+  const storedByRkey = new Map(
+    (storedCollections.results ?? []).map((row) => [row.rkey, row.record_json])
+  );
+
+  // Only editions whose record actually changed are rewritten: a re-run over
+  // unchanged ones would drop every resolved preview and make the next read pay the
+  // whole cross-PDS fan-out again.
+  const collectionWrites: D1PreparedStatement[] = [];
+  let deferredCollections = 0;
   for (const [rkey, record] of collections.byRkey) {
-    await upsertCollectionIfChanged(env, authorDid, rkey, record, now);
+    const next = JSON.stringify(record);
+    if (storedByRkey.get(rkey) === next) continue;
+    if (collectionWrites.length >= MAX_COLLECTION_WRITES_PER_BACKFILL) {
+      deferredCollections++;
+      continue;
+    }
+    collectionWrites.push(collectionUpsertStatement(env, authorDid, rkey, next, now));
   }
 
   // Sidecars drift the same way documents do — a delete missed during a pause
@@ -731,33 +944,40 @@ export async function backfillAuthorDocuments(
   // delete every edition we hold.
   let removedCollections = 0;
   if (collections.exhaustive) {
-    const storedRkeys = await env.DB.prepare('SELECT rkey FROM collections_v2 WHERE author_did = ?')
-      .bind(authorDid)
-      .all<{ rkey: string }>();
-    const goneRkeys = (storedRkeys.results ?? [])
-      .map((r) => r.rkey)
-      .filter((rkey) => !collections.byRkey.has(rkey));
-    if (goneRkeys.length > 0) {
-      await env.DB.batch(
-        goneRkeys.map((rkey) =>
-          env.DB.prepare('DELETE FROM collections_v2 WHERE author_did = ? AND rkey = ?').bind(
-            authorDid,
-            rkey
-          )
+    for (const rkey of storedByRkey.keys()) {
+      if (collections.byRkey.has(rkey)) continue;
+      if (collectionWrites.length >= MAX_COLLECTION_WRITES_PER_BACKFILL) {
+        deferredCollections++;
+        continue;
+      }
+      collectionWrites.push(
+        env.DB.prepare('DELETE FROM collections_v2 WHERE author_did = ? AND rkey = ?').bind(
+          authorDid,
+          rkey
         )
       );
-      removedCollections = goneRkeys.length;
+      removedCollections++;
     }
   }
 
+  if (collectionWrites.length > 0) {
+    chargeQueries(ctx.ledger, collectionWrites.length);
+    await env.DB.batch(collectionWrites);
+  }
+
+  chargeQueries(ctx.ledger, 1);
   await touchAuthor(env, { authorDid, lastListedAt: now, complete });
   log.info('documents_backfilled', {
     authorDid,
     documents: kept.length,
     collections: collections.byRkey.size,
-    removed: stale.length,
+    removed,
     removedCollections,
+    // Sidecar work past the per-walk cap, picked up by the next reconcile: each run
+    // writes what it can afford, so the remainder shrinks rather than recurring.
+    deferredCollections,
     complete,
+    queries: ctx.ledger.spent,
   });
 
   return {
@@ -767,36 +987,6 @@ export async function backfillAuthorDocuments(
     collections: collections.byRkey.size,
     complete,
   };
-}
-
-/**
- * Upsert a collection only when its record actually changed. A backfill re-runs
- * over unchanged editions; blindly upserting would drop every resolved preview and
- * make the next read pay the whole cross-PDS fan-out again.
- */
-async function upsertCollectionIfChanged(
-  env: Env,
-  authorDid: string,
-  rkey: string,
-  record: CollectionRecord,
-  now: number
-): Promise<void> {
-  const existing = await env.DB.prepare(
-    'SELECT record_json FROM collections_v2 WHERE author_did = ? AND rkey = ?'
-  )
-    .bind(authorDid, rkey)
-    .first<{ record_json: string }>();
-  const next = JSON.stringify(record);
-  if (existing?.record_json === next) return;
-  await env.DB.prepare(
-    `INSERT INTO collections_v2 (author_did, rkey, record_json, preview_json, preview_at, indexed_at)
-     VALUES (?, ?, ?, NULL, NULL, ?)
-     ON CONFLICT(author_did, rkey) DO UPDATE SET
-       record_json = excluded.record_json, preview_json = NULL, preview_at = NULL,
-       indexed_at = excluded.indexed_at`
-  )
-    .bind(authorDid, rkey, next, now)
-    .run();
 }
 
 /**
@@ -908,14 +1098,30 @@ export async function staleDocumentAuthors(
 
 /**
  * Re-list the stalest authors. Bounded per call — this rides the cron, one author a
- * minute plus three on the hour, and never more than `BACKFILL_QUERY_COST` queries
- * an author of that run's budget.
+ * minute plus three on the hour — and bounded per *invocation* by the ledger the
+ * caller passes, because on the hour both passes run in the same one. An author the
+ * ledger can't afford is simply left in the queue, still sorted to the front of it.
  */
-export async function reconcileStaleAuthors(env: Env, limit = 3): Promise<BackfillResult[]> {
+export async function reconcileStaleAuthors(
+  env: Env,
+  limit = CRON_HOURLY_RECONCILE_AUTHORS,
+  ctx: DocumentApplyContext = createDocumentApplyContext(
+    createQueryLedger(CRON_DOCUMENT_QUERY_BUDGET)
+  )
+): Promise<BackfillResult[]> {
+  chargeQueries(ctx.ledger, 1);
   const dids = await staleDocumentAuthors(env, limit);
   const results: BackfillResult[] = [];
   for (const did of dids) {
-    results.push(await backfillAuthorDocuments(env, did));
+    if (!canAffordBackfill(ctx.ledger)) {
+      log.info('documents_reconcile_budget_exhausted', {
+        deferred: dids.length - results.length,
+        spent: ctx.ledger.spent,
+        limit: ctx.ledger.limit,
+      });
+      break;
+    }
+    results.push(await backfillAuthorDocuments(env, did, ctx));
   }
   return results;
 }
@@ -940,10 +1146,12 @@ export const BACKFILL_FRESHNESS_MS = 60 * 60 * 1000;
 export async function ensureAuthorDocuments(
   env: Env,
   authorDid: string,
-  now = Date.now()
+  now = Date.now(),
+  ctx: DocumentApplyContext = createDocumentApplyContext()
 ): Promise<BackfillResult | null> {
   if (!isValidDid(authorDid)) return null;
 
+  chargeQueries(ctx.ledger, 1);
   const author = await env.DB.prepare(
     'SELECT last_listed_at, last_error_at, error_count FROM document_authors WHERE author_did = ?'
   )
@@ -958,7 +1166,7 @@ export async function ensureAuthorDocuments(
     return null;
   }
 
-  return backfillAuthorDocuments(env, authorDid);
+  return backfillAuthorDocuments(env, authorDid, ctx);
 }
 
 /**
@@ -969,10 +1177,11 @@ export async function ensureAuthorDocuments(
 export function scheduleAuthorDocuments(
   env: Env,
   waitUntil: (promise: Promise<unknown>) => void,
-  authorDid: string
+  authorDid: string,
+  ctx?: DocumentApplyContext
 ): void {
   waitUntil(
-    ensureAuthorDocuments(env, authorDid).catch((error) => {
+    ensureAuthorDocuments(env, authorDid, Date.now(), ctx).catch((error) => {
       log.warn('documents_backfill_schedule_failed', {
         authorDid,
         error: error instanceof Error ? error.message : String(error),
@@ -987,13 +1196,15 @@ export function scheduleAuthorDocuments(
  * A single subscribe schedules one walk and is done. The sync paths are different:
  * they can import or mirror dozens of `atproto.documents` rows in one pass, and
  * every scheduled walk runs in that same invocation via `waitUntil` — up to
- * `BACKFILL_QUERY_COST` D1 queries each, against the same
+ * `BACKFILL_QUERY_COST` subrequests each, against the same
  * `D1_QUERIES_PER_INVOCATION` ceiling the drain budgets for. Fifteen of them would
  * take the whole request past it, failing the surviving walks *and* whatever else
  * the sync had scheduled there.
  *
  * Two per path, then — `/api/sync` runs both — with the rest left to the reconcile,
- * where a never-listed author already sorts to the front of the queue.
+ * where a never-listed author already sorts to the front of the queue. The count is
+ * only half the bound: a sync that has already spent most of the invocation on its
+ * own inserts schedules fewer, or none (see the ledger below).
  */
 export const MAX_SYNC_BACKFILLS = 2;
 
@@ -1001,12 +1212,20 @@ export const MAX_SYNC_BACKFILLS = 2;
  * A bounded, de-duplicating scheduler for the sync paths. Returns a function that
  * schedules a walk and reports whether it did, so a caller can say how many authors
  * it left to the reconcile.
+ *
+ * Bounded twice over: by `limit` walks, and by the invocation's ledger. The second
+ * is what makes the bound true for a big restore — a pull that inserted 900 rows has
+ * spent most of the ceiling before any walk starts, and scheduling two more on top
+ * would put the invocation over it. Every scheduled-but-not-yet-run walk holds a
+ * worst-case reservation, because they all run in this invocation.
  */
 export function createBackfillScheduler(
   env: Env,
   waitUntil: (promise: Promise<unknown>) => void,
-  limit = MAX_SYNC_BACKFILLS
+  options: { limit?: number; ledger?: QueryLedger } = {}
 ): (authorDid: string) => boolean {
+  const limit = options.limit ?? MAX_SYNC_BACKFILLS;
+  const ledger = options.ledger ?? createQueryLedger();
   const scheduled = new Set<string>();
   return (authorDid: string) => {
     if (!isValidDid(authorDid)) return false;
@@ -1014,8 +1233,20 @@ export function createBackfillScheduler(
     // told it is covered rather than deferred.
     if (scheduled.has(authorDid)) return true;
     if (scheduled.size >= limit) return false;
+    if (ledger.spent + SCHEDULED_BACKFILL_QUERY_COST > ledger.limit) return false;
     scheduled.add(authorDid);
-    scheduleAuthorDocuments(env, waitUntil, authorDid);
+    // Reserved up front rather than counted as it is spent: these walks run
+    // concurrently in `waitUntil`, so a scheduler that waited to see the spend would
+    // admit every one of them before the first had charged anything. The walk then
+    // draws on its own ledger of exactly the reservation, which is what keeps the
+    // reservation and the actual spend from being counted twice.
+    chargeQueries(ledger, SCHEDULED_BACKFILL_QUERY_COST);
+    scheduleAuthorDocuments(
+      env,
+      waitUntil,
+      authorDid,
+      createDocumentApplyContext(createQueryLedger(SCHEDULED_BACKFILL_QUERY_COST))
+    );
     return true;
   };
 }

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -119,6 +119,13 @@ export function chargeQueries(ledger: QueryLedger, subrequests: number): void {
   ledger.spent += subrequests;
 }
 
+/** Reserve subrequests only when the invocation still has room for all of them. */
+export function tryChargeQueries(ledger: QueryLedger, subrequests: number): boolean {
+  if (ledger.spent + subrequests > ledger.limit) return false;
+  chargeQueries(ledger, subrequests);
+  return true;
+}
+
 /**
  * Subrequests one cold publication resolve costs: the cache read, the author's DID
  * document, the publication record, its theme sidecar and the cache write — two D1

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -71,6 +71,50 @@ export function authorRetryBackoffMs(errorCount: number): number {
 }
 
 /**
+ * D1's ceiling on queries per Worker invocation (paid plan), and the number every
+ * bounded loop in this file is really sized against.
+ *
+ * The unit is the *statement*, not the call: each statement inside a `DB.batch`
+ * counts on its own, so "one batch per event" is not one query per event. Hitting
+ * the ceiling is quiet in exactly the case the bounds exist for — the drain catches
+ * each throw per event, counts it as an error and advances its cursor past it — so
+ * the cost of every write here is counted rather than assumed.
+ * https://developers.cloudflare.com/d1/platform/limits/
+ */
+export const D1_QUERIES_PER_INVOCATION = 1000;
+
+/**
+ * What the drain leaves for the rest of a poll cycle: the subscriptions stream's
+ * writes, the flag and author-set reads, and the back-catalogue walks the alarm runs
+ * once both sockets are closed (`MAX_CYCLE_BACKFILLS` × `BACKFILL_QUERY_COST`).
+ */
+export const DOCUMENT_CYCLE_QUERY_RESERVE = 300;
+
+/** Queries one poll cycle's document drain may spend. */
+export const DOCUMENT_DRAIN_QUERY_BUDGET = D1_QUERIES_PER_INVOCATION - DOCUMENT_CYCLE_QUERY_RESERVE;
+
+/**
+ * Worst-case queries one applied event costs: the record write, plus a first-seen
+ * publication's cache read and its refresh. Every later event for that publication
+ * costs the write alone, because the resolved metadata is memoised on the context.
+ *
+ * Charging every event the cold-publication price is also what keeps the *fetch*
+ * subrequest budget in range: a resolve is three cross-PDS fetches, and a cycle of
+ * nothing but cold publications stops at a quarter of the query budget.
+ */
+const QUERIES_PER_APPLIED_EVENT = 4;
+
+/** Queries the end-of-run flush spends per author written during the run. */
+const QUERIES_PER_FLUSHED_AUTHOR = 2;
+
+/**
+ * Worst-case queries one author's backfill spends: a write per document up to the
+ * per-author cap, plus the prune, the sidecar reads and the bookkeeping. Callers
+ * that fan backfills out inside one invocation size their fan-out against this.
+ */
+export const BACKFILL_QUERY_COST = MAX_DOCUMENTS_PER_AUTHOR + 12;
+
+/**
  * `authorRetryBackoffMs` as SQL, so the queue query can apply it per row. Binds, in
  * order: the ceiling, the base. `1 << n` is SQLite's shift; the exponent is clamped
  * before shifting so a long-broken author can't overflow it.
@@ -116,6 +160,82 @@ function parseRecord<T>(raw: string): T | null {
 // --- Write path --------------------------------------------------------------
 
 /**
+ * State shared by a run of writes — one poll cycle's drain, or one author's
+ * backfill. Both of its jobs are about the query budget above.
+ *
+ * Publication metadata resolved once is reused by every later write in the run. A
+ * flood is one author and usually one publication, so this is the difference
+ * between one cache read for the burst and one per event.
+ *
+ * The per-author cap eviction and the ingest bookkeeping are settled once, in
+ * {@link flushDocumentApplyContext}, rather than riding every write: trimming after
+ * each of 500 events deletes nothing 499 times and spends 500 queries doing it. The
+ * trade is that the eviction is no longer atomic with the write that made it
+ * necessary — an author sits over the cap between the two, and a run that dies in
+ * between leaves them there until the next drain, backfill or reconcile trims,
+ * all of which do.
+ */
+export interface DocumentApplyContext {
+  /** Publication metadata already resolved during this run. */
+  siteMeta: Map<string, SiteMeta>;
+  /** Authors written during this run, trimmed and stamped at the flush. */
+  touched: Set<string>;
+  /** D1 queries spent so far — what the drain stops on. */
+  queries: number;
+  /** Timestamp of the most recent applied event, for the flush's bookkeeping. */
+  lastEventAt: number;
+}
+
+export function createDocumentApplyContext(): DocumentApplyContext {
+  return { siteMeta: new Map(), touched: new Set(), queries: 0, lastEventAt: 0 };
+}
+
+/**
+ * Settle the deferred per-author work: cap eviction and ingest bookkeeping, one
+ * pair of statements per author written during the run. Best effort — losing it
+ * costs a delayed eviction, never a document.
+ */
+export async function flushDocumentApplyContext(
+  env: Env,
+  ctx: DocumentApplyContext
+): Promise<void> {
+  if (ctx.touched.size === 0) return;
+  const authors = [...ctx.touched];
+  ctx.touched.clear();
+  const lastEventAt = ctx.lastEventAt || Date.now();
+  const statements = authors.flatMap((authorDid) => [
+    trimAuthorDocumentsStatement(env, authorDid),
+    authorBookkeepingStatement(env, { authorDid, lastEventAt }),
+  ]);
+  ctx.queries += statements.length;
+  try {
+    await env.DB.batch(statements);
+  } catch (error) {
+    console.error('[document-store] apply flush failed:', error);
+  }
+}
+
+/**
+ * Publication metadata for a write, resolved at most once per run. Cheap enough to
+ * do at write time — and doing it here is what keeps the serve path from ever
+ * blocking on a PDS for a canonical URL.
+ */
+async function siteMetaForWrite(
+  env: Env,
+  siteUri: string,
+  ctx: DocumentApplyContext
+): Promise<SiteMeta> {
+  const memoised = ctx.siteMeta.get(siteUri);
+  if (memoised) return memoised;
+  // A cold publication is a cache read plus a refresh write; a warm one is the
+  // read alone. Charged at the worst case, which is what the drain budgets for.
+  ctx.queries += 2;
+  const meta = await resolveSiteMeta(env, siteUri);
+  ctx.siteMeta.set(siteUri, meta);
+  return meta;
+}
+
+/**
  * The statement that upserts one `site.standard.document` record. Idempotent by
  * `record_uri`, so a replayed firehose event or a re-run backfill converges on the
  * same row — which is what makes Jetstream's at-least-once delivery safe here.
@@ -130,13 +250,14 @@ async function documentUpsertStatement(
   recordUri: string,
   recordCid: string,
   record: DocumentRecord,
-  now: number
+  now: number,
+  ctx: DocumentApplyContext
 ): Promise<D1PreparedStatement | null> {
   const parsed = parseAtUri(recordUri);
   if (!parsed) return null;
 
   const siteUri = record.site || '';
-  const meta = await resolveSiteMeta(env, siteUri);
+  const meta = await siteMetaForWrite(env, siteUri, ctx);
   const canonicalUrl = meta.baseUrl
     ? buildCanonicalUrl(meta.baseUrl, record.path || '')
     : record.path || '';
@@ -173,17 +294,22 @@ export async function upsertDocument(
   recordUri: string,
   recordCid: string,
   record: DocumentRecord,
-  now = Date.now()
+  now = Date.now(),
+  context?: DocumentApplyContext
 ): Promise<void> {
+  const ctx = context ?? createDocumentApplyContext();
   const statement = await documentUpsertStatement(
     env,
     authorDid,
     recordUri,
     recordCid,
     record,
-    now
+    now,
+    ctx
   );
-  if (statement) await statement.run();
+  if (!statement) return;
+  ctx.queries++;
+  await statement.run();
 }
 
 /**
@@ -270,20 +396,38 @@ export async function applyDocumentEvent(
   env: Env,
   event: DocumentCommitEvent,
   allowedDids: Set<string>,
-  now = Date.now()
+  now = Date.now(),
+  context?: DocumentApplyContext
 ): Promise<boolean> {
   const commit = event.commit;
   if (!commit) return false;
   if (!allowedDids.has(event.did)) return false;
 
+  // Without a caller-owned context this is a one-off write, so it flushes its own
+  // deferred work before returning and stays self-contained.
+  const ctx = context ?? createDocumentApplyContext();
+  const wrote = await applyToContext(env, event, now, ctx);
+  if (!context) await flushDocumentApplyContext(env, ctx);
+  return wrote;
+}
+
+async function applyToContext(
+  env: Env,
+  event: DocumentCommitEvent,
+  now: number,
+  ctx: DocumentApplyContext
+): Promise<boolean> {
+  const commit = event.commit!;
   const { collection, operation, rkey } = commit;
 
   if (collection === READER_COLLECTION) {
     if (operation === 'delete') {
+      ctx.queries++;
       await deleteCollection(env, event.did, rkey);
       return true;
     }
     if (!commit.record) return false;
+    ctx.queries++;
     await upsertCollection(env, event.did, rkey, commit.record as CollectionRecord, now);
     return true;
   }
@@ -293,6 +437,7 @@ export async function applyDocumentEvent(
   const recordUri = `at://${event.did}/${DOCUMENT_COLLECTION}/${rkey}`;
 
   if (operation === 'delete') {
+    ctx.queries++;
     await deleteDocument(env, recordUri);
     return true;
   }
@@ -304,21 +449,19 @@ export async function applyDocumentEvent(
     recordUri,
     commit.cid || '',
     commit.record as DocumentRecord,
-    now
+    now,
+    ctx
   );
   if (!upsert) return false;
 
-  // One `batch` rather than three `run`s: D1 calls count against the Worker's
-  // per-invocation subrequest budget, and the drain's whole job is to apply a
-  // burst's worth of events inside one alarm. Three statements per event would put
-  // the apply cap (500) at ~1500 subrequests, over the 1000 ceiling — see the cap's
-  // note in `document-flags.ts`. Batching also makes the write atomic: the cap
-  // eviction and the bookkeeping either land with the document or not at all.
-  await env.DB.batch([
-    upsert,
-    trimAuthorDocumentsStatement(env, event.did),
-    authorBookkeepingStatement(env, { authorDid: event.did, lastEventAt: now }),
-  ]);
+  // One statement per applied event. The cap eviction and the bookkeeping this
+  // write implies are recorded on the context and settled once at the flush — see
+  // `DocumentApplyContext` for why, and `D1_QUERIES_PER_INVOCATION` for the ceiling
+  // that makes per-event statement count the thing to economise on.
+  ctx.queries++;
+  await upsert.run();
+  ctx.touched.add(event.did);
+  ctx.lastEventAt = Math.max(ctx.lastEventAt, now);
   return true;
 }
 
@@ -327,11 +470,17 @@ export type DrainOutcome = 'applied' | 'skipped' | 'error' | 'capped';
 
 export interface DocumentDrain {
   handle(event: DocumentCommitEvent & { time_us?: number }): Promise<DrainOutcome>;
+  /** Settle the cycle's deferred per-author work. Call once, after the socket closes. */
+  flush(): Promise<void>;
   /** Events actually written this cycle. */
   readonly applied: number;
   readonly errors: number;
-  /** The cycle stopped on the apply cap. */
+  /** The cycle stopped early — on the apply cap or on the query budget. */
   readonly capped: boolean;
+  /** Which of the two stopped it, for the log line. */
+  readonly cappedBy: 'apply-cap' | 'query-budget' | null;
+  /** D1 queries this cycle's drain has spent, flush included. */
+  readonly queries: number;
   /** Cursor to persist: the last event this cycle finished handling, never past it. */
   readonly cursor: string;
 }
@@ -347,17 +496,37 @@ export interface DocumentDrain {
  * overrunning the alarm, and because the cursor never advances past unapplied work,
  * draining slowly costs latency rather than data.
  *
+ * `queryBudget` is the harder of the two bounds and the one that has to hold: D1
+ * refuses everything past `D1_QUERIES_PER_INVOCATION` in an invocation, and the
+ * drain would meet that ceiling by catching a throw per event and walking its cursor
+ * over the burst it was meant to protect. So the cycle stops while it can still
+ * afford another event *and* the flush its writes have already earned, whatever the
+ * configured cap says.
+ *
  * Kept out of the Durable Object so the spike behaviour can be driven directly with
  * M ≫ N events instead of through a WebSocket.
  */
 export function createDocumentDrain(
   env: Env,
-  options: { allowed: Set<string>; cap: number; cursor?: string; now?: () => number }
+  options: {
+    allowed: Set<string>;
+    cap: number;
+    cursor?: string;
+    now?: () => number;
+    queryBudget?: number;
+  }
 ): DocumentDrain {
   let applied = 0;
   let errors = 0;
-  let capped = false;
+  let cappedBy: 'apply-cap' | 'query-budget' | null = null;
   let cursor = options.cursor ?? String((options.now?.() ?? Date.now()) * 1000);
+  const ctx = createDocumentApplyContext();
+  const queryBudget = options.queryBudget ?? DOCUMENT_DRAIN_QUERY_BUDGET;
+
+  /** Room for one more event and for flushing the author it would touch. */
+  const affordable = () =>
+    ctx.queries + QUERIES_PER_APPLIED_EVENT + QUERIES_PER_FLUSHED_AUTHOR * (ctx.touched.size + 1) <=
+    queryBudget;
 
   return {
     get applied() {
@@ -367,23 +536,37 @@ export function createDocumentDrain(
       return errors;
     },
     get capped() {
-      return capped;
+      return cappedBy !== null;
+    },
+    get cappedBy() {
+      return cappedBy;
+    },
+    get queries() {
+      return ctx.queries;
     },
     get cursor() {
       return cursor;
+    },
+    async flush() {
+      await flushDocumentApplyContext(env, ctx);
     },
     async handle(event) {
       const collection = event.commit?.collection;
       if (collection !== DOCUMENT_COLLECTION && collection !== READER_COLLECTION) return 'skipped';
 
       if (applied >= options.cap) {
-        capped = true;
+        cappedBy = 'apply-cap';
+        return 'capped';
+      }
+
+      if (!affordable()) {
+        cappedBy = 'query-budget';
         return 'capped';
       }
 
       let outcome: DrainOutcome = 'skipped';
       try {
-        const wrote = await applyDocumentEvent(env, event, options.allowed, options.now?.());
+        const wrote = await applyDocumentEvent(env, event, options.allowed, options.now?.(), ctx);
         if (wrote) {
           applied++;
           outcome = 'applied';
@@ -478,7 +661,10 @@ export interface BackfillResult {
  */
 export async function backfillAuthorDocuments(
   env: Env,
-  authorDid: string
+  authorDid: string,
+  // One context per author: their documents nearly all share one publication, so
+  // the metadata behind every canonical URL is resolved once instead of per record.
+  ctx: DocumentApplyContext = createDocumentApplyContext()
 ): Promise<BackfillResult> {
   if (!isValidDid(authorDid)) {
     return {
@@ -515,7 +701,7 @@ export async function backfillAuthorDocuments(
   for (const record of kept) {
     const parsed = parseAtUri(record.uri);
     if (!parsed || parsed.did !== authorDid) continue;
-    await upsertDocument(env, authorDid, record.uri, record.cid, record.value, now);
+    await upsertDocument(env, authorDid, record.uri, record.cid, record.value, now, ctx);
   }
 
   // Anything not in the listed set is gone from the repo (or past the cap), which
@@ -720,7 +906,11 @@ export async function staleDocumentAuthors(
   return (result.results ?? []).map((r) => r.did).filter((did): did is string => isValidDid(did));
 }
 
-/** Re-list the stalest authors. Bounded per call — this rides the hourly cron. */
+/**
+ * Re-list the stalest authors. Bounded per call — this rides the cron, one author a
+ * minute plus three on the hour, and never more than `BACKFILL_QUERY_COST` queries
+ * an author of that run's budget.
+ */
 export async function reconcileStaleAuthors(env: Env, limit = 3): Promise<BackfillResult[]> {
   const dids = await staleDocumentAuthors(env, limit);
   const results: BackfillResult[] = [];
@@ -789,6 +979,45 @@ export function scheduleAuthorDocuments(
       });
     })
   );
+}
+
+/**
+ * Back catalogues one sync request may pull.
+ *
+ * A single subscribe schedules one walk and is done. The sync paths are different:
+ * they can import or mirror dozens of `atproto.documents` rows in one pass, and
+ * every scheduled walk runs in that same invocation via `waitUntil` — up to
+ * `BACKFILL_QUERY_COST` D1 queries each, against the same
+ * `D1_QUERIES_PER_INVOCATION` ceiling the drain budgets for. Fifteen of them would
+ * take the whole request past it, failing the surviving walks *and* whatever else
+ * the sync had scheduled there.
+ *
+ * Two per path, then — `/api/sync` runs both — with the rest left to the reconcile,
+ * where a never-listed author already sorts to the front of the queue.
+ */
+export const MAX_SYNC_BACKFILLS = 2;
+
+/**
+ * A bounded, de-duplicating scheduler for the sync paths. Returns a function that
+ * schedules a walk and reports whether it did, so a caller can say how many authors
+ * it left to the reconcile.
+ */
+export function createBackfillScheduler(
+  env: Env,
+  waitUntil: (promise: Promise<unknown>) => void,
+  limit = MAX_SYNC_BACKFILLS
+): (authorDid: string) => boolean {
+  const scheduled = new Set<string>();
+  return (authorDid: string) => {
+    if (!isValidDid(authorDid)) return false;
+    // Two publications by the same author are one walk, and the second caller is
+    // told it is covered rather than deferred.
+    if (scheduled.has(authorDid)) return true;
+    if (scheduled.size >= limit) return false;
+    scheduled.add(authorDid);
+    scheduleAuthorDocuments(env, waitUntil, authorDid);
+    return true;
+  };
 }
 
 // --- Read path ---------------------------------------------------------------

--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -1,0 +1,889 @@
+/**
+ * The D1 store for standard.site documents.
+ *
+ * Documents used to live in the Fly proxy's SQLite as one JSON blob per author,
+ * kept current by a persistent Bun WebSocket and served back through the Worker.
+ * They now live here, one row per record: the JetstreamPoller DO writes
+ * create/update/delete events straight in, `backfillAuthorDocuments` fills an
+ * author's back catalogue over `listRecords` (the firehose never replays history),
+ * and reads are plain D1 queries — no Fly on the read path.
+ *
+ * The wire shape the serve path produces is the proxy's, unchanged (see
+ * `ProxyDocumentEntry`), so the frontend does not change across the cutover.
+ */
+
+import type { Env } from '../types';
+import type { ProxyDocument, ProxyDocumentEntry, ProxyReaderCollection } from './feed-proxy-client';
+import {
+  DOCUMENT_COLLECTION,
+  MAX_DOCUMENTS_PER_AUTHOR,
+  READER_COLLECTION,
+  type CollectionRecord,
+  type DocumentRecord,
+  type SiteMeta,
+  EMPTY_SITE_META,
+  buildCanonicalUrl,
+  cachedSiteMeta,
+  digestScope,
+  getDocumentRecord,
+  isValidDid,
+  listAuthorCollections,
+  listAuthorDocuments,
+  publishedAtMs,
+  recordToDocument,
+  resolveReaderCollection,
+  resolveSiteMeta,
+} from './standard-site';
+import { parseAtUri } from '../utils/canonical-url';
+import { log } from '../utils/logger';
+
+/** How long a resolved curated-edition preview is reused before re-resolving. */
+const COLLECTION_PREVIEW_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How many curated editions one request may resolve from scratch. Each edition
+ * costs up to `MAX_COLLECTION_ITEMS` cross-PDS getRecords, so an unbounded fan-out
+ * would let a batch of magazine subscriptions blow the subrequest budget. Editions
+ * beyond the cap render without their item previews and resolve on a later read —
+ * a cold edition costs one refresh to warm, not a failed batch.
+ */
+export const MAX_COLLECTION_RESOLVES_PER_REQUEST = 3;
+
+/**
+ * How long an author's stored set may go unverified before the reconcile loop
+ * re-lists their repo. This is the self-heal the proxy got for free by
+ * full-replacing its blob on every refresh: the firehose only carries writes made
+ * while we were watching, so a gap (a reconnect, a cursor reset, an ingest pause)
+ * leaves a hole nothing else fills.
+ */
+export const AUTHOR_RECONCILE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface DocumentRow {
+  record_uri: string;
+  author_did: string;
+  rkey: string;
+  record_cid: string;
+  site_uri: string;
+  published_at: number;
+  canonical_url: string | null;
+  record_json: string;
+  indexed_at: number;
+}
+
+interface CollectionRow {
+  author_did: string;
+  rkey: string;
+  record_json: string;
+  preview_json: string | null;
+  preview_at: number | null;
+}
+
+interface AuthorRow {
+  author_did: string;
+  last_listed_at: number | null;
+  complete: number;
+  error_count: number;
+  last_error: string | null;
+}
+
+function parseRecord<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+// --- Write path --------------------------------------------------------------
+
+/**
+ * Upsert one `site.standard.document` record. Idempotent by `record_uri`, so a
+ * replayed firehose event or a re-run backfill converges on the same row — which
+ * is what makes Jetstream's at-least-once delivery safe here.
+ *
+ * Publication metadata is resolved (and D1-cached) at write time, so the serve
+ * path never blocks on a PDS for a canonical URL.
+ */
+export async function upsertDocument(
+  env: Env,
+  authorDid: string,
+  recordUri: string,
+  recordCid: string,
+  record: DocumentRecord,
+  now = Date.now()
+): Promise<void> {
+  const parsed = parseAtUri(recordUri);
+  if (!parsed) return;
+
+  const siteUri = record.site || '';
+  const meta = await resolveSiteMeta(env, siteUri);
+  const canonicalUrl = meta.baseUrl
+    ? buildCanonicalUrl(meta.baseUrl, record.path || '')
+    : record.path || '';
+
+  await env.DB.prepare(
+    `INSERT INTO documents_v2
+       (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(record_uri) DO UPDATE SET
+       record_cid = excluded.record_cid,
+       site_uri = excluded.site_uri,
+       published_at = excluded.published_at,
+       canonical_url = excluded.canonical_url,
+       record_json = excluded.record_json,
+       updated_at = excluded.updated_at`
+  )
+    .bind(
+      recordUri,
+      authorDid,
+      parsed.rkey,
+      recordCid,
+      siteUri,
+      publishedAtMs(record, now),
+      canonicalUrl || null,
+      JSON.stringify(record),
+      now,
+      now
+    )
+    .run();
+}
+
+/**
+ * Evict an author's oldest documents past the per-author cap. Ported from the
+ * proxy's `MAX_DOCUMENTS_PER_AUTHOR` slice: storage and serve cost per author stay
+ * bounded no matter how much that author publishes — which is the layer of spike
+ * defence no DID filter can provide, because a *subscribed* author's flood passes
+ * the filter by design.
+ */
+export async function trimAuthorDocuments(env: Env, authorDid: string): Promise<number> {
+  const result = await env.DB.prepare(
+    `DELETE FROM documents_v2
+      WHERE record_uri IN (
+        SELECT record_uri FROM documents_v2
+         WHERE author_did = ?
+         ORDER BY published_at DESC, record_uri DESC
+         LIMIT -1 OFFSET ?
+      )`
+  )
+    .bind(authorDid, MAX_DOCUMENTS_PER_AUTHOR)
+    .run();
+  return result.meta?.changes ?? 0;
+}
+
+export async function deleteDocument(env: Env, recordUri: string): Promise<void> {
+  await env.DB.prepare('DELETE FROM documents_v2 WHERE record_uri = ?').bind(recordUri).run();
+}
+
+/**
+ * Upsert a curated-edition sidecar. The stored preview is cleared on every write:
+ * the item list may have changed, and a stale preview would render last week's
+ * edition under this week's record.
+ */
+export async function upsertCollection(
+  env: Env,
+  authorDid: string,
+  rkey: string,
+  record: CollectionRecord,
+  now = Date.now()
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO collections_v2 (author_did, rkey, record_json, preview_json, preview_at, indexed_at)
+     VALUES (?, ?, ?, NULL, NULL, ?)
+     ON CONFLICT(author_did, rkey) DO UPDATE SET
+       record_json = excluded.record_json,
+       preview_json = NULL,
+       preview_at = NULL,
+       indexed_at = excluded.indexed_at`
+  )
+    .bind(authorDid, rkey, JSON.stringify(record), now)
+    .run();
+}
+
+export async function deleteCollection(env: Env, authorDid: string, rkey: string): Promise<void> {
+  await env.DB.prepare('DELETE FROM collections_v2 WHERE author_did = ? AND rkey = ?')
+    .bind(authorDid, rkey)
+    .run();
+}
+
+/** A Jetstream commit, narrowed to what the document streams care about. */
+export interface DocumentCommitEvent {
+  did: string;
+  commit?: {
+    operation: 'create' | 'update' | 'delete';
+    collection: string;
+    rkey: string;
+    cid?: string;
+    record?: unknown;
+  };
+}
+
+/**
+ * Apply one Jetstream commit to D1. Returns true when a write happened.
+ *
+ * `allowedDids` is the belt-and-braces re-check behind the server-side `wantedDids`
+ * filter: the filter is applied by Jetstream at connect time, but there is a brief
+ * unfiltered window when the DID set is large enough to be sent as an
+ * `options_update` frame after `open` — and a server that ever changed the filter's
+ * semantics (v2) would otherwise turn "more parse traffic" into "foreign rows".
+ */
+export async function applyDocumentEvent(
+  env: Env,
+  event: DocumentCommitEvent,
+  allowedDids: Set<string>,
+  now = Date.now()
+): Promise<boolean> {
+  const commit = event.commit;
+  if (!commit) return false;
+  if (!allowedDids.has(event.did)) return false;
+
+  const { collection, operation, rkey } = commit;
+
+  if (collection === READER_COLLECTION) {
+    if (operation === 'delete') {
+      await deleteCollection(env, event.did, rkey);
+      return true;
+    }
+    if (!commit.record) return false;
+    await upsertCollection(env, event.did, rkey, commit.record as CollectionRecord, now);
+    return true;
+  }
+
+  if (collection !== DOCUMENT_COLLECTION) return false;
+
+  const recordUri = `at://${event.did}/${DOCUMENT_COLLECTION}/${rkey}`;
+
+  if (operation === 'delete') {
+    await deleteDocument(env, recordUri);
+    return true;
+  }
+
+  if (!commit.record) return false;
+  await upsertDocument(
+    env,
+    event.did,
+    recordUri,
+    commit.cid || '',
+    commit.record as DocumentRecord,
+    now
+  );
+  await trimAuthorDocuments(env, event.did);
+  await touchAuthor(env, { authorDid: event.did, lastEventAt: now });
+  return true;
+}
+
+/** What one poll cycle did with an event. */
+export type DrainOutcome = 'applied' | 'skipped' | 'error' | 'capped';
+
+export interface DocumentDrain {
+  handle(event: DocumentCommitEvent & { time_us?: number }): Promise<DrainOutcome>;
+  /** Events actually written this cycle. */
+  readonly applied: number;
+  readonly errors: number;
+  /** The cycle stopped on the apply cap. */
+  readonly capped: boolean;
+  /** Cursor to persist: the last event this cycle finished handling, never past it. */
+  readonly cursor: string;
+}
+
+/**
+ * One poll cycle's bounded, resumable drain.
+ *
+ * The cap is the spike guard that no DID filter can provide, because the dangerous
+ * case is an author we *subscribe to* dumping thousands of documents — the filter
+ * passes all of it by design. So a cycle applies at most `cap` events, then reports
+ * `capped` and leaves its cursor at the last event it finished. The burst drains
+ * over the following cycles instead of starving the subscriptions stream or
+ * overrunning the alarm, and because the cursor never advances past unapplied work,
+ * draining slowly costs latency rather than data.
+ *
+ * Kept out of the Durable Object so the spike behaviour can be driven directly with
+ * M ≫ N events instead of through a WebSocket.
+ */
+export function createDocumentDrain(
+  env: Env,
+  options: { allowed: Set<string>; cap: number; cursor?: string; now?: () => number }
+): DocumentDrain {
+  let applied = 0;
+  let errors = 0;
+  let capped = false;
+  let cursor = options.cursor ?? String((options.now?.() ?? Date.now()) * 1000);
+
+  return {
+    get applied() {
+      return applied;
+    },
+    get errors() {
+      return errors;
+    },
+    get capped() {
+      return capped;
+    },
+    get cursor() {
+      return cursor;
+    },
+    async handle(event) {
+      const collection = event.commit?.collection;
+      if (collection !== DOCUMENT_COLLECTION && collection !== READER_COLLECTION) return 'skipped';
+
+      if (applied >= options.cap) {
+        capped = true;
+        return 'capped';
+      }
+
+      let outcome: DrainOutcome = 'skipped';
+      try {
+        const wrote = await applyDocumentEvent(env, event, options.allowed, options.now?.());
+        if (wrote) {
+          applied++;
+          outcome = 'applied';
+        }
+      } catch (error) {
+        errors++;
+        outcome = 'error';
+        console.error('[document-store] event apply failed:', error);
+      }
+      // Advance past anything we finished with, including a failure: a poison event
+      // must not wedge the stream forever. The reconcile loop closes the hole a
+      // dropped event leaves.
+      if (event.time_us) cursor = String(event.time_us);
+      return outcome;
+    },
+  };
+}
+
+/** Record ingest bookkeeping for an author (best effort — never fails a write). */
+async function touchAuthor(
+  env: Env,
+  fields: {
+    authorDid: string;
+    lastEventAt?: number;
+    lastListedAt?: number;
+    complete?: boolean;
+    error?: string | null;
+  }
+): Promise<void> {
+  const now = Date.now();
+  try {
+    if (fields.error) {
+      await env.DB.prepare(
+        `INSERT INTO document_authors (author_did, error_count, last_error, last_error_at)
+         VALUES (?, 1, ?, ?)
+         ON CONFLICT(author_did) DO UPDATE SET
+           error_count = document_authors.error_count + 1,
+           last_error = excluded.last_error,
+           last_error_at = excluded.last_error_at`
+      )
+        .bind(fields.authorDid, fields.error.slice(0, 500), now)
+        .run();
+      return;
+    }
+    await env.DB.prepare(
+      `INSERT INTO document_authors (author_did, last_listed_at, last_event_at, complete, error_count, last_error, last_error_at)
+       VALUES (?, ?, ?, ?, 0, NULL, NULL)
+       ON CONFLICT(author_did) DO UPDATE SET
+         last_listed_at = COALESCE(excluded.last_listed_at, document_authors.last_listed_at),
+         last_event_at = COALESCE(excluded.last_event_at, document_authors.last_event_at),
+         complete = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.complete ELSE excluded.complete END,
+         error_count = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.error_count ELSE 0 END,
+         last_error = CASE WHEN excluded.last_listed_at IS NULL THEN document_authors.last_error ELSE NULL END`
+    )
+      .bind(
+        fields.authorDid,
+        fields.lastListedAt ?? null,
+        fields.lastEventAt ?? null,
+        fields.complete ? 1 : 0
+      )
+      .run();
+  } catch (error) {
+    console.error('[document-store] author bookkeeping failed:', error);
+  }
+}
+
+// --- Backfill + reconcile ----------------------------------------------------
+
+export interface BackfillResult {
+  did: string;
+  ok: boolean;
+  documents: number;
+  collections: number;
+  complete: boolean;
+  error?: string;
+}
+
+/**
+ * Pull an author's back catalogue from their PDS into D1 and prune anything the
+ * repo no longer has.
+ *
+ * Network replay (Jetstream v2) recovers *gaps*, not history, so this stays the
+ * cold-start path: a brand-new `atproto.documents` subscription must see the
+ * author's existing writing, and nothing in the firehose will ever carry it. Pruning
+ * to the listed set reproduces what the proxy's full-blob replace did, which is also
+ * how a delete missed during an ingest pause finally disappears.
+ */
+export async function backfillAuthorDocuments(
+  env: Env,
+  authorDid: string
+): Promise<BackfillResult> {
+  if (!isValidDid(authorDid)) {
+    return {
+      did: authorDid,
+      ok: false,
+      documents: 0,
+      collections: 0,
+      complete: false,
+      error: 'Invalid DID',
+    };
+  }
+
+  const now = Date.now();
+  let listed: Awaited<ReturnType<typeof listAuthorDocuments>>;
+  try {
+    listed = await listAuthorDocuments(authorDid);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'listRecords failed';
+    await touchAuthor(env, { authorDid, error: message });
+    log.warn('documents_backfill_failed', { authorDid, error: message });
+    return {
+      did: authorDid,
+      ok: false,
+      documents: 0,
+      collections: 0,
+      complete: false,
+      error: message,
+    };
+  }
+
+  const complete = listed.length < MAX_DOCUMENTS_PER_AUTHOR;
+  const kept = listed.slice(0, MAX_DOCUMENTS_PER_AUTHOR);
+
+  for (const record of kept) {
+    const parsed = parseAtUri(record.uri);
+    if (!parsed || parsed.did !== authorDid) continue;
+    await upsertDocument(env, authorDid, record.uri, record.cid, record.value, now);
+  }
+
+  // Anything not in the listed set is gone from the repo (or past the cap), which
+  // is the drift the firehose alone can't correct.
+  const keptUris = new Set(kept.map((r) => r.uri));
+  const existing = await env.DB.prepare('SELECT record_uri FROM documents_v2 WHERE author_did = ?')
+    .bind(authorDid)
+    .all<{ record_uri: string }>();
+  const stale = (existing.results ?? [])
+    .map((r) => r.record_uri)
+    .filter((uri) => !keptUris.has(uri));
+  if (stale.length > 0) {
+    await env.DB.batch(
+      stale.map((uri) => env.DB.prepare('DELETE FROM documents_v2 WHERE record_uri = ?').bind(uri))
+    );
+  }
+
+  const collections = await listAuthorCollections(authorDid);
+  for (const [rkey, record] of collections) {
+    await upsertCollectionIfChanged(env, authorDid, rkey, record, now);
+  }
+
+  await touchAuthor(env, { authorDid, lastListedAt: now, complete });
+  log.info('documents_backfilled', {
+    authorDid,
+    documents: kept.length,
+    collections: collections.size,
+    removed: stale.length,
+    complete,
+  });
+
+  return {
+    did: authorDid,
+    ok: true,
+    documents: kept.length,
+    collections: collections.size,
+    complete,
+  };
+}
+
+/**
+ * Upsert a collection only when its record actually changed. A backfill re-runs
+ * over unchanged editions; blindly upserting would drop every resolved preview and
+ * make the next read pay the whole cross-PDS fan-out again.
+ */
+async function upsertCollectionIfChanged(
+  env: Env,
+  authorDid: string,
+  rkey: string,
+  record: CollectionRecord,
+  now: number
+): Promise<void> {
+  const existing = await env.DB.prepare(
+    'SELECT record_json FROM collections_v2 WHERE author_did = ? AND rkey = ?'
+  )
+    .bind(authorDid, rkey)
+    .first<{ record_json: string }>();
+  const next = JSON.stringify(record);
+  if (existing?.record_json === next) return;
+  await env.DB.prepare(
+    `INSERT INTO collections_v2 (author_did, rkey, record_json, preview_json, preview_at, indexed_at)
+     VALUES (?, ?, ?, NULL, NULL, ?)
+     ON CONFLICT(author_did, rkey) DO UPDATE SET
+       record_json = excluded.record_json, preview_json = NULL, preview_at = NULL,
+       indexed_at = excluded.indexed_at`
+  )
+    .bind(authorDid, rkey, next, now)
+    .run();
+}
+
+/**
+ * Every DID whose documents someone subscribes to. This is the true active-author
+ * set — it comes from the subscription table rather than from read traffic, which
+ * is the circularity the feed pipeline already fixed with the crawl-set pull.
+ * Parked subscriptions count: parking pauses what a reader is shown, not whether we
+ * hold the author's documents, and un-parking must not need a backfill.
+ */
+export async function subscribedDocumentAuthors(env: Env): Promise<string[]> {
+  const result = await env.DB.prepare(
+    `SELECT DISTINCT subject_did AS did FROM subscriptions_cache
+      WHERE source_type IN ('atproto.documents', 'atproto.collection') AND subject_did IS NOT NULL`
+  ).all<{ did: string }>();
+  // `isValidDid`, not just a `did:` prefix: this set becomes the Jetstream
+  // `wantedDids` filter, and one malformed entry is rejected wholesale — closing
+  // the socket and silently killing that cycle's drain.
+  return (result.results ?? []).map((r) => r.did).filter((did): did is string => isValidDid(did));
+}
+
+/**
+ * Authors whose stored set is stalest, for the reconcile loop. Never-listed authors
+ * sort first (a subscription created before this shipped, or a failed backfill).
+ */
+export async function staleDocumentAuthors(
+  env: Env,
+  limit: number,
+  now = Date.now()
+): Promise<string[]> {
+  const cutoff = now - AUTHOR_RECONCILE_INTERVAL_MS;
+  const result = await env.DB.prepare(
+    `SELECT DISTINCT s.subject_did AS did
+       FROM subscriptions_cache s
+       LEFT JOIN document_authors a ON a.author_did = s.subject_did
+      WHERE s.source_type IN ('atproto.documents', 'atproto.collection')
+        AND s.subject_did IS NOT NULL
+        AND (a.last_listed_at IS NULL OR a.last_listed_at < ?)
+      ORDER BY COALESCE(a.last_listed_at, 0) ASC
+      LIMIT ?`
+  )
+    .bind(cutoff, limit)
+    .all<{ did: string }>();
+  return (result.results ?? []).map((r) => r.did).filter((did): did is string => isValidDid(did));
+}
+
+/** Re-list the stalest authors. Bounded per call — this rides the hourly cron. */
+export async function reconcileStaleAuthors(env: Env, limit = 3): Promise<BackfillResult[]> {
+  const dids = await staleDocumentAuthors(env, limit);
+  const results: BackfillResult[] = [];
+  for (const did of dids) {
+    results.push(await backfillAuthorDocuments(env, did));
+  }
+  return results;
+}
+
+// --- Read path ---------------------------------------------------------------
+
+/**
+ * Resolve publication metadata for a set of site URIs, using the D1 cache and
+ * resolving at most `maxResolves` misses inline. A stale row is preferred to a
+ * blocking PDS fetch: it renders the document, and the write path refreshes it.
+ */
+async function metaForSites(
+  env: Env,
+  siteUris: string[],
+  maxResolves = 5
+): Promise<Map<string, SiteMeta>> {
+  const out = new Map<string, SiteMeta>();
+  let resolves = 0;
+  for (const siteUri of new Set(siteUris)) {
+    if (!siteUri) {
+      out.set(siteUri, EMPTY_SITE_META);
+      continue;
+    }
+    const fresh = await cachedSiteMeta(env, siteUri);
+    if (fresh) {
+      out.set(siteUri, fresh);
+      continue;
+    }
+    if (resolves < maxResolves) {
+      resolves++;
+      out.set(siteUri, await resolveSiteMeta(env, siteUri));
+      continue;
+    }
+    out.set(siteUri, (await cachedSiteMeta(env, siteUri, { allowStale: true })) ?? EMPTY_SITE_META);
+  }
+  return out;
+}
+
+/** The author's handle, when they're a Skyreader user. Masthead adornment only. */
+async function localHandle(env: Env, did: string): Promise<string | undefined> {
+  try {
+    const row = await env.DB.prepare('SELECT handle FROM users WHERE did = ?')
+      .bind(did)
+      .first<{ handle: string }>();
+    return row?.handle || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Attach a curated edition to the document that renders it, resolving item previews
+ * lazily and persisting them. The fan-out happens once per edition, in a request
+ * context — never inside the poller's alarm, where it would compete with the drain.
+ */
+async function attachReaderCollection(
+  env: Env,
+  document: ProxyDocument,
+  row: CollectionRow,
+  meta: SiteMeta,
+  budget: { remaining: number },
+  now = Date.now()
+): Promise<ProxyReaderCollection | null> {
+  const edition = {
+    publicationName: meta.name || undefined,
+    theme: meta.theme || undefined,
+    fonts: meta.fonts || undefined,
+    authorHandle: await localHandle(env, document.authorDid),
+  };
+
+  const cached = row.preview_json ? parseRecord<ProxyReaderCollection>(row.preview_json) : null;
+  const fresh = cached && row.preview_at && now - row.preview_at < COLLECTION_PREVIEW_TTL_MS;
+  if (cached && fresh) return { ...cached, ...edition };
+
+  if (budget.remaining <= 0) {
+    // Out of resolve budget: serve the previous preview if we have one, else drop
+    // the edition for this read. Either way the next read resolves it.
+    return cached ? { ...cached, ...edition } : null;
+  }
+  budget.remaining--;
+
+  const raw = parseRecord<CollectionRecord>(row.record_json);
+  if (!raw) return null;
+  const resolved = await resolveReaderCollection(env, raw, edition);
+  if (!resolved) return null;
+
+  try {
+    await env.DB.prepare(
+      'UPDATE collections_v2 SET preview_json = ?, preview_at = ? WHERE author_did = ? AND rkey = ?'
+    )
+      .bind(JSON.stringify(resolved), now, row.author_did, row.rkey)
+      .run();
+  } catch (error) {
+    console.error('[document-store] preview persist failed:', error);
+  }
+  return resolved;
+}
+
+/**
+ * Load one author's stored documents in the frontend's wire shape, newest first,
+ * optionally scoped to a publication.
+ */
+export async function loadAuthorDocuments(
+  env: Env,
+  authorDid: string,
+  options: { siteUri?: string; collectionBudget?: { remaining: number } } = {}
+): Promise<ProxyDocument[]> {
+  const scoped = options.siteUri
+    ? await env.DB.prepare(
+        `SELECT record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at
+           FROM documents_v2 WHERE author_did = ? AND site_uri = ?
+          ORDER BY published_at DESC LIMIT ?`
+      )
+        .bind(authorDid, options.siteUri, MAX_DOCUMENTS_PER_AUTHOR)
+        .all<DocumentRow>()
+    : await env.DB.prepare(
+        `SELECT record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at
+           FROM documents_v2 WHERE author_did = ?
+          ORDER BY published_at DESC LIMIT ?`
+      )
+        .bind(authorDid, MAX_DOCUMENTS_PER_AUTHOR)
+        .all<DocumentRow>();
+
+  const rows = scoped.results ?? [];
+  if (rows.length === 0) return [];
+
+  const metas = await metaForSites(
+    env,
+    rows.map((r) => r.site_uri)
+  );
+
+  // Curated editions are rare; one query per author covers every document here.
+  const collectionRows = await env.DB.prepare(
+    'SELECT author_did, rkey, record_json, preview_json, preview_at FROM collections_v2 WHERE author_did = ?'
+  )
+    .bind(authorDid)
+    .all<CollectionRow>();
+  const byRkey = new Map((collectionRows.results ?? []).map((r) => [r.rkey, r]));
+  const budget = options.collectionBudget ?? { remaining: MAX_COLLECTION_RESOLVES_PER_REQUEST };
+
+  const documents: ProxyDocument[] = [];
+  for (const row of rows) {
+    const record = parseRecord<DocumentRecord>(row.record_json);
+    if (!record) continue;
+    const meta = metas.get(row.site_uri) ?? EMPTY_SITE_META;
+    const document = recordToDocument(
+      row.author_did,
+      row.record_uri,
+      row.record_cid,
+      record,
+      meta,
+      {
+        indexedAt: new Date(row.indexed_at).toISOString(),
+      }
+    );
+    const collectionRow = byRkey.get(row.rkey);
+    if (collectionRow) {
+      const readerCollection = await attachReaderCollection(
+        env,
+        document,
+        collectionRow,
+        meta,
+        budget
+      );
+      if (readerCollection) document.readerCollection = readerCollection;
+    }
+    documents.push(document);
+  }
+
+  return documents;
+}
+
+/**
+ * Serve one requested `(did, siteUri)` scope in the proxy's response shape.
+ *
+ * `unchanged` / `ready` / `error` mean exactly what they meant on the proxy path,
+ * and the digest is computed over the same `(recordUri, recordCid)` pairs, so a
+ * client's stored digest keeps matching and the frontend's apply logic is untouched.
+ * The one thing that cannot be reproduced is a per-author retry schedule
+ * (`errorCount` / `nextRetryAt` were the proxy's cache-fetch backoff); an author we
+ * have never successfully listed reports `error` without them.
+ *
+ * The proxy's other compensating case is gone rather than ported: an empty scope
+ * over a non-empty author (subscribing to a publication whose back catalogue
+ * predates the subscription) needed a forced re-list there, because its cache was
+ * warmed by read traffic. Here, subscribing backfills the author's whole repo —
+ * every publication of theirs at once — so the scope is populated before the first
+ * read of it.
+ */
+export async function serveDocumentScope(
+  env: Env,
+  entry: { did: string; siteUri?: string; since_digest?: string },
+  collectionBudget: { remaining: number }
+): Promise<ProxyDocumentEntry> {
+  const { did, siteUri } = entry;
+
+  if (!isValidDid(did)) {
+    return { did: String(did), siteUri, documents: [], status: 'error', error: 'Invalid DID' };
+  }
+
+  const author = await env.DB.prepare(
+    'SELECT author_did, last_listed_at, complete, error_count, last_error FROM document_authors WHERE author_did = ?'
+  )
+    .bind(did)
+    .first<AuthorRow>();
+
+  const documents = await loadAuthorDocuments(env, did, { siteUri, collectionBudget });
+
+  // Nothing stored and nothing ever listed: this author is not ingested yet (a
+  // subscription created before the backfill ran, or a failed one). Report the
+  // proxy's `error` so the client keeps what it holds and retries, rather than a
+  // `ready` empty set, which would clear the scope.
+  if (documents.length === 0 && !author?.last_listed_at) {
+    return {
+      did,
+      siteUri,
+      documents: [],
+      status: 'error',
+      error: author?.last_error || 'Documents not yet ingested for this author',
+      errorCount: author?.error_count || 0,
+    };
+  }
+
+  const digest = await digestScope(documents);
+  if (entry.since_digest && entry.since_digest === digest) {
+    return { did, siteUri, status: 'unchanged' };
+  }
+
+  return {
+    did,
+    siteUri,
+    documents,
+    status: 'ready',
+    digest,
+    // The author's whole repo fits under the cap, so an absent record means
+    // deleted rather than merely beyond the cap.
+    complete: author?.complete === 1,
+  };
+}
+
+/**
+ * Serve a single document by at:// URI, for a piece opened from a curated edition
+ * whose author nobody subscribes to (so it is in no author's stored set). Falls
+ * back to a live `getRecord` on a miss, exactly as the proxy's on-demand path did —
+ * and doesn't store the result: an unsubscribed author's document is a one-shot
+ * read, not an ingest.
+ */
+export async function serveSingleDocument(env: Env, uri: string): Promise<ProxyDocument | null> {
+  const parsed = parseAtUri(uri);
+  if (!parsed || parsed.collection !== DOCUMENT_COLLECTION) return null;
+
+  const row = await env.DB.prepare(
+    `SELECT record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at
+       FROM documents_v2 WHERE record_uri = ?`
+  )
+    .bind(uri)
+    .first<DocumentRow>();
+
+  if (row) {
+    const record = parseRecord<DocumentRecord>(row.record_json);
+    if (record) {
+      const meta =
+        (await cachedSiteMeta(env, row.site_uri, { allowStale: true })) ?? EMPTY_SITE_META;
+      const document = recordToDocument(
+        row.author_did,
+        row.record_uri,
+        row.record_cid,
+        record,
+        meta,
+        { indexedAt: new Date(row.indexed_at).toISOString() }
+      );
+      const collectionRow = await env.DB.prepare(
+        'SELECT author_did, rkey, record_json, preview_json, preview_at FROM collections_v2 WHERE author_did = ? AND rkey = ?'
+      )
+        .bind(row.author_did, row.rkey)
+        .first<CollectionRow>();
+      if (collectionRow) {
+        const readerCollection = await attachReaderCollection(env, document, collectionRow, meta, {
+          remaining: 1,
+        });
+        if (readerCollection) document.readerCollection = readerCollection;
+      }
+      return document;
+    }
+  }
+
+  const fetched = await getDocumentRecord(uri);
+  if (!fetched) return null;
+  const meta = await resolveSiteMeta(env, fetched.value.site || '');
+  return recordToDocument(parsed.did, fetched.uri, fetched.cid, fetched.value, meta);
+}
+
+/** Documents currently stored, for the admin ops panel. */
+export async function documentStoreStats(
+  env: Env
+): Promise<{ documents: number; authors: number; collections: number }> {
+  const row = await env.DB.prepare(
+    `SELECT
+       (SELECT COUNT(*) FROM documents_v2) AS documents,
+       (SELECT COUNT(DISTINCT author_did) FROM documents_v2) AS authors,
+       (SELECT COUNT(*) FROM collections_v2) AS collections`
+  ).first<{ documents: number; authors: number; collections: number }>();
+  return {
+    documents: row?.documents ?? 0,
+    authors: row?.authors ?? 0,
+    collections: row?.collections ?? 0,
+  };
+}

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -208,6 +208,17 @@ async function fetchRecord<T>(
 }
 
 /**
+ * A loose `https://` site is its own base URL: there is no publication record to
+ * fetch and no cache row to read, so resolving one costs nothing. Callers that
+ * budget for a resolve check this first — charging for a site that never touches
+ * D1 or a PDS spends a bounded allowance on no I/O at all.
+ */
+export function looseSiteMeta(siteUri: string): SiteMeta | null {
+  if (!siteUri.startsWith('http://') && !siteUri.startsWith('https://')) return null;
+  return { ...EMPTY_SITE_META, baseUrl: siteUri };
+}
+
+/**
  * Read a publication's cached metadata, or null when there is no fresh row.
  * Separate from `resolveSiteMeta` because the serve path wants "what do we already
  * know?" without ever blocking on a PDS: a stale row still renders a document.
@@ -218,9 +229,8 @@ export async function cachedSiteMeta(
   { allowStale = false }: { allowStale?: boolean } = {}
 ): Promise<SiteMeta | null> {
   if (!siteUri) return null;
-  if (siteUri.startsWith('http://') || siteUri.startsWith('https://')) {
-    return { ...EMPTY_SITE_META, baseUrl: siteUri };
-  }
+  const loose = looseSiteMeta(siteUri);
+  if (loose) return loose;
   const row = await env.DB.prepare(
     `SELECT publication_uri, base_url, icon, name, theme, fonts, cached_at
        FROM publications_cache_v2 WHERE publication_uri = ?`
@@ -434,14 +444,50 @@ export interface ListedRecord<T> {
 }
 
 /**
+ * One walk's memo of resolved PDS endpoints.
+ *
+ * `fetchDidDocument` has no cache of its own, so every `resolvePdsUrl` is a live
+ * plc.directory fetch — and a backfill needs the author's PDS twice, once for the
+ * document listing and once for the sidecar listing. Without a memo shared between
+ * them a walk spends two DID documents where its budget
+ * (`BACKFILL_LIST_SUBREQUESTS`) counts one, which is enough to put a worst-case
+ * walk one subrequest over the bound its fan-outs are sized in.
+ *
+ * Promises rather than values, so two lookups of the same DID share one in-flight
+ * fetch. Scoped to a walk, not to the process: a stale PDS endpoint is a real
+ * failure mode (account migration) and this must not outlive the listing pair.
+ */
+export type PdsMemo = Map<string, Promise<string | null>>;
+
+export function createPdsMemo(): PdsMemo {
+  return new Map();
+}
+
+function resolveAuthorPds(authorDid: string, memo?: PdsMemo): Promise<string | null> {
+  if (!memo) return resolvePdsUrl(authorDid);
+  let pending = memo.get(authorDid);
+  if (!pending) {
+    // `resolvePdsUrl` resolves to null rather than rejecting, so a memoised
+    // failure is a null for the rest of the walk, never an unhandled rejection.
+    pending = resolvePdsUrl(authorDid);
+    memo.set(authorDid, pending);
+  }
+  return pending;
+}
+
+/**
  * List an author's recent `site.standard.document` records, newest-repo-order,
  * capped at `MAX_DOCUMENTS_PER_AUTHOR`. Throws on PDS resolution / fetch failure so
  * the caller records the error + backoff.
+ *
+ * Pass the same {@link PdsMemo} here and to {@link listAuthorCollections} to resolve
+ * the author's DID once for the pair.
  */
 export async function listAuthorDocuments(
-  authorDid: string
+  authorDid: string,
+  pds?: PdsMemo
 ): Promise<Array<ListedRecord<DocumentRecord>>> {
-  const pdsUrl = await resolvePdsUrl(authorDid);
+  const pdsUrl = await resolveAuthorPds(authorDid, pds);
   if (!pdsUrl) throw new Error(`Could not resolve PDS for ${authorDid}`);
 
   const raw: Array<ListedRecord<DocumentRecord>> = [];
@@ -492,11 +538,17 @@ const COLLECTION_PAGE_SIZE = 100;
  * collection shares its rkey with the document it renders). Best-effort: a fetch
  * failure yields an empty, non-exhaustive listing — no magazine enrichment, not a
  * failed backfill. Collections are few, so one page suffices.
+ *
+ * Takes the walk's {@link PdsMemo} so the author's DID document is fetched once for
+ * both listings rather than once each.
  */
-export async function listAuthorCollections(authorDid: string): Promise<AuthorCollectionListing> {
+export async function listAuthorCollections(
+  authorDid: string,
+  pds?: PdsMemo
+): Promise<AuthorCollectionListing> {
   const byRkey = new Map<string, CollectionRecord>();
   try {
-    const pdsUrl = await resolvePdsUrl(authorDid);
+    const pdsUrl = await resolveAuthorPds(authorDid, pds);
     if (!pdsUrl) return { exhaustive: false, byRkey };
     const params = new URLSearchParams({
       repo: authorDid,

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -320,6 +320,12 @@ export function publishedAtMs(doc: DocumentRecord, fallbackMs: number): number {
  * `indexedAt` is the row's ingest time rather than "now" (the proxy had no such
  * stamp and used fetch time); the frontend uses it only for display ordering
  * fallbacks.
+ *
+ * `canonicalUrl` is re-derived from `meta` whenever the publication resolves, so a
+ * repaired publication cache fixes served links without rewriting rows. When it
+ * does not resolve — a `getRecord` blip puts a negative entry in the cache for five
+ * minutes — `canonicalUrlFallback` (the absolute URL stored on the row at write
+ * time) is used instead of degrading the link to a bare relative path.
  */
 export function recordToDocument(
   authorDid: string,
@@ -327,13 +333,17 @@ export function recordToDocument(
   recordCid: string,
   doc: DocumentRecord,
   meta: SiteMeta,
-  options: { indexedAt?: string; readerCollection?: ProxyReaderCollection | null } = {}
+  options: {
+    indexedAt?: string;
+    readerCollection?: ProxyReaderCollection | null;
+    canonicalUrlFallback?: string | null;
+  } = {}
 ): ProxyDocument {
   const nowISO = new Date().toISOString();
   const siteUri = doc.site || '';
   const canonicalUrl = meta.baseUrl
     ? buildCanonicalUrl(meta.baseUrl, doc.path || '')
-    : doc.path || '';
+    : options.canonicalUrlFallback || doc.path || '';
 
   // Surface external resource refs (the shared article URL for link posts),
   // keeping only entries with a real uri.
@@ -457,39 +467,54 @@ export async function listAuthorDocuments(
   return raw;
 }
 
+/** One page of collection sidecars, plus whether absence from it proves deletion. */
+export interface AuthorCollectionListing {
+  /**
+   * True only when the listing succeeded *and* covered the whole collection. A
+   * failed fetch and an author with no editions both produce an empty map, so a
+   * caller that prunes stored rows against this listing has to be able to tell
+   * them apart — otherwise one blip deletes every curated edition we hold.
+   */
+  exhaustive: boolean;
+  byRkey: Map<string, CollectionRecord>;
+}
+
+/** listRecords page size; a full page means there may be more behind a cursor. */
+const COLLECTION_PAGE_SIZE = 100;
+
 /**
  * List an author's `app.standard-reader.collection` sidecars, keyed by rkey (a
  * collection shares its rkey with the document it renders). Best-effort: a fetch
- * failure yields an empty map — no magazine enrichment, not a failed backfill.
- * Collections are few, so one page suffices.
+ * failure yields an empty, non-exhaustive listing — no magazine enrichment, not a
+ * failed backfill. Collections are few, so one page suffices.
  */
-export async function listAuthorCollections(
-  authorDid: string
-): Promise<Map<string, CollectionRecord>> {
+export async function listAuthorCollections(authorDid: string): Promise<AuthorCollectionListing> {
   const byRkey = new Map<string, CollectionRecord>();
   try {
     const pdsUrl = await resolvePdsUrl(authorDid);
-    if (!pdsUrl) return byRkey;
+    if (!pdsUrl) return { exhaustive: false, byRkey };
     const params = new URLSearchParams({
       repo: authorDid,
       collection: READER_COLLECTION,
-      limit: '100',
+      limit: String(COLLECTION_PAGE_SIZE),
     });
     const res = await fetch(`${pdsUrl}/xrpc/com.atproto.repo.listRecords?${params}`, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-    if (!res.ok) return byRkey;
+    if (!res.ok) return { exhaustive: false, byRkey };
     const data = (await res.json()) as {
       records?: Array<{ uri: string; value: CollectionRecord }>;
     };
-    for (const record of data.records ?? []) {
+    const records = data.records ?? [];
+    for (const record of records) {
       const parsed = parseAtUri(record.uri);
       if (parsed) byRkey.set(parsed.rkey, record.value);
     }
+    return { exhaustive: records.length < COLLECTION_PAGE_SIZE, byRkey };
   } catch (error) {
     console.error('[standard-site] listCollections error:', error);
+    return { exhaustive: false, byRkey };
   }
-  return byRkey;
 }
 
 /** Fetch one `site.standard.document` record from its author's PDS. */

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -1,0 +1,618 @@
+/**
+ * standard.site record handling, ported from the feed proxy
+ * (`feed-proxy/src/standard-site.ts`) so documents can live in D1 instead of the
+ * proxy's SQLite blob cache.
+ *
+ * What changed in the port, and nothing else did:
+ * - `bun:sqlite` → D1 (`publications_cache_v2` for publication metadata).
+ * - Bun's `safeFetch` → plain `fetch`. The SSRF guard has no job in a Worker: it
+ *   cannot reach private networks. The **DID validation does** — `isValidDid`
+ *   guards the Jetstream `options_update` frame (see the poller), where one
+ *   malformed entry closes the socket.
+ * - `node:crypto` → `crypto.subtle`, which makes `digestScope` async. The bytes
+ *   hashed are identical, so a scope's digest is the same string the proxy
+ *   produced (test/standard-site.spec.ts pins it).
+ */
+
+import type { Env } from '../types';
+import type {
+  BasicTheme,
+  ProxyDocument,
+  ProxyReaderCollection,
+  ProxyReaderCollectionItem,
+  PublicationFonts,
+} from './feed-proxy-client';
+import { parseAtUri } from '../utils/canonical-url';
+import { resolvePdsUrl } from '../utils/did-resolver';
+
+// Publication records (base URL + icon) change rarely; cache for a day.
+export const PUBLICATION_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+// A failed resolution (no base URL — transient PDS/getRecord blip, or a publication
+// that doesn't exist yet) is only cached briefly. Without this a single blip would
+// pin every document's canonicalUrl to a bare relative path for a full day.
+export const PUBLICATION_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
+// How many documents (most recent) to keep per author. Bounds payload, storage and
+// work; matches what the proxy blob enforced, so it changes nothing observable.
+export const MAX_DOCUMENTS_PER_AUTHOR = 100;
+const MAX_LIST_PAGES = 5; // listRecords pages of 100 → up to 500 scanned
+const FETCH_TIMEOUT_MS = 15 * 1000;
+// A Standard Reader "Collection" curates other documents by at:// URI. Resolving
+// each to a preview is a cross-PDS fetch, so bound the fan-out.
+export const MAX_COLLECTION_ITEMS = 50;
+const COLLECTION_RESOLVE_CONCURRENCY = 8;
+
+export const DOCUMENT_COLLECTION = 'site.standard.document';
+export const READER_COLLECTION = 'app.standard-reader.collection';
+
+// AT Protocol DID syntax (https://atproto.com/specs/did). Deliberately the same
+// shape the upstream Go implementation enforces, because a value that only looks
+// like a DID ("did:" + anything) is accepted by our request path but *rejected* by
+// Jetstream — and Jetstream rejects the whole `options_update`, closing the socket,
+// so one bad row in D1 could take the document stream down entirely.
+const DID_RE = /^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$/;
+const MAX_DID_LENGTH = 2048;
+
+/** True if `did` is a syntactically valid AT Protocol DID. */
+export function isValidDid(did: unknown): did is string {
+  return typeof did === 'string' && did.length <= MAX_DID_LENGTH && DID_RE.test(did);
+}
+
+interface BlobRef {
+  ref?: { $link?: string };
+  mimeType?: string;
+}
+
+export interface DocumentRecord {
+  $type?: string;
+  site?: string;
+  title?: string;
+  publishedAt?: string;
+  path?: string;
+  description?: string;
+  coverImage?: BlobRef;
+  textContent?: string;
+  bskyPostRef?: { uri?: string; cid?: string };
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  content?: unknown;
+  links?: Array<{ uri?: string; rel?: string }>;
+  // Skyreader's provenance marker on a link post it wrote.
+  skyreaderLinkblog?: string;
+}
+
+/**
+ * A Markpub markdown body as it lives on a record. The lexicons accept either a
+ * structured `at.markpub.markdown` object or a legacy plain string, so we tolerate
+ * both; `markpubToMarkdown` flattens it.
+ */
+export type MarkpubBody = string | { text?: { markdown?: string } } | undefined;
+
+/** Raw `app.standard-reader.collection` record (the curated-edition sidecar). */
+export interface CollectionRecord {
+  document?: string;
+  editorial?: { title?: string; body?: MarkpubBody };
+  colophon?: { body?: MarkpubBody };
+  items?: Array<{ document?: string; note?: MarkpubBody }>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface PublicationRecord {
+  $type?: string;
+  url?: string;
+  name?: string;
+  description?: string;
+  icon?: BlobRef;
+  basicTheme?: BasicTheme;
+}
+
+/** A publication's typography record, paired to it by rkey. */
+interface PublicationThemeRecord {
+  $type?: string;
+  publication?: string;
+  fonts?: PublicationFonts;
+}
+
+/** Flatten a Markpub body (structured object or legacy string) to markdown text. */
+export function markpubToMarkdown(body: MarkpubBody): string | undefined {
+  if (!body) return undefined;
+  if (typeof body === 'string') return body || undefined;
+  return body.text?.markdown || undefined;
+}
+
+/** Bluesky CDN URL for a publication icon / image blob. */
+function resolveBlobUrl(did: string, blob: BlobRef | undefined): string | null {
+  if (!blob?.ref?.$link) return null;
+  return `https://cdn.bsky.app/img/feed_thumbnail/plain/${did}/${blob.ref.$link}@jpeg`;
+}
+
+/** Combine a publication base URL with a document path, normalizing slashes. */
+export function buildCanonicalUrl(baseUrl: string, path: string): string {
+  if (!baseUrl) return path || '';
+  if (!path) return baseUrl;
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+export interface SiteMeta {
+  baseUrl: string | null;
+  icon: string | null;
+  name: string | null;
+  theme: BasicTheme | null;
+  fonts: PublicationFonts | null;
+}
+
+export const EMPTY_SITE_META: SiteMeta = {
+  baseUrl: null,
+  icon: null,
+  name: null,
+  theme: null,
+  fonts: null,
+};
+
+interface PublicationCacheRow {
+  publication_uri: string;
+  base_url: string | null;
+  icon: string | null;
+  name: string | null;
+  theme: string | null;
+  fonts: string | null;
+  cached_at: number;
+}
+
+/** Parse a cached JSON column, tolerating null / malformed rows. */
+function parseJsonColumn<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function rowToMeta(row: PublicationCacheRow): SiteMeta {
+  return {
+    baseUrl: row.base_url,
+    icon: row.icon,
+    name: row.name,
+    theme: parseJsonColumn<BasicTheme>(row.theme),
+    fonts: parseJsonColumn<PublicationFonts>(row.fonts),
+  };
+}
+
+async function fetchRecord<T>(
+  pdsUrl: string,
+  did: string,
+  collection: string,
+  rkey: string
+): Promise<T | null> {
+  try {
+    const params = new URLSearchParams({ repo: did, collection, rkey });
+    const res = await fetch(`${pdsUrl}/xrpc/com.atproto.repo.getRecord?${params}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { value?: T };
+    return data.value ?? null;
+  } catch (error) {
+    console.error('[standard-site] getRecord error:', error);
+    return null;
+  }
+}
+
+/**
+ * Read a publication's cached metadata, or null when there is no fresh row.
+ * Separate from `resolveSiteMeta` because the serve path wants "what do we already
+ * know?" without ever blocking on a PDS: a stale row still renders a document.
+ */
+export async function cachedSiteMeta(
+  env: Env,
+  siteUri: string,
+  { allowStale = false }: { allowStale?: boolean } = {}
+): Promise<SiteMeta | null> {
+  if (!siteUri) return null;
+  if (siteUri.startsWith('http://') || siteUri.startsWith('https://')) {
+    return { ...EMPTY_SITE_META, baseUrl: siteUri };
+  }
+  const row = await env.DB.prepare(
+    `SELECT publication_uri, base_url, icon, name, theme, fonts, cached_at
+       FROM publications_cache_v2 WHERE publication_uri = ?`
+  )
+    .bind(siteUri)
+    .first<PublicationCacheRow>();
+  if (!row) return null;
+  if (allowStale) return rowToMeta(row);
+  const ttl = row.base_url ? PUBLICATION_CACHE_TTL_MS : PUBLICATION_NEGATIVE_CACHE_TTL_MS;
+  return Date.now() - row.cached_at < ttl ? rowToMeta(row) : null;
+}
+
+/**
+ * Resolve a publication's base URL / icon / name / theme / fonts from its
+ * `at://…/site.standard.publication/rkey` URI, caching the result in D1. Loose
+ * `https://` sites are their own base URL and have no record to fetch.
+ */
+export async function resolveSiteMeta(env: Env, siteUri: string): Promise<SiteMeta> {
+  if (!siteUri) return EMPTY_SITE_META;
+
+  const fresh = await cachedSiteMeta(env, siteUri);
+  if (fresh) return fresh;
+
+  const parsed = parseAtUri(siteUri);
+  if (!parsed || parsed.collection !== 'site.standard.publication') return EMPTY_SITE_META;
+
+  const pdsUrl = await resolvePdsUrl(parsed.did);
+  let baseUrl: string | null = null;
+  let icon: string | null = null;
+  let name: string | null = null;
+  let theme: BasicTheme | null = null;
+  let fonts: PublicationFonts | null = null;
+
+  if (pdsUrl) {
+    const record = await fetchRecord<PublicationRecord>(
+      pdsUrl,
+      parsed.did,
+      parsed.collection,
+      parsed.rkey
+    );
+    baseUrl = record?.url || null;
+    icon = resolveBlobUrl(parsed.did, record?.icon);
+    name = record?.name || null;
+    theme = record?.basicTheme ?? null;
+    // Typography lives on a sidecar `publicationTheme` record paired by rkey.
+    // Best-effort: a missing record just means the magazine uses default fonts.
+    const themeRecord = await fetchRecord<PublicationThemeRecord>(
+      pdsUrl,
+      parsed.did,
+      'app.standard-reader.publicationTheme',
+      parsed.rkey
+    );
+    const f = themeRecord?.fonts;
+    if (f && (f.title || f.body))
+      fonts = { title: f.title || undefined, body: f.body || undefined };
+  }
+
+  try {
+    await env.DB.prepare(
+      `INSERT INTO publications_cache_v2 (publication_uri, base_url, icon, name, theme, fonts, cached_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(publication_uri) DO UPDATE SET
+         base_url = excluded.base_url, icon = excluded.icon, name = excluded.name,
+         theme = excluded.theme, fonts = excluded.fonts, cached_at = excluded.cached_at`
+    )
+      .bind(
+        siteUri,
+        baseUrl,
+        icon,
+        name,
+        theme ? JSON.stringify(theme) : null,
+        fonts ? JSON.stringify(fonts) : null,
+        Date.now()
+      )
+      .run();
+  } catch (error) {
+    // A cache write failure costs a re-resolve, never a document.
+    console.error('[standard-site] publication cache write failed:', error);
+  }
+
+  return { baseUrl, icon, name, theme, fonts };
+}
+
+function toISO(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  const ms = new Date(value).getTime();
+  return isNaN(ms) ? fallback : new Date(ms).toISOString();
+}
+
+/** ms-epoch `publishedAt` for a record, falling back to `fallbackMs`. */
+export function publishedAtMs(doc: DocumentRecord, fallbackMs: number): number {
+  const ms = doc.publishedAt ? new Date(doc.publishedAt).getTime() : NaN;
+  return Number.isFinite(ms) ? ms : fallbackMs;
+}
+
+/**
+ * Map a raw `site.standard.document` record into the wire shape the frontend
+ * consumes, given already-resolved publication metadata. Pure: every network- or
+ * D1-touching part (`resolveSiteMeta`, collection previews) is resolved by the
+ * caller, which is what lets the serve path map a whole author from one query.
+ *
+ * `indexedAt` is the row's ingest time rather than "now" (the proxy had no such
+ * stamp and used fetch time); the frontend uses it only for display ordering
+ * fallbacks.
+ */
+export function recordToDocument(
+  authorDid: string,
+  recordUri: string,
+  recordCid: string,
+  doc: DocumentRecord,
+  meta: SiteMeta,
+  options: { indexedAt?: string; readerCollection?: ProxyReaderCollection | null } = {}
+): ProxyDocument {
+  const nowISO = new Date().toISOString();
+  const siteUri = doc.site || '';
+  const canonicalUrl = meta.baseUrl
+    ? buildCanonicalUrl(meta.baseUrl, doc.path || '')
+    : doc.path || '';
+
+  // Surface external resource refs (the shared article URL for link posts),
+  // keeping only entries with a real uri.
+  const links = Array.isArray(doc.links)
+    ? doc.links
+        .filter((l): l is { uri: string; rel?: string } => typeof l?.uri === 'string' && !!l.uri)
+        .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }))
+    : [];
+
+  return {
+    authorDid,
+    recordUri,
+    recordCid,
+    siteUri,
+    title: doc.title || '',
+    publishedAt: toISO(doc.publishedAt, nowISO),
+    path: doc.path || undefined,
+    description: doc.description || undefined,
+    coverImageCid: doc.coverImage?.ref?.$link || undefined,
+    textContent: doc.textContent || undefined,
+    bskyPostUri: doc.bskyPostRef?.uri || undefined,
+    tags: doc.tags && doc.tags.length > 0 ? doc.tags : undefined,
+    updatedAt: doc.updatedAt ? toISO(doc.updatedAt, nowISO) : undefined,
+    canonicalUrl: canonicalUrl || undefined,
+    content: doc.content ?? undefined,
+    indexedAt: options.indexedAt ?? nowISO,
+    createdAt: toISO(doc.createdAt, toISO(doc.publishedAt, nowISO)),
+    siteIcon: meta.icon || undefined,
+    links: links.length > 0 ? links : undefined,
+    readerCollection: options.readerCollection || undefined,
+    skyreaderLinkblog:
+      typeof doc.skyreaderLinkblog === 'string' ? doc.skyreaderLinkblog : undefined,
+  } as ProxyDocument;
+}
+
+/**
+ * Apply a subscription's publication scope to a document list:
+ * - empty/undefined → all documents
+ * - `at://…` → only documents whose `site` matches that publication
+ */
+export function filterByPublication(documents: ProxyDocument[], siteUri?: string): ProxyDocument[] {
+  if (!siteUri) return documents;
+  return documents.filter((d) => d.siteUri === siteUri);
+}
+
+/**
+ * Content digest for one publication scope: a stable hash over the scope's sorted
+ * `(recordUri, recordCid)` pairs — new, edited, deleted and cap-evicted documents
+ * all move it; an unchanged scope reproduces it exactly (CIDs are content-addressed
+ * over deterministic DAG-CBOR, so a re-read of identical content re-hashes the same).
+ *
+ * Byte-for-byte the proxy's algorithm, so the digests a client already holds keep
+ * matching across the cutover. The client treats it as opaque either way.
+ */
+export async function digestScope(documents: ProxyDocument[]): Promise<string> {
+  const pairs = documents.map((d) => `${d.recordUri}\t${d.recordCid}`).sort();
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(pairs.join('\n')));
+  return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Trim a (newest-first) document list to those newer than what the client already
+ * has, mirroring the feed `since_guids` mechanism. The current frontend sends no
+ * `since_uris`; retained for API completeness.
+ */
+export function filterSinceUris(
+  documents: ProxyDocument[],
+  sinceUris: Set<string>
+): ProxyDocument[] {
+  if (sinceUris.size === 0) return documents;
+  for (let i = 0; i < documents.length; i++) {
+    if (sinceUris.has(documents[i].recordUri)) return documents.slice(0, i);
+  }
+  return documents;
+}
+
+// --- PDS reads (backfill + on-demand) ---------------------------------------
+
+export interface ListedRecord<T> {
+  uri: string;
+  cid: string;
+  value: T;
+}
+
+/**
+ * List an author's recent `site.standard.document` records, newest-repo-order,
+ * capped at `MAX_DOCUMENTS_PER_AUTHOR`. Throws on PDS resolution / fetch failure so
+ * the caller records the error + backoff.
+ */
+export async function listAuthorDocuments(
+  authorDid: string
+): Promise<Array<ListedRecord<DocumentRecord>>> {
+  const pdsUrl = await resolvePdsUrl(authorDid);
+  if (!pdsUrl) throw new Error(`Could not resolve PDS for ${authorDid}`);
+
+  const raw: Array<ListedRecord<DocumentRecord>> = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_LIST_PAGES && raw.length < MAX_DOCUMENTS_PER_AUTHOR; page++) {
+    const params = new URLSearchParams({
+      repo: authorDid,
+      collection: DOCUMENT_COLLECTION,
+      limit: '100',
+    });
+    if (cursor) params.set('cursor', cursor);
+
+    const res = await fetch(`${pdsUrl}/xrpc/com.atproto.repo.listRecords?${params}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`listRecords failed for ${authorDid}: HTTP ${res.status}`);
+    const data = (await res.json()) as {
+      records?: Array<ListedRecord<DocumentRecord>>;
+      cursor?: string;
+    };
+    const records = data.records ?? [];
+    raw.push(...records);
+    if (!data.cursor || records.length === 0) break;
+    cursor = data.cursor;
+  }
+
+  return raw;
+}
+
+/**
+ * List an author's `app.standard-reader.collection` sidecars, keyed by rkey (a
+ * collection shares its rkey with the document it renders). Best-effort: a fetch
+ * failure yields an empty map — no magazine enrichment, not a failed backfill.
+ * Collections are few, so one page suffices.
+ */
+export async function listAuthorCollections(
+  authorDid: string
+): Promise<Map<string, CollectionRecord>> {
+  const byRkey = new Map<string, CollectionRecord>();
+  try {
+    const pdsUrl = await resolvePdsUrl(authorDid);
+    if (!pdsUrl) return byRkey;
+    const params = new URLSearchParams({
+      repo: authorDid,
+      collection: READER_COLLECTION,
+      limit: '100',
+    });
+    const res = await fetch(`${pdsUrl}/xrpc/com.atproto.repo.listRecords?${params}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return byRkey;
+    const data = (await res.json()) as {
+      records?: Array<{ uri: string; value: CollectionRecord }>;
+    };
+    for (const record of data.records ?? []) {
+      const parsed = parseAtUri(record.uri);
+      if (parsed) byRkey.set(parsed.rkey, record.value);
+    }
+  } catch (error) {
+    console.error('[standard-site] listCollections error:', error);
+  }
+  return byRkey;
+}
+
+/** Fetch one `site.standard.document` record from its author's PDS. */
+export async function getDocumentRecord(
+  uri: string
+): Promise<{ uri: string; cid: string; value: DocumentRecord } | null> {
+  const parsed = parseAtUri(uri);
+  if (!parsed || parsed.collection !== DOCUMENT_COLLECTION) return null;
+  const pdsUrl = await resolvePdsUrl(parsed.did);
+  if (!pdsUrl) return null;
+  try {
+    const params = new URLSearchParams({
+      repo: parsed.did,
+      collection: parsed.collection,
+      rkey: parsed.rkey,
+    });
+    const res = await fetch(`${pdsUrl}/xrpc/com.atproto.repo.getRecord?${params}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { uri?: string; cid?: string; value?: DocumentRecord };
+    if (!data.value) return null;
+    return { uri: data.uri || uri, cid: data.cid || '', value: data.value };
+  } catch (error) {
+    console.error('[standard-site] getDocumentRecord error:', error);
+    return null;
+  }
+}
+
+// --- Curated collections -----------------------------------------------------
+
+/**
+ * Resolve one curated item (an at:// document URI + the curator's note) into a
+ * preview. Best-effort: a malformed URI, unresolvable PDS or missing record
+ * degrades to a note-only stub rather than failing the whole edition.
+ */
+async function resolveCollectionItem(
+  env: Env,
+  item: { document?: string; note?: MarkpubBody }
+): Promise<ProxyReaderCollectionItem | null> {
+  const uri = item.document;
+  if (!uri) return null;
+
+  const note = markpubToMarkdown(item.note);
+
+  // Loose https:// references (rare): keep as a bare link, nothing to resolve.
+  if (uri.startsWith('http://') || uri.startsWith('https://')) {
+    return { document: uri, note, canonicalUrl: uri };
+  }
+
+  const parsed = parseAtUri(uri);
+  if (!parsed) return { document: uri, note };
+
+  const stub: ProxyReaderCollectionItem = { document: uri, note, authorDid: parsed.did };
+
+  try {
+    const record = await getDocumentRecord(uri);
+    if (!record) return stub;
+    const doc = record.value;
+    const meta = await resolveSiteMeta(env, doc.site || '');
+    const canonicalUrl = meta.baseUrl ? buildCanonicalUrl(meta.baseUrl, doc.path || '') : undefined;
+
+    return {
+      ...stub,
+      title: doc.title || undefined,
+      description: doc.description || undefined,
+      canonicalUrl: canonicalUrl || undefined,
+      siteIcon: meta.icon || undefined,
+      sourceName: meta.name || undefined,
+      publishedAt: doc.publishedAt || undefined,
+    };
+  } catch (error) {
+    console.error('[standard-site] collection item resolve error:', error);
+    return stub;
+  }
+}
+
+/**
+ * Resolve an `app.standard-reader.collection` record into renderable previews.
+ * Items are capped at `MAX_COLLECTION_ITEMS` and resolved through a bounded worker
+ * pool (curated order preserved); each resolution is independently fault-tolerant.
+ * Returns null when nothing resolves, so the caller drops `readerCollection`
+ * entirely and the frontend falls through to the ordinary document body.
+ */
+export async function resolveReaderCollection(
+  env: Env,
+  raw: CollectionRecord,
+  edition: {
+    publicationName?: string;
+    theme?: BasicTheme;
+    fonts?: PublicationFonts;
+    authorHandle?: string;
+  } = {}
+): Promise<ProxyReaderCollection | null> {
+  const rawItems = Array.isArray(raw.items) ? raw.items.slice(0, MAX_COLLECTION_ITEMS) : [];
+
+  // Drain a shared cursor through a bounded pool, writing each result back by
+  // index so the curated order survives out-of-order completion.
+  const slots: Array<ProxyReaderCollectionItem | null> = new Array(rawItems.length).fill(null);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (let i = next++; i < rawItems.length; i = next++) {
+      slots[i] = await resolveCollectionItem(env, rawItems[i]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(COLLECTION_RESOLVE_CONCURRENCY, rawItems.length) }, worker)
+  );
+  const resolved = slots.filter((i): i is ProxyReaderCollectionItem => i !== null);
+  if (resolved.length === 0) return null;
+
+  const editorialBody = markpubToMarkdown(raw.editorial?.body);
+  const editorialTitle = raw.editorial?.title || undefined;
+  const colophonBody = markpubToMarkdown(raw.colophon?.body);
+
+  return {
+    editorial:
+      editorialBody || editorialTitle ? { title: editorialTitle, body: editorialBody } : undefined,
+    colophon: colophonBody ? { body: colophonBody } : undefined,
+    items: resolved,
+    publicationName: edition.publicationName || undefined,
+    theme: edition.theme || undefined,
+    fonts: edition.fonts || undefined,
+    authorHandle: edition.authorHandle || undefined,
+  };
+}

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -34,7 +34,12 @@ export const PUBLICATION_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
 // How many documents (most recent) to keep per author. Bounds payload, storage and
 // work; matches what the proxy blob enforced, so it changes nothing observable.
 export const MAX_DOCUMENTS_PER_AUTHOR = 100;
-const MAX_LIST_PAGES = 5; // listRecords pages of 100 → up to 500 scanned
+/**
+ * listRecords pages of 100 → up to 500 scanned. Exported because a backfill's
+ * subrequest budget counts these pages: they come out of the same per-invocation
+ * ceiling as its D1 writes.
+ */
+export const MAX_LIST_PAGES = 5;
 const FETCH_TIMEOUT_MS = 15 * 1000;
 // A Standard Reader "Collection" curates other documents by at:// URI. Resolving
 // each to a preview is a cross-PDS fetch, so bound the fan-out.

--- a/backend/src/services/subscription-sync.ts
+++ b/backend/src/services/subscription-sync.ts
@@ -1,10 +1,19 @@
 import type { Env, Session } from '../types';
 import { createPDSClient, type PDSResult, type WriteOp } from './pds-client';
 import { getUserTierLimits } from './user-tier';
-import { createBackfillScheduler } from './document-store';
+import { chargeQueries, createBackfillScheduler, type QueryLedger } from './document-store';
 import { log } from '../utils/logger';
 
 const COLLECTION = 'app.skyreader.feed.subscription';
+
+/**
+ * A pull this size is worth a line in the logs: the insert batch is one query per
+ * row against a 1,000-per-invocation ceiling, so a restore of this order is the
+ * shape of request that can exhaust it on its own. Nothing here caps it — the mirror
+ * cap does, at 1000/5000 rows — but an operator reading a 500 from `/api/sync`
+ * should be able to find the reason.
+ */
+const LARGE_PULL_BATCH = 400;
 
 /**
  * PDS subscription record schema
@@ -196,7 +205,12 @@ export async function syncSubscriptions(
   sessionId?: string,
   // Lets the pull step warm the linkblogs it restores. Absent (a background or
   // test caller), those authors are left to the reconcile.
-  waitUntil?: (promise: Promise<unknown>) => void
+  waitUntil?: (promise: Promise<unknown>) => void,
+  // This request's subrequest ledger, shared with anything else the invocation runs
+  // (`/api/sync` also runs the Atmosphere reconcile). The pull charges its inserts
+  // to it so the back-catalogue walks it schedules are admitted against what the
+  // request has actually spent, not against a count alone.
+  ledger?: QueryLedger
 ): Promise<SyncResult> {
   const result: SyncResult = {
     success: true,
@@ -432,6 +446,18 @@ export async function syncSubscriptions(
       });
 
       await env.DB.batch(statements);
+      // Each statement in the batch is its own query against the invocation's
+      // ceiling. This is the term that dwarfs everything else in a restore, and it
+      // is still unbounded here (the mirror cap, 1000/5000 rows, is the only limit):
+      // charging it is what stops the walks below from being scheduled on top of an
+      // invocation that has already spent its budget. See `backend/CLAUDE.md`.
+      if (ledger) chargeQueries(ledger, statements.length);
+      if (statements.length > LARGE_PULL_BATCH) {
+        log.warn('subscription_pull_batch_large', {
+          inserted: statements.length,
+          userDid: session.did,
+        });
+      }
       result.pulledFromPds = toAddLocally.length;
       console.log(`[SubscriptionSync] Successfully inserted ${toAddLocally.length} subscriptions`);
 
@@ -443,7 +469,7 @@ export async function syncSubscriptions(
       // hence the bound. The rest are left to the reconcile, which takes
       // never-listed authors first.
       if (waitUntil) {
-        const scheduleBackfill = createBackfillScheduler(env, waitUntil);
+        const scheduleBackfill = createBackfillScheduler(env, waitUntil, { ledger });
         let deferred = 0;
         for (const sub of toAddLocally) {
           if (!sub.sourceType?.startsWith('atproto.') || !sub.subjectDid) continue;
@@ -481,6 +507,7 @@ export async function syncSubscriptions(
             ).bind(session.did, row.record_uri)
           )
         );
+        if (ledger) chargeQueries(ledger, toPromote.length);
         result.reactivated = toPromote.length;
         console.log(`[SubscriptionSync] Reactivated ${toPromote.length} parked subscription(s)`);
       }

--- a/backend/src/services/subscription-sync.ts
+++ b/backend/src/services/subscription-sync.ts
@@ -1,6 +1,8 @@
 import type { Env, Session } from '../types';
 import { createPDSClient, type PDSResult, type WriteOp } from './pds-client';
 import { getUserTierLimits } from './user-tier';
+import { createBackfillScheduler } from './document-store';
+import { log } from '../utils/logger';
 
 const COLLECTION = 'app.skyreader.feed.subscription';
 
@@ -191,7 +193,10 @@ export async function countDirtySubscriptions(env: Env, did: string): Promise<nu
 export async function syncSubscriptions(
   session: Session,
   env: Env,
-  sessionId?: string
+  sessionId?: string,
+  // Lets the pull step warm the linkblogs it restores. Absent (a background or
+  // test caller), those authors are left to the reconcile.
+  waitUntil?: (promise: Promise<unknown>) => void
 ): Promise<SyncResult> {
   const result: SyncResult = {
     success: true,
@@ -429,6 +434,23 @@ export async function syncSubscriptions(
       await env.DB.batch(statements);
       result.pulledFromPds = toAddLocally.length;
       console.log(`[SubscriptionSync] Successfully inserted ${toAddLocally.length} subscriptions`);
+
+      // A restored `atproto.documents` row needs the author's back catalogue like
+      // any other new subscription: documents are served from D1, so an author
+      // nobody has listed serves `status:'error'` on every poll. This is the
+      // restore-from-the-Atmosphere case — the PDS records survive, the local rows
+      // don't — and it can pull in far more rows at once than a subscribe does,
+      // hence the bound. The rest are left to the reconcile, which takes
+      // never-listed authors first.
+      if (waitUntil) {
+        const scheduleBackfill = createBackfillScheduler(env, waitUntil);
+        let deferred = 0;
+        for (const sub of toAddLocally) {
+          if (!sub.sourceType?.startsWith('atproto.') || !sub.subjectDid) continue;
+          if (!scheduleBackfill(sub.subjectDid)) deferred++;
+        }
+        if (deferred > 0) log.info('subscription_sync_backfills_deferred', { deferred });
+      }
     }
 
     // Step 3b: Auto-fill freed active slots from capacity-parked rows. Rows the

--- a/backend/test/documents-shadow-compare.spec.ts
+++ b/backend/test/documents-shadow-compare.spec.ts
@@ -1,0 +1,194 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { handleDocumentShadowCompare } from '../src/routes/documents';
+import { applyDocumentEvent } from '../src/services/document-store';
+import type { Env } from '../src/types';
+
+const SECRET = 'test-secret';
+const READER = 'did:plc:comparereader';
+const AUTHOR_A = 'did:plc:aaaaaaaaaaaaaaaa';
+const AUTHOR_B = 'did:plc:bbbbbbbbbbbbbbbb';
+const AUTHOR_C = 'did:plc:cccccccccccccccc';
+const AUTHORS = [AUTHOR_A, AUTHOR_B, AUTHOR_C];
+
+function testEnv(): Env {
+  return { ...env, FEED_PROXY_URL: 'https://proxy.example', FEED_PROXY_SECRET: SECRET } as Env;
+}
+
+function compareRequest(body: unknown): Request {
+  return new Request('https://api.example/api/internal/documents/shadow-compare', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Proxy-Secret': SECRET },
+    body: JSON.stringify(body),
+  });
+}
+
+/** The proxy's answer for whichever authors the route asked about. */
+function mockProxy(entryFor: (did: string) => Record<string, unknown> | null): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as { authors?: Array<{ did: string }> };
+    const authors = (body.authors ?? [])
+      .map((a) => entryFor(a.did))
+      .filter((entry): entry is Record<string, unknown> => entry !== null);
+    return new Response(JSON.stringify({ authors }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+async function seed(): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url) VALUES (?, 'compare.test', 'https://pds.example')
+     ON CONFLICT(did) DO NOTHING`
+  )
+    .bind(READER)
+    .run();
+  await env.DB.batch(
+    AUTHORS.map((did, i) =>
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(
+        READER,
+        `at://reader/app.skyreader.feed.subscription/${i}`,
+        `at://${did}/site.standard.publication/pub`,
+        did
+      )
+    )
+  );
+}
+
+async function cleanup(): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM documents_v2'),
+    env.DB.prepare('DELETE FROM document_authors'),
+    env.DB.prepare('DELETE FROM subscriptions_cache'),
+    env.DB.prepare('DELETE FROM users WHERE did = ?').bind(READER),
+  ]);
+}
+
+describe('the shadow-compare cutover gate', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seed();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  // The gate is "every subscribed author agrees", so a single call cannot be it:
+  // without a cursor the endpoint compared the same first page forever and any
+  // drift behind it was invisible.
+  it('walks every subscribed author across pages', async () => {
+    mockProxy((did) => ({ did, status: 'ready', documents: [] }));
+
+    const first = (await (
+      await handleDocumentShadowCompare(compareRequest({ limit: 2 }), testEnv())
+    ).json()) as { compared: number; clean: boolean; cursor: string | null; remaining: number };
+    expect(first.compared).toBe(2);
+    expect(first.clean).toBe(true);
+    expect(first.cursor).toBe(AUTHOR_B);
+    expect(first.remaining).toBe(1);
+
+    const second = (await (
+      await handleDocumentShadowCompare(
+        compareRequest({ limit: 2, cursor: first.cursor }),
+        testEnv()
+      )
+    ).json()) as {
+      compared: number;
+      cursor: string | null;
+      remaining: number;
+      scopes: Array<{ did: string }>;
+    };
+    expect(second.compared).toBe(1);
+    expect(second.scopes[0].did).toBe(AUTHOR_C);
+    // Null cursor is what tells the operator the walk covered the whole set.
+    expect(second.cursor).toBeNull();
+    expect(second.remaining).toBe(0);
+  });
+
+  it('reports drift for an author on a later page', async () => {
+    // AUTHOR_C is the one the proxy holds a document for and D1 does not — the
+    // drift a first-page-only compare could never see.
+    mockProxy((did) =>
+      did === AUTHOR_C
+        ? {
+            did,
+            status: 'ready',
+            documents: [
+              {
+                authorDid: did,
+                recordUri: `at://${did}/site.standard.document/only-on-proxy`,
+                recordCid: 'cid-proxy',
+                siteUri: '',
+                title: 'Only on the proxy',
+                publishedAt: '2026-01-01T00:00:00.000Z',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                indexedAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+          }
+        : { did, status: 'ready', documents: [] }
+    );
+
+    const firstPage = (await (
+      await handleDocumentShadowCompare(compareRequest({ limit: 2 }), testEnv())
+    ).json()) as { clean: boolean; cursor: string | null };
+    expect(firstPage.clean).toBe(true);
+
+    const lastPage = (await (
+      await handleDocumentShadowCompare(
+        compareRequest({ limit: 2, cursor: firstPage.cursor }),
+        testEnv()
+      )
+    ).json()) as { clean: boolean; scopes: Array<{ missingInD1: string[] }> };
+    expect(lastPage.clean).toBe(false);
+    expect(lastPage.scopes[0].missingInD1).toEqual([
+      `at://${AUTHOR_C}/site.standard.document/only-on-proxy`,
+    ]);
+  });
+
+  // An author the proxy silently omits is not agreement, and counting it as such
+  // would let the walk report a coverage it never had.
+  it('counts an author the proxy did not answer for as drift', async () => {
+    await applyDocumentEvent(
+      env,
+      {
+        did: AUTHOR_A,
+        commit: {
+          operation: 'create',
+          collection: 'site.standard.document',
+          rkey: 'a',
+          cid: 'cid-a',
+          record: { title: 'A', path: '/a', publishedAt: '2026-01-01T00:00:00.000Z' },
+        },
+      },
+      new Set([AUTHOR_A])
+    );
+    mockProxy((did) => (did === AUTHOR_A ? null : { did, status: 'ready', documents: [] }));
+
+    const body = (await (
+      await handleDocumentShadowCompare(compareRequest({ limit: 3 }), testEnv())
+    ).json()) as {
+      compared: number;
+      clean: boolean;
+      scopes: Array<{ did: string; clean: boolean; error?: string }>;
+    };
+    expect(body.compared).toBe(3);
+    expect(body.clean).toBe(false);
+    const missing = body.scopes.find((s) => s.did === AUTHOR_A);
+    expect(missing?.clean).toBe(false);
+    expect(missing?.error).toBe('No proxy entry returned');
+  });
+
+  it('rejects a request without the shared secret', async () => {
+    const res = await handleDocumentShadowCompare(
+      new Request('https://api.example/api/internal/documents/shadow-compare', { method: 'POST' }),
+      testEnv()
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -2,22 +2,30 @@ import { env } from 'cloudflare:test';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   applyDocumentEvent,
+  authorRetryBackoffMs,
   backfillAuthorDocuments,
   createDocumentDrain,
+  ensureAuthorDocuments,
   loadAuthorDocuments,
   reconcileStaleAuthors,
   serveDocumentScope,
   serveSingleDocument,
   staleDocumentAuthors,
+  subscribedDocumentAuthorPage,
   subscribedDocumentAuthors,
   trimAuthorDocuments,
+  AUTHOR_RETRY_BASE_MS,
+  AUTHOR_RETRY_MAX_MS,
+  BACKFILL_FRESHNESS_MS,
   type DocumentCommitEvent,
 } from '../src/services/document-store';
 import { digestScope, MAX_DOCUMENTS_PER_AUTHOR } from '../src/services/standard-site';
 import {
   readDocumentFlags,
   setDocumentFlag,
+  DOCUMENTS_APPLY_CAP_KEY,
   DOCUMENTS_V2_ENABLED_KEY,
+  MAX_DOCUMENT_APPLY_CAP,
 } from '../src/services/document-flags';
 import {
   buildDocumentSubscribeUrl,
@@ -348,9 +356,23 @@ describe('backfill and reconcile', () => {
     await cleanup();
   });
 
-  function mockPds(records: Array<{ rkey: string; cid: string; title: string }>): void {
+  function mockPds(
+    records: Array<{ rkey: string; cid: string; title: string }>,
+    collections: { rkeys?: string[]; fails?: boolean } = {}
+  ): void {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
+      if (url.includes('listRecords') && url.includes('app.standard-reader.collection')) {
+        if (collections.fails) return new Response('nope', { status: 503 });
+        return new Response(
+          JSON.stringify({
+            records: (collections.rkeys ?? []).map((rkey) => ({
+              uri: `at://${AUTHOR}/app.standard-reader.collection/${rkey}`,
+              value: { document: `at://${AUTHOR}/site.standard.document/${rkey}`, items: [] },
+            })),
+          })
+        );
+      }
       if (url.includes('plc.directory')) {
         return new Response(
           JSON.stringify({
@@ -426,6 +448,47 @@ describe('backfill and reconcile', () => {
     expect(author?.error_count).toBe(1);
   });
 
+  it('prunes a curated edition the author deleted', async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO collections_v2 (author_did, rkey, record_json, indexed_at) VALUES (?, 'keep', '{}', ?)`
+      ).bind(AUTHOR, Date.now()),
+      env.DB.prepare(
+        `INSERT INTO collections_v2 (author_did, rkey, record_json, indexed_at) VALUES (?, 'gone', '{}', ?)`
+      ).bind(AUTHOR, Date.now()),
+    ]);
+
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }], { rkeys: ['keep'] });
+    await backfillAuthorDocuments(env, AUTHOR);
+
+    const rows = await env.DB.prepare(
+      'SELECT rkey FROM collections_v2 WHERE author_did = ? ORDER BY rkey'
+    )
+      .bind(AUTHOR)
+      .all<{ rkey: string }>();
+    expect(rows.results?.map((r) => r.rkey)).toEqual(['keep']);
+  });
+
+  // An empty map from a failed fetch and an empty map from an author with no
+  // editions look identical; pruning against the first would delete every curated
+  // edition we hold on one blip.
+  it('leaves stored editions alone when the collection listing fails', async () => {
+    await env.DB.prepare(
+      `INSERT INTO collections_v2 (author_did, rkey, record_json, indexed_at) VALUES (?, 'keep', '{}', ?)`
+    )
+      .bind(AUTHOR, Date.now())
+      .run();
+
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }], { fails: true });
+    const result = await backfillAuthorDocuments(env, AUTHOR);
+    expect(result.ok).toBe(true);
+
+    const row = await env.DB.prepare('SELECT rkey FROM collections_v2 WHERE author_did = ?')
+      .bind(AUTHOR)
+      .first();
+    expect(row).not.toBeNull();
+  });
+
   it('picks never-listed subscribed authors first and re-lists them', async () => {
     await seedReader();
     await env.DB.prepare(
@@ -442,6 +505,121 @@ describe('backfill and reconcile', () => {
     expect(results.map((r) => r.ok)).toEqual([true]);
     // Freshly listed: it drops out of the stale set until the reconcile interval.
     expect(await staleDocumentAuthors(env, 5)).toEqual([]);
+  });
+
+  // The reconcile is the only self-heal in this design. An author who can never be
+  // listed — deleted account, dead PDS — used to sort first on every run forever
+  // (their `last_listed_at` stays NULL), so a handful of them starved it silently.
+  it('yields the reconcile slot after a failed list instead of monopolising it', async () => {
+    await seedReader();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/1', PUBLICATION, AUTHOR),
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/2', OTHER_PUBLICATION, OTHER),
+    ]);
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('gone', { status: 404 }));
+    expect((await backfillAuthorDocuments(env, AUTHOR)).ok).toBe(false);
+
+    // Inside its backoff the dead author is out of the queue, so the other one —
+    // which the old ordering could never reach — gets the slot.
+    expect(await staleDocumentAuthors(env, 5)).toEqual([OTHER]);
+
+    // Held off, not abandoned: it is retried once the backoff expires.
+    const later = Date.now() + authorRetryBackoffMs(1) + 1_000;
+    expect(await staleDocumentAuthors(env, 5, later)).toContain(AUTHOR);
+  });
+
+  it('backs off further with each consecutive failure', () => {
+    expect(authorRetryBackoffMs(1)).toBe(AUTHOR_RETRY_BASE_MS);
+    expect(authorRetryBackoffMs(3)).toBe(AUTHOR_RETRY_BASE_MS * 4);
+    expect(authorRetryBackoffMs(50)).toBe(AUTHOR_RETRY_MAX_MS);
+  });
+
+  // Every path that creates an atproto.documents subscription funnels through
+  // this, and the same author subscribed by ten readers must cost one walk.
+  it('skips a backfill for an author listed recently', async () => {
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }]);
+    expect((await ensureAuthorDocuments(env, AUTHOR))?.ok).toBe(true);
+    const callsAfterFirst = vi.mocked(globalThis.fetch).mock.calls.length;
+
+    expect(await ensureAuthorDocuments(env, AUTHOR)).toBeNull();
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBe(callsAfterFirst);
+
+    // Past the freshness window it lists again — this is also the reconcile's path.
+    const later = Date.now() + BACKFILL_FRESHNESS_MS + 1_000;
+    expect((await ensureAuthorDocuments(env, AUTHOR, later))?.ok).toBe(true);
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('does not retry an author inside their failure backoff', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('gone', { status: 404 }));
+    expect((await ensureAuthorDocuments(env, AUTHOR))?.ok).toBe(false);
+    const calls = vi.mocked(globalThis.fetch).mock.calls.length;
+
+    expect(await ensureAuthorDocuments(env, AUTHOR)).toBeNull();
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBe(calls);
+  });
+});
+
+describe('walking the subscribed-author set', () => {
+  const AUTHOR_A = 'did:plc:aaaaaaaaaaaaaaaa';
+  const AUTHOR_B = 'did:plc:bbbbbbbbbbbbbbbb';
+  const AUTHOR_C = 'did:plc:cccccccccccccccc';
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedReader();
+    await env.DB.batch(
+      [AUTHOR_A, AUTHOR_B, AUTHOR_C].map((did, i) =>
+        env.DB.prepare(
+          `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+           VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+        ).bind(
+          READER,
+          `at://reader/app.skyreader.feed.subscription/${i}`,
+          `at://${did}/site.standard.publication/pub`,
+          did
+        )
+      )
+    );
+  });
+
+  afterEach(cleanup);
+
+  // The shadow-compare is the gate on the read cutover, so it has to be able to
+  // reach author 26 — comparing the same first page repeatedly says nothing about
+  // the rest of the set.
+  it('pages the whole set and reports what is left behind each page', async () => {
+    const first = await subscribedDocumentAuthorPage(env, { limit: 2 });
+    expect(first.dids).toEqual([AUTHOR_A, AUTHOR_B]);
+    expect(first.cursor).toBe(AUTHOR_B);
+    expect(first.remaining).toBe(1);
+
+    const second = await subscribedDocumentAuthorPage(env, { limit: 2, after: first.cursor! });
+    expect(second.dids).toEqual([AUTHOR_C]);
+    expect(second.cursor).toBeNull();
+    expect(second.remaining).toBe(0);
+  });
+
+  it('walks past a malformed DID rather than stalling on it', async () => {
+    await env.DB.prepare(
+      `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+       VALUES (?, ?, ?, 'atproto.documents', 'did:', unixepoch())`
+    )
+      .bind(READER, 'at://reader/app.skyreader.feed.subscription/junk', 'at://junk/pub')
+      .run();
+
+    const first = await subscribedDocumentAuthorPage(env, { limit: 1 });
+    expect(first.dids).toEqual([]); // 'did:' sorts first and is dropped…
+    expect(first.cursor).toBe('did:'); // …but the cursor still moves past it.
+    const second = await subscribedDocumentAuthorPage(env, { limit: 10, after: first.cursor! });
+    expect(second.dids).toEqual([AUTHOR_A, AUTHOR_B, AUTHOR_C]);
   });
 });
 
@@ -536,6 +714,66 @@ describe('serveDocumentScope', () => {
     expect(entry.status).toBe('error');
     expect(entry.error).toBe('Invalid DID');
   });
+
+  // `complete` says "an absent record is deleted, not merely evicted". The flag on
+  // the author row was set at the last successful list and the poller keeps writing
+  // afterwards, so an author listed under the cap who has since published past it
+  // would otherwise claim completeness while eviction drops their oldest.
+  it('reports complete from the stored row count, not the last list alone', async () => {
+    await ingest();
+    expect((await serveDocumentScope(env, { did: AUTHOR }, { remaining: 0 })).complete).toBe(true);
+
+    const filler = [];
+    for (let i = 0; i < MAX_DOCUMENTS_PER_AUTHOR; i++) {
+      filler.push(
+        env.DB.prepare(
+          `INSERT INTO documents_v2 (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at)
+           VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)`
+        ).bind(
+          `at://${AUTHOR}/site.standard.document/fill${i}`,
+          AUTHOR,
+          `fill${i}`,
+          `cid-fill${i}`,
+          PUBLICATION,
+          Date.now() - i,
+          JSON.stringify({ title: `Fill ${i}`, site: PUBLICATION }),
+          Date.now()
+        )
+      );
+    }
+    await env.DB.batch(filler);
+
+    const atCap = await serveDocumentScope(env, { did: AUTHOR }, { remaining: 0 });
+    expect(atCap.status).toBe('ready');
+    expect(atCap.complete).toBe(false);
+  });
+
+  // The row's stored URL is the durable one. A publication `getRecord` blip writes
+  // a five-minute negative cache entry; without the fallback every document of that
+  // publication serves a bare relative path for the duration.
+  it('falls back to the stored canonical URL while the publication will not resolve', async () => {
+    await ingest();
+    await env.DB.prepare(
+      'UPDATE publications_cache_v2 SET base_url = NULL, cached_at = ? WHERE publication_uri = ?'
+    )
+      .bind(Date.now(), PUBLICATION)
+      .run();
+
+    const entry = await serveDocumentScope(
+      env,
+      { did: AUTHOR, siteUri: PUBLICATION },
+      {
+        remaining: 0,
+      }
+    );
+    expect(entry.documents?.map((d) => d.canonicalUrl)).toEqual([
+      'https://ex.com/b',
+      'https://ex.com/a',
+    ]);
+
+    const single = await serveSingleDocument(env, `at://${AUTHOR}/site.standard.document/a`);
+    expect(single?.canonicalUrl).toBe('https://ex.com/a');
+  });
 });
 
 describe('the read rollout gate', () => {
@@ -556,6 +794,17 @@ describe('the read rollout gate', () => {
       body: JSON.stringify(body),
     });
   }
+
+  // The cap is sized from burst shape, but it also has to fit the Worker's
+  // per-invocation subrequest budget — an override typed past that would make the
+  // drain fail quietly, dropping the events the cap exists to protect.
+  it('clamps an apply-cap override to the subrequest budget', async () => {
+    await setDocumentFlag(env, DOCUMENTS_APPLY_CAP_KEY, '5000');
+    expect((await readDocumentFlags(env)).applyCap).toBe(MAX_DOCUMENT_APPLY_CAP);
+
+    await setDocumentFlag(env, DOCUMENTS_APPLY_CAP_KEY, '120');
+    expect((await readDocumentFlags(env)).applyCap).toBe(120);
+  });
 
   it('defaults to the proxy and switches to D1 on the flag', async () => {
     expect((await readDocumentFlags(env)).serveFromD1).toBe(false);

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -21,6 +21,7 @@ import {
   AUTHOR_RETRY_BASE_MS,
   AUTHOR_RETRY_MAX_MS,
   BACKFILL_FRESHNESS_MS,
+  BACKFILL_LIST_SUBREQUESTS,
   BACKFILL_QUERY_COST,
   CRON_DOCUMENT_QUERY_BUDGET,
   CRON_HOURLY_RECONCILE_AUTHORS,
@@ -31,10 +32,16 @@ import {
   DOCUMENT_DRAIN_QUERY_BUDGET,
   MAX_COLLECTION_WRITES_PER_BACKFILL,
   MAX_CYCLE_BACKFILLS,
+  MAX_SITE_RESOLVES_PER_BACKFILL,
   SCHEDULED_BACKFILL_QUERY_COST,
+  SUBREQUESTS_PER_SITE_RESOLVE,
   type DocumentCommitEvent,
 } from '../src/services/document-store';
-import { digestScope, MAX_DOCUMENTS_PER_AUTHOR } from '../src/services/standard-site';
+import {
+  digestScope,
+  MAX_DOCUMENTS_PER_AUTHOR,
+  MAX_LIST_PAGES,
+} from '../src/services/standard-site';
 import {
   readDocumentFlags,
   setDocumentFlag,
@@ -765,6 +772,82 @@ describe('the backfill query budget', () => {
     });
   }
 
+  const DID_DOCUMENT = JSON.stringify({
+    id: AUTHOR,
+    service: [
+      {
+        id: '#atproto_pds',
+        type: 'AtprotoPersonalDataServer',
+        serviceEndpoint: 'https://pds.example',
+      },
+    ],
+  });
+
+  function listedDocument(i: number) {
+    const rkey = `new${String(i).padStart(3, '0')}`;
+    return {
+      uri: `at://${AUTHOR}/site.standard.document/${rkey}`,
+      cid: `cid-${rkey}`,
+      value: {
+        site: PUBLICATION,
+        title: `New ${i}`,
+        path: `/${rkey}`,
+        publishedAt: '2026-02-01T00:00:00.000Z',
+      },
+    };
+  }
+
+  /** What the walk actually spent on the network, by kind of request. */
+  interface PdsFetchCounts {
+    didDocuments: number;
+    documentPages: number;
+    collectionPages: number;
+  }
+
+  /**
+   * A PDS that pages its document listing — a page is whatever the server chooses to
+   * return, so `MAX_LIST_PAGES` fetches for one repo is a real shape, not a
+   * hypothetical. Returns the per-kind counts so a test can check what the walk spent
+   * rather than what it charged itself.
+   */
+  function mockBigPdsPaged(documents: number, collections: number, pageSize = 20): PdsFetchCounts {
+    const counts: PdsFetchCounts = { didDocuments: 0, documentPages: 0, collectionPages: 0 };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'plc.directory') {
+        counts.didDocuments++;
+        return new Response(DID_DOCUMENT);
+      }
+      const collection = url.searchParams.get('collection');
+      if (collection === 'app.standard-reader.collection') {
+        counts.collectionPages++;
+        return new Response(
+          JSON.stringify({
+            records: Array.from({ length: collections }, (_, i) => ({
+              uri: `at://${AUTHOR}/app.standard-reader.collection/new${String(i).padStart(3, '0')}`,
+              value: { document: `at://${AUTHOR}/site.standard.document/new${i}`, items: [] },
+            })),
+          })
+        );
+      }
+      if (collection === 'site.standard.document') {
+        counts.documentPages++;
+        const page = Number(url.searchParams.get('cursor') ?? '0');
+        const start = page * pageSize;
+        const records = Array.from(
+          { length: Math.max(0, Math.min(pageSize, documents - start)) },
+          (_, i) => listedDocument(start + i)
+        );
+        const more = start + records.length < documents;
+        return new Response(
+          JSON.stringify({ records, ...(more ? { cursor: String(page + 1) } : {}) })
+        );
+      }
+      return new Response('{}', { status: 404 });
+    });
+    return counts;
+  }
+
   /** Stored rows a re-list will find nothing for — the prune-heavy shape. */
   async function seedStoredDocuments(count: number): Promise<void> {
     const stamp = Date.now() - 60_000;
@@ -809,27 +892,69 @@ describe('the backfill query budget', () => {
     expect((await loadAuthorDocuments(env, AUTHOR)).length).toBe(MAX_DOCUMENTS_PER_AUTHOR);
   });
 
-  // Sidecars are the other per-row term. Capped per walk, and each walk writes the
-  // ones it can afford — so the remainder shrinks instead of recurring forever.
-  it('caps sidecar writes per walk and converges over the next one', async () => {
+  /** Sidecars stored for the author. */
+  async function storedCollections(): Promise<number> {
+    const row = await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM collections_v2 WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    return row?.n ?? 0;
+  }
+
+  // A small author leaves most of the document term unspent, and the sidecars get
+  // it: the flat 20 was the worst case's share, not every walk's.
+  it('spends its unused headroom on sidecars rather than a flat cap', async () => {
     const editions = MAX_COLLECTION_WRITES_PER_BACKFILL + 10;
     mockBigPds(1, editions);
 
-    await backfillAuthorDocuments(env, AUTHOR);
-    const afterFirst = await env.DB.prepare(
-      'SELECT COUNT(*) AS n FROM collections_v2 WHERE author_did = ?'
-    )
-      .bind(AUTHOR)
-      .first<{ n: number }>();
-    expect(afterFirst?.n).toBe(MAX_COLLECTION_WRITES_PER_BACKFILL);
+    const result = await backfillAuthorDocuments(env, AUTHOR);
 
-    await backfillAuthorDocuments(env, AUTHOR);
-    const afterSecond = await env.DB.prepare(
-      'SELECT COUNT(*) AS n FROM collections_v2 WHERE author_did = ?'
+    expect(result.ok).toBe(true);
+    expect(await storedCollections()).toBe(editions);
+    const author = await env.DB.prepare(
+      'SELECT collections_pending FROM document_authors WHERE author_did = ?'
     )
       .bind(AUTHOR)
-      .first<{ n: number }>();
-    expect(afterSecond?.n).toBe(editions);
+      .first<{ collections_pending: number }>();
+    expect(author?.collections_pending).toBe(0);
+  });
+
+  // The author who does hit the cap — a full repo of curated editions, which is the
+  // magazine back catalogue a subscribe-time walk exists to pull. Each walk writes
+  // what it can afford; the remainder stays in the reconcile queue instead of
+  // waiting a full interval, so the whole set lands over the next passes.
+  it('defers the sidecars it cannot afford and requeues the author for them', async () => {
+    const editions = 90;
+    mockBigPdsPaged(MAX_DOCUMENTS_PER_AUTHOR, editions);
+    await seedReader();
+    await env.DB.prepare(
+      `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+       VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+    )
+      .bind(READER, 'at://reader/app.skyreader.feed.subscription/1', PUBLICATION, AUTHOR)
+      .run();
+
+    const ctx = createDocumentApplyContext(createQueryLedger());
+    await backfillAuthorDocuments(env, AUTHOR, ctx);
+
+    const first = await storedCollections();
+    expect(first).toBeGreaterThanOrEqual(MAX_COLLECTION_WRITES_PER_BACKFILL);
+    expect(first).toBeLessThan(editions);
+    expect(ctx.ledger.spent).toBeLessThanOrEqual(BACKFILL_QUERY_COST);
+
+    // Freshly listed, so the interval alone would park them for a week — the
+    // pending sidecars are what keeps them eligible, and they are still eligible
+    // only because the walk made progress.
+    expect(await staleDocumentAuthors(env, 5)).toEqual([AUTHOR]);
+
+    // Each further pass advances by at least as much again, and stops requeueing
+    // once nothing is left over.
+    for (let pass = 0; pass < 3 && (await staleDocumentAuthors(env, 5)).length > 0; pass++) {
+      await backfillAuthorDocuments(env, AUTHOR);
+    }
+    expect(await storedCollections()).toBe(editions);
+    expect(await staleDocumentAuthors(env, 5)).toEqual([]);
   });
 
   // The fan-out bound the reviewer's scenario broke: five authors sized against a
@@ -860,6 +985,120 @@ describe('the backfill query budget', () => {
     expect(await staleDocumentAuthors(env, 5)).toHaveLength(1);
   });
 
+  /**
+   * A PDS whose authors publish to whatever publications the test names, none of
+   * them cached — so every one of them costs a resolve out of the walk's allowance.
+   */
+  function mockPdsWithPublications(sites: Record<string, string[]>): void {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'plc.directory') {
+        return new Response(
+          JSON.stringify({
+            id: url.pathname.slice(1),
+            service: [
+              {
+                id: '#atproto_pds',
+                type: 'AtprotoPersonalDataServer',
+                serviceEndpoint: 'https://pds.example',
+              },
+            ],
+          })
+        );
+      }
+      const collection = url.searchParams.get('collection');
+      const repo = url.searchParams.get('repo') ?? '';
+      if (url.pathname.endsWith('getRecord') && collection === 'site.standard.publication') {
+        const rkey = url.searchParams.get('rkey');
+        return new Response(JSON.stringify({ value: { url: `https://${rkey}.example` } }));
+      }
+      if (url.pathname.endsWith('listRecords') && collection === 'site.standard.document') {
+        return new Response(
+          JSON.stringify({
+            records: (sites[repo] ?? []).map((site, i) => ({
+              uri: `at://${repo}/site.standard.document/doc${i}`,
+              cid: `cid-doc${i}`,
+              value: { site, title: `Doc ${i}`, path: `/doc${i}` },
+            })),
+          })
+        );
+      }
+      if (url.pathname.endsWith('listRecords'))
+        return new Response(JSON.stringify({ records: [] }));
+      return new Response('{}', { status: 404 });
+    });
+  }
+
+  async function canonicalUrlOf(authorDid: string, rkey: string): Promise<string | null> {
+    const row = await env.DB.prepare(
+      'SELECT canonical_url FROM documents_v2 WHERE author_did = ? AND rkey = ?'
+    )
+      .bind(authorDid, rkey)
+      .first<{ canonical_url: string | null }>();
+    return row?.canonical_url ?? null;
+  }
+
+  // A loose `https://` site is its own base URL — no cache row, no PDS record. It
+  // used to be charged a full resolve anyway, so five of them starved the walk's
+  // allowance on requests it never made.
+  it('does not spend its resolve allowance on loose https sites', async () => {
+    const loose = Array.from(
+      { length: MAX_SITE_RESOLVES_PER_BACKFILL + 1 },
+      (_, i) => `https://loose${i}.example`
+    );
+    mockPdsWithPublications({
+      [AUTHOR]: [...loose, `at://${AUTHOR}/site.standard.publication/pub9`],
+    });
+
+    await backfillAuthorDocuments(env, AUTHOR);
+
+    // The one document that actually needed a resolve still got one.
+    expect(await canonicalUrlOf(AUTHOR, `doc${loose.length}`)).toBe(
+      `https://pub9.example/doc${loose.length}`
+    );
+  });
+
+  // The allowance is per author but the context is shared by a fan-out. A
+  // publication starved during one author's walk must not stay starved for the next.
+  it('gives each author in a fan-out a fresh allowance for the same publication', async () => {
+    const pubs = Array.from(
+      { length: MAX_SITE_RESOLVES_PER_BACKFILL + 1 },
+      (_, i) => `at://${AUTHOR}/site.standard.publication/pub${i}`
+    );
+    const starved = pubs[pubs.length - 1];
+    mockPdsWithPublications({ [AUTHOR]: pubs, [OTHER]: [starved] });
+
+    const ctx = createDocumentApplyContext(createQueryLedger());
+    await backfillAuthorDocuments(env, AUTHOR, ctx);
+    // The last publication is past the first author's allowance: path only.
+    expect(await canonicalUrlOf(AUTHOR, `doc${pubs.length - 1}`)).toBe(`/doc${pubs.length - 1}`);
+
+    await backfillAuthorDocuments(env, OTHER, ctx);
+    expect(await canonicalUrlOf(OTHER, 'doc0')).toBe(
+      `https://pub${MAX_SITE_RESOLVES_PER_BACKFILL}.example/doc0`
+    );
+  });
+
+  // The listing term, counted against the network rather than against itself. A
+  // walk needs the author's PDS twice — once per listing — and `resolvePdsUrl` is an
+  // uncached plc.directory fetch, so without the shared memo this is 8 spent against
+  // 7 charged and the whole per-author bound is off by one.
+  it('resolves the author once for both of its listings', async () => {
+    const counts = mockBigPdsPaged(MAX_DOCUMENTS_PER_AUTHOR, 10);
+
+    const ctx = createDocumentApplyContext(createQueryLedger());
+    const result = await backfillAuthorDocuments(env, AUTHOR, ctx);
+
+    expect(result.ok).toBe(true);
+    expect(counts.didDocuments).toBe(1);
+    expect(counts.documentPages).toBe(MAX_LIST_PAGES);
+    expect(counts.collectionPages).toBe(1);
+    expect(counts.didDocuments + counts.documentPages + counts.collectionPages).toBe(
+      BACKFILL_LIST_SUBREQUESTS
+    );
+    expect(ctx.ledger.spent).toBeLessThanOrEqual(BACKFILL_QUERY_COST);
+  });
+
   // The arithmetic each fan-out is sized by, pinned: a constant edited without its
   // budget is exactly how "five authors is well under" became untrue.
   it('sizes every fan-out budget to the worst case it admits', () => {
@@ -880,6 +1119,21 @@ describe('the backfill query budget', () => {
 
     // An apply-cap override can never claim more events than the cycle can fund.
     expect(MAX_DOCUMENT_APPLY_CAP).toBe(DOCUMENT_DRAIN_QUERY_BUDGET);
+
+    // The sidecar allowance is derived from what a walk has left, so the flat
+    // constant has to be exactly what that arithmetic leaves at every other cap at
+    // once — the listing, a full repo of documents, every resolve, the prune, the
+    // sidecar read and the bookkeeping. Raise a term without this and the "floor"
+    // silently becomes a walk that overspends its own reservation.
+    const worstCaseBeforeSidecars =
+      BACKFILL_LIST_SUBREQUESTS +
+      MAX_DOCUMENTS_PER_AUTHOR +
+      MAX_SITE_RESOLVES_PER_BACKFILL * SUBREQUESTS_PER_SITE_RESOLVE +
+      // the prune, the sidecar read
+      2;
+    expect(BACKFILL_QUERY_COST - worstCaseBeforeSidecars - 1).toBe(
+      MAX_COLLECTION_WRITES_PER_BACKFILL
+    );
   });
 
   // The sync paths schedule their walks into the same invocation that just ran the

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -9,6 +9,7 @@ import {
   createDocumentApplyContext,
   createDocumentDrain,
   createQueryLedger,
+  tryChargeQueries,
   ensureAuthorDocuments,
   loadAuthorDocuments,
   reconcileStaleAuthors,
@@ -710,6 +711,16 @@ describe('backfill and reconcile', () => {
 // per-author cost has to be a real worst case, and the fan-out has to be admitted
 // against one shared ledger rather than against a per-loop rule.
 describe('the backfill query budget', () => {
+  it('admits a charged operation atomically', () => {
+    const ledger = createQueryLedger(10);
+
+    chargeQueries(ledger, 3);
+    expect(tryChargeQueries(ledger, 7)).toBe(true);
+    expect(ledger.spent).toBe(10);
+    expect(tryChargeQueries(ledger, 1)).toBe(false);
+    expect(ledger.spent).toBe(10);
+  });
+
   beforeEach(async () => {
     await cleanup();
     await seedPublication();

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -4,7 +4,11 @@ import {
   applyDocumentEvent,
   authorRetryBackoffMs,
   backfillAuthorDocuments,
+  chargeQueries,
+  createBackfillScheduler,
+  createDocumentApplyContext,
   createDocumentDrain,
+  createQueryLedger,
   ensureAuthorDocuments,
   loadAuthorDocuments,
   reconcileStaleAuthors,
@@ -17,6 +21,17 @@ import {
   AUTHOR_RETRY_BASE_MS,
   AUTHOR_RETRY_MAX_MS,
   BACKFILL_FRESHNESS_MS,
+  BACKFILL_QUERY_COST,
+  CRON_DOCUMENT_QUERY_BUDGET,
+  CRON_HOURLY_RECONCILE_AUTHORS,
+  CRON_MINUTE_RECONCILE_AUTHORS,
+  CYCLE_BACKFILL_QUERY_BUDGET,
+  D1_QUERIES_PER_INVOCATION,
+  DOCUMENT_CYCLE_QUERY_RESERVE,
+  DOCUMENT_DRAIN_QUERY_BUDGET,
+  MAX_COLLECTION_WRITES_PER_BACKFILL,
+  MAX_CYCLE_BACKFILLS,
+  SCHEDULED_BACKFILL_QUERY_COST,
   type DocumentCommitEvent,
 } from '../src/services/document-store';
 import { digestScope, MAX_DOCUMENTS_PER_AUTHOR } from '../src/services/standard-site';
@@ -309,7 +324,7 @@ describe('the per-cycle apply cap (spike drill)', () => {
       allowed,
       cap: 1_000,
       cursor: '1_000',
-      queryBudget: 12,
+      queryBudget: 20,
     });
     for (const event of burst) await drain.handle(event);
 
@@ -337,8 +352,10 @@ describe('the per-cycle apply cap (spike drill)', () => {
     const drain = createDocumentDrain(env, { allowed, cap: 100, cursor: '2_999' });
     for (const event of burst) await drain.handle(event);
 
-    // Eight writes plus the one publication-metadata resolve they share.
-    expect(drain.queries).toBe(burst.length + 2);
+    // Eight writes plus the one publication resolve they share — charged whole, at
+    // five subrequests, because its three cross-PDS fetches come out of the same
+    // per-invocation ceiling as its two D1 statements.
+    expect(drain.queries).toBe(burst.length + 5);
     // Bookkeeping is deferred with the trim, so nothing has stamped the author yet.
     const before = await env.DB.prepare(
       'SELECT last_event_at FROM document_authors WHERE author_did = ?'
@@ -355,7 +372,31 @@ describe('the per-cycle apply cap (spike drill)', () => {
       .first<{ last_event_at: number | null }>();
     expect(after?.last_event_at).toBeTruthy();
     // Two statements for the one author written, whatever the event count.
-    expect(drain.queries).toBe(burst.length + 4);
+    expect(drain.queries).toBe(burst.length + 7);
+  });
+
+  // `last_event_at` is meant to read as "the last event we applied for this
+  // author". A cycle that only deletes applies events too, and used to leave the
+  // author unstamped because only the upsert path marked them.
+  it('stamps an author whose cycle only deleted', async () => {
+    await applyDocumentEvent(env, docEvent('gone'), allowed);
+    await env.DB.prepare('UPDATE document_authors SET last_event_at = NULL WHERE author_did = ?')
+      .bind(AUTHOR)
+      .run();
+
+    const drain = createDocumentDrain(env, { allowed, cap: 10, cursor: '5_000' });
+    expect(await drain.handle(docEvent('gone', { operation: 'delete', time_us: 5_001 }))).toBe(
+      'applied'
+    );
+    await drain.flush();
+
+    const row = await env.DB.prepare(
+      'SELECT last_event_at FROM document_authors WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ last_event_at: number | null }>();
+    expect(row?.last_event_at).toBeTruthy();
+    expect((await loadAuthorDocuments(env, AUTHOR)).length).toBe(0);
   });
 
   // The per-author row cap is layer 4 of the spike guard. It now lands at the
@@ -654,6 +695,220 @@ describe('backfill and reconcile', () => {
 
     expect(await ensureAuthorDocuments(env, AUTHOR)).toBeNull();
     expect(vi.mocked(globalThis.fetch).mock.calls.length).toBe(calls);
+  });
+});
+
+// D1 refuses everything past `D1_QUERIES_PER_INVOCATION`, and a fan-out of walks is
+// the one place where crossing it mutates D1 half way and then throws. So the
+// per-author cost has to be a real worst case, and the fan-out has to be admitted
+// against one shared ledger rather than against a per-loop rule.
+describe('the backfill query budget', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  /** A PDS with `documents` documents and `collections` curated editions. */
+  function mockBigPds(documents: number, collections: number): void {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('plc.directory')) {
+        return new Response(
+          JSON.stringify({
+            id: AUTHOR,
+            service: [
+              {
+                id: '#atproto_pds',
+                type: 'AtprotoPersonalDataServer',
+                serviceEndpoint: 'https://pds.example',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('listRecords') && url.includes('app.standard-reader.collection')) {
+        return new Response(
+          JSON.stringify({
+            records: Array.from({ length: collections }, (_, i) => ({
+              uri: `at://${AUTHOR}/app.standard-reader.collection/new${String(i).padStart(3, '0')}`,
+              value: { document: `at://${AUTHOR}/site.standard.document/new${i}`, items: [] },
+            })),
+          })
+        );
+      }
+      if (url.includes('listRecords') && url.includes('site.standard.document')) {
+        return new Response(
+          JSON.stringify({
+            records: Array.from({ length: documents }, (_, i) => {
+              const rkey = `new${String(i).padStart(3, '0')}`;
+              return {
+                uri: `at://${AUTHOR}/site.standard.document/${rkey}`,
+                cid: `cid-${rkey}`,
+                value: {
+                  site: PUBLICATION,
+                  title: `New ${i}`,
+                  path: `/${rkey}`,
+                  publishedAt: '2026-02-01T00:00:00.000Z',
+                },
+              };
+            }),
+          })
+        );
+      }
+      if (url.includes('listRecords')) return new Response(JSON.stringify({ records: [] }));
+      return new Response('{}', { status: 404 });
+    });
+  }
+
+  /** Stored rows a re-list will find nothing for — the prune-heavy shape. */
+  async function seedStoredDocuments(count: number): Promise<void> {
+    const stamp = Date.now() - 60_000;
+    await env.DB.batch(
+      Array.from({ length: count }, (_, i) =>
+        env.DB.prepare(
+          `INSERT INTO documents_v2
+             (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at, updated_at)
+           VALUES (?, ?, ?, 'cid-old', ?, ?, NULL, '{"site":"","title":"Old"}', ?, ?)`
+        ).bind(
+          `at://${AUTHOR}/site.standard.document/old${String(i).padStart(3, '0')}`,
+          AUTHOR,
+          `old${String(i).padStart(3, '0')}`,
+          PUBLICATION,
+          stamp,
+          stamp,
+          stamp
+        )
+      )
+    );
+  }
+
+  // The shape the old constant (`MAX_DOCUMENTS_PER_AUTHOR + 12`) was three times
+  // short on: a full stored set that shares nothing with the listing, so the prune
+  // is as large as the write loop, plus a sidecar page to go with it.
+  it('stays under the per-author cost on a prune-heavy author', async () => {
+    await seedStoredDocuments(MAX_DOCUMENTS_PER_AUTHOR);
+    mockBigPds(MAX_DOCUMENTS_PER_AUTHOR, 100);
+
+    const ctx = createDocumentApplyContext(createQueryLedger());
+    const result = await backfillAuthorDocuments(env, AUTHOR, ctx);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.ledger.spent).toBeLessThanOrEqual(BACKFILL_QUERY_COST);
+    // The whole stored set was replaced, in one statement rather than a hundred.
+    const rows = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM documents_v2 WHERE author_did = ? AND rkey LIKE 'old%'"
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    expect(rows?.n).toBe(0);
+    expect((await loadAuthorDocuments(env, AUTHOR)).length).toBe(MAX_DOCUMENTS_PER_AUTHOR);
+  });
+
+  // Sidecars are the other per-row term. Capped per walk, and each walk writes the
+  // ones it can afford — so the remainder shrinks instead of recurring forever.
+  it('caps sidecar writes per walk and converges over the next one', async () => {
+    const editions = MAX_COLLECTION_WRITES_PER_BACKFILL + 10;
+    mockBigPds(1, editions);
+
+    await backfillAuthorDocuments(env, AUTHOR);
+    const afterFirst = await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM collections_v2 WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    expect(afterFirst?.n).toBe(MAX_COLLECTION_WRITES_PER_BACKFILL);
+
+    await backfillAuthorDocuments(env, AUTHOR);
+    const afterSecond = await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM collections_v2 WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    expect(afterSecond?.n).toBe(editions);
+  });
+
+  // The fan-out bound the reviewer's scenario broke: five authors sized against a
+  // per-author constant that did not hold. Now the loop asks the ledger before each
+  // one and leaves the rest in the queue, where they still sort to the front.
+  it('stops the reconcile at the author the invocation can no longer afford', async () => {
+    await seedReader();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/1', PUBLICATION, AUTHOR),
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/2', OTHER_PUBLICATION, OTHER),
+    ]);
+    mockBigPds(2, 0);
+
+    // Room for exactly one worst-case walk (plus the queue query it charges first).
+    const ctx = createDocumentApplyContext(createQueryLedger(BACKFILL_QUERY_COST + 1));
+    const results = await reconcileStaleAuthors(env, 5, ctx);
+
+    expect(results.length).toBe(1);
+    expect(ctx.ledger.spent).toBeLessThanOrEqual(ctx.ledger.limit);
+    // Nothing was recorded against the author it skipped, so they are still at the
+    // front of the queue rather than in a retry backoff.
+    expect(await staleDocumentAuthors(env, 5)).toHaveLength(1);
+  });
+
+  // The arithmetic each fan-out is sized by, pinned: a constant edited without its
+  // budget is exactly how "five authors is well under" became untrue.
+  it('sizes every fan-out budget to the worst case it admits', () => {
+    // The poll cycle: what the drain reserves must actually cover its walks.
+    expect(CYCLE_BACKFILL_QUERY_BUDGET).toBeGreaterThanOrEqual(
+      MAX_CYCLE_BACKFILLS * SCHEDULED_BACKFILL_QUERY_COST
+    );
+    expect(DOCUMENT_CYCLE_QUERY_RESERVE).toBeGreaterThanOrEqual(CYCLE_BACKFILL_QUERY_BUDGET);
+    expect(DOCUMENT_DRAIN_QUERY_BUDGET + DOCUMENT_CYCLE_QUERY_RESERVE).toBe(
+      D1_QUERIES_PER_INVOCATION
+    );
+
+    // The hourly cron runs both reconcile passes in one invocation.
+    expect(CRON_DOCUMENT_QUERY_BUDGET).toBeGreaterThanOrEqual(
+      (CRON_MINUTE_RECONCILE_AUTHORS + CRON_HOURLY_RECONCILE_AUTHORS) * BACKFILL_QUERY_COST
+    );
+    expect(CRON_DOCUMENT_QUERY_BUDGET).toBeLessThan(D1_QUERIES_PER_INVOCATION);
+
+    // An apply-cap override can never claim more events than the cycle can fund.
+    expect(MAX_DOCUMENT_APPLY_CAP).toBe(DOCUMENT_DRAIN_QUERY_BUDGET);
+  });
+
+  // The sync paths schedule their walks into the same invocation that just ran the
+  // pull. A restore big enough to spend the budget schedules none of them.
+  it('schedules no walks once the request has spent its budget', async () => {
+    const ledger = createQueryLedger(BACKFILL_QUERY_COST * 2);
+    const scheduled: Array<Promise<unknown>> = [];
+    const schedule = createBackfillScheduler(env, (p) => scheduled.push(p), { ledger });
+
+    chargeQueries(ledger, 900);
+    expect(schedule(AUTHOR)).toBe(false);
+    expect(scheduled.length).toBe(0);
+  });
+
+  it('reserves the whole worst case for every walk it has already scheduled', async () => {
+    mockBigPds(1, 0);
+    const ledger = createQueryLedger(SCHEDULED_BACKFILL_QUERY_COST * 2);
+    const scheduled: Array<Promise<unknown>> = [];
+    const schedule = createBackfillScheduler(env, (p) => scheduled.push(p), {
+      ledger,
+      limit: 5,
+    });
+
+    // Two fit; the third would only fit if the first two were assumed free.
+    expect(schedule(AUTHOR)).toBe(true);
+    expect(schedule(OTHER)).toBe(true);
+    expect(schedule('did:plc:athirdauthor')).toBe(false);
+    await Promise.all(scheduled);
+    expect(ledger.spent).toBeLessThanOrEqual(ledger.limit);
   });
 });
 

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -297,6 +297,96 @@ describe('the per-cycle apply cap (spike drill)', () => {
     expect(drain.applied).toBe(0);
     expect(drain.capped).toBe(false);
   });
+
+  // D1 refuses every query past its per-invocation ceiling, and the drain would
+  // meet that ceiling the worst possible way: a throw per event, counted as an
+  // error, cursor walked past the burst. So the budget stops the cycle first, with
+  // the same cursor-carry the apply cap gets.
+  it('stops on the query budget before D1 would refuse the write', async () => {
+    const burst = Array.from({ length: 20 }, (_, i) => docEvent(`b${i}`, { time_us: 2_000 + i }));
+    // Room for a handful of events plus the flush they earn, far below `cap`.
+    const drain = createDocumentDrain(env, {
+      allowed,
+      cap: 1_000,
+      cursor: '1_000',
+      queryBudget: 12,
+    });
+    for (const event of burst) await drain.handle(event);
+
+    expect(drain.capped).toBe(true);
+    expect(drain.cappedBy).toBe('query-budget');
+    expect(drain.applied).toBeGreaterThan(0);
+    expect(drain.applied).toBeLessThan(burst.length);
+    expect(drain.errors).toBe(0);
+    // The cursor sits at the last event it applied, so the rest replay next cycle.
+    expect(drain.cursor).toBe(String(2_000 + drain.applied - 1));
+
+    await drain.flush();
+    // Nothing was lost: what it refused, the next cycle applies.
+    const second = createDocumentDrain(env, { allowed, cap: 1_000, cursor: drain.cursor });
+    for (const event of burst.slice(drain.applied)) await second.handle(event);
+    await second.flush();
+    expect(second.capped).toBe(false);
+    expect((await loadAuthorDocuments(env, AUTHOR)).length).toBe(burst.length);
+  });
+
+  // One statement per applied event is what makes the budget above affordable: the
+  // cap eviction and the bookkeeping ride the flush, once per author.
+  it('spends one query per applied event and evicts past the cap at the flush', async () => {
+    const burst = Array.from({ length: 8 }, (_, i) => docEvent(`q${i}`, { time_us: 3_000 + i }));
+    const drain = createDocumentDrain(env, { allowed, cap: 100, cursor: '2_999' });
+    for (const event of burst) await drain.handle(event);
+
+    // Eight writes plus the one publication-metadata resolve they share.
+    expect(drain.queries).toBe(burst.length + 2);
+    // Bookkeeping is deferred with the trim, so nothing has stamped the author yet.
+    const before = await env.DB.prepare(
+      'SELECT last_event_at FROM document_authors WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ last_event_at: number | null }>();
+    expect(before).toBeNull();
+
+    await drain.flush();
+    const after = await env.DB.prepare(
+      'SELECT last_event_at FROM document_authors WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ last_event_at: number | null }>();
+    expect(after?.last_event_at).toBeTruthy();
+    // Two statements for the one author written, whatever the event count.
+    expect(drain.queries).toBe(burst.length + 4);
+  });
+
+  // The per-author row cap is layer 4 of the spike guard. It now lands at the
+  // flush rather than on every write, so the drill is: burst past the cap in one
+  // cycle, and check the cycle still ends under it.
+  it('holds the per-author row cap across a burst that overshoots it', async () => {
+    const overshoot = 5;
+    const burst = Array.from({ length: MAX_DOCUMENTS_PER_AUTHOR + overshoot }, (_, i) =>
+      docEvent(`cap${String(i).padStart(3, '0')}`, {
+        time_us: 4_000 + i,
+        publishedAt: new Date(Date.UTC(2026, 0, 1) + i * 60_000).toISOString(),
+      })
+    );
+    const drain = createDocumentDrain(env, { allowed, cap: burst.length, cursor: '3_999' });
+    for (const event of burst) await drain.handle(event);
+    await drain.flush();
+
+    const count = await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM documents_v2 WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    expect(count?.n).toBe(MAX_DOCUMENTS_PER_AUTHOR);
+    // The oldest are the ones evicted, exactly as the per-event trim did.
+    const oldest = await env.DB.prepare(
+      'SELECT rkey FROM documents_v2 WHERE author_did = ? ORDER BY published_at ASC LIMIT 1'
+    )
+      .bind(AUTHOR)
+      .first<{ rkey: string }>();
+    expect(oldest?.rkey).toBe(`cap${String(overshoot).padStart(3, '0')}`);
+  });
 });
 
 describe('the connect-time DID filter', () => {

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -1,0 +1,621 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  applyDocumentEvent,
+  backfillAuthorDocuments,
+  createDocumentDrain,
+  loadAuthorDocuments,
+  reconcileStaleAuthors,
+  serveDocumentScope,
+  serveSingleDocument,
+  staleDocumentAuthors,
+  subscribedDocumentAuthors,
+  trimAuthorDocuments,
+  type DocumentCommitEvent,
+} from '../src/services/document-store';
+import { digestScope, MAX_DOCUMENTS_PER_AUTHOR } from '../src/services/standard-site';
+import {
+  readDocumentFlags,
+  setDocumentFlag,
+  DOCUMENTS_V2_ENABLED_KEY,
+} from '../src/services/document-flags';
+import {
+  buildDocumentSubscribeUrl,
+  DID_URL_PARAM_LIMIT,
+} from '../src/durable-objects/jetstream-poller';
+import { handleV2BatchDocumentFetch, handleV2GetDocument } from '../src/routes/feeds-v2';
+import type { Env, Session } from '../src/types';
+
+const AUTHOR = 'did:plc:documentauthor';
+const OTHER = 'did:plc:someoneelse';
+const PUBLICATION = `at://${AUTHOR}/site.standard.publication/pub1`;
+const OTHER_PUBLICATION = `at://${AUTHOR}/site.standard.publication/pub2`;
+const READER = 'did:plc:documentreader';
+
+const SESSION = { did: READER } as Session;
+
+function docEvent(
+  rkey: string,
+  overrides: {
+    did?: string;
+    operation?: 'create' | 'update' | 'delete';
+    cid?: string;
+    site?: string;
+    title?: string;
+    publishedAt?: string;
+    path?: string;
+    time_us?: number;
+  } = {}
+): DocumentCommitEvent & { kind: 'commit'; time_us?: number } {
+  const { operation = 'create', did = AUTHOR, cid = `cid-${rkey}` } = overrides;
+  return {
+    did,
+    kind: 'commit',
+    time_us: overrides.time_us,
+    commit: {
+      operation,
+      collection: 'site.standard.document',
+      rkey,
+      cid,
+      record:
+        operation === 'delete'
+          ? undefined
+          : {
+              $type: 'site.standard.document',
+              site: overrides.site ?? PUBLICATION,
+              title: overrides.title ?? `Post ${rkey}`,
+              path: overrides.path ?? `/${rkey}`,
+              publishedAt: overrides.publishedAt ?? '2026-01-01T00:00:00.000Z',
+            },
+    },
+  };
+}
+
+async function seedPublication(uri = PUBLICATION, baseUrl = 'https://ex.com'): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO publications_cache_v2 (publication_uri, base_url, icon, name, theme, fonts, cached_at)
+     VALUES (?, ?, NULL, ?, NULL, NULL, ?)
+     ON CONFLICT(publication_uri) DO UPDATE SET base_url = excluded.base_url, cached_at = excluded.cached_at`
+  )
+    .bind(uri, baseUrl, 'Ex', Date.now())
+    .run();
+}
+
+/** `subscriptions_cache` is keyed to a real user row. */
+async function seedReader(): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO users (did, handle, pds_url) VALUES (?, ?, 'https://pds.example')
+     ON CONFLICT(did) DO NOTHING`
+  )
+    .bind(READER, 'reader.test')
+    .run();
+}
+
+async function cleanup(): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM documents_v2'),
+    env.DB.prepare('DELETE FROM collections_v2'),
+    env.DB.prepare('DELETE FROM document_authors'),
+    env.DB.prepare('DELETE FROM publications_cache_v2'),
+    env.DB.prepare('DELETE FROM subscriptions_cache'),
+    env.DB.prepare("DELETE FROM sync_state WHERE key LIKE 'documents%'"),
+  ]);
+}
+
+describe('document event apply', () => {
+  const allowed = new Set([AUTHOR]);
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  it('creates, edits in place, and deletes', async () => {
+    expect(await applyDocumentEvent(env, docEvent('a'), allowed)).toBe(true);
+    let docs = await loadAuthorDocuments(env, AUTHOR);
+    expect(docs.map((d) => d.title)).toEqual(['Post a']);
+    expect(docs[0].canonicalUrl).toBe('https://ex.com/a');
+
+    // An edit to the same rkey replaces the row rather than adding one — the cid
+    // change is what moves the scope digest.
+    expect(
+      await applyDocumentEvent(
+        env,
+        docEvent('a', { operation: 'update', cid: 'cid-a2', title: 'Edited' }),
+        allowed
+      )
+    ).toBe(true);
+    docs = await loadAuthorDocuments(env, AUTHOR);
+    expect(docs.length).toBe(1);
+    expect(docs[0].title).toBe('Edited');
+    expect(docs[0].recordCid).toBe('cid-a2');
+
+    expect(await applyDocumentEvent(env, docEvent('a', { operation: 'delete' }), allowed)).toBe(
+      true
+    );
+    expect(await loadAuthorDocuments(env, AUTHOR)).toEqual([]);
+  });
+
+  // Layer 2 of the spike defence: even if the server-side DID filter is absent,
+  // broken, or briefly not yet applied (the options_update window), a foreign
+  // author's event is a no-op, never a wrong row.
+  it('ignores an author nobody subscribes to', async () => {
+    expect(await applyDocumentEvent(env, docEvent('x', { did: OTHER }), allowed)).toBe(false);
+    expect(await loadAuthorDocuments(env, OTHER)).toEqual([]);
+  });
+
+  it('ignores collections outside the document pair', async () => {
+    const event = docEvent('a');
+    event.commit!.collection = 'app.bsky.feed.post';
+    expect(await applyDocumentEvent(env, event, allowed)).toBe(false);
+  });
+
+  it('stores and clears a reader-collection sidecar', async () => {
+    const upsert: DocumentCommitEvent = {
+      did: AUTHOR,
+      commit: {
+        operation: 'create',
+        collection: 'app.standard-reader.collection',
+        rkey: 'edition1',
+        cid: 'cid-edition',
+        record: { document: `at://${AUTHOR}/site.standard.document/edition1`, items: [] },
+      },
+    };
+    expect(await applyDocumentEvent(env, upsert, allowed)).toBe(true);
+    let row = await env.DB.prepare('SELECT rkey FROM collections_v2 WHERE author_did = ?')
+      .bind(AUTHOR)
+      .first();
+    expect(row).not.toBeNull();
+
+    expect(
+      await applyDocumentEvent(
+        env,
+        { did: AUTHOR, commit: { ...upsert.commit!, operation: 'delete', record: undefined } },
+        allowed
+      )
+    ).toBe(true);
+    row = await env.DB.prepare('SELECT rkey FROM collections_v2 WHERE author_did = ?')
+      .bind(AUTHOR)
+      .first();
+    expect(row).toBeNull();
+  });
+
+  // Layer 4: the flood a subscribed author can cause passes every filter by
+  // design, so storage per author has to be bounded at the row level.
+  it('evicts an author’s oldest documents past the per-author cap', async () => {
+    const rows = [];
+    for (let i = 0; i < MAX_DOCUMENTS_PER_AUTHOR + 5; i++) {
+      const day = String((i % 28) + 1).padStart(2, '0');
+      rows.push(
+        env.DB.prepare(
+          `INSERT INTO documents_v2 (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at)
+           VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)`
+        ).bind(
+          `at://${AUTHOR}/site.standard.document/doc${i}`,
+          AUTHOR,
+          `doc${i}`,
+          `cid${i}`,
+          PUBLICATION,
+          Date.parse(`2026-01-${day}T00:00:00.000Z`) + i,
+          JSON.stringify({ title: `Doc ${i}`, site: PUBLICATION }),
+          Date.now()
+        )
+      );
+    }
+    await env.DB.batch(rows);
+
+    const evicted = await trimAuthorDocuments(env, AUTHOR);
+    expect(evicted).toBe(5);
+    const count = await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM documents_v2 WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ n: number }>();
+    expect(count?.n).toBe(MAX_DOCUMENTS_PER_AUTHOR);
+  });
+});
+
+describe('the per-cycle apply cap (spike drill)', () => {
+  const allowed = new Set([AUTHOR]);
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+  });
+
+  afterEach(cleanup);
+
+  it('applies exactly the cap, carries the cursor, and drains the rest next cycle', async () => {
+    const burst = Array.from({ length: 12 }, (_, i) =>
+      docEvent(`burst${i}`, { time_us: 1_000 + i })
+    );
+
+    const first = createDocumentDrain(env, { allowed, cap: 5, cursor: '900' });
+    const outcomes: string[] = [];
+    for (const event of burst) outcomes.push(await first.handle(event));
+
+    expect(first.applied).toBe(5);
+    expect(first.capped).toBe(true);
+    expect(outcomes.filter((o) => o === 'applied').length).toBe(5);
+    // The cursor sits at the fifth event, NOT at the twelfth: the seven skipped
+    // events are still ahead of it, so the next cycle replays them.
+    expect(first.cursor).toBe(String(1_000 + 4));
+
+    const afterFirst = await loadAuthorDocuments(env, AUTHOR);
+    expect(afterFirst.length).toBe(5);
+
+    // Resume from the carried cursor with the events it never saw.
+    const second = createDocumentDrain(env, { allowed, cap: 100, cursor: first.cursor });
+    for (const event of burst.slice(5)) await second.handle(event);
+    expect(second.capped).toBe(false);
+    expect(second.applied).toBe(7);
+    expect(second.cursor).toBe(String(1_000 + 11));
+
+    const all = await loadAuthorDocuments(env, AUTHOR);
+    expect(all.length).toBe(12);
+  });
+
+  it('keeps same-rkey edits in order and counts an edit as one applied event', async () => {
+    const drain = createDocumentDrain(env, { allowed, cap: 10, cursor: '1' });
+    await drain.handle(docEvent('same', { time_us: 10, title: 'First' }));
+    await drain.handle(
+      docEvent('same', { operation: 'update', cid: 'cid-2', title: 'Second', time_us: 20 })
+    );
+    const docs = await loadAuthorDocuments(env, AUTHOR);
+    expect(docs.length).toBe(1);
+    expect(docs[0].title).toBe('Second');
+    expect(drain.applied).toBe(2);
+    expect(drain.cursor).toBe('20');
+  });
+
+  it('does not advance the cursor past an event it refused on the cap', async () => {
+    const drain = createDocumentDrain(env, { allowed, cap: 1, cursor: '5' });
+    await drain.handle(docEvent('one', { time_us: 100 }));
+    const outcome = await drain.handle(docEvent('two', { time_us: 200 }));
+    expect(outcome).toBe('capped');
+    expect(drain.cursor).toBe('100');
+  });
+
+  it('skips a non-document collection without spending cap budget', async () => {
+    const drain = createDocumentDrain(env, { allowed, cap: 1, cursor: '5' });
+    const event = docEvent('post', { time_us: 50 });
+    event.commit!.collection = 'app.bsky.feed.post';
+    expect(await drain.handle(event)).toBe('skipped');
+    expect(drain.applied).toBe(0);
+    expect(drain.capped).toBe(false);
+  });
+});
+
+describe('the connect-time DID filter', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it('sends a small author set as wantedDids URL params', () => {
+    const { url, viaFrame } = buildDocumentSubscribeUrl([AUTHOR, OTHER], '1234');
+    const parsed = new URL(url);
+    expect(viaFrame).toBe(false);
+    expect(parsed.searchParams.getAll('wantedCollections')).toEqual([
+      'site.standard.document',
+      'app.standard-reader.collection',
+    ]);
+    expect(parsed.searchParams.getAll('wantedDids')).toEqual([AUTHOR, OTHER]);
+    expect(parsed.searchParams.get('cursor')).toBe('1234');
+  });
+
+  it('switches to an options_update frame past the URL limit', () => {
+    const many = Array.from({ length: DID_URL_PARAM_LIMIT + 1 }, (_, i) => `did:plc:author${i}`);
+    const { url, viaFrame } = buildDocumentSubscribeUrl(many);
+    expect(viaFrame).toBe(true);
+    expect(new URL(url).searchParams.getAll('wantedDids')).toEqual([]);
+  });
+
+  // A junk row in D1 would be rejected by Jetstream *wholesale*, closing the socket
+  // and silently killing the cycle's drain — so it must never reach the filter.
+  it('excludes malformed DIDs from the subscribed-author set', async () => {
+    await seedReader();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/1', PUBLICATION, AUTHOR),
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+         VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/2', OTHER_PUBLICATION, 'did:'),
+      env.DB.prepare(
+        `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, created_at)
+         VALUES (?, ?, ?, unixepoch())`
+      ).bind(READER, 'at://reader/app.skyreader.feed.subscription/3', 'https://rss.example/feed'),
+    ]);
+
+    expect(await subscribedDocumentAuthors(env)).toEqual([AUTHOR]);
+  });
+});
+
+describe('backfill and reconcile', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  function mockPds(records: Array<{ rkey: string; cid: string; title: string }>): void {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('plc.directory')) {
+        return new Response(
+          JSON.stringify({
+            id: AUTHOR,
+            service: [
+              {
+                id: '#atproto_pds',
+                type: 'AtprotoPersonalDataServer',
+                serviceEndpoint: 'https://pds.example',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('listRecords') && url.includes('site.standard.document')) {
+        return new Response(
+          JSON.stringify({
+            records: records.map((r) => ({
+              uri: `at://${AUTHOR}/site.standard.document/${r.rkey}`,
+              cid: r.cid,
+              value: {
+                site: PUBLICATION,
+                title: r.title,
+                path: `/${r.rkey}`,
+                publishedAt: '2026-01-01T00:00:00.000Z',
+              },
+            })),
+          })
+        );
+      }
+      if (url.includes('listRecords')) return new Response(JSON.stringify({ records: [] }));
+      return new Response('{}', { status: 404 });
+    });
+  }
+
+  it('is idempotent and prunes what the repo no longer has', async () => {
+    mockPds([
+      { rkey: 'one', cid: 'cid1', title: 'One' },
+      { rkey: 'two', cid: 'cid2', title: 'Two' },
+    ]);
+
+    const first = await backfillAuthorDocuments(env, AUTHOR);
+    expect(first.ok).toBe(true);
+    expect(first.documents).toBe(2);
+    expect(first.complete).toBe(true);
+
+    const second = await backfillAuthorDocuments(env, AUTHOR);
+    expect(second.documents).toBe(2);
+    const docs = await loadAuthorDocuments(env, AUTHOR);
+    expect(docs.length).toBe(2);
+
+    // A record deleted upstream while we weren't watching is the drift the
+    // firehose alone can never correct.
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }]);
+    await backfillAuthorDocuments(env, AUTHOR);
+    expect((await loadAuthorDocuments(env, AUTHOR)).map((d) => d.title)).toEqual(['One']);
+  });
+
+  it('records the error and leaves the stored set alone when the PDS fails', async () => {
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }]);
+    await backfillAuthorDocuments(env, AUTHOR);
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
+    const failed = await backfillAuthorDocuments(env, AUTHOR);
+    expect(failed.ok).toBe(false);
+    // The reader keeps seeing what we already hold.
+    expect((await loadAuthorDocuments(env, AUTHOR)).length).toBe(1);
+    const author = await env.DB.prepare(
+      'SELECT error_count FROM document_authors WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ error_count: number }>();
+    expect(author?.error_count).toBe(1);
+  });
+
+  it('picks never-listed subscribed authors first and re-lists them', async () => {
+    await seedReader();
+    await env.DB.prepare(
+      `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, source_type, subject_did, created_at)
+       VALUES (?, ?, ?, 'atproto.documents', ?, unixepoch())`
+    )
+      .bind(READER, 'at://reader/app.skyreader.feed.subscription/1', PUBLICATION, AUTHOR)
+      .run();
+
+    expect(await staleDocumentAuthors(env, 5)).toEqual([AUTHOR]);
+
+    mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }]);
+    const results = await reconcileStaleAuthors(env, 5);
+    expect(results.map((r) => r.ok)).toEqual([true]);
+    // Freshly listed: it drops out of the stale set until the reconcile interval.
+    expect(await staleDocumentAuthors(env, 5)).toEqual([]);
+  });
+});
+
+describe('serveDocumentScope', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+    await seedPublication(OTHER_PUBLICATION, 'https://other.example');
+  });
+
+  afterEach(cleanup);
+
+  async function ingest(): Promise<void> {
+    const allowed = new Set([AUTHOR]);
+    await applyDocumentEvent(
+      env,
+      docEvent('a', { publishedAt: '2026-01-01T00:00:00.000Z' }),
+      allowed
+    );
+    await applyDocumentEvent(
+      env,
+      docEvent('b', { publishedAt: '2026-02-01T00:00:00.000Z' }),
+      allowed
+    );
+    await applyDocumentEvent(
+      env,
+      docEvent('c', { site: OTHER_PUBLICATION, publishedAt: '2026-03-01T00:00:00.000Z' }),
+      allowed
+    );
+    // Backfill bookkeeping is what makes an empty scope "ready and empty" rather
+    // than "not ingested yet".
+    await env.DB.prepare(
+      `INSERT INTO document_authors (author_did, last_listed_at, complete) VALUES (?, ?, 1)
+       ON CONFLICT(author_did) DO UPDATE SET last_listed_at = excluded.last_listed_at, complete = 1`
+    )
+      .bind(AUTHOR, Date.now())
+      .run();
+  }
+
+  it('serves an author newest-first, scoped to a publication', async () => {
+    await ingest();
+    const entry = await serveDocumentScope(env, { did: AUTHOR }, { remaining: 0 });
+    expect(entry.status).toBe('ready');
+    expect(entry.complete).toBe(true);
+    expect(entry.documents?.map((d) => d.title)).toEqual(['Post c', 'Post b', 'Post a']);
+
+    const scoped = await serveDocumentScope(
+      env,
+      { did: AUTHOR, siteUri: PUBLICATION },
+      { remaining: 0 }
+    );
+    expect(scoped.documents?.map((d) => d.title)).toEqual(['Post b', 'Post a']);
+  });
+
+  it('short-circuits an unchanged scope on the digest', async () => {
+    await ingest();
+    const first = await serveDocumentScope(env, { did: AUTHOR }, { remaining: 0 });
+    expect(first.digest).toBe(await digestScope(first.documents!));
+
+    const repeat = await serveDocumentScope(
+      env,
+      { did: AUTHOR, since_digest: first.digest },
+      { remaining: 0 }
+    );
+    expect(repeat.status).toBe('unchanged');
+    expect(repeat.documents).toBeUndefined();
+
+    // An edit changes the cid, so the digest misses and the full set is re-sent.
+    await applyDocumentEvent(
+      env,
+      docEvent('a', { operation: 'update', cid: 'cid-a-edited' }),
+      new Set([AUTHOR])
+    );
+    const afterEdit = await serveDocumentScope(
+      env,
+      { did: AUTHOR, since_digest: first.digest },
+      { remaining: 0 }
+    );
+    expect(afterEdit.status).toBe('ready');
+  });
+
+  // "Ready and empty" would tell the client to clear the scope. An author we have
+  // never successfully listed is an error, so the client keeps what it holds.
+  it('reports an un-ingested author as an error, not an empty ready', async () => {
+    const entry = await serveDocumentScope(env, { did: AUTHOR }, { remaining: 0 });
+    expect(entry.status).toBe('error');
+    expect(entry.documents).toEqual([]);
+  });
+
+  it('rejects a malformed DID', async () => {
+    const entry = await serveDocumentScope(env, { did: 'did:' }, { remaining: 0 });
+    expect(entry.status).toBe('error');
+    expect(entry.error).toBe('Invalid DID');
+  });
+});
+
+describe('the read rollout gate', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seedPublication();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  function batchRequest(body: unknown): Request {
+    return new Request('https://api.example/api/v2/documents/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('defaults to the proxy and switches to D1 on the flag', async () => {
+    expect((await readDocumentFlags(env)).serveFromD1).toBe(false);
+
+    const allowed = new Set([AUTHOR]);
+    await applyDocumentEvent(env, docEvent('a'), allowed);
+    await env.DB.prepare(
+      `INSERT INTO document_authors (author_did, last_listed_at, complete) VALUES (?, ?, 1)
+       ON CONFLICT(author_did) DO UPDATE SET last_listed_at = excluded.last_listed_at, complete = 1`
+    )
+      .bind(AUTHOR, Date.now())
+      .run();
+
+    const proxyFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ authors: [{ did: AUTHOR, status: 'ready', documents: [] }] }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const viaProxy = await handleV2BatchDocumentFetch(
+      batchRequest({ documents: [{ did: AUTHOR }] }),
+      env as Env,
+      SESSION
+    );
+    expect(proxyFetch).toHaveBeenCalled();
+    expect(((await viaProxy.json()) as { authors: unknown[] }).authors.length).toBe(1);
+
+    proxyFetch.mockClear();
+    await setDocumentFlag(env, DOCUMENTS_V2_ENABLED_KEY, '1');
+
+    const viaD1 = await handleV2BatchDocumentFetch(
+      batchRequest({ documents: [{ did: AUTHOR }] }),
+      env as Env,
+      SESSION
+    );
+    const body = (await viaD1.json()) as {
+      authors: Array<{ status: string; documents?: Array<{ title: string; read?: boolean }> }>;
+    };
+    expect(proxyFetch).not.toHaveBeenCalled();
+    expect(body.authors[0].status).toBe('ready');
+    expect(body.authors[0].documents?.map((d) => d.title)).toEqual(['Post a']);
+    // The per-user read annotation is applied to the D1 path exactly as before.
+    expect(body.authors[0].documents?.[0].read).toBe(false);
+  });
+
+  it('serves a single document from D1 when the gate is on', async () => {
+    await applyDocumentEvent(env, docEvent('single'), new Set([AUTHOR]));
+    await setDocumentFlag(env, DOCUMENTS_V2_ENABLED_KEY, '1');
+    const uri = `at://${AUTHOR}/site.standard.document/single`;
+
+    expect((await serveSingleDocument(env, uri))?.title).toBe('Post single');
+
+    const res = await handleV2GetDocument(
+      new Request(`https://api.example/api/v2/documents/get?uri=${encodeURIComponent(uri)}`),
+      env as Env,
+      SESSION
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { document: { title: string; read: boolean } };
+    expect(body.document.title).toBe('Post single');
+    expect(body.document.read).toBe(false);
+  });
+});

--- a/backend/test/documents-subscribe-backfill.spec.ts
+++ b/backend/test/documents-subscribe-backfill.spec.ts
@@ -1,0 +1,112 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ensureLocalDocumentSubscription } from '../src/routes/subscriptions';
+import { loadAuthorDocuments } from '../src/services/document-store';
+import type { Env, Session } from '../src/types';
+
+const READER = 'did:plc:subscribereader';
+const AUTHOR = 'did:plc:linkblogauthor';
+const PUBLICATION = `at://${AUTHOR}/site.standard.publication/pub`;
+const SESSION = { did: READER } as Session;
+
+/**
+ * The author's PDS, holding one document. Everything else the subscribe path
+ * touches (profile lookup, linkblog target) degrades to a default on a miss.
+ */
+function mockAuthorPds(): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes('plc.directory')) {
+      return new Response(
+        JSON.stringify({
+          id: AUTHOR,
+          service: [
+            {
+              id: '#atproto_pds',
+              type: 'AtprotoPersonalDataServer',
+              serviceEndpoint: 'https://pds.example',
+            },
+          ],
+        })
+      );
+    }
+    if (url.includes('listRecords') && url.includes('site.standard.document')) {
+      return new Response(
+        JSON.stringify({
+          records: [
+            {
+              uri: `at://${AUTHOR}/site.standard.document/first`,
+              cid: 'cid-first',
+              value: {
+                site: PUBLICATION,
+                title: 'First post',
+                path: '/first',
+                publishedAt: '2026-01-01T00:00:00.000Z',
+              },
+            },
+          ],
+        })
+      );
+    }
+    if (url.includes('listRecords')) return new Response(JSON.stringify({ records: [] }));
+    return new Response('{}', { status: 404 });
+  });
+}
+
+async function cleanup(): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM documents_v2'),
+    env.DB.prepare('DELETE FROM collections_v2'),
+    env.DB.prepare('DELETE FROM document_authors'),
+    env.DB.prepare('DELETE FROM publications_cache_v2'),
+    env.DB.prepare('DELETE FROM subscriptions_cache'),
+    env.DB.prepare('DELETE FROM users WHERE did = ?').bind(READER),
+  ]);
+}
+
+describe('subscribing to a linkblog from the Atmosphere button', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await env.DB.prepare(
+      `INSERT INTO users (did, handle, pds_url) VALUES (?, 'reader.test', 'https://pds.example')
+       ON CONFLICT(did) DO NOTHING`
+    )
+      .bind(READER)
+      .run();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  // Without this, the row lands with nothing behind it and every poll of the new
+  // linkblog serves `status:'error'` until the hourly reconcile reaches that
+  // author — the window the proxy never had, because it listed on first read.
+  it('pulls the author’s back catalogue, not just the subscription row', async () => {
+    mockAuthorPds();
+    const scheduled: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => scheduled.push(p) } as ExecutionContext;
+
+    await ensureLocalDocumentSubscription(env as Env, SESSION, ctx, PUBLICATION);
+    await Promise.all(scheduled);
+
+    const row = await env.DB.prepare(
+      `SELECT subject_did FROM subscriptions_cache
+        WHERE user_did = ? AND source_type = 'atproto.documents'`
+    )
+      .bind(READER)
+      .first<{ subject_did: string }>();
+    expect(row?.subject_did).toBe(AUTHOR);
+
+    expect((await loadAuthorDocuments(env as Env, AUTHOR)).map((d) => d.title)).toEqual([
+      'First post',
+    ]);
+    const author = await env.DB.prepare(
+      'SELECT last_listed_at FROM document_authors WHERE author_did = ?'
+    )
+      .bind(AUTHOR)
+      .first<{ last_listed_at: number | null }>();
+    expect(author?.last_listed_at).toBeTruthy();
+  });
+});

--- a/backend/test/ops-metrics.spec.ts
+++ b/backend/test/ops-metrics.spec.ts
@@ -39,10 +39,22 @@ function envWithPollerStatus(status: Record<string, unknown>): Env {
   } as unknown as Env;
 }
 
-const pollerStatusBody = (lagMs: number | null) => ({
-  lag: { subscriptionsMs: lagMs },
+const pollerStatusBody = (
+  lagMs: number | null,
+  documents: Record<string, unknown> = {
+    processed: 5,
+    errors: 0,
+    capped: false,
+    capStreak: 0,
+    authors: 7,
+    skipped: false,
+  },
+  documentsLagMs: number | null = 1000
+) => ({
+  lag: { subscriptionsMs: lagMs, documentsMs: documentsLagMs },
   lastStats: {
     subscriptions: { processed: 3, errors: 1 },
+    documents,
     duration: 4200,
     lastPollAt: 1_700_000_000_000,
   },
@@ -262,6 +274,70 @@ describe('recordPollerStatus', () => {
 
     const row = await readSystemStatus<PollerStatusValue>(env as Env, 'poller_status');
     expect(row?.value.lagAlertAt).toBe(now);
+  });
+
+  it('records the document stream alongside subscriptions', async () => {
+    const value = await recordPollerStatus(envWithPollerStatus(pollerStatusBody(30_000)), 5000);
+    expect(value.documentsLagMs).toBe(1000);
+    expect(value.documentsProcessed).toBe(5);
+    expect(value.documentsAuthors).toBe(7);
+    expect(value.documentsCapStreak).toBe(0);
+    expect(value.documentsIngestPaused).toBe(false);
+  });
+
+  it('alerts on document lag independently of the subscriptions stream', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Subscriptions healthy, documents stalled: a shared number would hide this.
+    const env2 = envWithPollerStatus(
+      pollerStatusBody(1000, undefined, FIREHOSE_LAG_ALERT_MS + 60_000)
+    );
+
+    await recordPollerStatus(env2, 1_000_000_000);
+
+    const events = errors.mock.calls.map(([entry]) => (entry as { event?: string })?.event);
+    expect(events).toContain('documents_stream_lag_high');
+    expect(events).not.toContain('firehose_lag_high');
+  });
+
+  it('stays quiet about a deliberately paused ingest', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The kill switch is off, so lag climbs by construction. That is a state, not
+    // an incident.
+    const paused = envWithPollerStatus(
+      pollerStatusBody(
+        1000,
+        { processed: 0, errors: 0, capped: false, capStreak: 0, authors: 0, skipped: true },
+        FIREHOSE_LAG_ALERT_MS + 60_000
+      )
+    );
+
+    const value = await recordPollerStatus(paused, 1_000_000_000);
+    expect(value.documentsIngestPaused).toBe(true);
+    const events = errors.mock.calls.map(([entry]) => (entry as { event?: string })?.event);
+    expect(events).not.toContain('documents_stream_lag_high');
+  });
+
+  it('alerts once when the apply cap saturates for ten straight cycles', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const flooded = envWithPollerStatus(
+      pollerStatusBody(1000, {
+        processed: 500,
+        errors: 0,
+        capped: true,
+        capStreak: 12,
+        authors: 7,
+        skipped: false,
+      })
+    );
+    const now = 1_000_000_000;
+
+    await recordPollerStatus(flooded, now);
+    await recordPollerStatus(flooded, now + 60_000);
+
+    const alerts = errors.mock.calls
+      .map(([entry]) => entry as { event?: string })
+      .filter((entry) => entry?.event === 'documents_cap_saturated');
+    expect(alerts).toHaveLength(1);
   });
 
   it('throws when the poller cannot be reached, so the caller records the failure', async () => {

--- a/backend/test/standard-site.spec.ts
+++ b/backend/test/standard-site.spec.ts
@@ -1,0 +1,236 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  buildCanonicalUrl,
+  digestScope,
+  isValidDid,
+  markpubToMarkdown,
+  publishedAtMs,
+  recordToDocument,
+  resolveSiteMeta,
+  EMPTY_SITE_META,
+  filterByPublication,
+  filterSinceUris,
+  PUBLICATION_NEGATIVE_CACHE_TTL_MS,
+} from '../src/services/standard-site';
+import type { ProxyDocument } from '../src/services/feed-proxy-client';
+
+const AUTHOR = 'did:plc:author';
+const PUBLICATION = 'at://did:plc:author/site.standard.publication/pub1';
+
+function doc(uri: string, cid: string): ProxyDocument {
+  return { recordUri: uri, recordCid: cid } as ProxyDocument;
+}
+
+describe('isValidDid', () => {
+  it('accepts real DIDs', () => {
+    expect(isValidDid('did:plc:abcdef123456')).toBe(true);
+    expect(isValidDid('did:web:example.com')).toBe(true);
+  });
+
+  // The whole point of the strict check: Jetstream rejects an `options_update`
+  // wholesale on one malformed entry and closes the socket, so a value that merely
+  // starts with "did:" must never reach the filter.
+  it('rejects values that only look like DIDs', () => {
+    expect(isValidDid('did:')).toBe(false);
+    expect(isValidDid('did:plc:')).toBe(false);
+    expect(isValidDid('did:PLC:abc')).toBe(false);
+    expect(isValidDid('not-a-did')).toBe(false);
+    expect(isValidDid('did:plc:abc ')).toBe(false);
+    expect(isValidDid(null)).toBe(false);
+    expect(isValidDid('did:plc:' + 'a'.repeat(3000))).toBe(false);
+  });
+});
+
+describe('digestScope', () => {
+  // Parity with the proxy's `digestScope` (sha256 over sorted "uri\tcid" pairs
+  // joined by newlines). The expected values are the proxy algorithm's output for
+  // these fixtures, so a drift in either implementation fails here rather than in
+  // production as a permanent client cache miss.
+  it('matches the proxy digest for the same documents', async () => {
+    const documents = [
+      doc('at://did:plc:author/site.standard.document/3lb', 'bafyreib'),
+      doc('at://did:plc:author/site.standard.document/3la', 'bafyreia'),
+    ];
+    await expect(digestScope(documents)).resolves.toBe(
+      '15e6a709a682456eb0d24ae380af5bb81e301858d0297c86a467a28053de288e'
+    );
+  });
+
+  it('digests the empty scope to the empty-string hash', async () => {
+    await expect(digestScope([])).resolves.toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('is order-independent but cid-sensitive', async () => {
+    const a = doc('at://did:plc:author/site.standard.document/1', 'cid1');
+    const b = doc('at://did:plc:author/site.standard.document/2', 'cid2');
+    expect(await digestScope([a, b])).toBe(await digestScope([b, a]));
+    expect(await digestScope([a, b])).not.toBe(
+      await digestScope([a, doc('at://did:plc:author/site.standard.document/2', 'cid2-edited')])
+    );
+  });
+});
+
+describe('buildCanonicalUrl', () => {
+  it('normalizes slashes between base and path', () => {
+    expect(buildCanonicalUrl('https://ex.com/', '/post')).toBe('https://ex.com/post');
+    expect(buildCanonicalUrl('https://ex.com', 'post')).toBe('https://ex.com/post');
+    expect(buildCanonicalUrl('https://ex.com', '')).toBe('https://ex.com');
+    expect(buildCanonicalUrl('', '/post')).toBe('/post');
+  });
+});
+
+describe('markpubToMarkdown', () => {
+  it('flattens both the structured and the legacy string form', () => {
+    expect(markpubToMarkdown({ text: { markdown: '# hi' } })).toBe('# hi');
+    expect(markpubToMarkdown('# hi')).toBe('# hi');
+    expect(markpubToMarkdown(undefined)).toBeUndefined();
+    expect(markpubToMarkdown('')).toBeUndefined();
+  });
+});
+
+describe('recordToDocument', () => {
+  it('maps a record into the wire shape', () => {
+    const mapped = recordToDocument(
+      AUTHOR,
+      `at://${AUTHOR}/site.standard.document/3la`,
+      'bafycid',
+      {
+        site: PUBLICATION,
+        title: 'A Post',
+        path: '/a-post',
+        publishedAt: '2026-01-02T03:04:05.000Z',
+        description: 'about things',
+        tags: ['reading'],
+        links: [{ uri: 'https://example.com/article', rel: 'related' }, { rel: 'noop' }],
+        skyreaderLinkblog: 'https://skyreader.app/linkblog',
+      },
+      { ...EMPTY_SITE_META, baseUrl: 'https://ex.com', icon: 'https://cdn/icon', name: 'Ex' },
+      { indexedAt: '2026-02-01T00:00:00.000Z' }
+    );
+
+    expect(mapped.canonicalUrl).toBe('https://ex.com/a-post');
+    expect(mapped.siteIcon).toBe('https://cdn/icon');
+    expect(mapped.publishedAt).toBe('2026-01-02T03:04:05.000Z');
+    // createdAt falls back to publishedAt when the record carries none.
+    expect(mapped.createdAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(mapped.indexedAt).toBe('2026-02-01T00:00:00.000Z');
+    expect(mapped.tags).toEqual(['reading']);
+    // Link entries without a uri are dropped, not emitted as holes.
+    expect(mapped.links).toEqual([{ uri: 'https://example.com/article', rel: 'related' }]);
+    expect(mapped.skyreaderLinkblog).toBe('https://skyreader.app/linkblog');
+  });
+
+  it('falls back to the bare path when the publication has no base URL', () => {
+    const mapped = recordToDocument(
+      AUTHOR,
+      'at://x/site.standard.document/1',
+      'cid',
+      {
+        path: '/loose',
+      },
+      EMPTY_SITE_META
+    );
+    expect(mapped.canonicalUrl).toBe('/loose');
+    expect(mapped.title).toBe('');
+  });
+});
+
+describe('publishedAtMs', () => {
+  it('falls back when the record has no usable date', () => {
+    expect(publishedAtMs({ publishedAt: '2026-01-01T00:00:00.000Z' }, 5)).toBe(
+      Date.parse('2026-01-01T00:00:00.000Z')
+    );
+    expect(publishedAtMs({ publishedAt: 'nonsense' }, 5)).toBe(5);
+    expect(publishedAtMs({}, 5)).toBe(5);
+  });
+});
+
+describe('scope helpers', () => {
+  it('filters by publication and stops at the first seen uri', () => {
+    const docs = [
+      { recordUri: 'a', siteUri: PUBLICATION } as ProxyDocument,
+      { recordUri: 'b', siteUri: 'at://other/site.standard.publication/x' } as ProxyDocument,
+    ];
+    expect(filterByPublication(docs, PUBLICATION).map((d) => d.recordUri)).toEqual(['a']);
+    expect(filterByPublication(docs).length).toBe(2);
+    expect(filterSinceUris(docs, new Set(['b'])).map((d) => d.recordUri)).toEqual(['a']);
+    expect(filterSinceUris(docs, new Set()).length).toBe(2);
+  });
+});
+
+describe('resolveSiteMeta', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await env.DB.prepare('DELETE FROM publications_cache_v2').run();
+  });
+
+  it('treats a loose https site as its own base URL without fetching', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const meta = await resolveSiteMeta(env, 'https://blog.example');
+    expect(meta.baseUrl).toBe('https://blog.example');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves a publication once and then serves it from D1', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('plc.directory')) {
+        return new Response(
+          JSON.stringify({
+            id: AUTHOR,
+            service: [
+              {
+                id: '#atproto_pds',
+                type: 'AtprotoPersonalDataServer',
+                serviceEndpoint: 'https://pds.example',
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes('site.standard.publication')) {
+        return new Response(
+          JSON.stringify({ value: { url: 'https://ex.com', name: 'Ex', basicTheme: {} } })
+        );
+      }
+      // publicationTheme sidecar — absent is the common case.
+      return new Response('{}', { status: 404 });
+    });
+
+    const first = await resolveSiteMeta(env, PUBLICATION);
+    expect(first.baseUrl).toBe('https://ex.com');
+    expect(first.name).toBe('Ex');
+    const callsAfterFirst = fetchSpy.mock.calls.length;
+
+    const second = await resolveSiteMeta(env, PUBLICATION);
+    expect(second.baseUrl).toBe('https://ex.com');
+    expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('caches a failed resolution only briefly', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 500 }));
+    const meta = await resolveSiteMeta(env, PUBLICATION);
+    expect(meta.baseUrl).toBeNull();
+
+    const row = await env.DB.prepare(
+      'SELECT cached_at FROM publications_cache_v2 WHERE publication_uri = ?'
+    )
+      .bind(PUBLICATION)
+      .first<{ cached_at: number }>();
+    expect(row).not.toBeNull();
+
+    // Age the negative entry past its short TTL: the next read must re-resolve
+    // rather than pin every document's canonical URL to a bare path for a day.
+    await env.DB.prepare('UPDATE publications_cache_v2 SET cached_at = ? WHERE publication_uri = ?')
+      .bind(Date.now() - PUBLICATION_NEGATIVE_CACHE_TTL_MS - 1000, PUBLICATION)
+      .run();
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockClear();
+    await resolveSiteMeta(env, PUBLICATION);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/backend/test/subscription-sync.spec.ts
+++ b/backend/test/subscription-sync.spec.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:test';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { syncSubscriptions } from '../src/services/subscription-sync';
+import { MAX_SYNC_BACKFILLS } from '../src/services/document-store';
 import { upsertSubscriptionFromFirehose } from '../src/services/firehose-subscription';
 import type { Session } from '../src/types';
 
@@ -144,6 +145,65 @@ describe('Subscription Sync', () => {
         .all();
 
       expect(localRecords.results).toHaveLength(1);
+    });
+
+    // The restore-from-the-Atmosphere case: the PDS records survived, the local
+    // rows didn't. Documents are served from D1 now, so a restored linkblog whose
+    // author nobody has listed polls `status:'error'` until something lists them —
+    // and this path can restore far more of them at once than a subscribe does,
+    // which is why only the first few are warmed here.
+    it('warms a bounded number of restored linkblogs and leaves the rest to the reconcile', async () => {
+      const session = createTestSession();
+      const authors = ['did:plc:author1', 'did:plc:author2', 'did:plc:author3'];
+      const pdsRecords = authors.map((did, i) => ({
+        uri: `at://${TEST_DID}/${COLLECTION}/doc${i}`,
+        cid: `bafyreidoc${i}`,
+        value: {
+          $type: COLLECTION,
+          feedUrl: `at://${did}/site.standard.publication/pub`,
+          title: `Linkblog ${i}`,
+          sourceType: 'atproto.documents',
+          subjectDid: did,
+          createdAt: new Date().toISOString(),
+        },
+      }));
+
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+        if (String(url).includes('plc.directory')) {
+          return {
+            ok: true,
+            headers: new Headers(),
+            json: async () => ({
+              service: [
+                {
+                  id: '#atproto_pds',
+                  type: 'AtprotoPersonalDataServer',
+                  serviceEndpoint: 'https://pds.example',
+                },
+              ],
+            }),
+          };
+        }
+        if (String(url).includes('site.standard.document')) {
+          return { ok: true, headers: new Headers(), json: async () => ({ records: [] }) };
+        }
+        return { ok: true, headers: new Headers(), json: async () => ({ records: pdsRecords }) };
+      });
+
+      const scheduled: Promise<unknown>[] = [];
+      const result = await syncSubscriptions(session, env, undefined, (p) => scheduled.push(p));
+      await Promise.all(scheduled);
+
+      expect(result.pulledFromPds).toBe(3);
+      // Two walks ran now; the third author has no bookkeeping row at all, which
+      // is what puts them at the front of the reconcile queue.
+      const listed = await env.DB.prepare(
+        'SELECT author_did FROM document_authors WHERE last_listed_at IS NOT NULL'
+      ).all<{ author_did: string }>();
+      expect(listed.results?.length).toBe(MAX_SYNC_BACKFILLS);
+      expect(scheduled.length).toBe(MAX_SYNC_BACKFILLS);
+
+      await env.DB.prepare('DELETE FROM document_authors').run();
     });
   });
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -399,16 +399,17 @@ The first section of the admin dashboard. It reads two D1 tables the backend cro
 writes (migration `0067_system_status.sql`) — no API token, no production-only
 path, so it works in local dev and staging the moment the cron has run once.
 
-| Tile                     | Source                             | Green             | Amber              | Red                            |
-| ------------------------ | ---------------------------------- | ----------------- | ------------------ | ------------------------------ |
-| Cron Last Run            | `system_status.cron_last_run`      | <3 min ago        | <10 min ago        | ≥10 min, or the run failed     |
-| Firehose Lag             | `poller_status.lagMs`              | <5 min (SLO bar)  | <15 min            | ≥15 min (= the Sentry alert)   |
-| Last Poll                | `poller_status.lastPollAt`         | <5 min ago        | never polled       | ≥5 min ago                     |
-| Poll Errors (last cycle) | `poller_status.errors`             | 0                 | ≥1                 | —                              |
-| Document Stream Lag      | `poller_status.documentsLagMs`     | <5 min            | <15 min, or paused | ≥15 min (= the Sentry alert)   |
-| Document Ingest          | `poller_status.documentsCapStreak` | 0–2 capped cycles | ≥3 capped cycles   | ≥10 capped, or ingest disabled |
-| Proxy Cache Fresh        | `proxy_stats.freshPct`             | ≥95% (SLO bar)    | ≥80%               | <80%, or stats >15 min old     |
-| Proxy Feeds in Error     | `proxy_stats.feedsInError`         | 0                 | ≥1                 | any permanent failures         |
+| Tile                     | Source                              | Green             | Amber                                             | Red                                               |
+| ------------------------ | ----------------------------------- | ----------------- | ------------------------------------------------- | ------------------------------------------------- |
+| Cron Last Run            | `system_status.cron_last_run`       | <3 min ago        | <10 min ago                                       | ≥10 min, or the run failed                        |
+| Firehose Lag             | `poller_status.lagMs`               | <5 min (SLO bar)  | <15 min                                           | ≥15 min (= the Sentry alert)                      |
+| Last Poll                | `poller_status.lastPollAt`          | <5 min ago        | never polled                                      | ≥5 min ago                                        |
+| Poll Errors (last cycle) | `poller_status.errors`              | 0                 | ≥1                                                | —                                                 |
+| Document Stream Lag      | `poller_status.documentsLagMs`      | <5 min            | <15 min, or paused                                | ≥15 min (= the Sentry alert)                      |
+| Document Ingest          | `poller_status.documentsCapStreak`  | 0–2 capped cycles | ≥3 capped cycles                                  | ≥10 capped, or ingest disabled                    |
+| Proxy Cache Fresh        | `proxy_stats.freshPct`              | ≥95% (SLO bar)    | ≥80%                                              | <80%, or stats >15 min old                        |
+| Proxy Feeds in Error     | `proxy_stats.feedsInError`          | 0                 | ≥1                                                | any permanent failures                            |
+| Document Sync            | `proxy_stats.documentAuthorsFrozen` | 0 frozen          | 1–2 frozen, or the proxy's document firehose down | ≥3 frozen, or ≥25% of active (= the Sentry alert) |
 
 "SLO bar" means the tile grades the **latest reading** against the number §7's SLO
 uses; the SLO itself is that bar held across a month of hourly points, so an amber
@@ -419,8 +420,8 @@ values are written by the cron, so they stop moving exactly when it does. Cross-
 against the `backend-cron` heartbeat before assuming the panel is broken.
 
 Staleness is graded on the **row**, not on the numbers inside it: the five poller
-tiles go red together once `poller_status` is more than 5 minutes old, and both
-proxy tiles once `proxy_stats` is more than 15 minutes old. That's the case a
+tiles go red together once `poller_status` is more than 5 minutes old, and all
+three proxy tiles once `proxy_stats` is more than 15 minutes old. That's the case a
 value can't see about itself — the cron alive and healthy, but its DO `/status` or
 proxy `/stats` fetch failing, leaving a green lag from an hour ago in the table.
 Stale poller tiles with a green Cron Last Run mean **the collector is
@@ -532,9 +533,12 @@ a heartbeat that never arrives is configuration, not a restart.
 ### Document publication feed goes quiet
 
 The admin's **Document Sync** tile and proxy `/stats` → `documents` cover the
-Jetstream lane used by standard.site/Leaflet publications. `frozen > 0` means an
-actively read author has not had a full PDS re-list for more than twice the
-24-hour floor; `inBackoff > 0` explains why a repair is waiting.
+Jetstream lane used by standard.site/Leaflet publications. This is the **proxy**
+read path, which is the live one only while `documents_v2_enabled` is off; once it
+is on, these numbers decay to zero by construction and §4e's D1 tiles are what a
+reader depends on. `frozen > 0` means an actively read author has not had a full
+PDS re-list for more than twice the 24-hour floor; `inBackoff > 0` explains why a
+repair is waiting.
 
 The `proxy-document-cache-frozen` alert fires when **3 or more** authors are
 frozen, or when frozen authors are **25% or more** of the active ones (whichever
@@ -570,6 +574,49 @@ The next client poll serves the existing cache and refreshes it in the
 background; a changed scope digest replaces the stale list without user action.
 For multiple victims, update small batches of recently requested rows so the
 upstream PDSes are not hit in a stampede.
+
+### The timeline rollout gate
+
+`ingestActive` is the AND of two things: a fresh crawler heartbeat and
+`sync_state.timeline_enabled`. They are separate because the heartbeat lands
+_seconds_ into the first backfill of an environment and that backfill takes hours
+— without the gate, every reader switches to the timeline at the moment the
+archive is emptiest and then drags the whole backfill through the incremental
+drain (the expensive global scan, at its worst case, for the duration).
+
+Only an explicit `'0'` gates. Migration 0071 sets it for a database that already
+has users, so prod and staging start shut and a fresh environment (local dev,
+e2e, CI) starts open.
+
+```bash
+# Open it — after ingest.pending has trended to ~0.
+npx wrangler d1 execute skyreader --remote --command \
+  "UPDATE sync_state SET value='1', updated_at=unixepoch() WHERE key='timeline_enabled'"
+
+# Shut it — every client is back on the legacy batch path at its next poll.
+npx wrangler d1 execute skyreader --remote --command \
+  "UPDATE sync_state SET value='0', updated_at=unixepoch() WHERE key='timeline_enabled'"
+```
+
+Shutting it is the **fast rollback for the read path**, and the first thing to
+reach for if the timeline misbehaves after a rollout: no Worker deploy, no waiting
+out the 30-minute heartbeat freshness window, and the crawler keeps filling the
+archive the whole time. It is not a fix for a bad Worker deploy generally — only
+for "readers should not be on the timeline right now".
+
+One caveat when shutting it: clients hold a committed `timelineCursor` and stop
+advancing their per-subscription `feedCursors` while on the timeline, so the
+batch path re-drains from wherever those cursors were left. The proxy's K=200
+window bounds that, and the merge dedupes by GUID, so the cost is one heavier
+sync, not duplicates.
+
+**Guests have no batch path.** `/api/v2/feeds/batch` needs a session, so shutting
+the gate doesn't move guest readers to a fallback — it empties their refresh
+(they keep whatever is cached, and the client retries on the next poll rather
+than fanning out to endpoints that would 401). Guest reading mode is therefore
+only meaningful with the gate open; check it before announcing the feature.
+
+---
 
 ## 4e. standard.site documents in D1
 
@@ -656,6 +703,25 @@ npx wrangler d1 execute skyreader --remote --command \
    **Rollback is the same statement with `'0'`** — every client is back on the proxy
    path at its next poll, and D1 keeps ingesting the whole time.
 
+**Which document verdict is the live one.** The ops panel carries two while this
+rollout is in flight, and the gate decides which one means a reader is missing
+documents. Until the flip that is the proxy's: `Document Sync` and
+`proxy-document-cache-frozen` (§4d), with `Document Stream Lag` / `Document Ingest`
+saying only whether the D1 copy is keeping up. After the flip it inverts — the D1
+tiles are the read path, and the proxy tile grades a cache nobody reads.
+
+Nothing needs silencing by hand. `frozen` and `active` count only authors requested
+inside the proxy's 14-day warm window, and the warm loop re-lists those rows on its
+own clock, so after the flip the counts don't spike — they drain to zero as rows age
+out, and both the tile and the alert go quiet within that window. A `frozen` count
+that keeps climbing after the flip means something is still on the proxy read path;
+check the gate before touching the threshold.
+
+Retire the proxy document cache and its alert together, in a pruning pass (§8), once
+the flip has held long enough that you would not roll back — not at the flip itself.
+For as long as `documents_v2_enabled` can go back to `'0'`, that cache is the
+rollback target and its verdict still has to be trustworthy.
+
 **Flood response.** `documents_cap_saturated`, or a `Document Ingest` tile stuck
 red, means pausing writes:
 
@@ -706,47 +772,6 @@ curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
 
 An explicit `dids` list ignores both the reconcile interval and the failure backoff,
 so this is also how you retry an author sooner than their backoff would allow.
-
-### The timeline rollout gate
-
-`ingestActive` is the AND of two things: a fresh crawler heartbeat and
-`sync_state.timeline_enabled`. They are separate because the heartbeat lands
-_seconds_ into the first backfill of an environment and that backfill takes hours
-— without the gate, every reader switches to the timeline at the moment the
-archive is emptiest and then drags the whole backfill through the incremental
-drain (the expensive global scan, at its worst case, for the duration).
-
-Only an explicit `'0'` gates. Migration 0071 sets it for a database that already
-has users, so prod and staging start shut and a fresh environment (local dev,
-e2e, CI) starts open.
-
-```bash
-# Open it — after ingest.pending has trended to ~0.
-npx wrangler d1 execute skyreader --remote --command \
-  "UPDATE sync_state SET value='1', updated_at=unixepoch() WHERE key='timeline_enabled'"
-
-# Shut it — every client is back on the legacy batch path at its next poll.
-npx wrangler d1 execute skyreader --remote --command \
-  "UPDATE sync_state SET value='0', updated_at=unixepoch() WHERE key='timeline_enabled'"
-```
-
-Shutting it is the **fast rollback for the read path**, and the first thing to
-reach for if the timeline misbehaves after a rollout: no Worker deploy, no waiting
-out the 30-minute heartbeat freshness window, and the crawler keeps filling the
-archive the whole time. It is not a fix for a bad Worker deploy generally — only
-for "readers should not be on the timeline right now".
-
-One caveat when shutting it: clients hold a committed `timelineCursor` and stop
-advancing their per-subscription `feedCursors` while on the timeline, so the
-batch path re-drains from wherever those cursors were left. The proxy's K=200
-window bounds that, and the merge dedupes by GUID, so the cost is one heavier
-sync, not duplicates.
-
-**Guests have no batch path.** `/api/v2/feeds/batch` needs a session, so shutting
-the gate doesn't move guest readers to a fallback — it empties their refresh
-(they keep whatever is cached, and the client retries on the next poll rather
-than fanning out to endpoints that would 401). Guest reading mode is therefore
-only meaningful with the gate open; check it before announcing the feature.
 
 ---
 
@@ -978,7 +1003,7 @@ regression. The steady state to protect is a quiet phone that you still trust.
 
 ### Pruning log
 
-| Date        | Change                                                       | Why |
-| ----------- | ------------------------------------------------------------ | --- |
+| Date        | Change                                                                                                  | Why                                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-09-03  | `proxy-document-cache-frozen`: threshold `frozen > 0` → 3 authors or 25% of active; re-alert 30m → 24h. | One stuck author fired 93 events over two days with no action available. Root cause fixed in the proxy the same day (the re-list floor was only checked on the firehose-covered path). |
-| _(pending)_ | First pass due 2–4 weeks after the §2 checks are configured. | —   |
+| _(pending)_ | First pass due 2–4 weeks after the §2 checks are configured.                                            | —                                                                                                                                                                                      |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -597,19 +597,37 @@ npx wrangler d1 execute skyreader --remote --command \
    ```
 
    The hourly cron re-lists the three stalest authors anyway, so this only makes the
-   migration finish in an afternoon instead of over weeks.
+   migration finish in an afternoon instead of over weeks. `remaining` does reach 0
+   even with authors nobody can list (deleted account, dead PDS): a failed list holds
+   that author out of the queue for a backoff window that doubles per consecutive
+   failure, up to the 7-day reconcile interval. Their `last_error` is on
+   `document_authors`, and their scopes serve `status:'error'` — which is what keeps
+   a reader's existing copy on screen rather than clearing it.
 
 2. **Shadow-compare.** The gate on flipping reads: serve authors both ways and diff.
+   It compares **one page** per call — pass the returned `cursor` back for the next
+   one, and keep going until it comes back `null`. A single call says nothing about
+   the authors behind its page, so the gate is _every page clean_, not one clean
+   response.
 
    ```bash
-   curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
-     -d '{"limit":25}' https://api.skyreader.app/api/internal/documents/shadow-compare \
-     | jq '{clean, drift: [.scopes[] | select(.clean|not)]}'
+   cursor=null
+   while :; do
+     out=$(curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
+       -d "{\"limit\":25,\"cursor\":$( [ "$cursor" = null ] && echo null || echo "\"$cursor\"" )}" \
+       https://api.skyreader.app/api/internal/documents/shadow-compare)
+     echo "$out" | jq '{clean, remaining, drift: [.scopes[] | select(.clean|not)]}'
+     cursor=$(echo "$out" | jq -r '.cursor')
+     [ "$cursor" = null ] && break
+   done
    ```
 
    `missingInD1` is the one that costs a reader content; `cidMismatches` is an edit
    one side hasn't seen (usually a race, gone on the next run);
    `canonicalMismatches` points at a publication-cache divergence, not at documents.
+   An author the proxy returned no entry for is reported as drift too
+   (`No proxy entry returned`) — coverage of the walk has to be a fact, not an
+   assumption. Pass `{"dids":[…]}` to re-check specific authors after a fix.
 
 3. **Flip reads**, after a clean compare and a soak:
 
@@ -635,6 +653,14 @@ The subscriptions stream keeps running, reads keep serving whatever D1 holds, an
 the document cursor stays put — so re-enabling resumes the drain rather than
 skipping the backlog. Expect `Document Stream Lag` to read "Paused" while it's off.
 
+**A held cursor is only worth as much as Jetstream's replay buffer.** That buffer is
+hours, not days: past it, reconnecting is served from the oldest event the server
+still holds and everything in between is simply gone from the stream. So treat a
+pause of a few hours as resumable and anything longer as lossy — after a long pause,
+force the affected authors through the backfill endpoint rather than waiting on the
+7-day reconcile to find the holes. (Jetstream v2's network replay is what removes
+this bound; see `docs/plans/DOCUMENTS_TO_D1.md`.)
+
 **Repairing one author** (the D1 equivalent of the proxy re-list below): force them
 to the front of the reconcile queue, or backfill them directly.
 
@@ -642,6 +668,9 @@ to the front of the reconcile queue, or backfill them directly.
 curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
   -d '{"dids":["did:plc:..."]}' https://api.skyreader.app/api/internal/documents/backfill
 ```
+
+An explicit `dids` list ignores both the reconcile interval and the failure backoff,
+so this is also how you retry an author sooner than their backoff would allow.
 
 ### The timeline rollout gate
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -607,7 +607,13 @@ npx wrangler d1 execute skyreader --remote --command \
    call takes a handful of authors, sized so one request stays inside D1's
    per-invocation query ceiling; loop it. The response's `deferred` is how many of
    the chunk the call declined to start because that budget ran out before them —
-   they are still queued, so just call again. `remaining` does reach 0
+   they are still queued, so just call again. An author can also come back in the
+   queue after a successful walk: a repo with more curated editions than one walk's
+   budget covers records the rest as `document_authors.collections_pending` and stays
+   eligible so the next pass writes them, rather than dripping them out one walk's
+   worth per reconcile interval. That converges — a walk only requeues an author when
+   it wrote some — so it costs a few extra chunks, not a loop that never ends.
+   `remaining` does reach 0
    even with authors nobody can list (deleted account, dead PDS): a failed list holds
    that author out of the queue for a backoff window that doubles per consecutive
    failure, up to the 7-day reconcile interval. Their `last_error` is on

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -605,7 +605,9 @@ npx wrangler d1 execute skyreader --remote --command \
    The cron re-lists stale authors anyway — one a minute plus three on the hour — so
    this only makes the migration finish in an afternoon instead of over days. Each
    call takes a handful of authors, sized so one request stays inside D1's
-   per-invocation query ceiling; loop it. `remaining` does reach 0
+   per-invocation query ceiling; loop it. The response's `deferred` is how many of
+   the chunk the call declined to start because that budget ran out before them —
+   they are still queued, so just call again. `remaining` does reach 0
    even with authors nobody can list (deleted account, dead PDS): a failed list holds
    that author out of the queue for a backoff window that doubles per consecutive
    failure, up to the 7-day reconcile interval. Their `last_error` is on
@@ -661,12 +663,24 @@ The subscriptions stream keeps running, reads keep serving whatever D1 holds, an
 the document cursor stays put — so re-enabling resumes the drain rather than
 skipping the backlog. Expect `Document Stream Lag` to read "Paused" while it's off.
 
-The switch stops **every background write**, not just the drain: the poller's
+The switch stops **every background loop that writes**: the drain, the poller's
 per-cycle back catalogues and the cron's reconcile pause with it, since either would
 otherwise keep writing up to a hundred rows an author while the flood is supposedly
-paused. Their queues survive the pause. The one path that still writes is the
-backfill endpoint below — an operator asking for a specific repair, which is what
-you want available during an incident.
+paused. Their queues survive the pause.
+
+Two kinds of write are deliberately exempt, so read the switch as "the loops stop",
+not "nothing writes":
+
+- **The backfill endpoint below** — an operator asking for a specific repair, which
+  is what you want available during an incident.
+- **Subscribe-time walks** (`ensureAuthorDocuments`, from the API subscribe, the
+  Atmosphere subscribe/import and the PDS→local pull). A reader subscribing during
+  an incident would otherwise see nothing but `status:'error'` on that linkblog.
+  Each is one author, capped at 100 rows and deduped to one walk an hour, and the
+  sync paths schedule at most `MAX_SYNC_BACKFILLS` of them per request — so this is
+  a trickle, not a channel the flood can come back through. If a flood is arriving
+  _via_ subscriptions, unsubscribe/park the author — the fix under
+  `documents_cap_saturated` — rather than expecting this switch to stop it.
 
 **A held cursor is only worth as much as Jetstream's replay buffer.** That buffer is
 hours, not days: past it, reconnecting is served from the oldest event the server

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -223,10 +223,10 @@ reach Jetstream at all, so subscription records written on a user's PDS (another
 device, another Atmospheric app) stop reaching Skyreader. Their feed list quietly
 stops converging.
 
-This is the poller's **only** stream. The `site.standard.document` stream that used
-to run beside it was removed when documents moved to on-demand proxy fetch
-(`fetchDocumentsBatch` in `backend/src/routes/feeds-v2.ts`); the alert that surfaced
-its 32h backlog is what found the leftover.
+This alert is about the **subscriptions** stream only. The poller also drains a
+`site.standard.document` stream (documents came back to the DO from the proxy), and
+it is measured and alerted separately — see `documents_stream_lag_high` below. One
+stream stuck while the other is healthy is exactly what a shared number would hide.
 
 Lag is time since the most recent **proof** the stream was current, from either of
 two one-sided signals (see `streamLagMs` in
@@ -255,6 +255,55 @@ backlog, and one at the live edge points at the drain signal instead.
 **Fix:** usually none — a backlog after a Jetstream outage drains on its own; watch
 that the number is falling. If it's flat or growing over 30 minutes, redeploy the
 backend to recycle the DO (it resumes from its stored cursor, so nothing is lost).
+
+### `documents_stream_lag_high` (Sentry message)
+
+**Means:** the poller's `site.standard.document` stream (plus its
+`app.standard-reader.collection` sidecar) has gone more than **15 minutes** without
+being confirmed current. New posts from standard.site / Leaflet publications stop
+appearing for their subscribers; nothing else is affected, and every document
+already in D1 keeps serving.
+
+Same threshold, same lag definition and the same fingerprint-once behaviour as
+`firehose_lag_high`, decided independently. Two states are deliberately **not**
+alerts: an ingest paused with `documents_ingest_enabled = '0'` (its lag climbs by
+construction, and the tile says "Paused"), and an empty subscribed-author set
+(nothing to be behind on, so the stream marks itself caught up).
+
+**Check:** the Ops panel's **Document Stream Lag** and **Document Ingest** tiles,
+then `event = jetstream_poll` in Workers Logs — `documentsProcessed`,
+`documentsCapped`, `documentsAuthors`. A cycle capping every minute is the next
+alert, not this one. `documentsAuthors: 0` with lag climbing means no subscription
+rows carry `source_type = 'atproto.documents'`, which is a data problem, not a
+stream problem.
+**Fix:** usually none — a backlog drains at up to the apply cap per minute. If it's
+flat over 30 minutes, redeploy the backend to recycle the DO; it resumes from its
+stored cursor.
+
+### `documents_cap_saturated` (Sentry message)
+
+**Means:** ten consecutive poll cycles stopped on the per-cycle apply cap. One or
+two capped cycles is a burst draining exactly as designed; ten in a row is a
+sustained flood — most likely a **subscribed** author dumping thousands of
+documents, which the server-side DID filter passes by design.
+
+Nothing is lost while this lasts: the cursor is carried at the last applied event,
+so the backlog keeps draining a capful per cycle, and the per-author 100-row cap
+bounds what any single author can cost in storage. The risk it flags is the
+document stream monopolising cycles while a flood lasts.
+
+**Check:** who is writing — `event = documents_apply_cap_hit` for the streak, and
+
+```sql
+SELECT author_did, COUNT(*) FROM documents_v2
+WHERE indexed_at > (unixepoch() - 3600) * 1000
+GROUP BY author_did ORDER BY 2 DESC LIMIT 5;
+```
+
+**Fix:** if it's a legitimate large publisher, raise the cap
+(`sync_state.documents_apply_cap`) and let it drain. If it's abuse, pause ingest
+(§4e) and unsubscribe/park the author before resuming — the subscriptions stream
+and document reads are untouched either way.
 
 ### `source: client` errors after a deploy
 
@@ -344,14 +393,16 @@ The first section of the admin dashboard. It reads two D1 tables the backend cro
 writes (migration `0067_system_status.sql`) — no API token, no production-only
 path, so it works in local dev and staging the moment the cron has run once.
 
-| Tile                     | Source                        | Green            | Amber        | Red                          |
-| ------------------------ | ----------------------------- | ---------------- | ------------ | ---------------------------- |
-| Cron Last Run            | `system_status.cron_last_run` | <3 min ago       | <10 min ago  | ≥10 min, or the run failed   |
-| Firehose Lag             | `poller_status.lagMs`         | <5 min (SLO bar) | <15 min      | ≥15 min (= the Sentry alert) |
-| Last Poll                | `poller_status.lastPollAt`    | <5 min ago       | never polled | ≥5 min ago                   |
-| Poll Errors (last cycle) | `poller_status.errors`        | 0                | ≥1           | —                            |
-| Proxy Cache Fresh        | `proxy_stats.freshPct`        | ≥95% (SLO bar)   | ≥80%         | <80%, or stats >15 min old   |
-| Proxy Feeds in Error     | `proxy_stats.feedsInError`    | 0                | ≥1           | any permanent failures       |
+| Tile                     | Source                             | Green             | Amber              | Red                            |
+| ------------------------ | ---------------------------------- | ----------------- | ------------------ | ------------------------------ |
+| Cron Last Run            | `system_status.cron_last_run`      | <3 min ago        | <10 min ago        | ≥10 min, or the run failed     |
+| Firehose Lag             | `poller_status.lagMs`              | <5 min (SLO bar)  | <15 min            | ≥15 min (= the Sentry alert)   |
+| Last Poll                | `poller_status.lastPollAt`         | <5 min ago        | never polled       | ≥5 min ago                     |
+| Poll Errors (last cycle) | `poller_status.errors`             | 0                 | ≥1                 | —                              |
+| Document Stream Lag      | `poller_status.documentsLagMs`     | <5 min            | <15 min, or paused | ≥15 min (= the Sentry alert)   |
+| Document Ingest          | `poller_status.documentsCapStreak` | 0–2 capped cycles | ≥3 capped cycles   | ≥10 capped, or ingest disabled |
+| Proxy Cache Fresh        | `proxy_stats.freshPct`             | ≥95% (SLO bar)    | ≥80%               | <80%, or stats >15 min old     |
+| Proxy Feeds in Error     | `proxy_stats.feedsInError`         | 0                 | ≥1                 | any permanent failures         |
 
 "SLO bar" means the tile grades the **latest reading** against the number §7's SLO
 uses; the SLO itself is that bar held across a month of hourly points, so an amber
@@ -361,12 +412,12 @@ tile right now is not a breach and a green one is not compliance.
 values are written by the cron, so they stop moving exactly when it does. Cross-check
 against the `backend-cron` heartbeat before assuming the panel is broken.
 
-Staleness is graded on the **row**, not on the numbers inside it: the three poller
+Staleness is graded on the **row**, not on the numbers inside it: the five poller
 tiles go red together once `poller_status` is more than 5 minutes old, and both
 proxy tiles once `proxy_stats` is more than 15 minutes old. That's the case a
 value can't see about itself — the cron alive and healthy, but its DO `/status` or
 proxy `/stats` fetch failing, leaving a green lag from an hour ago in the table.
-Three stale poller tiles with a green Cron Last Run means **the collector is
+Stale poller tiles with a green Cron Last Run mean **the collector is
 broken, not the poller**: look for `event = ops_metrics_failed` → `step`.
 
 Below the tiles, **Trends (30 days, hourly)** sparklines the same numbers plus the
@@ -514,6 +565,84 @@ background; a changed scope digest replaces the stale list without user action.
 For multiple victims, update small batches of recently requested rows so the
 upstream PDSes are not hit in a stampede.
 
+## 4e. standard.site documents in D1
+
+Documents are moving off the Fly proxy the same way feeds did: the poller DO writes
+`site.standard.document` (and its reader-collection sidecar) straight into D1, and
+reads are served from there. Two independent `sync_state` switches govern it — one
+for writes, one for reads — so ingest can run and fill for as long as it takes while
+readers stay on the proxy.
+
+| Key                        | Default          | Governs                                                      |
+| -------------------------- | ---------------- | ------------------------------------------------------------ |
+| `documents_ingest_enabled` | on (absent = on) | The poller's document stream. `'0'` = flood kill switch.     |
+| `documents_v2_enabled`     | off (only `'1'`) | Reads served from D1 instead of the proxy. The rollout gate. |
+| `documents_apply_cap`      | 500              | Applied events per poll cycle before the drain carries over. |
+
+```bash
+# State of all three.
+npx wrangler d1 execute skyreader --remote --command \
+  "SELECT key, value, updated_at FROM sync_state WHERE key LIKE 'documents%'"
+```
+
+**Cutover, in order.** Nothing here needs a deploy.
+
+1. **Backfill.** The firehose never replays history, so every already-subscribed
+   author needs one `listRecords` walk. Drive it as a loop of bounded calls until
+   `remaining` is 0 (new subscriptions backfill themselves at subscribe time):
+
+   ```bash
+   curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
+     https://api.skyreader.app/api/internal/documents/backfill | jq '.backfilled, .remaining'
+   ```
+
+   The hourly cron re-lists the three stalest authors anyway, so this only makes the
+   migration finish in an afternoon instead of over weeks.
+
+2. **Shadow-compare.** The gate on flipping reads: serve authors both ways and diff.
+
+   ```bash
+   curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
+     -d '{"limit":25}' https://api.skyreader.app/api/internal/documents/shadow-compare \
+     | jq '{clean, drift: [.scopes[] | select(.clean|not)]}'
+   ```
+
+   `missingInD1` is the one that costs a reader content; `cidMismatches` is an edit
+   one side hasn't seen (usually a race, gone on the next run);
+   `canonicalMismatches` points at a publication-cache divergence, not at documents.
+
+3. **Flip reads**, after a clean compare and a soak:
+
+   ```bash
+   npx wrangler d1 execute skyreader --remote --command \
+     "INSERT INTO sync_state (key, value, updated_at) VALUES ('documents_v2_enabled','1',unixepoch())
+      ON CONFLICT(key) DO UPDATE SET value='1', updated_at=unixepoch()"
+   ```
+
+   **Rollback is the same statement with `'0'`** — every client is back on the proxy
+   path at its next poll, and D1 keeps ingesting the whole time.
+
+**Flood response.** `documents_cap_saturated`, or a `Document Ingest` tile stuck
+red, means pausing writes:
+
+```bash
+npx wrangler d1 execute skyreader --remote --command \
+  "INSERT INTO sync_state (key, value, updated_at) VALUES ('documents_ingest_enabled','0',unixepoch())
+   ON CONFLICT(key) DO UPDATE SET value='0', updated_at=unixepoch()"
+```
+
+The subscriptions stream keeps running, reads keep serving whatever D1 holds, and
+the document cursor stays put — so re-enabling resumes the drain rather than
+skipping the backlog. Expect `Document Stream Lag` to read "Paused" while it's off.
+
+**Repairing one author** (the D1 equivalent of the proxy re-list below): force them
+to the front of the reconcile queue, or backfill them directly.
+
+```bash
+curl -sX POST -H "X-Proxy-Secret: $FEED_PROXY_SECRET" \
+  -d '{"dids":["did:plc:..."]}' https://api.skyreader.app/api/internal/documents/backfill
+```
+
 ### The timeline rollout gate
 
 `ingestActive` is the AND of two things: a fresh crawler heartbeat and
@@ -557,7 +686,7 @@ only meaningful with the gate open; check it before announcing the feature.
 
 ---
 
-## 4e. Guest reading mode (unauthenticated surface)
+## 4f. Guest reading mode (unauthenticated surface)
 
 Two public endpoints, both under `/api/guest/` (`backend/src/routes/guest.ts`),
 both keyed by `CF-Connecting-IP` because there is no DID, and **both read-only**:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -305,6 +305,12 @@ GROUP BY author_did ORDER BY 2 DESC LIMIT 5;
 (§4e) and unsubscribe/park the author before resuming — the subscriptions stream
 and document reads are untouched either way.
 
+`documents_apply_cap_hit` also carries `cappedBy`. `apply-cap` is the tunable
+bound above. `query-budget` means the cycle ran out of D1 queries first, which
+raising the cap will not change: its events were costlier than the usual one
+statement apiece — many distinct authors in one cycle, or publications whose
+metadata had to be resolved cold. That drains too, just at fewer events per cycle.
+
 ### `source: client` errors after a deploy
 
 **Means:** the browser is throwing. One report is a user with an extension or a
@@ -575,7 +581,7 @@ readers stay on the proxy.
 
 | Key                        | Default          | Governs                                                      |
 | -------------------------- | ---------------- | ------------------------------------------------------------ |
-| `documents_ingest_enabled` | on (absent = on) | The poller's document stream. `'0'` = flood kill switch.     |
+| `documents_ingest_enabled` | on (absent = on) | Every background document write. `'0'` = flood kill switch.  |
 | `documents_v2_enabled`     | off (only `'1'`) | Reads served from D1 instead of the proxy. The rollout gate. |
 | `documents_apply_cap`      | 500              | Applied events per poll cycle before the drain carries over. |
 
@@ -596,8 +602,10 @@ npx wrangler d1 execute skyreader --remote --command \
      https://api.skyreader.app/api/internal/documents/backfill | jq '.backfilled, .remaining'
    ```
 
-   The hourly cron re-lists the three stalest authors anyway, so this only makes the
-   migration finish in an afternoon instead of over weeks. `remaining` does reach 0
+   The cron re-lists stale authors anyway — one a minute plus three on the hour — so
+   this only makes the migration finish in an afternoon instead of over days. Each
+   call takes a handful of authors, sized so one request stays inside D1's
+   per-invocation query ceiling; loop it. `remaining` does reach 0
    even with authors nobody can list (deleted account, dead PDS): a failed list holds
    that author out of the queue for a backoff window that doubles per consecutive
    failure, up to the 7-day reconcile interval. Their `last_error` is on
@@ -652,6 +660,13 @@ npx wrangler d1 execute skyreader --remote --command \
 The subscriptions stream keeps running, reads keep serving whatever D1 holds, and
 the document cursor stays put — so re-enabling resumes the drain rather than
 skipping the backlog. Expect `Document Stream Lag` to read "Paused" while it's off.
+
+The switch stops **every background write**, not just the drain: the poller's
+per-cycle back catalogues and the cron's reconcile pause with it, since either would
+otherwise keep writing up to a hundred rows an author while the flood is supposedly
+paused. Their queues survive the pause. The one path that still writes is the
+backfill endpoint below — an operator asking for a specific repair, which is what
+you want available during an incident.
 
 **A held cursor is only worth as much as Jetstream's replay buffer.** That buffer is
 hours, not days: past it, reconnecting is served from the oldest event the server

--- a/docs/plans/DOCUMENTS_TO_D1.md
+++ b/docs/plans/DOCUMENTS_TO_D1.md
@@ -42,14 +42,25 @@ collection stream would eat all of it, so:
    `documents_apply_cap` (500) events per cycle and only ever advances its cursor past an
    event it finished. A burst drains over successive cycles instead of starving the
    subscriptions stream or overrunning the alarm, and slow draining costs latency, not
-   data.
+   data. The cap has a harder twin: the drain also counts the D1 queries it spends and
+   stops at `DOCUMENT_DRAIN_QUERY_BUDGET`, because D1 refuses everything past
+   `D1_QUERIES_PER_INVOCATION` (1000, counting each statement in a `batch` separately) and
+   the drain would meet that ceiling the worst possible way — a throw per event, counted as
+   an error, cursor walked over the burst the cap exists to protect. Applying an event is
+   one statement for exactly this reason: the cap eviction (layer 4) and the ingest
+   bookkeeping are settled once per author at the end of the cycle rather than riding every
+   write.
 4. **Per-author row cap** — 100 rows, oldest evicted by `published_at`. This is the only
    layer that helps against the dangerous case: an author we _subscribe to_ dumping
    thousands of documents passes the DID filter by design.
 5. **Observability + kill switch** — the document stream has its own `streamLagMs`, its own
    Sentry alert, a cap-saturation streak counter surfaced on the admin ops panel, and
    `documents_ingest_enabled` to pause writes without touching reads or the subscriptions
-   stream.
+   stream. "Writes" means every background one: the drain, the back catalogues the poller
+   pulls for mirrored subscriptions, and the cron's reconcile. Otherwise the switch would
+   leave the poller writing up to a hundred rows an author a minute, because the
+   subscriptions stream keeps enqueuing DIDs while it is off. The operator backfill
+   endpoint is the deliberate exception.
 
 ## What's in D1
 
@@ -93,11 +104,19 @@ accounts at the front of the queue would starve every other author forever, sile
 
 Cold start is the reconcile's other job, and it is not supposed to have to do it: every
 path that creates an `atproto.documents` subscription — the API, the Atmosphere subscribe
-button, the PDS→local sync, and a subscription mirrored in by the poller — calls
-`ensureAuthorDocuments`, which lists the author unless we hold a fresh listing or are
-inside their backoff. A subscription whose author has never been listed serves
-`status:'error'` on every poll, so leaving that to the hourly reconcile means an hour of a
-visibly broken linkblog.
+button, the Atmosphere graph import, the PDS→local subscription pull, and a subscription
+mirrored in by the poller — calls `ensureAuthorDocuments`, which lists the author unless we
+hold a fresh listing or are inside their backoff. A subscription whose author has never
+been listed serves `status:'error'` on every poll, so leaving that to the reconcile means a
+visibly broken linkblog in the meantime.
+
+The two sync paths are the ones that can create many subscriptions at once, and every walk
+they schedule runs in the same invocation via `waitUntil` — a dozen of them would exhaust
+`D1_QUERIES_PER_INVOCATION` and take down the mirrors scheduled alongside. So each warms
+`MAX_SYNC_BACKFILLS` (2) authors and leaves the rest to the reconcile, where an author with
+no `document_authors` row already sorts to the front of the queue. That queue is drained by
+the every-minute cron at one author a tick as well as by the hourly three, so the tail of a
+large restore is minutes rather than an afternoon.
 
 ## Rollout
 
@@ -111,9 +130,12 @@ soaked; rollback is the same flag set back to `'0'`.
 
 - **Phase 0 measurement.** The apply cap (500) is a strawman sized by reasoning, not by a
   measured burst shape. `documents_apply_cap` exists so it can be tuned from the observed
-  `documents_apply_cap_hit` rate without a deploy — under `MAX_DOCUMENT_APPLY_CAP` (900),
-  which is the Worker subrequest budget rather than the burst shape talking: an applied
-  event costs one batched D1 call plus, on a cold publication, its metadata resolve.
+  `documents_apply_cap_hit` rate without a deploy — clamped at `MAX_DOCUMENT_APPLY_CAP`,
+  which is the query budget rather than the burst shape talking: an applied event costs one
+  D1 statement (plus, on a publication this cycle has not seen, its metadata resolve), so
+  the budget is also the most events any cap could buy. A `cappedBy: 'query-budget'` line
+  in `documents_apply_cap_hit` means the cycle's events were costlier than that common
+  case — many distinct authors, or cold publications — not that the cap is set too low.
 - **`linkblog-site`** still fetches documents from the proxy's `/documents`. It moves to
   the Worker after the prod flag flip, so both apps cut over from the same store.
 - **Decommission.** Once the soak passes: remove `DocumentFirehose`, `document_cache`, its

--- a/docs/plans/DOCUMENTS_TO_D1.md
+++ b/docs/plans/DOCUMENTS_TO_D1.md
@@ -142,6 +142,20 @@ the next reconcile rather than being dropped. Each fan-out asks `canAffordBackfi
 starting an author, so an invocation that is out of budget leaves the author in the queue
 instead of throwing partway through a walk that has already written rows and not yet pruned.
 
+Two details make that constant true rather than nearly true. A walk resolves the author's DID
+**once** and hands the memo to both listings: `resolvePdsUrl` is an uncached plc.directory
+fetch, so a walk that let each listing resolve for itself spent one subrequest more than the
+listing term budgets — enough to put a batch of worst-case authors over the endpoint ledger
+that is sized as batch × cost. And the sidecar cap is a **floor**, not the actual allowance:
+a walk spends whatever is left of its own reservation once the listing, the upserts, the
+resolves and the prune are paid for, which is exactly `MAX_COLLECTION_WRITES_PER_BACKFILL`
+when every other term is at its cap and much more for an ordinary author. What it still can't
+afford is recorded as `document_authors.collections_pending`, which keeps the author in the
+reconcile queue (sorted last, behind everything genuinely stale) instead of parking them for
+a full `AUTHOR_RECONCILE_INTERVAL_MS` — a back catalogue of curated editions landing 20 a
+week is weeks of magazines rendering without their item lists. Only a walk that wrote some
+sets the flag, so each requeued pass strictly advances.
+
 One thing is still unbounded: the PDS→local pull's insert batch is one statement per restored
 row, capped only by the plan's mirror limit (1000 / 5000). A very large restore can exhaust
 the invocation by itself — it is charged to the ledger, which is what keeps walks from being

--- a/docs/plans/DOCUMENTS_TO_D1.md
+++ b/docs/plans/DOCUMENTS_TO_D1.md
@@ -66,7 +66,9 @@ that grows a field needs no migration — the mapper reads it back out.
 ## Wire compatibility
 
 `/api/v2/documents/batch` keeps the proxy's contract exactly: `ready` / `unchanged` /
-`error`, the same `complete` semantics, and a digest computed over the same sorted
+`error`, the same `complete` semantics (recomputed per serve from the author's stored row
+count, as the proxy did from the set it was about to return — the stored flag alone would
+still claim completeness after cap eviction), and a digest computed over the same sorted
 `(recordUri, recordCid)` pairs with the same algorithm (parity pinned in
 `test/standard-site.spec.ts`). **The frontend does not change.** The one thing that cannot
 be reproduced is the proxy's per-author fetch backoff (`errorCount` / `nextRetryAt`); an
@@ -78,7 +80,24 @@ client holding what it has rather than clearing the scope.
 The proxy self-healed drift by full-replacing its blob on every refresh. Here that's two
 things: deletes applied live from the firehose, and a low-frequency reconcile — the hourly
 cron re-lists the three stalest authors (`AUTHOR_RECONCILE_INTERVAL_MS`, 7 days), which is
-also what closes a hole left by a cursor gap or a paused ingest.
+also what closes a hole left by a cursor gap or a paused ingest. A re-list prunes both
+documents and reader-collection sidecars the repo no longer has, but only against a
+listing that succeeded _and_ was exhaustive — a failed fetch and an author with no
+editions produce the same empty result, and pruning on the first would delete everything.
+
+Because the reconcile is the only self-heal, it must never be monopolised: a failed list
+holds that author out of the queue for `authorRetryBackoffMs` (1h, doubling per
+consecutive failure, capped at the reconcile interval) and sorts them by that failure
+rather than by their still-NULL `last_listed_at`. Without both halves, three deleted
+accounts at the front of the queue would starve every other author forever, silently.
+
+Cold start is the reconcile's other job, and it is not supposed to have to do it: every
+path that creates an `atproto.documents` subscription — the API, the Atmosphere subscribe
+button, the PDS→local sync, and a subscription mirrored in by the poller — calls
+`ensureAuthorDocuments`, which lists the author unless we hold a fresh listing or are
+inside their backoff. A subscription whose author has never been listed serves
+`status:'error'` on every poll, so leaving that to the hourly reconcile means an hour of a
+visibly broken linkblog.
 
 ## Rollout
 
@@ -92,7 +111,9 @@ soaked; rollback is the same flag set back to `'0'`.
 
 - **Phase 0 measurement.** The apply cap (500) is a strawman sized by reasoning, not by a
   measured burst shape. `documents_apply_cap` exists so it can be tuned from the observed
-  `documents_apply_cap_hit` rate without a deploy.
+  `documents_apply_cap_hit` rate without a deploy — under `MAX_DOCUMENT_APPLY_CAP` (900),
+  which is the Worker subrequest budget rather than the burst shape talking: an applied
+  event costs one batched D1 call plus, on a cold publication, its metadata resolve.
 - **`linkblog-site`** still fetches documents from the proxy's `/documents`. It moves to
   the Worker after the prod flag flip, so both apps cut over from the same store.
 - **Decommission.** Once the soak passes: remove `DocumentFirehose`, `document_cache`, its

--- a/docs/plans/DOCUMENTS_TO_D1.md
+++ b/docs/plans/DOCUMENTS_TO_D1.md
@@ -49,18 +49,21 @@ collection stream would eat all of it, so:
    an error, cursor walked over the burst the cap exists to protect. Applying an event is
    one statement for exactly this reason: the cap eviction (layer 4) and the ingest
    bookkeeping are settled once per author at the end of the cycle rather than riding every
-   write.
+   write. The spend it counts includes the cross-PDS fetches a publication resolve makes —
+   see "The invocation budget" below for why they belong in the same number.
 4. **Per-author row cap** — 100 rows, oldest evicted by `published_at`. This is the only
    layer that helps against the dangerous case: an author we _subscribe to_ dumping
    thousands of documents passes the DID filter by design.
 5. **Observability + kill switch** — the document stream has its own `streamLagMs`, its own
    Sentry alert, a cap-saturation streak counter surfaced on the admin ops panel, and
    `documents_ingest_enabled` to pause writes without touching reads or the subscriptions
-   stream. "Writes" means every background one: the drain, the back catalogues the poller
+   stream. "Writes" means every background _loop_: the drain, the back catalogues the poller
    pulls for mirrored subscriptions, and the cron's reconcile. Otherwise the switch would
    leave the poller writing up to a hundred rows an author a minute, because the
-   subscriptions stream keeps enqueuing DIDs while it is off. The operator backfill
-   endpoint is the deliberate exception.
+   subscriptions stream keeps enqueuing DIDs while it is off. Two deliberate exceptions: the
+   operator backfill endpoint, and the subscribe-time walk (`ensureAuthorDocuments`), which a
+   reader subscribing during an incident needs or their new linkblog serves nothing but an
+   error — one author, 100 rows, one walk an hour, at most `MAX_SYNC_BACKFILLS` per request.
 
 ## What's in D1
 
@@ -118,6 +121,33 @@ no `document_authors` row already sorts to the front of the queue. That queue is
 the every-minute cron at one author a tick as well as by the hourly three, so the tail of a
 large restore is minutes rather than an afternoon.
 
+## The invocation budget
+
+The ceiling is per Worker invocation, so the budget is too: a `QueryLedger` is created once
+per invocation and shared by everything that writes documents in it — the cron's two
+reconcile passes, the operator endpoint's batch, and both halves of `/api/sync` including
+the walks they schedule into `waitUntil`. Two things share the 1,000: D1 counts each
+statement inside a `batch` separately, and the limit is the _read subrequest_ limit, so a
+cross-PDS `fetch()` comes out of it as well. Everything is therefore counted in subrequests —
+a cold publication resolve is charged its two D1 statements _and_ its three fetches, since a
+budget counting only the D1 half would report a cycle as halfway through when it was already
+at the ceiling.
+
+`BACKFILL_QUERY_COST` is a real worst case rather than an estimate: the document prune is a
+single `updated_at`-scoped DELETE (every kept row was just upserted, so "untouched by this
+walk" is the stale set) instead of a read plus a DELETE per row, the sidecars are one read
+plus one capped batch instead of a SELECT each, and what remains per-row is capped —
+`MAX_SITE_RESOLVES_PER_BACKFILL`, `MAX_COLLECTION_WRITES_PER_BACKFILL`, both converging on
+the next reconcile rather than being dropped. Each fan-out asks `canAffordBackfill` before
+starting an author, so an invocation that is out of budget leaves the author in the queue
+instead of throwing partway through a walk that has already written rows and not yet pruned.
+
+One thing is still unbounded: the PDS→local pull's insert batch is one statement per restored
+row, capped only by the plan's mirror limit (1000 / 5000). A very large restore can exhaust
+the invocation by itself — it is charged to the ledger, which is what keeps walks from being
+scheduled on top of it, and logged as `subscription_pull_batch_large`, but chunking it (and
+resuming across syncs) is still open.
+
 ## Rollout
 
 Both switches are `sync_state` rows; flipping either is a D1 write, not a deploy. Operator
@@ -136,6 +166,11 @@ soaked; rollback is the same flag set back to `'0'`.
   the budget is also the most events any cap could buy. A `cappedBy: 'query-budget'` line
   in `documents_apply_cap_hit` means the cycle's events were costlier than that common
   case — many distinct authors, or cold publications — not that the cap is set too low.
+- **Chunk the PDS→local subscription pull.** Its insert batch is the one unbounded term
+  left in an invocation that has to fit 1,000 subrequests (see "The invocation budget"): a
+  restore of ~900 mirrored rows can exhaust the ceiling on its own, and the fix — cap the
+  rows one sync materialises and resume on the next — is a user-visible behaviour change on
+  the restore path, so it wants deciding rather than assuming.
 - **`linkblog-site`** still fetches documents from the proxy's `/documents`. It moves to
   the Worker after the prod flag flip, so both apps cut over from the same store.
 - **Decommission.** Once the soak passes: remove `DocumentFirehose`, `document_cache`, its

--- a/docs/plans/DOCUMENTS_TO_D1.md
+++ b/docs/plans/DOCUMENTS_TO_D1.md
@@ -1,0 +1,104 @@
+# standard.site documents: off the Fly proxy, into D1
+
+Documents were the last content type where Fly held authoritative state and sat on the
+read path. This is the same move feeds already made (`D1_FEED_TIMELINE.md`), applied to
+`site.standard.document`: the Jetstream consumer comes back to the `JetstreamPoller`
+Durable Object, records land in D1, and reads become plain queries.
+
+## Why the DO and not the proxy
+
+There were two Jetstream consumers in two runtimes — a persistent Bun socket on Fly for
+documents, and the DO's poll-drain-disconnect loop for subscriptions — with two cursor
+stores, two reconnect implementations and two observability surfaces. The proxy's copy
+also derived its `wantedDids` from **read traffic** (`document_cache.last_requested_at`)
+while the real subscription set sat in D1, which is exactly the circularity the crawl-set
+pull fixed for feeds.
+
+The filter is what makes the DO the better host, not a worse one. A long-lived socket has
+to _mutate_ its filter in place as subscriptions change — the ~550 lines of
+`options_update` + reconcile machinery on the proxy. The DO reconnects fresh every 60s, so
+the filter is just connect-time state read from D1: at most one alarm interval stale, by
+construction, with no live-update protocol.
+
+The trade is freshness: ~60s worst case on top of the client's own poll interval. Clients
+poll `/api/v2/documents/batch` anyway, and for a calm reading product that is well inside
+tolerance.
+
+## Spike handling (five layers)
+
+Big platforms occasionally dump large volumes of standard.site documents. An unfiltered
+collection stream would eat all of it, so:
+
+1. **Server-side DID filter, refreshed per cycle** — `wantedDids` as URL params up to
+   `DID_URL_PARAM_LIMIT` (150) authors, one `options_update` frame on `open` beyond that
+   (a several-kilobyte query string risks a rejected upgrade). Every DID is validated with
+   `isValidDid` first: Jetstream rejects the whole frame on one malformed entry and closes
+   the socket.
+2. **Per-event membership re-check** — every applied event's author is checked against the
+   same D1 set before any write. This covers the brief unfiltered window in the frame
+   path, and means a filter that is broken or whose semantics change (Jetstream v2)
+   degrades to "more parse traffic", never to wrong rows.
+3. **Per-cycle apply cap with cursor carry** — `createDocumentDrain` applies at most
+   `documents_apply_cap` (500) events per cycle and only ever advances its cursor past an
+   event it finished. A burst drains over successive cycles instead of starving the
+   subscriptions stream or overrunning the alarm, and slow draining costs latency, not
+   data.
+4. **Per-author row cap** — 100 rows, oldest evicted by `published_at`. This is the only
+   layer that helps against the dangerous case: an author we _subscribe to_ dumping
+   thousands of documents passes the DID filter by design.
+5. **Observability + kill switch** — the document stream has its own `streamLagMs`, its own
+   Sentry alert, a cap-saturation streak counter surfaced on the admin ops panel, and
+   `documents_ingest_enabled` to pause writes without touching reads or the subscriptions
+   stream.
+
+## What's in D1
+
+| Table                   | Holds                                                                     |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `documents_v2`          | One row per record: raw `record_json` + queried scalars. PK `record_uri`. |
+| `collections_v2`        | Reader-collection sidecars, paired by rkey, with persisted item previews. |
+| `publications_cache_v2` | Publication base URL / icon / name / theme / fonts. 24h TTL, 5m negative. |
+| `document_authors`      | Per-author last-listed stamp, completeness, last backfill error.          |
+
+The raw record is stored rather than a flattened projection (what 0030 did), so a lexicon
+that grows a field needs no migration — the mapper reads it back out.
+
+## Wire compatibility
+
+`/api/v2/documents/batch` keeps the proxy's contract exactly: `ready` / `unchanged` /
+`error`, the same `complete` semantics, and a digest computed over the same sorted
+`(recordUri, recordCid)` pairs with the same algorithm (parity pinned in
+`test/standard-site.spec.ts`). **The frontend does not change.** The one thing that cannot
+be reproduced is the proxy's per-author fetch backoff (`errorCount` / `nextRetryAt`); an
+author we have never successfully listed reports `error` without them, which keeps a
+client holding what it has rather than clearing the scope.
+
+## Self-heal
+
+The proxy self-healed drift by full-replacing its blob on every refresh. Here that's two
+things: deletes applied live from the firehose, and a low-frequency reconcile — the hourly
+cron re-lists the three stalest authors (`AUTHOR_RECONCILE_INTERVAL_MS`, 7 days), which is
+also what closes a hole left by a cursor gap or a paused ingest.
+
+## Rollout
+
+Both switches are `sync_state` rows; flipping either is a D1 write, not a deploy. Operator
+steps, the backfill loop, the shadow-compare and the flood response are in
+[`RUNBOOK.md` §4e](../RUNBOOK.md). In short: ingest is on by default and fills D1;
+`documents_v2_enabled` stays off until a shadow-compare against the proxy is clean and has
+soaked; rollback is the same flag set back to `'0'`.
+
+## Still to do
+
+- **Phase 0 measurement.** The apply cap (500) is a strawman sized by reasoning, not by a
+  measured burst shape. `documents_apply_cap` exists so it can be tuned from the observed
+  `documents_apply_cap_hit` rate without a deploy.
+- **`linkblog-site`** still fetches documents from the proxy's `/documents`. It moves to
+  the Worker after the prod flag flip, so both apps cut over from the same store.
+- **Decommission.** Once the soak passes: remove `DocumentFirehose`, `document_cache`, its
+  warm loop and `/documents` serve path, and `standard-site.ts` from the proxy; drop the
+  orphaned 0030/0031 tables; retire the admin's proxy-side Document Sync tile.
+- **Jetstream v2.** Move the DO to the v2 endpoint and use network replay for gap recovery
+  (a cursor older than the buffer becomes a `planSnapshot` instead of a hole). Re-verify
+  `wantedDids` semantics there first; if v2 drops them, layer 2 keeps collection-only
+  operation correct.


### PR DESCRIPTION
Moves standard.site document ingest and reads from the Fly proxy to Cloudflare's Jetstream Durable Object and D1 store, behind rollout and ingest gates.

This continuation merges the latest `main` (guest reading mode, the standard.site handle-authority discovery fix, the proxy `/stats` index, the archive's oversized-body summary). One textual conflict — both sides added a row to `backend/CLAUDE.md`'s routes table — plus two the merge machinery couldn't see: both sides wrote a RUNBOOK `## 4e` (documents keeps 4e, guest reading mode becomes 4f), and `### The timeline rollout gate` was stranded under the new section, so it moved back under §4d Ingest health where main had just appended to it.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-vp2sy2ttosjlcyozxkw7eyxm)
[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-ekismjythmvehbygfadybfdj)


This continuation re-merges `main` at `5971142` — the previous merge resolved against a stale `origin/main` and landed unmergeable. The one conflict is adjacent additive tests in `admin/src/lib/metrics/ops.test.ts`; both sides stay. The judgment behind it: `documents_v2_enabled` decides which of the panel's two document verdicts a reader depends on, main's `proxy-document-cache-frozen` alert survives the cutover unchanged and goes quiet on its own as the proxy's 14-day active window drains, and it is retired in a later pruning pass — the runbook now says so in §4d and §4e.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-kelunfaqhfh4rxsmeimxaeqo)
