### PR TITLE
Converge article sync state across devices

### DIFF
--- a/backend/migrations/0076_item_labels_client_updated_at.sql
+++ b/backend/migrations/0076_item_labels_client_updated_at.sql
@@ -1,0 +1,28 @@
+-- User-time last-write-wins for item labels.
+--
+-- Until now every label write blindly overwrote whatever was there, so the
+-- winner was whichever HTTP request arrived last. A device draining an offline
+-- queue an hour late therefore resurrected stale intent — re-marking unread
+-- something the user had since read on another device.
+--
+-- `client_updated_at` is the moment the USER acted, in unix MILLISECONDS,
+-- clamped server-side to "now" so a forward-skewed clock can't pin a row
+-- permanently. Every write path compares it before overwriting:
+--
+--   ON CONFLICT(...) DO UPDATE SET ... WHERE excluded.client_updated_at >= client_updated_at
+--
+-- `updated_at` (server seconds) keeps its job unchanged: it is the delta
+-- cursor, so the sync stream stays arrival-ordered and monotonic. This column
+-- is only the conflict tiebreaker.
+--
+-- Backfilled from updated_at so pre-existing rows compare sensibly against new
+-- writes; COALESCE guards the row an older Worker might still insert mid-deploy.
+ALTER TABLE item_labels_cache ADD COLUMN client_updated_at INTEGER;
+
+UPDATE item_labels_cache SET client_updated_at = updated_at * 1000;
+
+-- The delta is now ordered by (updated_at, id) so same-second rows can't be
+-- skipped by a strictly-greater cursor. This index is what keeps that ordered
+-- scan a seek rather than a per-user sort.
+CREATE INDEX IF NOT EXISTS idx_item_labels_user_updated
+  ON item_labels_cache(user_did, updated_at, id);

--- a/backend/src/config/window.ts
+++ b/backend/src/config/window.ts
@@ -1,0 +1,22 @@
+/**
+ * K — the canonical per-feed article window.
+ *
+ * One number, enforced in three places that used to disagree:
+ *
+ *  - the timeline's cold start (`COLD_START_PER_FEED`, timeline.ts) — what a
+ *    fresh device receives per feed,
+ *  - the server-computed unread counts (timeline.ts) — what every device
+ *    displays,
+ *  - the client's local cap (`MAX_ARTICLES_PER_FEED`,
+ *    `frontend/src/lib/services/articleMerge.ts`) — what an established device
+ *    keeps.
+ *
+ * They were 30 / — / 100, which is why two devices signed into one account
+ * showed different unread numbers for the same feed no matter how well read
+ * state synced: they were counting over different sets. Anything that changes
+ * this value must change the frontend constant in the same commit.
+ *
+ * 100 rather than 50: a cold start is rare and paged (COLD_START_MAX_ITEMS
+ * bounds each request), while divergence is daily.
+ */
+export const ARTICLE_WINDOW_PER_FEED = 100;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,6 +53,7 @@ import {
   handleMarkAsRead,
   handleMarkAsUnread,
   handleBulkMarkAsRead,
+  handleMarkFeedRead,
 } from './routes/reading';
 import { handleLexicon, handleLexiconIndex } from './routes/lexicons';
 import {
@@ -522,6 +523,12 @@ async function route(
       break;
     case url.pathname === '/api/reading/mark-read-bulk':
       response = await handleBulkMarkAsRead(request, env);
+      break;
+    // Mark the canonical per-feed window read server-side, so every device
+    // converges — including on items the acting device never held locally.
+    case url.pathname === '/api/reading/mark-feed-read':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleMarkFeedRead(request, env, session);
       break;
 
     // Labels routes (unified item labels)

--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -123,6 +123,12 @@ function proxyErrorFields(error: unknown): Record<string, unknown> {
  *   feed — the "retry this feed" action, the one path that still asks the
  *   crawler for a fresh fetch on demand.
  * - since_guids: accepted and ignored (legacy); the client dedupes by GUID.
+ * - offset: skip N items into the feed's ordered archive. This is the "Show
+ *   older" read — the client's local set is capped per feed, so it asks for the
+ *   page below its own window rather than being told those items are gone. An
+ *   offset read never triggers the pull-through: it is a deliberate walk down an
+ *   archive that already exists, and an empty page means the bottom, not a
+ *   missing feed.
  */
 export async function handleV2FeedFetch(
   request: Request,
@@ -157,13 +163,16 @@ export async function handleV2FeedFetch(
 
   const forceRefresh = url.searchParams.get('refresh') === '1';
 
+  const parsedOffset = parseInt(url.searchParams.get('offset') ?? '', 10);
+  const offset = Number.isInteger(parsedOffset) && parsedOffset > 0 ? parsedOffset : 0;
+
   // Hoisted out of the try so the outer catch can log it. Whether the archive
   // had anything is what separates a fatal pull-through (nothing to serve, so
   // the error is the response) from a refresh failure we swallow.
   let archiveEmpty = false;
 
   try {
-    let items = await readFeedSlice(env, session.did, feedUrl, limit);
+    let items = await readFeedSlice(env, session.did, feedUrl, limit, offset);
     let metadata = await readFeedMetadata(env, feedUrl);
 
     // Pull-through: the archive has nothing for this feed (first subscriber, so
@@ -172,7 +181,9 @@ export async function handleV2FeedFetch(
     // every other user — comes from D1. Gated on the caller's own subscription
     // (see the note above); a non-subscriber just reads whatever D1 already holds.
     archiveEmpty = items.length === 0;
-    const wantsPullThrough = archiveEmpty || forceRefresh;
+    // An offset read is a walk down an archive we know exists; an empty page is
+    // its bottom, not a feed nobody has ever crawled.
+    const wantsPullThrough = offset === 0 && (archiveEmpty || forceRefresh);
     if (wantsPullThrough && (await callerSubscribes(env, session.did, feedUrl))) {
       try {
         const client = new FeedProxyClient(env);

--- a/backend/src/routes/labels.ts
+++ b/backend/src/routes/labels.ts
@@ -1,6 +1,16 @@
 import type { Env } from '../types';
 import { getSessionFromRequest } from '../services/oauth';
 import { generateTid } from '../utils/tid';
+import {
+  afterCursorParams,
+  afterCursorSql,
+  clampClientUpdatedAt,
+  decodeDeltaCursor,
+  encodeDeltaCursor,
+  maxCursor,
+  parseSince,
+  type DeltaCursor,
+} from '../utils/delta-cursor';
 
 interface LabelRow {
   item_key: string;
@@ -11,27 +21,11 @@ interface LabelRow {
   created_at: number;
   updated_at: number;
   deleted_at: number | null;
+  client_updated_at: number | null;
 }
 
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
-
-function encodeCursor(updatedAt: number, id: number): string {
-  return btoa(`${updatedAt}:${id}`);
-}
-
-function decodeCursor(cursor: string): { updatedAt: number; id: number } | null {
-  try {
-    const decoded = atob(cursor);
-    const [updatedAtStr, idStr] = decoded.split(':');
-    const updatedAt = Number(updatedAtStr);
-    const id = Number(idStr);
-    if (isNaN(updatedAt) || isNaN(id)) return null;
-    return { updatedAt, id };
-  } catch {
-    return null;
-  }
-}
 
 // GET /api/labels - Get all labels for the current user
 export async function handleGetLabels(request: Request, env: Env): Promise<Response> {
@@ -56,13 +50,15 @@ export async function handleGetLabels(request: Request, env: Env): Promise<Respo
   const cursor = url.searchParams.get('cursor');
   const limitParam = url.searchParams.get('limit');
   const limit = Math.min(Math.max(1, Number(limitParam) || DEFAULT_LIMIT), MAX_LIMIT);
-  // Delta sync: `?since=<unix_seconds>` returns only rows changed since the
-  // client's cursor (updated_at strictly greater). Omit it for a full fetch.
-  const sinceParam = url.searchParams.get('since');
-  const since = sinceParam !== null ? parseInt(sinceParam, 10) : NaN;
+  // Delta sync: `?since=` returns only rows changed since the client's cursor.
+  // The cursor is compound — base64 `updatedAt:id` — so strictly-greater is
+  // lossless across same-second rows; a bare unix-seconds value from the
+  // previous release is still accepted (see parseSince). Omit for a full fetch.
+  const since = parseSince(url.searchParams.get('since'));
+  const isDelta = since !== null;
 
   try {
-    let query = `SELECT id, item_key, item_type, label, props, rkey, created_at, updated_at, deleted_at
+    let query = `SELECT id, item_key, item_type, label, props, rkey, created_at, updated_at, deleted_at, client_updated_at
       FROM item_labels_cache
       WHERE user_did = ?`;
     const params: (string | number)[] = [session.did];
@@ -79,29 +75,39 @@ export async function handleGetLabels(request: Request, env: Env): Promise<Respo
       query += ' AND item_type = ?';
       params.push(itemTypeFilter);
     }
-    if (Number.isFinite(since)) {
-      // Delta: include tombstones (deleted_at set) so the client can replay
-      // deletions made on other devices. The row stays until GC purges it.
-      query += ' AND updated_at > ?';
-      params.push(since);
-    } else {
-      // Full snapshot: live rows only — a fresh client has nothing to remove.
-      query += ' AND deleted_at IS NULL';
-    }
-
+    let parsedCursor: DeltaCursor | null = null;
     if (cursor) {
-      const parsed = decodeCursor(cursor);
-      if (!parsed) {
+      parsedCursor = decodeDeltaCursor(cursor);
+      if (!parsedCursor) {
         return new Response(JSON.stringify({ error: 'Invalid cursor' }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      query += ' AND (updated_at < ? OR (updated_at = ? AND id < ?))';
-      params.push(parsed.updatedAt, parsed.updatedAt, parsed.id);
     }
 
-    query += ' ORDER BY updated_at DESC, id DESC';
+    if (isDelta) {
+      // Delta: include tombstones (deleted_at set) so the client can replay
+      // deletions made on other devices. The row stays until GC purges it.
+      //
+      // Ordered ASCENDING, unlike the full snapshot: a delta is drained forward
+      // from the client's cursor, so pages must be contiguous and the last row
+      // of the last page is the new cursor. Pagination therefore uses the SAME
+      // compound bound as `since` — whichever is larger — rather than a second,
+      // opposite-direction predicate.
+      const lower = maxCursor(since, parsedCursor)!;
+      query += ` AND ${afterCursorSql()}`;
+      params.push(...afterCursorParams(lower));
+      query += ' ORDER BY updated_at ASC, id ASC';
+    } else {
+      // Full snapshot: live rows only — a fresh client has nothing to remove.
+      query += ' AND deleted_at IS NULL';
+      if (parsedCursor) {
+        query += ' AND (updated_at < ? OR (updated_at = ? AND id < ?))';
+        params.push(parsedCursor.updatedAt, parsedCursor.updatedAt, parsedCursor.id);
+      }
+      query += ' ORDER BY updated_at DESC, id DESC';
+    }
     query += ' LIMIT ?';
     params.push(limit + 1);
 
@@ -121,13 +127,26 @@ export async function handleGetLabels(request: Request, env: Env): Promise<Respo
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       deletedAt: row.deleted_at,
+      // The user's own action time (unix ms). The client compares it against
+      // its local label before applying a remote row, so a late-arriving old
+      // write can't overwrite a newer local one.
+      clientUpdatedAt: row.client_updated_at,
     }));
 
-    const nextCursor = hasMore
-      ? encodeCursor(rows[rows.length - 1].updated_at, rows[rows.length - 1].id)
+    const last = rows[rows.length - 1];
+    const nextCursor = hasMore && last ? encodeDeltaCursor(last.updated_at, last.id) : undefined;
+
+    // The delta cursor to persist: the last row DELIVERED, or the caller's own
+    // cursor when the page was empty. Never a clock reading — a cursor that
+    // moved past rows the client didn't receive is exactly the silent loss this
+    // endpoint is meant to be free of. Only meaningful in delta mode.
+    const nextSince = isDelta
+      ? last
+        ? encodeDeltaCursor(last.updated_at, last.id)
+        : encodeDeltaCursor(since.updatedAt, since.id)
       : undefined;
 
-    return new Response(JSON.stringify({ labels, cursor: nextCursor }), {
+    return new Response(JSON.stringify({ labels, cursor: nextCursor, nextSince, hasMore }), {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
@@ -144,7 +163,28 @@ interface AddLabelRequest {
   itemType: string;
   label: string;
   props?: Record<string, unknown>;
+  // When the USER made this change, unix ms. Optional: an older client omits it
+  // and gets server-now, i.e. today's arrival-ordered behaviour.
+  updatedAt?: number;
 }
+
+/**
+ * The conflict clause every label write shares.
+ *
+ * `WHERE excluded.client_updated_at >= client_updated_at` is what makes the
+ * winner the later USER action rather than the later HTTP request: a queue
+ * draining an hour after the fact no longer overwrites what the user did on
+ * another device in the meantime. `>=` (not `>`) so an idempotent retry of the
+ * same write still lands.
+ *
+ * COALESCE covers a row an older Worker inserted mid-deploy with no value.
+ */
+const LABEL_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE SET
+         props = excluded.props,
+         updated_at = excluded.updated_at,
+         client_updated_at = excluded.client_updated_at,
+         deleted_at = NULL
+       WHERE excluded.client_updated_at >= COALESCE(item_labels_cache.client_updated_at, 0)`;
 
 // POST /api/labels - Add or update a label
 export async function handleAddLabel(request: Request, env: Env): Promise<Response> {
@@ -176,16 +216,15 @@ export async function handleAddLabel(request: Request, env: Env): Promise<Respon
   }
 
   const rkey = generateTid();
-  const now = Math.floor(Date.now() / 1000);
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
+  const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
 
   try {
     await env.DB.prepare(
-      `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(user_did, item_key, label) DO UPDATE SET
-         props = excluded.props,
-         updated_at = excluded.updated_at,
-         deleted_at = NULL`
+      `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ${LABEL_UPSERT_CONFLICT}`
     )
       .bind(
         session.did,
@@ -195,7 +234,8 @@ export async function handleAddLabel(request: Request, env: Env): Promise<Respon
         props ? JSON.stringify(props) : null,
         rkey,
         now,
-        now
+        now,
+        clientUpdatedAt
       )
       .run();
 
@@ -214,6 +254,7 @@ export async function handleAddLabel(request: Request, env: Env): Promise<Respon
 interface DeleteLabelRequest {
   itemKey: string;
   label: string;
+  updatedAt?: number;
 }
 
 // DELETE /api/labels - Remove a label
@@ -251,11 +292,19 @@ export async function handleDeleteLabel(request: Request, env: Env): Promise<Res
     // resurrects it (ON CONFLICT clears deleted_at); the hourly cron GCs old
     // tombstones. `read` positions are owned by the reading route and are still
     // hard-deleted there — they never reach this handler.
-    const now = Math.floor(Date.now() / 1000);
+    //
+    // Guarded by the same user-time comparison as the upsert, so a late-draining
+    // queue can't resurrect stale intent in EITHER direction: removing a label
+    // is as much a user action as adding one.
+    const nowMs = Date.now();
+    const now = Math.floor(nowMs / 1000);
+    const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
     await env.DB.prepare(
-      'UPDATE item_labels_cache SET deleted_at = ?, updated_at = ? WHERE user_did = ? AND item_key = ? AND label = ?'
+      `UPDATE item_labels_cache SET deleted_at = ?, updated_at = ?, client_updated_at = ?
+        WHERE user_did = ? AND item_key = ? AND label = ?
+          AND ? >= COALESCE(client_updated_at, 0)`
     )
-      .bind(now, now, session.did, itemKey, label)
+      .bind(now, now, clientUpdatedAt, session.did, itemKey, label, clientUpdatedAt)
       .run();
 
     return new Response(JSON.stringify({ success: true }), {
@@ -276,7 +325,10 @@ interface BulkAddLabelsRequest {
     itemType: string;
     label: string;
     props?: Record<string, unknown>;
+    updatedAt?: number;
   }>;
+  // Per-request fallback for callers whose items share one intent time.
+  updatedAt?: number;
 }
 
 // POST /api/labels/bulk - Bulk add labels
@@ -315,18 +367,17 @@ export async function handleBulkAddLabels(request: Request, env: Env): Promise<R
     });
   }
 
-  const now = Math.floor(Date.now() / 1000);
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
 
   try {
     const statements = labels.map((item) => {
       const rkey = generateTid();
+      const clientUpdatedAt = clampClientUpdatedAt(item.updatedAt ?? body.updatedAt, nowMs);
       return env.DB.prepare(
-        `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(user_did, item_key, label) DO UPDATE SET
-           props = excluded.props,
-           updated_at = excluded.updated_at,
-           deleted_at = NULL`
+        `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ${LABEL_UPSERT_CONFLICT}`
       ).bind(
         session.did,
         item.itemKey,
@@ -335,7 +386,8 @@ export async function handleBulkAddLabels(request: Request, env: Env): Promise<R
         item.props ? JSON.stringify(item.props) : null,
         rkey,
         now,
-        now
+        now,
+        clientUpdatedAt
       );
     });
 

--- a/backend/src/routes/reading.ts
+++ b/backend/src/routes/reading.ts
@@ -49,6 +49,10 @@ const READ_POSITIONS_MAX_LIMIT = 1000;
 const READ_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE SET
         props = excluded.props,
         item_type = excluded.item_type,
+        rkey = CASE
+          WHEN item_labels_cache.deleted_at IS NULL THEN item_labels_cache.rkey
+          ELSE excluded.rkey
+        END,
         deleted_at = NULL,
         updated_at = excluded.updated_at,
         client_updated_at = excluded.client_updated_at

--- a/backend/src/routes/reading.ts
+++ b/backend/src/routes/reading.ts
@@ -55,6 +55,12 @@ const READ_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE S
         client_updated_at = excluded.client_updated_at
       WHERE excluded.client_updated_at >= COALESCE(item_labels_cache.client_updated_at, 0)`;
 
+const UNREAD_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE SET
+        deleted_at = excluded.deleted_at,
+        updated_at = excluded.updated_at,
+        client_updated_at = excluded.client_updated_at
+      WHERE excluded.client_updated_at >= COALESCE(item_labels_cache.client_updated_at, 0)`;
+
 /**
  * Read-state join used by the feed/document annotation path (see feeds-v2.ts).
  * Returns the subset of `keys` the user has an active (non-tombstoned) `read`
@@ -260,18 +266,14 @@ export async function handleMarkAsRead(request: Request, env: Env): Promise<Resp
   const readAt = clientUpdatedAt;
 
   try {
-    // Check if already read (and live — a tombstoned row must resurrect, not skip).
+    // Preserve the stable rkey for an existing live row, but never skip the
+    // guarded upsert: a later read is itself new user intent and must advance
+    // client_updated_at so an older, delayed unread cannot win afterward.
     const existing = await env.DB.prepare(
-      "SELECT id FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read' AND deleted_at IS NULL"
+      "SELECT rkey FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read' AND deleted_at IS NULL"
     )
       .bind(session.did, itemGuid)
-      .first();
-
-    if (existing) {
-      return new Response(JSON.stringify({ success: true, alreadyRead: true }), {
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
+      .first<{ rkey: string | null }>();
 
     const props = buildReadProps({ readAt, itemUrl, itemTitle, authorDid });
 
@@ -287,12 +289,24 @@ export async function handleMarkAsRead(request: Request, env: Env): Promise<Resp
       ${READ_UPSERT_CONFLICT}
     `
     )
-      .bind(session.did, itemGuid, itemType, props, rkey, now, now, clientUpdatedAt)
+      .bind(
+        session.did,
+        itemGuid,
+        itemType,
+        props,
+        existing?.rkey ?? rkey,
+        now,
+        now,
+        clientUpdatedAt
+      )
       .run();
 
-    return new Response(JSON.stringify({ success: true, rkey }), {
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({ success: true, rkey: existing?.rkey ?? rkey, alreadyRead: !!existing }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
   } catch (error) {
     console.error('Failed to mark as read:', error);
     return new Response(JSON.stringify({ error: 'Failed to mark as read' }), {
@@ -357,11 +371,12 @@ export async function handleMarkAsUnread(request: Request, env: Env): Promise<Re
     const now = Math.floor(nowMs / 1000);
     const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
     await env.DB.prepare(
-      `UPDATE item_labels_cache SET deleted_at = ?, updated_at = ?, client_updated_at = ?
-        WHERE user_did = ? AND item_key = ? AND label = 'read'
-          AND ? >= COALESCE(client_updated_at, 0)`
+      `INSERT INTO item_labels_cache
+         (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, deleted_at, client_updated_at)
+       VALUES (?, ?, 'article', 'read', NULL, ?, ?, ?, ?, ?)
+       ${UNREAD_UPSERT_CONFLICT}`
     )
-      .bind(now, now, clientUpdatedAt, session.did, itemGuid, clientUpdatedAt)
+      .bind(session.did, itemGuid, generateTid(), now, now, now, clientUpdatedAt)
       .run();
 
     return new Response(JSON.stringify({ success: true }), {
@@ -439,10 +454,9 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
   const results: Array<{ itemGuid: string; rkey: string }> = [];
 
   try {
-    // Get already-read (live) labels for these items so we skip them. Tombstoned
-    // rows are intentionally NOT skipped — they must resurrect (chunked to avoid
-    // SQL variable limit).
-    const existingGuids = new Set<string>();
+    // Preserve stable rkeys for existing live rows. They still go through the
+    // conditional upsert so this read intent advances client_updated_at.
+    const existingRkeys = new Map<string, string>();
     const guidChunks = chunkArray(
       items.map((i) => i.itemGuid),
       MAX_SQL_PARAMS - 1
@@ -451,23 +465,20 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
     for (const chunk of guidChunks) {
       const placeholders = chunk.map(() => '?').join(',');
       const existingResult = await env.DB.prepare(
-        `SELECT item_key FROM item_labels_cache WHERE user_did = ? AND label = 'read' AND deleted_at IS NULL AND item_key IN (${placeholders})`
+        `SELECT item_key, rkey FROM item_labels_cache WHERE user_did = ? AND label = 'read' AND deleted_at IS NULL AND item_key IN (${placeholders})`
       )
         .bind(session.did, ...chunk)
-        .all<{ item_key: string }>();
+        .all<{ item_key: string; rkey: string | null }>();
 
       for (const row of existingResult.results) {
-        existingGuids.add(row.item_key);
+        if (row.rkey) existingRkeys.set(row.item_key, row.rkey);
       }
     }
 
-    // Filter out already-read items
-    const newItems = items.filter((item) => !existingGuids.has(item.itemGuid));
-
     // Generate rkeys and prepare batch insert
-    const itemsWithRkeys = newItems.map((item) => ({
+    const itemsWithRkeys = items.map((item) => ({
       ...item,
-      rkey: item.rkey || generateTid(),
+      rkey: existingRkeys.get(item.itemGuid) ?? item.rkey ?? generateTid(),
     }));
 
     // Batch insert/resurrect read labels using D1 batch to avoid subrequest limit
@@ -625,9 +636,9 @@ export async function handleMarkFeedRead(
     for (let i = 0; i < feedUrls.length; i += MARK_FEED_CHUNK) {
       const chunk = feedUrls.slice(i, i + MARK_FEED_CHUNK);
 
-      // The unread GUIDs inside each feed's newest-K window. `NOT EXISTS` rather
-      // than a join so a duplicate label row can't multiply the result, matching
-      // the timeline's read probe.
+      // Every GUID inside each feed's newest-K window. Already-live rows still
+      // need the guarded upsert: mark-all-read is fresh user intent and must
+      // advance its user-time clock so an older queued unread cannot beat it.
       const selects = chunk.map((feedUrl) =>
         env.DB.prepare(
           `SELECT w.guid, json_extract(w.item_json, '$.url') AS url,
@@ -635,12 +646,7 @@ export async function handleMarkFeedRead(
              FROM (SELECT fi.guid, fi.item_json FROM feed_items fi
                     WHERE fi.feed_url = ?2 ${beforeSeq !== null ? 'AND fi.seq <= ?4' : ''}
                     ORDER BY fi.published_at DESC, fi.seq DESC
-                    LIMIT ?3) w
-            WHERE NOT EXISTS (
-                    SELECT 1 FROM item_labels_cache il
-                     WHERE il.user_did = ?1 AND il.item_key = w.guid
-                       AND il.item_type = 'article' AND il.label = 'read'
-                       AND il.deleted_at IS NULL)`
+                    LIMIT ?3) w`
         ).bind(
           ...(beforeSeq !== null
             ? [session.did, feedUrl, ARTICLE_WINDOW_PER_FEED, beforeSeq]

--- a/backend/src/routes/reading.ts
+++ b/backend/src/routes/reading.ts
@@ -1,6 +1,15 @@
-import type { Env } from '../types';
+import type { Env, Session } from '../types';
 import { getSessionFromRequest } from '../services/oauth';
 import { generateTid } from '../utils/tid';
+import { ARTICLE_WINDOW_PER_FEED } from '../config/window';
+import { rssSubscriptionPredicate } from './ingest';
+import {
+  afterCursorParams,
+  afterCursorSql,
+  clampClientUpdatedAt,
+  encodeDeltaCursor,
+  parseSince,
+} from '../utils/delta-cursor';
 
 const MAX_SQL_PARAMS = 90; // Conservative limit for D1 (empirically lower than SQLite's 999)
 
@@ -13,19 +22,38 @@ export function chunkArray<T>(array: T[], chunkSize: number): T[][] {
 }
 
 interface ItemLabelRow {
+  id: number;
   item_key: string;
   item_type: string;
   props: string | null;
   rkey: string | null;
   updated_at: number;
   deleted_at: number | null;
+  client_updated_at: number | null;
 }
 
 export type ReadItemType = 'article' | 'document';
 
-// Backstop on a single delta response. The delta is bounded by read churn since
-// the client's cursor, so this is only a runaway guard.
-const READ_POSITIONS_MAX_ROWS = 100000;
+// Rows in one delta page. This used to be a 100 000-row "runaway guard" with no
+// `hasMore` and no way to page: if it ever truncated, the client advanced its
+// forward-only cursor to the newest row it saw and permanently skipped the
+// older tail. It is now an ordinary page size — the client drains until
+// `hasMore` is false.
+const READ_POSITIONS_DEFAULT_LIMIT = 500;
+const READ_POSITIONS_MAX_LIMIT = 1000;
+
+/**
+ * The conflict clause the read writers share — the same user-time
+ * last-write-wins guard as the label route. See migration 0076.
+ */
+const READ_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE SET
+        props = excluded.props,
+        rkey = excluded.rkey,
+        item_type = excluded.item_type,
+        deleted_at = NULL,
+        updated_at = excluded.updated_at,
+        client_updated_at = excluded.client_updated_at
+      WHERE excluded.client_updated_at >= COALESCE(item_labels_cache.client_updated_at, 0)`;
 
 /**
  * Read-state join used by the feed/document annotation path (see feeds-v2.ts).
@@ -71,6 +99,12 @@ export async function getReadKeys(
 // The cost is bounded by read churn since the last refresh, not by cache or
 // history. There is no full/windowed branch: bootstrap read state arrives via
 // annotation, and the client seeds its cursor from the batch fetch response.
+//
+// The cursor is compound — `(updated_at, id)`, base64 `updatedAt:id` on the
+// wire — because `updated_at` alone has one-second resolution and a
+// strictly-greater timestamp predicate silently drops every row written in the
+// same second as the cursor's max. Legacy numeric cursors are still accepted.
+// Pages are bounded and report `hasMore`; the client drains before persisting.
 export async function handleGetReadPositions(request: Request, env: Env): Promise<Response> {
   const session = await getSessionFromRequest(request, env);
   if (!session) {
@@ -82,28 +116,34 @@ export async function handleGetReadPositions(request: Request, env: Env): Promis
 
   try {
     const url = new URL(request.url);
-    const sinceParam = url.searchParams.get('since');
-    const parsed = sinceParam !== null ? parseInt(sinceParam, 10) : NaN;
     // A missing/invalid cursor falls back to "everything" (since 0). In practice
     // the client always sends a cursor (seeded from the batch fetch), so this is
     // only a safety net, never the steady-state path.
-    const since = Number.isFinite(parsed) ? parsed : 0;
+    const since = parseSince(url.searchParams.get('since')) ?? { updatedAt: 0, id: 0 };
+
+    const limitParam = url.searchParams.get('limit');
+    const parsedLimit = limitParam ? parseInt(limitParam, 10) : NaN;
+    const limit = Number.isInteger(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), READ_POSITIONS_MAX_LIMIT)
+      : READ_POSITIONS_DEFAULT_LIMIT;
 
     const result = await env.DB.prepare(
       `
-      SELECT item_key, item_type, props, rkey, updated_at, deleted_at FROM item_labels_cache
-      WHERE user_did = ? AND label = 'read' AND item_type IN ('article', 'document') AND updated_at > ?
-      ORDER BY updated_at DESC
+      SELECT id, item_key, item_type, props, rkey, updated_at, deleted_at, client_updated_at
+        FROM item_labels_cache
+      WHERE user_did = ? AND label = 'read' AND item_type IN ('article', 'document')
+        AND ${afterCursorSql()}
+      ORDER BY updated_at ASC, id ASC
       LIMIT ?
     `
     )
-      .bind(session.did, since, READ_POSITIONS_MAX_ROWS)
+      .bind(session.did, ...afterCursorParams(since), limit + 1)
       .all<ItemLabelRow>();
 
-    let cursor = since;
-    const positions = result.results.map((row) => {
-      if (row.updated_at > cursor) cursor = row.updated_at;
+    const hasMore = result.results.length > limit;
+    const rows = hasMore ? result.results.slice(0, limit) : result.results;
 
+    const positions = rows.map((row) => {
       let readAt: number | string | null = null;
       if (row.props) {
         try {
@@ -119,10 +159,22 @@ export async function handleGetReadPositions(request: Request, env: Env): Promis
         read_at: readAt,
         rkey: row.rkey,
         deleted: row.deleted_at != null,
+        // When the user acted, unix ms. The client refuses a remote row older
+        // than its own local intent for the same item.
+        client_updated_at: row.client_updated_at,
       };
     });
 
-    return new Response(JSON.stringify({ positions, cursor }), {
+    const last = rows[rows.length - 1];
+    // `cursor` stays a plain unix-seconds max for the previous release's client,
+    // which compares it numerically. New clients use `nextSince` — the compound
+    // cursor of the last row actually DELIVERED, never a clock reading.
+    const cursor = last ? last.updated_at : since.updatedAt;
+    const nextSince = last
+      ? encodeDeltaCursor(last.updated_at, last.id)
+      : encodeDeltaCursor(since.updatedAt, since.id);
+
+    return new Response(JSON.stringify({ positions, cursor, nextSince, hasMore }), {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
@@ -143,6 +195,9 @@ interface MarkAsReadRequest {
   itemTitle?: string;
   rkey?: string;
   authorDid?: string;
+  // When the USER marked this read, unix ms. Optional — an older client omits
+  // it and gets server-now, i.e. today's arrival-ordered behaviour.
+  updatedAt?: number;
 }
 
 function buildReadProps(opts: {
@@ -198,8 +253,11 @@ export async function handleMarkAsRead(request: Request, env: Env): Promise<Resp
   }
 
   const rkey = body.rkey || generateTid();
-  const readAt = Date.now();
-  const now = Math.floor(Date.now() / 1000);
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
+  const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
+  // The moment the user read it, not the moment the queue drained.
+  const readAt = clientUpdatedAt;
 
   try {
     // Check if already read (and live — a tombstoned row must resurrect, not skip).
@@ -218,20 +276,18 @@ export async function handleMarkAsRead(request: Request, env: Env): Promise<Resp
     const props = buildReadProps({ readAt, itemUrl, itemTitle, authorDid });
 
     // Resurrecting upsert: a re-read of a tombstoned (un-read) row clears
-    // deleted_at and bumps updated_at so the change carries on the forward delta.
+    // deleted_at and bumps updated_at so the change carries on the forward
+    // delta — but only if this read is at least as recent, in USER time, as
+    // whatever last touched the row. Otherwise a queue draining late would
+    // re-read something the user has since marked unread elsewhere.
     await env.DB.prepare(
       `
-      INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at)
-      VALUES (?, ?, ?, 'read', ?, ?, ?, ?)
-      ON CONFLICT(user_did, item_key, label) DO UPDATE SET
-        props = excluded.props,
-        rkey = excluded.rkey,
-        item_type = excluded.item_type,
-        deleted_at = NULL,
-        updated_at = excluded.updated_at
+      INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+      VALUES (?, ?, ?, 'read', ?, ?, ?, ?, ?)
+      ${READ_UPSERT_CONFLICT}
     `
     )
-      .bind(session.did, itemGuid, itemType, props, rkey, now, now)
+      .bind(session.did, itemGuid, itemType, props, rkey, now, now, clientUpdatedAt)
       .run();
 
     return new Response(JSON.stringify({ success: true, rkey }), {
@@ -248,6 +304,7 @@ export async function handleMarkAsRead(request: Request, env: Env): Promise<Resp
 
 interface MarkAsUnreadRequest {
   itemGuid: string;
+  updatedAt?: number;
 }
 
 // POST /api/reading/mark-unread - Mark an item as unread (soft-delete read label)
@@ -292,11 +349,19 @@ export async function handleMarkAsUnread(request: Request, env: Env): Promise<Re
     // later re-read resurrects the row (handleMarkAsRead); the hourly cron GCs old
     // tombstones (label/type-agnostic). Keyed by item_key, so it covers both
     // articles and documents.
-    const now = Math.floor(Date.now() / 1000);
+    //
+    // Guarded by user time, symmetrically with mark-read: an un-read that the
+    // user performed BEFORE a read recorded elsewhere must not win just because
+    // its request arrived later.
+    const nowMs = Date.now();
+    const now = Math.floor(nowMs / 1000);
+    const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
     await env.DB.prepare(
-      "UPDATE item_labels_cache SET deleted_at = ?, updated_at = ? WHERE user_did = ? AND item_key = ? AND label = 'read'"
+      `UPDATE item_labels_cache SET deleted_at = ?, updated_at = ?, client_updated_at = ?
+        WHERE user_did = ? AND item_key = ? AND label = 'read'
+          AND ? >= COALESCE(client_updated_at, 0)`
     )
-      .bind(now, now, session.did, itemGuid)
+      .bind(now, now, clientUpdatedAt, session.did, itemGuid, clientUpdatedAt)
       .run();
 
     return new Response(JSON.stringify({ success: true }), {
@@ -319,7 +384,10 @@ interface BulkMarkAsReadRequest {
     itemTitle?: string;
     rkey?: string;
     authorDid?: string;
+    updatedAt?: number;
   }>;
+  // Per-request fallback when every item shares one intent time.
+  updatedAt?: number;
 }
 
 // POST /api/reading/mark-read-bulk - Mark multiple items (articles or documents) as read
@@ -366,8 +434,8 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
     });
   }
 
-  const readAt = Date.now();
-  const now = Math.floor(Date.now() / 1000);
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
   const results: Array<{ itemGuid: string; rkey: string }> = [];
 
   try {
@@ -406,8 +474,9 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
     if (itemsWithRkeys.length > 0) {
       const insertStatements = itemsWithRkeys.map((item) => {
         const itemType: ReadItemType = item.itemType === 'document' ? 'document' : 'article';
+        const clientUpdatedAt = clampClientUpdatedAt(item.updatedAt ?? body.updatedAt, nowMs);
         const props = buildReadProps({
-          readAt,
+          readAt: clientUpdatedAt,
           itemUrl: item.itemUrl,
           itemTitle: item.itemTitle,
           authorDid: item.authorDid,
@@ -415,16 +484,11 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
 
         return env.DB.prepare(
           `
-          INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at)
-          VALUES (?, ?, ?, 'read', ?, ?, ?, ?)
-          ON CONFLICT(user_did, item_key, label) DO UPDATE SET
-            props = excluded.props,
-            rkey = excluded.rkey,
-            item_type = excluded.item_type,
-            deleted_at = NULL,
-            updated_at = excluded.updated_at
+          INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+          VALUES (?, ?, ?, 'read', ?, ?, ?, ?, ?)
+          ${READ_UPSERT_CONFLICT}
         `
-        ).bind(session.did, item.itemGuid, itemType, props, item.rkey, now, now);
+        ).bind(session.did, item.itemGuid, itemType, props, item.rkey, now, now, clientUpdatedAt);
       });
       await env.DB.batch(insertStatements);
     }
@@ -447,6 +511,181 @@ export async function handleBulkMarkAsRead(request: Request, env: Env): Promise<
   } catch (error) {
     console.error('Failed to bulk mark as read:', error);
     return new Response(JSON.stringify({ error: 'Failed to bulk mark as read' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+interface MarkFeedReadRequest {
+  // Omit to mark every subscribed RSS feed (the global "mark all read" action).
+  feedUrl?: string;
+  // The archive head the client saw. Items ingested after the user pressed the
+  // button stay unread, which is what the user meant. Omit for "everything in
+  // the window right now".
+  beforeSeq?: number;
+  updatedAt?: number;
+}
+
+// Statements per D1 batch when inserting read rows.
+const MARK_FEED_CHUNK = 100;
+// A global mark-all touches every subscribed feed; bound the work the same way
+// the timeline's cold start does, and log rather than truncate silently.
+const MARK_FEED_MAX_FEEDS = 500;
+
+/**
+ * POST /api/reading/mark-feed-read — mark the canonical window read, server-side.
+ *
+ * `markAllAsRead` used to iterate the articles the ACTING DEVICE happened to
+ * hold, so items another device held below this device's window stayed unread
+ * there: the one action that should force agreement didn't. Doing it on the
+ * server, over the same newest-K window every device is meant to display, makes
+ * the result identical everywhere — and the rows ride the existing forward
+ * delta out to every other device, covering items the acting device never had.
+ *
+ * Deliberately per-item rows rather than a per-feed `readWatermark` label: a
+ * watermark would be O(1) per action but introduces a second read-state
+ * authority needing precedence rules against per-item unread overrides. At most
+ * K rows per feed is cheap enough not to buy that.
+ */
+export async function handleMarkFeedRead(
+  request: Request,
+  env: Env,
+  session: Session
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: MarkFeedReadRequest;
+  try {
+    body = (await request.json()) as MarkFeedReadRequest;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
+  const clientUpdatedAt = clampClientUpdatedAt(body.updatedAt, nowMs);
+  const beforeSeq =
+    typeof body.beforeSeq === 'number' && Number.isFinite(body.beforeSeq)
+      ? Math.floor(body.beforeSeq)
+      : null;
+
+  try {
+    let feedUrls: string[];
+    if (body.feedUrl) {
+      // Scoped to the caller's own subscriptions: this endpoint writes read
+      // state, so it must not be usable to probe feeds the user doesn't follow.
+      const subscribed = await env.DB.prepare(
+        `SELECT 1 FROM subscriptions_cache
+          WHERE user_did = ? AND feed_url = ? AND active = 1
+            AND ${rssSubscriptionPredicate()}
+          LIMIT 1`
+      )
+        .bind(session.did, body.feedUrl)
+        .first();
+      if (!subscribed) {
+        return new Response(JSON.stringify({ error: 'Not subscribed to that feed' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      feedUrls = [body.feedUrl];
+    } else {
+      const rows = await env.DB.prepare(
+        `SELECT DISTINCT feed_url FROM subscriptions_cache
+          WHERE user_did = ? AND active = 1
+            AND feed_url IS NOT NULL AND feed_url <> ''
+            AND ${rssSubscriptionPredicate()}
+          ORDER BY feed_url`
+      )
+        .bind(session.did)
+        .all<{ feed_url: string }>();
+      feedUrls = rows.results.map((r) => r.feed_url);
+      if (feedUrls.length > MARK_FEED_MAX_FEEDS) {
+        console.warn(
+          `[reading] mark-feed-read covering ${MARK_FEED_MAX_FEEDS} of ${feedUrls.length} feeds for ${session.did}.`
+        );
+        feedUrls = feedUrls.slice(0, MARK_FEED_MAX_FEEDS);
+      }
+    }
+
+    // Select and write one feed-chunk at a time rather than accumulating every
+    // row first: on a large account the full set is tens of thousands of rows,
+    // and a Worker has no business holding all of them to do work it can do
+    // incrementally.
+    let marked = 0;
+    for (let i = 0; i < feedUrls.length; i += MARK_FEED_CHUNK) {
+      const chunk = feedUrls.slice(i, i + MARK_FEED_CHUNK);
+
+      // The unread GUIDs inside each feed's newest-K window. `NOT EXISTS` rather
+      // than a join so a duplicate label row can't multiply the result, matching
+      // the timeline's read probe.
+      const selects = chunk.map((feedUrl) =>
+        env.DB.prepare(
+          `SELECT w.guid, json_extract(w.item_json, '$.url') AS url,
+                  json_extract(w.item_json, '$.title') AS title
+             FROM (SELECT fi.guid, fi.item_json FROM feed_items fi
+                    WHERE fi.feed_url = ?2 ${beforeSeq !== null ? 'AND fi.seq <= ?4' : ''}
+                    ORDER BY fi.published_at DESC, fi.seq DESC
+                    LIMIT ?3) w
+            WHERE NOT EXISTS (
+                    SELECT 1 FROM item_labels_cache il
+                     WHERE il.user_did = ?1 AND il.item_key = w.guid
+                       AND il.item_type = 'article' AND il.label = 'read'
+                       AND il.deleted_at IS NULL)`
+        ).bind(
+          ...(beforeSeq !== null
+            ? [session.did, feedUrl, ARTICLE_WINDOW_PER_FEED, beforeSeq]
+            : [session.did, feedUrl, ARTICLE_WINDOW_PER_FEED])
+        )
+      );
+      const results = await env.DB.batch<{
+        guid: string;
+        url: string | null;
+        title: string | null;
+      }>(selects);
+
+      const rows = results.flatMap((result) => result.results ?? []);
+      for (let j = 0; j < rows.length; j += MARK_FEED_CHUNK) {
+        await env.DB.batch(
+          rows.slice(j, j + MARK_FEED_CHUNK).map((row) =>
+            env.DB.prepare(
+              `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+               VALUES (?, ?, 'article', 'read', ?, ?, ?, ?, ?)
+               ${READ_UPSERT_CONFLICT}`
+            ).bind(
+              session.did,
+              row.guid,
+              buildReadProps({
+                readAt: clientUpdatedAt,
+                itemUrl: row.url ?? undefined,
+                itemTitle: row.title ?? undefined,
+              }),
+              generateTid(),
+              now,
+              now,
+              clientUpdatedAt
+            )
+          )
+        );
+      }
+      marked += rows.length;
+    }
+
+    return new Response(JSON.stringify({ success: true, marked }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Failed to mark feed as read:', error);
+    return new Response(JSON.stringify({ error: 'Failed to mark feed as read' }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/backend/src/routes/reading.ts
+++ b/backend/src/routes/reading.ts
@@ -48,7 +48,6 @@ const READ_POSITIONS_MAX_LIMIT = 1000;
  */
 const READ_UPSERT_CONFLICT = `ON CONFLICT(user_did, item_key, label) DO UPDATE SET
         props = excluded.props,
-        rkey = excluded.rkey,
         item_type = excluded.item_type,
         deleted_at = NULL,
         updated_at = excluded.updated_at,

--- a/backend/src/routes/telemetry.ts
+++ b/backend/src/routes/telemetry.ts
@@ -44,6 +44,12 @@ const KINDS = new Set([
   // The stale-chunk reload guard tripped twice: recovery itself failed, which is
   // the "a deploy bricked the PWA" signal. Never sampled away by the client.
   'preload_recovery_failed',
+  // The server's per-feed unread counts disagreed with the client's own
+  // derivation after a completed refresh. Not an exception — a reconciliation
+  // signal. Cross-device count divergence was only ever discoverable by a user
+  // noticing two devices showing different numbers and filing a report; this is
+  // what makes the next occurrence visible to us first.
+  'unread_count_drift',
 ]);
 
 interface ClientErrorReport {

--- a/backend/src/routes/timeline.ts
+++ b/backend/src/routes/timeline.ts
@@ -1,4 +1,5 @@
 import type { Env, FeedItem, Session } from '../types';
+import { ARTICLE_WINDOW_PER_FEED } from '../config/window';
 import { log } from '../utils/logger';
 import { timedAll, timedBatch, timedFirst, getD1Timings, d1Summary } from '../utils/d1-timing';
 import {
@@ -28,7 +29,14 @@ const DEFAULT_LIMIT = 200;
 
 // Cold start delivers a per-feed newest slice, not a global one: a global
 // `ORDER BY seq DESC LIMIT n` would let one chatty feed starve every other.
-const COLD_START_PER_FEED = 30;
+//
+// This is K — the same window the client caps its local set at and the same
+// window the unread counts below are computed over. It was 30 while the client
+// kept 100, which is why a fresh device and an established one showed different
+// unread numbers for the same feed however well read state synced. Cold start
+// is paged (COLD_START_MAX_ITEMS), so the larger value costs more pages, not a
+// heavier response.
+const COLD_START_PER_FEED = ARTICLE_WINDOW_PER_FEED;
 // Statements per D1 batch on the cold-start path.
 const COLD_START_CHUNK = 25;
 // A cold start touches every subscribed feed; bound the work (and log if hit —
@@ -82,12 +90,24 @@ function toTimelineItems(rows: ItemRow[]): TimelineItem[] {
 /**
  * Newest slice of one feed, read-annotated — the single-feed read path
  * (`GET /api/v2/feeds/fetch`), which now serves D1 like everything else.
+ *
+ * `offset` pages DOWN into the archive: the client's local set is capped at K
+ * per feed and trims oldest-first, so anything below that is invisible to it
+ * even though D1 never pruned a thing. The "Show older" affordance starts at
+ * `offset = K` and walks down — which is what turns local eviction back into a
+ * cache miss instead of something the reader experiences as lost data.
+ *
+ * Offset rather than a keyset cursor because the client doesn't hold `seq` for
+ * its own articles, and the ordering key (`published_at`) is not unique. This is
+ * a manual, transient browse of an append-mostly list: an item ingested
+ * mid-browse can shift a row by one, which is not worth a wire-level cursor.
  */
 export async function readFeedSlice(
   env: Env,
   userDid: string,
   feedUrl: string,
-  limit: number
+  limit: number,
+  offset = 0
 ): Promise<TimelineItem[]> {
   const rows = await timedAll<ItemRow>(
     'feed_slice',
@@ -96,8 +116,8 @@ export async function readFeedSlice(
          FROM feed_items fi
         WHERE fi.feed_url = ?2
         ORDER BY fi.published_at DESC, fi.seq DESC
-        LIMIT ?3`
-    ).bind(userDid, feedUrl, limit)
+        LIMIT ?3 OFFSET ?4`
+    ).bind(userDid, feedUrl, limit, offset)
   );
   return toTimelineItems(rows.results);
 }
@@ -304,6 +324,67 @@ async function subscribedFeedMetadata(
   return feeds;
 }
 
+// Statements per D1 batch on the counts path.
+const COUNTS_CHUNK = 25;
+
+/**
+ * Per-feed unread counts over the canonical newest-K window.
+ *
+ * These numbers were derived client-side, over whatever articles the device
+ * happened to hold — and no two devices hold the same slice, so the same feed
+ * showed different unread numbers on a phone and a laptop even with read state
+ * perfectly in sync. Computing them here, over one window every device agrees
+ * on, is what makes them converge; the client displays these when online and
+ * falls back to its local derivation offline.
+ *
+ * One per-feed index seek (`idx_feed_items_feed_seq` / the published_at order
+ * the cold start already uses), bounded by K × subscriptions, and only on
+ * requests that ask for it — once per refresh, not per drain page.
+ */
+async function subscribedUnreadCounts(
+  env: Env,
+  userDid: string,
+  allFeedUrls: string[]
+): Promise<Record<string, number>> {
+  // Same bound as the cold start, for the same reason: one request must not turn
+  // into unbounded work. A feed past the cap simply has no server count and the
+  // client keeps deriving that one locally — degraded, not wrong.
+  const feedUrls = allFeedUrls.slice(0, COLD_START_MAX_FEEDS);
+  if (allFeedUrls.length > feedUrls.length) {
+    console.warn(
+      `[timeline] Unread counts covering ${feedUrls.length} of ${allFeedUrls.length} feeds for ${userDid}.`
+    );
+  }
+
+  const counts: Record<string, number> = {};
+  for (let i = 0; i < feedUrls.length; i += COUNTS_CHUNK) {
+    const chunk = feedUrls.slice(i, i + COUNTS_CHUNK);
+    const statements = chunk.map((feedUrl) =>
+      env.DB.prepare(
+        `SELECT ?2 AS feed_url, COUNT(*) AS unread FROM (
+                SELECT fi.guid FROM feed_items fi
+                 WHERE fi.feed_url = ?2
+                 ORDER BY fi.published_at DESC, fi.seq DESC
+                 LIMIT ?3) w
+          WHERE NOT EXISTS (
+                  SELECT 1 FROM item_labels_cache il
+                   WHERE il.user_did = ?1 AND il.item_key = w.guid
+                     AND il.item_type = 'article' AND il.label = 'read'
+                     AND il.deleted_at IS NULL)`
+      ).bind(userDid, feedUrl, ARTICLE_WINDOW_PER_FEED)
+    );
+    const results = await timedBatch<{ feed_url: string; unread: number }>(
+      'unread_counts',
+      env.DB,
+      statements
+    );
+    for (const result of results) {
+      for (const row of result.results ?? []) counts[row.feed_url] = row.unread;
+    }
+  }
+  return counts;
+}
+
 export async function handleTimeline(
   request: Request,
   env: Env,
@@ -379,6 +460,9 @@ async function runTimeline(request: Request, env: Env, session: Session): Promis
   // The feed-health revision this client already holds. Absent (a fresh page
   // load, whose status store is empty) means "send it".
   const healthRevParam = url.searchParams.get('health_rev');
+  // Server-authoritative per-feed unread counts. Asked for once per refresh (the
+  // first page), never on drain pages — the numbers don't change between them.
+  const wantsCounts = url.searchParams.get('include_counts') === '1';
 
   const parsedLimit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
   const limit = Number.isInteger(parsedLimit)
@@ -494,6 +578,17 @@ async function runTimeline(request: Request, env: Env, session: Session): Promis
           feeds: items.length > 0 ? await subscribedFeedMetadata(env, session.did) : undefined,
           healthRev,
           feedHealth: healthStale ? await subscribedFeedHealth(env, session.did) : undefined,
+          unreadCounts: wantsCounts
+            ? await subscribedUnreadCounts(
+                env,
+                session.did,
+                await subscribedFeedUrls(env, session.did)
+              )
+            : undefined,
+          // The archive head as of this response — what the client passes back as
+          // `beforeSeq` when it marks a feed read, so items ingested after the
+          // user pressed the button stay unread.
+          head: wantsCounts ? await archiveHead(env) : undefined,
         });
       }
     }
@@ -554,6 +649,12 @@ async function runTimeline(request: Request, env: Env, session: Session): Promis
       feeds: items.length > 0 ? await subscribedFeedMetadata(env, session.did) : undefined,
       healthRev,
       feedHealth: await subscribedFeedHealth(env, session.did),
+      // Counts cover every subscribed feed, not just the page's slice — a paged
+      // cold start would otherwise report a partial picture on its first page.
+      unreadCounts: wantsCounts
+        ? await subscribedUnreadCounts(env, session.did, allFeedUrls)
+        : undefined,
+      head: wantsCounts ? cursor : undefined,
     });
   } catch (error) {
     console.error('[timeline] Query error:', error);

--- a/backend/src/utils/delta-cursor.ts
+++ b/backend/src/utils/delta-cursor.ts
@@ -1,0 +1,83 @@
+/**
+ * The compound `(updated_at, id)` cursor shared by the two label deltas
+ * (`GET /api/labels`, `GET /api/reading/positions`).
+ *
+ * `updated_at` has one-second resolution, so a cursor that is only a timestamp
+ * cannot express "everything after this row". Both deltas used
+ * `updated_at > since`, which silently drops every row written in the same
+ * wall-clock second as the cursor's max — a real loss, because the client then
+ * never asks for those rows again. Pairing the timestamp with the row's `id`
+ * makes strictly-greater safe: same-second rows still differ by id.
+ *
+ * The wire form is the base64 `updatedAt:id` encoding the label pagination
+ * cursor already used, so one decoder covers both.
+ */
+export interface DeltaCursor {
+  updatedAt: number;
+  id: number;
+}
+
+export function encodeDeltaCursor(updatedAt: number, id: number): string {
+  return btoa(`${updatedAt}:${id}`);
+}
+
+export function decodeDeltaCursor(cursor: string): DeltaCursor | null {
+  try {
+    const [updatedAtStr, idStr] = atob(cursor).split(':');
+    const updatedAt = Number(updatedAtStr);
+    const id = Number(idStr);
+    if (!Number.isFinite(updatedAt) || !Number.isFinite(id)) return null;
+    return { updatedAt, id };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a `?since=` value that may be either form.
+ *
+ * A client on the previous release sends unix seconds; it is read as
+ * `(since, 0)`, which re-delivers that second's rows exactly once. Harmless —
+ * application is an idempotent upsert — and it is what lets the backend deploy
+ * ahead of the frontend, as this repo always does.
+ */
+export function parseSince(raw: string | null): DeltaCursor | null {
+  if (raw === null || raw === '') return null;
+  if (/^\d+$/.test(raw)) return { updatedAt: parseInt(raw, 10), id: 0 };
+  return decodeDeltaCursor(raw);
+}
+
+/** The larger of two compound cursors (either may be null). */
+export function maxCursor(a: DeltaCursor | null, b: DeltaCursor | null): DeltaCursor | null {
+  if (!a) return b;
+  if (!b) return a;
+  if (a.updatedAt !== b.updatedAt) return a.updatedAt > b.updatedAt ? a : b;
+  return a.id >= b.id ? a : b;
+}
+
+/**
+ * `(updated_at, id) > (?, ?)` in a form D1 plans well, plus its bind params.
+ * Row-value comparisons are avoided deliberately — the expanded form uses
+ * `idx_item_labels_user_updated` on every SQLite build we run against.
+ */
+export function afterCursorSql(column = 'updated_at', idColumn = 'id'): string {
+  return `(${column} > ? OR (${column} = ? AND ${idColumn} > ?))`;
+}
+
+export function afterCursorParams(cursor: DeltaCursor): number[] {
+  return [cursor.updatedAt, cursor.updatedAt, cursor.id];
+}
+
+/**
+ * The user's own timestamp for a write, in unix ms, made safe to store.
+ *
+ * Clamped to server-now: a device whose clock runs fast would otherwise pin its
+ * row against every later write from every other device, permanently. A
+ * backward-skewed device just loses ties, which is exactly today's
+ * arrival-ordered behaviour and therefore no regression. Missing or nonsense
+ * input means "now" — an old client that sends nothing keeps working.
+ */
+export function clampClientUpdatedAt(value: unknown, nowMs: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return nowMs;
+  return Math.min(Math.floor(value), nowMs);
+}

--- a/backend/test/labels.spec.ts
+++ b/backend/test/labels.spec.ts
@@ -77,8 +77,11 @@ type LabelsResponse = {
     props: Record<string, unknown>;
     updatedAt: number;
     deletedAt: number | null;
+    clientUpdatedAt?: number | null;
   }>;
   cursor?: string;
+  nextSince?: string;
+  hasMore?: boolean;
 };
 
 async function getLabels(path: string): Promise<{ status: number; body: LabelsResponse }> {
@@ -180,13 +183,49 @@ describe('GET /api/labels', () => {
   });
 
   describe('delta sync (?since=)', () => {
-    it('returns only rows changed strictly after the cursor', async () => {
+    // A legacy numeric cursor is read as `(seconds, 0)`, so the cursor's own
+    // second is re-delivered exactly once rather than dropped forever — the
+    // same-second loss the compound cursor exists to fix. Application is an
+    // idempotent upsert, so a single repeat costs nothing.
+    it('re-delivers the cursor second with a legacy numeric cursor, then moves past it', async () => {
       const now = Math.floor(Date.now() / 1000);
       await insertLabel('at-cursor', { updatedAt: now - 100 });
       await insertLabel('after-cursor', { updatedAt: now - 50 });
 
       const { body } = await getLabels(`/api/labels?since=${now - 100}`);
-      expect(body.labels.map((l) => l.itemKey)).toEqual(['after-cursor']);
+      expect(body.labels.map((l) => l.itemKey)).toEqual(['at-cursor', 'after-cursor']);
+
+      const { body: second } = await getLabels(
+        `/api/labels?since=${encodeURIComponent(body.nextSince!)}`
+      );
+      expect(second.labels).toHaveLength(0);
+    });
+
+    it('delivers same-second rows exactly once across pages', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      await insertLabel('same-1', { updatedAt: now - 10 });
+      await insertLabel('same-2', { updatedAt: now - 10 });
+      await insertLabel('same-3', { updatedAt: now - 10 });
+
+      const seen: string[] = [];
+      let since = '0';
+      for (let page = 0; page < 5; page++) {
+        const { body } = await getLabels(`/api/labels?since=${encodeURIComponent(since)}&limit=1`);
+        seen.push(...body.labels.map((l) => l.itemKey));
+        since = body.nextSince!;
+        if (!body.hasMore) break;
+      }
+
+      expect(seen).toEqual(['same-1', 'same-2', 'same-3']);
+    });
+
+    it('echoes the caller cursor back on an empty delta rather than a clock reading', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      await insertLabel('existing', { updatedAt: now - 100 });
+
+      const { body } = await getLabels(`/api/labels?since=${now}`);
+      expect(body.labels).toHaveLength(0);
+      expect(atob(body.nextSince!)).toBe(`${now}:0`);
     });
 
     it('returns an empty delta when nothing is newer', async () => {
@@ -259,5 +298,108 @@ describe('GET /api/labels', () => {
       expect(body.labels[0].deletedAt).toBeNull();
       expect(body.labels[0].props).toEqual({ tags: ['b'] });
     });
+  });
+});
+
+// The user-time last-write-wins guard (migration 0076). Before it, the winner
+// was whichever HTTP request arrived last, so a device draining an offline
+// queue overwrote everything the user had done elsewhere in the meantime.
+describe('/api/labels user-time last-write-wins', () => {
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM item_labels_cache').run();
+    await env.DB.prepare('DELETE FROM sessions').run();
+    await env.DB.prepare('DELETE FROM users').run();
+    await setupTestUser();
+  });
+
+  async function readRow(itemKey: string) {
+    return env.DB.prepare(
+      `SELECT props, deleted_at, client_updated_at FROM item_labels_cache
+        WHERE user_did = ? AND item_key = ? AND label = 'tagged'`
+    )
+      .bind(TEST_DID, itemKey)
+      .first<{ props: string; deleted_at: number | null; client_updated_at: number }>();
+  }
+
+  it('rejects a write whose user time is older than the stored one', async () => {
+    const now = Date.now();
+    await mutateLabels('POST', {
+      itemKey: 'lww',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['recent'] },
+      updatedAt: now,
+    });
+    // The late-draining queue: enqueued an hour ago, arriving now.
+    await mutateLabels('POST', {
+      itemKey: 'lww',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['stale'] },
+      updatedAt: now - 3600_000,
+    });
+
+    const row = await readRow('lww');
+    expect(JSON.parse(row!.props)).toEqual({ tags: ['recent'] });
+  });
+
+  it('accepts an equal user time so an idempotent retry still lands', async () => {
+    const at = Date.now() - 1000;
+    await mutateLabels('POST', {
+      itemKey: 'retry',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['first'] },
+      updatedAt: at,
+    });
+    await mutateLabels('POST', {
+      itemKey: 'retry',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['second'] },
+      updatedAt: at,
+    });
+
+    const row = await readRow('retry');
+    expect(JSON.parse(row!.props)).toEqual({ tags: ['second'] });
+  });
+
+  it('applies the guard to deletes too, so a stale un-tag cannot win', async () => {
+    const now = Date.now();
+    await mutateLabels('POST', {
+      itemKey: 'del',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['a'] },
+      updatedAt: now,
+    });
+    await mutateLabels('DELETE', { itemKey: 'del', label: 'tagged', updatedAt: now - 3600_000 });
+
+    const row = await readRow('del');
+    expect(row!.deleted_at).toBeNull();
+  });
+
+  it('clamps a forward-skewed clock to server now instead of pinning the row', async () => {
+    const future = Date.now() + 10 * 365 * 24 * 3600_000;
+    await mutateLabels('POST', {
+      itemKey: 'skew',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['from-the-future'] },
+      updatedAt: future,
+    });
+
+    const row = await readRow('skew');
+    expect(row!.client_updated_at).toBeLessThanOrEqual(Date.now());
+
+    // A subsequent honest write still wins, which is the point of clamping.
+    await mutateLabels('POST', {
+      itemKey: 'skew',
+      itemType: 'article',
+      label: 'tagged',
+      props: { tags: ['now'] },
+      updatedAt: Date.now(),
+    });
+    expect(JSON.parse((await readRow('skew'))!.props)).toEqual({ tags: ['now'] });
   });
 });

--- a/backend/test/reading-positions.spec.ts
+++ b/backend/test/reading-positions.spec.ts
@@ -393,9 +393,7 @@ describe('POST /api/reading write path (documents, resurrect, skip)', () => {
     });
   });
 
-  // The positive skip: a LIVE read short-circuits as alreadyRead and is left
-  // untouched (the complement of the existing resurrect-a-tombstone test).
-  it('mark-read on a live row returns alreadyRead and does not rewrite it', async () => {
+  it('mark-read on a live row preserves its rkey and advances the intent time', async () => {
     const now = Math.floor(Date.now() / 1000);
     await insertReadLabel('article-live', { updatedAt: now - 100, rkey: 'original-rkey' });
 
@@ -406,12 +404,18 @@ describe('POST /api/reading write path (documents, resurrect, skip)', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ alreadyRead: true });
 
-    // rkey/props untouched — the handler returned before any write.
+    // The stable identity stays put, but the later read intent is durable.
     const row = await readRow('article-live');
     expect(row?.rkey).toBe('original-rkey');
+    const intent = await env.DB.prepare(
+      "SELECT client_updated_at FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read'"
+    )
+      .bind(TEST_DID, 'article-live')
+      .first<{ client_updated_at: number }>();
+    expect(intent!.client_updated_at).toBeGreaterThan((now - 100) * 1000);
   });
 
-  it('bulk mark-read resurrects a tombstoned row but skips a live one', async () => {
+  it('bulk mark-read resurrects a tombstoned row and refreshes a live one', async () => {
     const now = Math.floor(Date.now() / 1000);
     await insertReadLabel('live-guid', { updatedAt: now - 100, rkey: 'live-rkey' });
     await insertReadLabel('tombstoned-guid', {
@@ -424,12 +428,9 @@ describe('POST /api/reading write path (documents, resurrect, skip)', () => {
       items: [{ itemGuid: 'live-guid' }, { itemGuid: 'tombstoned-guid', rkey: 'new-rkey' }],
     });
     expect(res.status).toBe(200);
-    // Only the tombstoned item is "new" (the live one is filtered out by the
-    // deleted_at IS NULL existing-check), so exactly one row is marked and the
-    // live one is skipped.
     const body = (await res.json()) as { marked: number; skipped: number };
-    expect(body.marked).toBe(1);
-    expect(body.skipped).toBe(1);
+    expect(body.marked).toBe(2);
+    expect(body.skipped).toBe(0);
 
     // The tombstone resurrected (deleted_at cleared, rkey updated)...
     const resurrected = await readRow('tombstoned-guid');
@@ -698,6 +699,54 @@ describe('read writes ordered by user time', () => {
     await postJson('/api/reading/mark-unread', { itemGuid: 'later-unread', updatedAt: now });
 
     expect((await readRow('later-unread'))!.deleted_at).not.toBeNull();
+  });
+
+  it('a repeated read advances user time so an older delayed unread loses', async () => {
+    const now = Date.now();
+    await postJson('/api/reading/mark-read', { itemGuid: 'reread', updatedAt: now - 120_000 });
+    await postJson('/api/reading/mark-read', { itemGuid: 'reread', updatedAt: now });
+    await postJson('/api/reading/mark-unread', {
+      itemGuid: 'reread',
+      updatedAt: now - 60_000,
+    });
+
+    const row = await readRow('reread');
+    expect(row!.deleted_at).toBeNull();
+    expect(row!.client_updated_at).toBe(now);
+  });
+
+  it('an unread arriving before its older read creates a winning tombstone', async () => {
+    const now = Date.now();
+    await postJson('/api/reading/mark-unread', {
+      itemGuid: 'unread-first',
+      updatedAt: now,
+    });
+    await postJson('/api/reading/mark-read', {
+      itemGuid: 'unread-first',
+      updatedAt: now - 60_000,
+    });
+
+    const row = await readRow('unread-first');
+    expect(row).not.toBeNull();
+    expect(row!.deleted_at).not.toBeNull();
+    expect(row!.client_updated_at).toBe(now);
+  });
+
+  it('a repeated bulk read also advances user time', async () => {
+    const now = Date.now();
+    await postJson('/api/reading/mark-read', {
+      itemGuid: 'bulk-reread',
+      updatedAt: now - 120_000,
+    });
+    await postJson('/api/reading/mark-read-bulk', {
+      items: [{ itemGuid: 'bulk-reread', updatedAt: now }],
+    });
+    await postJson('/api/reading/mark-unread', {
+      itemGuid: 'bulk-reread',
+      updatedAt: now - 60_000,
+    });
+
+    expect((await readRow('bulk-reread'))!.deleted_at).toBeNull();
   });
 
   it('a stale bulk read cannot resurrect an item un-read more recently', async () => {

--- a/backend/test/reading-positions.spec.ts
+++ b/backend/test/reading-positions.spec.ts
@@ -88,8 +88,11 @@ type PositionsResponse = {
     read_at: number;
     rkey: string;
     deleted: boolean;
+    client_updated_at?: number | null;
   }>;
   cursor: number;
+  nextSince?: string;
+  hasMore?: boolean;
 };
 
 async function getPositions(path: string): Promise<{ status: number; body: PositionsResponse }> {
@@ -164,25 +167,80 @@ describe('GET /api/reading/positions (forward read delta)', () => {
     expect(body.cursor).toBe(now - 5);
   });
 
-  it('returns positions ordered newest-first', async () => {
+  // Oldest-first, deliberately: the delta is DRAINED forward from a cursor, so
+  // pages have to be contiguous and the last row of a page has to be the next
+  // cursor. Newest-first only worked while the response was unbounded.
+  it('returns positions ordered oldest-first', async () => {
     const now = Math.floor(Date.now() / 1000);
     await insertReadLabel('oldest', { updatedAt: now - 300 });
     await insertReadLabel('middle', { updatedAt: now - 200 });
     await insertReadLabel('newest', { updatedAt: now - 100 });
 
     const { body } = await getPositions('/api/reading/positions?since=0');
-    expect(body.positions.map((p) => p.item_guid)).toEqual(['newest', 'middle', 'oldest']);
+    expect(body.positions.map((p) => p.item_guid)).toEqual(['oldest', 'middle', 'newest']);
   });
 
   describe('delta (?since=)', () => {
-    it('returns only rows changed strictly after the cursor', async () => {
+    // A legacy numeric cursor is read as `(seconds, 0)`, so a row written in the
+    // cursor's own second is still delivered — exactly once. Under the old
+    // `updated_at > since` predicate that row was dropped forever, which is the
+    // silent same-second loss this cursor exists to fix. The cost is that a
+    // numeric cursor re-delivers its own second once; application is an
+    // idempotent upsert, so that is harmless.
+    it('re-delivers the cursor second with a legacy numeric cursor, then moves past it', async () => {
       const now = Math.floor(Date.now() / 1000);
       await insertReadLabel('at-cursor', { updatedAt: now - 100 });
       await insertReadLabel('after-cursor', { updatedAt: now - 50 });
 
       const { body } = await getPositions(`/api/reading/positions?since=${now - 100}`);
-      expect(body.positions.map((p) => p.item_guid)).toEqual(['after-cursor']);
+      expect(body.positions.map((p) => p.item_guid)).toEqual(['at-cursor', 'after-cursor']);
       expect(body.cursor).toBe(now - 50);
+
+      // The compound cursor it hands back excludes everything already delivered.
+      const { body: second } = await getPositions(
+        `/api/reading/positions?since=${encodeURIComponent(body.nextSince!)}`
+      );
+      expect(second.positions).toHaveLength(0);
+    });
+
+    it('delivers same-second rows exactly once across pages', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      // Three rows sharing one wall-clock second: the case a seconds-only
+      // cursor cannot express a position inside.
+      await insertReadLabel('same-1', { updatedAt: now - 10 });
+      await insertReadLabel('same-2', { updatedAt: now - 10 });
+      await insertReadLabel('same-3', { updatedAt: now - 10 });
+
+      const seen: string[] = [];
+      let since = '0';
+      for (let page = 0; page < 5; page++) {
+        const { body } = await getPositions(
+          `/api/reading/positions?since=${encodeURIComponent(since)}&limit=1`
+        );
+        seen.push(...body.positions.map((p) => p.item_guid));
+        since = body.nextSince!;
+        if (!body.hasMore) break;
+      }
+
+      expect(seen).toEqual(['same-1', 'same-2', 'same-3']);
+      expect(new Set(seen).size).toBe(3);
+    });
+
+    it('reports hasMore and never advances past an undelivered row', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      await insertReadLabel('a', { updatedAt: now - 30 });
+      await insertReadLabel('b', { updatedAt: now - 20 });
+      await insertReadLabel('c', { updatedAt: now - 10 });
+
+      const { body } = await getPositions('/api/reading/positions?since=0&limit=2');
+      expect(body.positions.map((p) => p.item_guid)).toEqual(['a', 'b']);
+      expect(body.hasMore).toBe(true);
+
+      const { body: rest } = await getPositions(
+        `/api/reading/positions?since=${encodeURIComponent(body.nextSince!)}&limit=2`
+      );
+      expect(rest.positions.map((p) => p.item_guid)).toEqual(['c']);
+      expect(rest.hasMore).toBe(false);
     });
 
     it('has no retention window — even very old rows sync once changed past the cursor', async () => {
@@ -578,5 +636,98 @@ describe('inline read annotation (batch fetch handlers)', () => {
     expect(docs.find((d) => d.recordUri.endsWith('/read'))?.read).toBe(true);
     expect(docs.find((d) => d.recordUri.endsWith('/unread'))?.read).toBe(false);
     expect(typeof json.readCursor).toBe('number');
+  });
+});
+
+/**
+ * User-time last-write-wins on the read path.
+ *
+ * The scenario from the report: device B is offline and marks something unread;
+ * device A marks it read later; B comes back and drains its queue. Arrival order
+ * says B wins, which resurrects intent the user has already superseded. Ordering
+ * by when the user acted says A wins, which is what the user meant.
+ */
+describe('read writes ordered by user time', () => {
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM item_labels_cache').run();
+    await env.DB.prepare('DELETE FROM sessions').run();
+    await env.DB.prepare('DELETE FROM users').run();
+    await setupTestUser();
+  });
+
+  async function postJson(path: string, body: unknown) {
+    const ctx = createExecutionContext();
+    const request = new IncomingRequest(`http://localhost${path}`, {
+      method: 'POST',
+      headers: {
+        Cookie: `session_id=${TEST_SESSION_ID}`,
+        Origin: env.FRONTEND_URL,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    return response;
+  }
+
+  function readRow(itemKey: string) {
+    return env.DB.prepare(
+      "SELECT deleted_at, client_updated_at FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read'"
+    )
+      .bind(TEST_DID, itemKey)
+      .first<{ deleted_at: number | null; client_updated_at: number }>();
+  }
+
+  it('a late-draining un-read loses to a newer read from another device', async () => {
+    const now = Date.now();
+    // Device A read it a minute ago; the request lands first.
+    await postJson('/api/reading/mark-read', { itemGuid: 'contested', updatedAt: now - 60_000 });
+    // Device B un-read it an hour ago and only now drains its queue.
+    await postJson('/api/reading/mark-unread', {
+      itemGuid: 'contested',
+      updatedAt: now - 3600_000,
+    });
+
+    expect((await readRow('contested'))!.deleted_at).toBeNull();
+  });
+
+  it('a genuinely newer un-read still wins', async () => {
+    const now = Date.now();
+    await postJson('/api/reading/mark-read', { itemGuid: 'later-unread', updatedAt: now - 60_000 });
+    await postJson('/api/reading/mark-unread', { itemGuid: 'later-unread', updatedAt: now });
+
+    expect((await readRow('later-unread'))!.deleted_at).not.toBeNull();
+  });
+
+  it('a stale bulk read cannot resurrect an item un-read more recently', async () => {
+    const now = Date.now();
+    await postJson('/api/reading/mark-read', { itemGuid: 'bulk-stale', updatedAt: now - 7200_000 });
+    await postJson('/api/reading/mark-unread', { itemGuid: 'bulk-stale', updatedAt: now - 60_000 });
+    // The offline queue finally drains a read the user performed two hours ago.
+    await postJson('/api/reading/mark-read-bulk', {
+      items: [{ itemGuid: 'bulk-stale', updatedAt: now - 7200_000 }],
+    });
+
+    expect((await readRow('bulk-stale'))!.deleted_at).not.toBeNull();
+  });
+
+  it('records readAt as the user time, not the moment the queue drained', async () => {
+    const readAt = Date.now() - 3600_000;
+    await postJson('/api/reading/mark-read', { itemGuid: 'when', updatedAt: readAt });
+
+    const row = await env.DB.prepare(
+      "SELECT props FROM item_labels_cache WHERE user_did = ? AND item_key = 'when' AND label = 'read'"
+    )
+      .bind(TEST_DID)
+      .first<{ props: string }>();
+    expect(JSON.parse(row!.props).readAt).toBe(readAt);
+  });
+
+  it('an omitted timestamp falls back to server now (old clients keep working)', async () => {
+    const before = Date.now();
+    await postJson('/api/reading/mark-read', { itemGuid: 'no-stamp' });
+    const row = await readRow('no-stamp');
+    expect(row!.client_updated_at).toBeGreaterThanOrEqual(before);
   });
 });

--- a/backend/test/reading-positions.spec.ts
+++ b/backend/test/reading-positions.spec.ts
@@ -319,20 +319,27 @@ describe('POST /api/reading/mark-unread (soft-delete)', () => {
 
   it('re-read resurrects a tombstoned row (deleted_at cleared)', async () => {
     const now = Math.floor(Date.now() / 1000);
-    await insertReadLabel('article-y', { updatedAt: now - 100, deletedAt: now - 100 });
+    await insertReadLabel('article-y', {
+      updatedAt: now - 100,
+      deletedAt: now - 100,
+      rkey: 'tombstone-rkey',
+    });
 
     const res = await postJson('/api/reading/mark-read', {
       itemGuid: 'article-y',
       itemUrl: 'https://example.com/y',
     });
     expect(res.status).toBe(200);
+    const body = await res.json<{ rkey: string }>();
 
     const row = await env.DB.prepare(
-      "SELECT deleted_at FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read'"
+      "SELECT rkey, deleted_at FROM item_labels_cache WHERE user_did = ? AND item_key = ? AND label = 'read'"
     )
       .bind(TEST_DID, 'article-y')
-      .first<{ deleted_at: number | null }>();
+      .first<{ rkey: string; deleted_at: number | null }>();
     expect(row?.deleted_at).toBeNull();
+    expect(row?.rkey).toBe(body.rkey);
+    expect(row?.rkey).not.toBe('tombstone-rkey');
   });
 });
 

--- a/backend/test/unread-window.spec.ts
+++ b/backend/test/unread-window.spec.ts
@@ -259,8 +259,19 @@ describe('POST /api/reading/mark-feed-read', () => {
     await subscribe(FEED);
 
     await markFeedRead({ feedUrl: FEED });
+    const before = await env.DB.prepare(
+      "SELECT item_key, rkey FROM item_labels_cache WHERE user_did = ? AND label = 'read' ORDER BY item_key"
+    )
+      .bind(TEST_DID)
+      .all<{ item_key: string; rkey: string }>();
     const second = await markFeedRead({ feedUrl: FEED });
     expect(await second.json()).toEqual({ success: true, marked: 8 });
+    const after = await env.DB.prepare(
+      "SELECT item_key, rkey FROM item_labels_cache WHERE user_did = ? AND label = 'read' ORDER BY item_key"
+    )
+      .bind(TEST_DID)
+      .all<{ item_key: string; rkey: string }>();
+    expect(after.results).toEqual(before.results);
   });
 
   it('covers every subscribed feed when no feedUrl is given', async () => {

--- a/backend/test/unread-window.spec.ts
+++ b/backend/test/unread-window.spec.ts
@@ -1,0 +1,325 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { handleIngest, CRAWLER_HEARTBEAT_KEY } from '../src/routes/ingest';
+import { handleTimeline, readFeedSlice } from '../src/routes/timeline';
+import { handleMarkFeedRead } from '../src/routes/reading';
+import { ARTICLE_WINDOW_PER_FEED } from '../src/config/window';
+import type { Env, FeedItem, Session } from '../src/types';
+
+/**
+ * The canonical per-feed window (K) and everything that depends on it agreeing:
+ * server-computed unread counts, and a mark-all-read that covers the window
+ * rather than the acting device's slice.
+ *
+ * This is the headline bug from the report — "the same feed will show different
+ * unread numbers on different devices". Cold start served 30 per feed while the
+ * client kept 100, so the two devices were counting over different sets and no
+ * amount of read-state sync could reconcile them.
+ */
+
+const TEST_DID = 'did:plc:unreadwindow';
+const SECRET = 'test-proxy-secret';
+const FEED = 'https://example.com/window.xml';
+const OTHER_FEED = 'https://example.com/other.xml';
+
+const SESSION: Session = {
+  did: TEST_DID,
+  handle: 'window.bsky.social',
+  pdsUrl: 'https://test.pds.example',
+  accessToken: 'token',
+  refreshToken: 'refresh',
+  dpopPrivateKey: '{}',
+  expiresAt: Date.now() + 3600000,
+};
+
+function item(guid: string, publishedAt: string): FeedItem {
+  return {
+    guid,
+    url: `https://example.com/${guid}`,
+    title: `Title ${guid}`,
+    publishedAt,
+  };
+}
+
+/** `count` items for `feedUrl`, newest first by publish date. */
+async function seedFeed(feedUrl: string, count: number, prefix = 'i') {
+  const items = Array.from({ length: count }, (_, i) => {
+    // Descending publish time so index 0 is the newest.
+    const published = new Date(Date.UTC(2026, 0, 1) - i * 3600_000).toISOString();
+    return item(`${prefix}-${String(i).padStart(4, '0')}`, published);
+  });
+
+  const res = await handleIngest(
+    new Request('https://api.example/api/internal/ingest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Proxy-Secret': SECRET },
+      body: JSON.stringify({
+        feeds: [{ feedUrl, title: 'Window Feed' }],
+        items: items.map((it) => ({
+          feedUrl,
+          guid: it.guid,
+          item: it,
+          publishedAt: Date.parse(it.publishedAt),
+          firstSeenAt: Date.now(),
+          contentHash: it.guid,
+        })),
+      }),
+    }),
+    env
+  );
+  expect(res.status).toBe(200);
+  return items;
+}
+
+async function subscribe(feedUrl: string) {
+  await env.DB.prepare(
+    `INSERT INTO subscriptions_cache (user_did, record_uri, feed_url, title, source_type, active)
+     VALUES (?, ?, ?, 'Feed', NULL, 1)`
+  )
+    .bind(TEST_DID, `at://${TEST_DID}/app.skyreader.feed.subscription/${feedUrl.length}`, feedUrl)
+    .run();
+}
+
+async function markRead(guid: string) {
+  await env.DB.prepare(
+    `INSERT INTO item_labels_cache (user_did, item_key, item_type, label, props, rkey, created_at, updated_at, client_updated_at)
+     VALUES (?, ?, 'article', 'read', '{}', ?, unixepoch(), unixepoch(), ?)`
+  )
+    .bind(TEST_DID, guid, `rk-${guid}`, Date.now())
+    .run();
+}
+
+type TimelineBody = {
+  items: Array<{ guid: string; feedUrl: string; read: boolean }>;
+  hasMore: boolean;
+  nextColdOffset?: number;
+  coldStart: boolean;
+  unreadCounts?: Record<string, number>;
+  head?: number;
+};
+
+async function timeline(params: Record<string, string> = {}): Promise<TimelineBody> {
+  const search = new URLSearchParams(params).toString();
+  const res = await handleTimeline(
+    new Request(`https://api.example/api/v2/timeline${search ? `?${search}` : ''}`),
+    env,
+    SESSION
+  );
+  expect(res.status).toBe(200);
+  return (await res.json()) as TimelineBody;
+}
+
+async function markFeedRead(body: unknown) {
+  return handleMarkFeedRead(
+    new Request('https://api.example/api/reading/mark-feed-read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    env,
+    SESSION
+  );
+}
+
+async function unreadRowCount(): Promise<number> {
+  const row = await env.DB.prepare(
+    `SELECT COUNT(*) AS n FROM item_labels_cache
+      WHERE user_did = ? AND label = 'read' AND deleted_at IS NULL`
+  )
+    .bind(TEST_DID)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+describe('canonical per-feed window', () => {
+  let savedSecret: string | undefined;
+
+  beforeEach(async () => {
+    savedSecret = (env as Env).FEED_PROXY_SECRET;
+    (env as Env).FEED_PROXY_SECRET = SECRET;
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (did, handle, pds_url, tier, created_at)
+       VALUES (?, 'window.test', 'https://test.pds.example', 'free', unixepoch())`
+    )
+      .bind(TEST_DID)
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO sync_state (key, value, updated_at) VALUES (?, ?, unixepoch())
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+    )
+      .bind(CRAWLER_HEARTBEAT_KEY, String(Math.floor(Date.now() / 1000)))
+      .run();
+  });
+
+  afterEach(async () => {
+    (env as Env).FEED_PROXY_SECRET = savedSecret as string;
+    await env.DB.prepare('DELETE FROM feed_items').run();
+    await env.DB.prepare('DELETE FROM feeds').run();
+    await env.DB.prepare('DELETE FROM subscriptions_cache').run();
+    await env.DB.prepare('DELETE FROM item_labels_cache').run();
+    await env.DB.prepare('DELETE FROM sync_state WHERE key = ?').bind(CRAWLER_HEARTBEAT_KEY).run();
+  });
+
+  it('cold-starts a device with K per feed, not 30', async () => {
+    await seedFeed(FEED, 150);
+    await subscribe(FEED);
+
+    // Drain every cold-start page — the budget bounds a page, not the bootstrap.
+    const guids = new Set<string>();
+    let coldOffset: string | undefined;
+    for (let page = 0; page < 20; page++) {
+      const body = await timeline(coldOffset ? { cold_offset: coldOffset } : {});
+      for (const it of body.items) guids.add(it.guid);
+      if (!body.hasMore || body.nextColdOffset == null) break;
+      coldOffset = String(body.nextColdOffset);
+    }
+
+    expect(guids.size).toBe(ARTICLE_WINDOW_PER_FEED);
+  });
+
+  it('computes unread counts over the window, ignoring everything below it', async () => {
+    const items = await seedFeed(FEED, 150);
+    await subscribe(FEED);
+
+    // Read one item inside the window and one below it. Only the first can move
+    // the number: the one below the window was never counted to begin with.
+    await markRead(items[0].guid);
+    await markRead(items[ARTICLE_WINDOW_PER_FEED + 10].guid);
+
+    const body = await timeline({ include_counts: '1' });
+    expect(body.unreadCounts?.[FEED]).toBe(ARTICLE_WINDOW_PER_FEED - 1);
+    expect(typeof body.head).toBe('number');
+  });
+
+  it('omits counts unless asked, so drain pages pay nothing for them', async () => {
+    await seedFeed(FEED, 5);
+    await subscribe(FEED);
+
+    const body = await timeline();
+    expect(body.unreadCounts).toBeUndefined();
+  });
+
+  it('counts every subscribed feed, including one with nothing archived', async () => {
+    await seedFeed(FEED, 3);
+    await subscribe(FEED);
+    await subscribe(OTHER_FEED);
+
+    const body = await timeline({ include_counts: '1' });
+    expect(body.unreadCounts?.[FEED]).toBe(3);
+    expect(body.unreadCounts?.[OTHER_FEED]).toBe(0);
+  });
+});
+
+describe('POST /api/reading/mark-feed-read', () => {
+  let savedSecret: string | undefined;
+
+  beforeEach(async () => {
+    savedSecret = (env as Env).FEED_PROXY_SECRET;
+    (env as Env).FEED_PROXY_SECRET = SECRET;
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (did, handle, pds_url, tier, created_at)
+       VALUES (?, 'window.test', 'https://test.pds.example', 'free', unixepoch())`
+    )
+      .bind(TEST_DID)
+      .run();
+  });
+
+  afterEach(async () => {
+    (env as Env).FEED_PROXY_SECRET = savedSecret as string;
+    await env.DB.prepare('DELETE FROM feed_items').run();
+    await env.DB.prepare('DELETE FROM feeds').run();
+    await env.DB.prepare('DELETE FROM subscriptions_cache').run();
+    await env.DB.prepare('DELETE FROM item_labels_cache').run();
+  });
+
+  it('marks the whole window, including items the acting device never held', async () => {
+    await seedFeed(FEED, 150);
+    await subscribe(FEED);
+
+    const res = await markFeedRead({ feedUrl: FEED });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, marked: ARTICLE_WINDOW_PER_FEED });
+    expect(await unreadRowCount()).toBe(ARTICLE_WINDOW_PER_FEED);
+  });
+
+  it('respects beforeSeq so items ingested after the press stay unread', async () => {
+    await seedFeed(FEED, 10, 'old');
+    await subscribe(FEED);
+    const head = (await env.DB.prepare('SELECT MAX(seq) AS s FROM feed_items').first<{
+      s: number;
+    }>())!.s;
+    await seedFeed(FEED, 5, 'new');
+
+    const res = await markFeedRead({ feedUrl: FEED, beforeSeq: head });
+    expect(await res.json()).toEqual({ success: true, marked: 10 });
+  });
+
+  it('is idempotent — a second call marks nothing new', async () => {
+    await seedFeed(FEED, 8);
+    await subscribe(FEED);
+
+    await markFeedRead({ feedUrl: FEED });
+    const second = await markFeedRead({ feedUrl: FEED });
+    expect(await second.json()).toEqual({ success: true, marked: 0 });
+  });
+
+  it('covers every subscribed feed when no feedUrl is given', async () => {
+    await seedFeed(FEED, 4, 'a');
+    await seedFeed(OTHER_FEED, 6, 'b');
+    await subscribe(FEED);
+    await subscribe(OTHER_FEED);
+
+    const res = await markFeedRead({});
+    expect(await res.json()).toEqual({ success: true, marked: 10 });
+  });
+
+  // The endpoint WRITES read state, so it must not be usable to learn anything
+  // about a feed the caller doesn't follow.
+  it('refuses a feed the caller is not subscribed to', async () => {
+    await seedFeed(FEED, 3);
+    const res = await markFeedRead({ feedUrl: FEED });
+    expect(res.status).toBe(404);
+    expect(await unreadRowCount()).toBe(0);
+  });
+});
+
+describe('archive paging (readFeedSlice offset)', () => {
+  let savedSecret: string | undefined;
+
+  beforeEach(async () => {
+    savedSecret = (env as Env).FEED_PROXY_SECRET;
+    (env as Env).FEED_PROXY_SECRET = SECRET;
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (did, handle, pds_url, tier, created_at)
+       VALUES (?, 'window.test', 'https://test.pds.example', 'free', unixepoch())`
+    )
+      .bind(TEST_DID)
+      .run();
+  });
+
+  afterEach(async () => {
+    (env as Env).FEED_PROXY_SECRET = savedSecret as string;
+    await env.DB.prepare('DELETE FROM feed_items').run();
+    await env.DB.prepare('DELETE FROM feeds').run();
+    await env.DB.prepare('DELETE FROM item_labels_cache').run();
+  });
+
+  it('pages below the local window without repeating it', async () => {
+    const items = await seedFeed(FEED, 130);
+
+    const windowSlice = await readFeedSlice(env, TEST_DID, FEED, ARTICLE_WINDOW_PER_FEED);
+    const older = await readFeedSlice(env, TEST_DID, FEED, 30, ARTICLE_WINDOW_PER_FEED);
+
+    expect(windowSlice[0].guid).toBe(items[0].guid);
+    expect(older).toHaveLength(30);
+    expect(older[0].guid).toBe(items[ARTICLE_WINDOW_PER_FEED].guid);
+    const overlap = new Set(windowSlice.map((i) => i.guid));
+    expect(older.some((i) => overlap.has(i.guid))).toBe(false);
+  });
+
+  it('returns an empty page at the bottom of the archive', async () => {
+    await seedFeed(FEED, 10);
+    const older = await readFeedSlice(env, TEST_DID, FEED, 30, 50);
+    expect(older).toHaveLength(0);
+  });
+});

--- a/backend/test/unread-window.spec.ts
+++ b/backend/test/unread-window.spec.ts
@@ -254,13 +254,13 @@ describe('POST /api/reading/mark-feed-read', () => {
     expect(await res.json()).toEqual({ success: true, marked: 10 });
   });
 
-  it('is idempotent — a second call marks nothing new', async () => {
+  it('reasserts read intent for the whole window on a second call', async () => {
     await seedFeed(FEED, 8);
     await subscribe(FEED);
 
     await markFeedRead({ feedUrl: FEED });
     const second = await markFeedRead({ feedUrl: FEED });
-    expect(await second.json()).toEqual({ success: true, marked: 0 });
+    expect(await second.json()).toEqual({ success: true, marked: 8 });
   });
 
   it('covers every subscribed feed when no feedUrl is given', async () => {

--- a/docs/plans/CROSS_DEVICE_SYNC.md
+++ b/docs/plans/CROSS_DEVICE_SYNC.md
@@ -1,0 +1,156 @@
+# Converging article sync state across devices
+
+**Status:** Implemented.
+
+The report ([userinput thread](https://userinput.app/d/did:plc:esmiuxk53vmsllayghrq676w/3mufwllspa42m)):
+
+> "Subscribing to a feed syncs the subscription but doesn't sync the associated articles. In
+> practice … the same feed will show different unread numbers on different devices. … I even lost
+> data before I realized this syncing limitation."
+
+Read state _did_ sync. Several separate mechanisms nonetheless guaranteed that two devices signed
+into one account would disagree — persistently, not transiently — and one of them made an eviction
+look like deletion. This is what each was and what replaced it.
+
+## 1. Article membership was device-local, so the numbers could never agree
+
+Unread counts were derived client-side over whatever articles the device happened to hold, and no
+two devices held the same slice: a fresh device cold-started with the newest **30** per feed, an
+established one accumulated up to **100**, and each trimmed at different moments against different
+sets. A device holding 100 and a device holding 30 show different numbers for the same feed even
+with read state perfectly in sync. No amount of sync work could have fixed that.
+
+**Now:** one **K** (`backend/src/config/window.ts` → `ARTICLE_WINDOW_PER_FEED = 100`), enforced in
+the cold start, the counts query, and the client's `MAX_ARTICLES_PER_FEED`. The server computes
+per-feed unread counts over that window (`include_counts=1`, first page of a refresh only) and the
+client displays those when online, falling back to its local derivation offline. A mismatch after a
+completed refresh reports `unread_count_drift` telemetry — divergence is now something we observe
+rather than something a user has to notice and write up.
+
+K = 100 rather than 50: cold start is rare and paged; divergence was daily.
+
+## 2. "Mark all read" only marked the acting device's window
+
+It iterated the articles that device held. Items another device held below that window stayed
+unread there — so the one action whose entire purpose is to force agreement didn't.
+
+**Now:** `POST /api/reading/mark-feed-read { feedUrl?, beforeSeq? }` writes read rows for the
+canonical window server-side (≤ K per feed), and they ride the existing forward delta out to every
+device. The client keeps its optimistic local pass and still falls back to the per-item queue
+offline. `beforeSeq` is the archive head the client saw, so items ingested after the press stay
+unread — which is what the user meant.
+
+_Rejected:_ a per-feed `readWatermark` label. O(1) per action, but it introduces a second read-state
+authority needing precedence rules against per-item unread overrides — more invariants than it
+removes, for rows that are already cheap.
+
+## 3. The local cap silently deleted unread articles
+
+Past 100 items a feed's older entries vanished with no trace and no way to page them back, even
+though D1 keeps everything. Eviction from a cache is fine; eviction from the only _visible_ copy is
+indistinguishable from data loss, and that is what the reporter experienced.
+
+**Now:** `GET /api/v2/feeds/fetch?offset=K` pages below the local window, surfaced as a quiet "Show
+older" at the end of a single-feed list with one line of copy. Those items are deliberately
+**transient** — never merged into the capped Dexie set, because merging would push the local set
+past K and re-open §1. Separately, items carrying a tag or a highlight are now exempt from eviction
+alongside starred ones, so eviction can't orphan an annotation. Unread is deliberately **not**
+exempt: that would let each device's set grow without bound and diverge again.
+
+## 4. The label delta could lose rows silently
+
+Four defects, all in the same "the cursor moved past something you never got" family:
+
+- **Same-second loss.** Both deltas used `updated_at > since` against a one-second-resolution
+  cursor, so any row written in the same wall-clock second as the cursor's max was dropped and never
+  offered again. The cursor is now compound `(updated_at, id)` — base64 `updatedAt:id`, the encoding
+  the label pagination cursor already used — which makes strictly-greater safe. Legacy numeric
+  cursors are read as `(seconds, 0)`, re-delivering that one second exactly once; application is an
+  idempotent upsert, so the cost is nil and the backend can deploy ahead of the frontend as usual.
+- **Unpaginated read delta.** `GET /api/reading/positions` was `LIMIT 100000, ORDER BY updated_at
+DESC` with no `hasMore`. Had it ever truncated, the client would have advanced its forward-only
+  cursor to the newest row it saw and permanently skipped the older tail. It is now an ordinary
+  paged, ascending delta the client drains.
+- **Cursors committed before the write.** Both deltas persisted their cursor in a separate `try`
+  from the Dexie write, so a failed write lost the batch and still advanced past it. The cursor now
+  moves only on the success path.
+- **Mixed time units.** Local labels stored `updatedAt` in ms, delta-written ones in unix seconds —
+  a factor of a thousand between two values that were being compared. Converted once, at the
+  boundary (`localTimestamps`); the store's invariant is milliseconds everywhere.
+
+## 5. Last-write-wins was by HTTP arrival, not by user time
+
+Every label write blindly overwrote, so the winner was whichever request landed last. A device
+draining an offline queue an hour late therefore resurrected superseded intent — re-marking unread
+something the user had since read elsewhere.
+
+**Now:** `client_updated_at` (unix ms, migration `0076`) on every row, clamped server-side to now.
+Every write path takes an optional `updatedAt` and the upsert is conditional:
+
+```sql
+ON CONFLICT(…) DO UPDATE SET … WHERE excluded.client_updated_at >= COALESCE(client_updated_at, 0)
+```
+
+`>=` rather than `>` so an idempotent retry still lands. The soft-delete paths carry the same guard,
+so stale intent can't win in either direction. Clients send the sync queue's own enqueue time — the
+moment the user acted. `updated_at` (server seconds) keeps its job unchanged as the delta cursor, so
+the sync stream stays arrival-ordered and monotonic; `client_updated_at` is only the tiebreaker.
+
+**Clock skew:** clamping bounds forward skew. A backward-skewed device loses ties, which is exactly
+today's arrival-ordered behaviour — no regression, and it can't pin a row against every other
+device the way an unclamped future timestamp could.
+
+Inbound, `planReadDelta` applies the same comparison: a tombstone older than the local read label is
+dropped, and a live row older than a local un-read is dropped (the un-read intent is remembered in a
+small expiring map, since removing the label leaves nothing to compare against). A backend that
+sends no `client_updated_at` degrades to the previous in-flight-only guard rather than guessing.
+
+## 6. An open tab never saw another device's changes
+
+Labels were pulled at app init, on manual refresh, on tab-visible-and-≥30-minutes-stale, and via
+Chromium periodic background sync. The `online` event only drained the outbound queue. So a laptop
+left open all afternoon showed its own reading and nobody else's.
+
+**Now:** `itemLabelsStore.pullDelta()` also runs on `online` (after the queue drains, so our own
+writes are already reflected in what comes back), on `visibilitychange`, and on a 5-minute
+while-open timer — all gated to one pull a minute, all skipped when hidden or offline. A no-change
+delta is one indexed query returning zero rows.
+
+No push channel, deliberately: the delta is cheap, and the product is calm.
+
+## 7. readProgress could move backwards and republish itself
+
+The delta overwrote local progress unconditionally while a two-stage 500 ms debounce might still be
+pending; the debounced push then won server-side. Merging is now by `props.lastReadAt` on both
+sides, and the flush re-checks what is actually stored before writing. `lastReadAt` is the ordering
+and `paragraphIndex` never is — position legitimately moves backwards on a re-read, and treating
+"further along" as "newer" would make re-reading impossible to sync. The change guard also no longer
+drops `totalParagraphs`-only updates, which is how an article's first (wrong) denominator used to
+stick.
+
+## Scope
+
+standard.site documents ride the same label table and delta, so §4–§7 cover them. Their _membership_
+is already authoritative (per-scope digest reconciliation), so §1–§3 are RSS-only. This answers the
+maintainer's question on the thread: the persistent-divergence mechanism was the RSS window; the
+staleness and LWW defects affected both.
+
+**Deliberately out of scope**, listed so none reads as an oversight: per-highlight tombstones (union
+merge can still resurrect a single deleted highlight — the documented gap in `itemLabels.svelte.ts`),
+any push/real-time channel, and per-user timeline materialization.
+
+## Verification
+
+- `backend/test/unread-window.spec.ts` — K on cold start, counts over the window, mark-feed-read
+  (scope, `beforeSeq`, idempotence, subscription gating), archive offset paging.
+- `backend/test/labels.spec.ts`, `backend/test/reading-positions.spec.ts` — compound cursor,
+  same-second delivery, pagination, and the LWW guard in both directions plus clamping.
+- `frontend/src/lib/services/readDelta.test.ts` — the newer-local-intent guards and the
+  `readProgress` merge; `articleMerge.test.ts` — the eviction exemption.
+- `e2e/sync-convergence.spec.ts` — two browser contexts on one account: equal counts, a read on one
+  reaching the other, mark-all converging both to zero, user-time LWW, and same-second delivery.
+
+**Before production:** deploy backend first (as usual), run the two-device flow manually on phone +
+desktop against staging, and watch `unread_count_drift` and D1 row-reads on the admin ops panel for
+a few days. Note that counts may _drop_ for users whose fresh devices previously undercounted
+against a 30-item window — that is the fix working.

--- a/docs/plans/D1_FEED_TIMELINE.md
+++ b/docs/plans/D1_FEED_TIMELINE.md
@@ -255,6 +255,26 @@ step deleting `feeds`/`feed_items` rows whose feed has had **zero active subscri
   `Date.now() + backoff`; D1 stores seconds like the rest of the backend and converts back on the
   way out. Rescaling it a second time is what put every retry ~50,000 years out and made
   `canFetch` retire a feed permanently after one transient error.
+- **One K, enforced in three places.** `ARTICLE_WINDOW_PER_FEED` (`backend/src/config/window.ts`)
+  is the cold start's per-feed slice, the window the server's `unread_counts` are computed over, and
+  the client's `MAX_ARTICLES_PER_FEED`. They were 30 / — / 100, which meant a fresh device and an
+  established one were counting unread over different sets: the same feed showed different numbers
+  on a phone and a laptop no matter how well read state synced, and no amount of sync work could
+  have fixed it. Changing one without the others reintroduces exactly that.
+- **Unread counts are the server's, not each device's.** `include_counts=1` on the first page of a
+  refresh returns a per-feed count over the newest-K window (per-feed index seeks, bounded by
+  K × subscriptions). Clients display it when online and fall back to their local derivation
+  offline; a mismatch after a completed refresh is reported as `unread_count_drift` telemetry, so
+  divergence is something we see rather than something a user reports.
+- **Mark-all-read is a server operation.** `POST /api/reading/mark-feed-read` writes read rows for
+  the canonical window (≤ K per feed, `beforeSeq` bounding it to what the client saw), because a
+  client-side loop can only mark what THAT device holds — leaving items another device held below
+  its window unread there.
+- **Eviction is not deletion.** D1 still never prunes; the client's per-feed cap is a cache bound.
+  `GET /api/v2/feeds/fetch?offset=K` pages below the local window ("Show older"), so an evicted
+  unread item is a cache miss rather than something the reader experiences as lost. Starred, tagged
+  and highlighted items are exempt from eviction; unread deliberately is not, since exempting it
+  would let each device's set grow past K and diverge again.
 
 ## Known scaling knob
 

--- a/e2e/sync-convergence.spec.ts
+++ b/e2e/sync-convergence.spec.ts
@@ -1,0 +1,252 @@
+import { test, expect } from './fixtures';
+import type { BrowserContext, Page } from '@playwright/test';
+import { seedSubscription, seedFeedItems, cleanupFeedItems, type TestUser } from './seed';
+
+/**
+ * Two devices, one account — the decisive test for the report behind this work:
+ *
+ *   "the same feed will show different unread numbers on different devices"
+ *
+ * Every assertion here failed before the canonical window and server-computed
+ * counts: device A cold-started with a different slice than device B kept, and
+ * "mark all read" only ever covered the acting device's slice.
+ *
+ * The two contexts share one seeded session cookie, which is what makes them two
+ * devices rather than two tabs: separate IndexedDB, separate cursors, separate
+ * in-memory stores.
+ */
+test.describe('Cross-device sync convergence', () => {
+  const FEED_URL = 'https://example.com/two-device-feed.xml';
+  const FEED_TITLE = 'Two Device Feed';
+  // Deliberately more than the canonical window (100), so a device that
+  // cold-starts and a device that accumulates could hold different sets.
+  const ITEM_COUNT = 150;
+
+  test.afterEach(async () => {
+    await cleanupFeedItems(FEED_URL);
+  });
+
+  /** A second "device": its own context, same session, same account. */
+  async function openDevice(context: BrowserContext, user: TestUser): Promise<Page> {
+    await context.addCookies([
+      {
+        name: 'session_id',
+        value: user.sessionId,
+        domain: '127.0.0.1',
+        path: '/',
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    ]);
+    const page = await context.newPage();
+    await page.goto('/');
+    await page.evaluate(
+      ({ handle, did }) => {
+        localStorage.setItem(
+          'skyreader-auth',
+          JSON.stringify({
+            user: { did, handle, displayName: 'Test User' },
+          })
+        );
+      },
+      { handle: user.handle, did: user.did }
+    );
+    await page.reload();
+    return page;
+  }
+
+  /** Wait for a completed refresh, then read the server-authoritative count. */
+  async function unreadForFeed(page: Page): Promise<number> {
+    const response = await page.waitForResponse(
+      (r) => r.url().includes('/api/v2/timeline') && r.url().includes('include_counts=1'),
+      { timeout: 30_000 }
+    );
+    const body = (await response.json()) as { unreadCounts?: Record<string, number> };
+    return body.unreadCounts?.[FEED_URL] ?? -1;
+  }
+
+  async function seedFeed() {
+    await seedFeedItems(
+      FEED_URL,
+      Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        guid: `two-device-${String(i).padStart(4, '0')}`,
+        title: `Two Device Article ${i}`,
+        publishedAt: new Date(Date.now() - i * 60_000).toISOString(),
+      })),
+      { title: FEED_TITLE, siteUrl: 'https://example.com' }
+    );
+  }
+
+  test('two devices agree on the unread count for the same feed', async ({
+    authedPage,
+    testUser,
+    browser,
+  }) => {
+    await seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
+    await seedFeed();
+
+    const countsA = unreadForFeed(authedPage);
+    await authedPage.reload();
+    const a = await countsA;
+
+    const contextB = await browser.newContext();
+    const pageB = await openDevice(contextB, testUser);
+    const countsB = unreadForFeed(pageB);
+    await pageB.reload();
+    const b = await countsB;
+
+    // Both are the canonical window, and — the actual point — they are equal.
+    expect(a).toBe(b);
+    expect(a).toBe(100);
+
+    await contextB.close();
+  });
+
+  test('a read on one device reaches the other, and mark-all converges both to zero', async ({
+    authedPage,
+    testUser,
+    browser,
+  }) => {
+    await seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
+    await seedFeed();
+
+    await authedPage.reload();
+    await unreadForFeed(authedPage);
+
+    // Device A marks three items read, through the same API the UI uses.
+    await authedPage.evaluate(async () => {
+      await fetch('/api/reading/mark-read-bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          items: [
+            { itemGuid: 'two-device-0000' },
+            { itemGuid: 'two-device-0001' },
+            { itemGuid: 'two-device-0002' },
+          ],
+          updatedAt: Date.now(),
+        }),
+      });
+    });
+
+    // Device B, opened fresh, sees the reduced count.
+    const contextB = await browser.newContext();
+    const pageB = await openDevice(contextB, testUser);
+    const countsB = unreadForFeed(pageB);
+    await pageB.reload();
+    expect(await countsB).toBe(97);
+
+    // Mark-all is a SERVER operation over the window, so it covers items neither
+    // device necessarily held — which is exactly what the local loop couldn't do.
+    await pageB.evaluate(async () => {
+      await fetch('/api/reading/mark-feed-read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          feedUrl: 'https://example.com/two-device-feed.xml',
+          updatedAt: Date.now(),
+        }),
+      });
+    });
+
+    const countsAfterA = unreadForFeed(authedPage);
+    await authedPage.reload();
+    expect(await countsAfterA).toBe(0);
+
+    await contextB.close();
+  });
+
+  test('a late-draining un-read loses to a newer read from the other device', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
+    await seedFeed();
+    await authedPage.reload();
+    await unreadForFeed(authedPage);
+
+    const guid = 'two-device-0000';
+
+    const finalState = await authedPage.evaluate(async (itemGuid) => {
+      const now = Date.now();
+      // Device A read it a minute ago; its request lands first.
+      await fetch('/api/reading/mark-read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ itemGuid, updatedAt: now - 60_000 }),
+      });
+      // Device B un-read it an HOUR ago and only now drains its offline queue.
+      // Arrival order says B wins; user time says A does, and the user is right.
+      await fetch('/api/reading/mark-unread', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ itemGuid, updatedAt: now - 3_600_000 }),
+      });
+
+      const res = await fetch('/api/reading/positions?since=0', { credentials: 'include' });
+      const body = (await res.json()) as {
+        positions: Array<{ item_guid: string; deleted: boolean }>;
+      };
+      return body.positions.find((p) => p.item_guid === itemGuid);
+    }, guid);
+
+    expect(finalState?.deleted).toBe(false);
+  });
+
+  // The same-second case a seconds-only cursor cannot express a position inside:
+  // every row written in the cursor's own second used to be dropped and never
+  // offered again.
+  test('same-second read changes are all delivered exactly once', async ({
+    authedPage,
+    testUser,
+  }) => {
+    await seedSubscription(testUser, { feedUrl: FEED_URL, title: FEED_TITLE });
+    await seedFeed();
+    await authedPage.reload();
+    await unreadForFeed(authedPage);
+
+    const delivered = await authedPage.evaluate(async () => {
+      // Three reads inside one wall-clock second.
+      await fetch('/api/reading/mark-read-bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          items: [
+            { itemGuid: 'two-device-0010' },
+            { itemGuid: 'two-device-0011' },
+            { itemGuid: 'two-device-0012' },
+          ],
+        }),
+      });
+
+      // Drain one row at a time, which is what forces the cursor to sit INSIDE
+      // that second between pages.
+      const seen: string[] = [];
+      let since = '0';
+      for (let page = 0; page < 10; page++) {
+        const res = await fetch(
+          `/api/reading/positions?since=${encodeURIComponent(since)}&limit=1`,
+          { credentials: 'include' }
+        );
+        const body = (await res.json()) as {
+          positions: Array<{ item_guid: string }>;
+          nextSince: string;
+          hasMore: boolean;
+        };
+        seen.push(...body.positions.map((p) => p.item_guid));
+        since = body.nextSince;
+        if (!body.hasMore) break;
+      }
+      return seen;
+    });
+
+    for (const guid of ['two-device-0010', 'two-device-0011', 'two-device-0012']) {
+      expect(delivered.filter((g) => g === guid)).toHaveLength(1);
+    }
+  });
+});

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,15 +27,16 @@ Skyreader frontend is a SvelteKit PWA that provides an RSS reading experience wi
 
 All stores use Svelte 5 runes (`.svelte.ts` files):
 
-| Store                     | Purpose                              |
-| ------------------------- | ------------------------------------ |
-| `auth.svelte.ts`          | User session state                   |
-| `subscriptions.svelte.ts` | Feed subscriptions CRUD              |
-| `reading.svelte.ts`       | Read/starred state for articles      |
-| `social.svelte.ts`        | Social feed from followed users      |
-| `sync.svelte.ts`          | Online status and pending sync count |
-| `preferences.svelte.ts`   | User preferences                     |
-| `realtime.svelte.ts`      | WebSocket connection state           |
+| Store                     | Purpose                                             |
+| ------------------------- | --------------------------------------------------- |
+| `auth.svelte.ts`          | User session state                                  |
+| `subscriptions.svelte.ts` | Feed subscriptions CRUD                             |
+| `itemLabels.svelte.ts`    | Read/tag/archive/highlight labels + the delta sync  |
+| `unreadCounts.svelte.ts`  | Unread counts (server's when online, local offline) |
+| `feedArchive.svelte.ts`   | Transient "Show older" items below the local window |
+| `social.svelte.ts`        | Social feed from followed users                     |
+| `sync.svelte.ts`          | Online status, pending queue count, last sync       |
+| `preferences.svelte.ts`   | User preferences                                    |
 
 ### Services
 
@@ -46,7 +47,7 @@ All stores use Svelte 5 runes (`.svelte.ts` files):
 | `feedFetcher.ts`  | Feed refresh (timeline sync + legacy batch path)   |
 | `timelineSync.ts` | Pure helpers for the timeline sync (unit-tested)   |
 | `sync-queue.ts`   | Queue operations when offline, process when online |
-| `realtime.ts`     | WebSocket connection management                    |
+| `readDelta.ts`    | Pure delta/merge decisions (unit-tested)           |
 | `telemetry.ts`    | Sampled client error reports to the backend        |
 
 ### Feed refresh
@@ -79,6 +80,32 @@ The legacy per-feed `/api/v2/feeds/batch` path (`fetchAllFeedsViaBatch`, with pe
 `feedCursors`) is kept for one release as a fallback: it runs when the timeline 404s and whenever
 the server reports `ingestActive: false` (this environment's crawler isn't pushing into D1). See
 `docs/plans/D1_FEED_TIMELINE.md`.
+
+### Label sync (read state, tags, progress, highlights)
+
+Two forward deltas, both in `itemLabels.svelte.ts`: `GET /api/reading/positions` for `read`, and
+`GET /api/labels?labels=…` for tagged/archived/readProgress/highlights. Four rules keep them from
+diverging across devices — each one is a bug that was actually shipped:
+
+- **The cursor is compound `(updated_at, id)`**, base64 on the wire, and it is the last row
+  _delivered_, never a clock reading. `updated_at` has one-second resolution, so a timestamp-only
+  cursor with a strictly-greater predicate silently dropped every row written in its own second and
+  never offered them again. A legacy numeric cursor is still accepted (read as `(seconds, 0)`).
+- **The cursor moves only after the Dexie write succeeds.** It used to be committed in a separate
+  `try`, so a failed IndexedDB write lost the batch _and_ skipped past it — permanently, since the
+  delta is forward-only. Both deltas are paged; drain until `hasMore` is false.
+- **Conflicts resolve by user time, not arrival time.** Every write carries `updatedAt` (unix ms —
+  the sync queue's own enqueue time, or `Date.now()` for an optimistic call), and the server keeps
+  the later one. Without it, a queue draining an hour late re-marked-unread something the user had
+  since read elsewhere. `planReadDelta` applies the same comparison inbound; `readProgress` merges
+  by `props.lastReadAt` (never `paragraphIndex` — re-reading legitimately moves backwards).
+- **Timestamps are milliseconds everywhere in the label store.** Server rows arrive in seconds and
+  are converted once, at the boundary (`localTimestamps`).
+
+Freshness: `refreshFromBackend` pulls both, plus `itemLabelsStore.pullDelta()` on `online` (after
+the queue drains), on `visibilitychange`, and on a 5-minute while-open timer — all gated to one
+pull a minute. There is deliberately **no push channel**: a no-change delta is one indexed query
+returning zero rows, and the product is calm.
 
 Client errors flow through `/api/telemetry/error`; no Sentry SDK ships in the frontend bundle.
 See [`docs/RUNBOOK.md`](../docs/RUNBOOK.md) for sampling and recovery details.

--- a/frontend/src/lib/components/feed/FeedListView.svelte
+++ b/frontend/src/lib/components/feed/FeedListView.svelte
@@ -5,6 +5,8 @@
   import SavedReader from '$lib/components/feed/SavedReader.svelte';
   import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';
   import { feedViewStore, type FeedDisplayItem } from '$lib/stores/feedView.svelte';
+  import { feedArchiveStore } from '$lib/stores/feedArchive.svelte';
+  import { MAX_ARTICLES_PER_FEED } from '$lib/services/articleMerge';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { linkblogStore } from '$lib/stores/linkblog.svelte';
@@ -221,6 +223,36 @@
     return articleElements;
   }
 
+  // --- Archive ("Show older") ----------------------------------------------
+  //
+  // Only offered in a single-RSS-feed view: the archive read is per-feed, and in
+  // a combined view "older" has no single meaning. The items render below the
+  // list and outside the indexed `#each`, so keyboard navigation and
+  // scroll-to-mark-read still operate on the reading list only — this is a
+  // deliberate look into the archive, not more of the feed.
+  let archiveSub = $derived.by(() => {
+    const filter = feedViewStore.feedFilter;
+    if (!filter || feedViewStore.isSavedView) return undefined;
+    const sub = subscriptionsStore.subscriptions.find((s) => s.id === Number(filter));
+    if (!sub?.feedUrl) return undefined;
+    if (sub.sourceType && sub.sourceType !== 'rss') return undefined;
+    return sub;
+  });
+
+  // Switching feeds (or leaving the single-feed view) drops whatever was loaded.
+  $effect(() => {
+    const id = archiveSub?.id ?? null;
+    if (feedArchiveStore.subscriptionId !== id) feedArchiveStore.reset(id);
+  });
+
+  // The affordance only makes sense once the local window is actually full —
+  // below that there is nothing the cap has trimmed, so there is nothing older
+  // to show that the list isn't already showing.
+  let archiveOffered = $derived.by(() => {
+    if (!archiveSub || feedViewStore.hasMore) return false;
+    return feedViewStore.filteredArticles.length >= MAX_ARTICLES_PER_FEED;
+  });
+
   export { scrollToCenter };
 </script>
 
@@ -294,6 +326,46 @@
     onLoadMore={() => feedViewStore.loadMore()}
   />
 
+  {#if archiveOffered && archiveSub}
+    {#each feedArchiveStore.items as article (article.guid)}
+      <div class="article-item-anchor">
+        <ArticleCard
+          {article}
+          siteUrl={archiveSub.siteUrl || archiveSub.feedUrl}
+          feedTitle={archiveSub.customTitle || archiveSub.title}
+          feedId={archiveSub.id}
+          isRead={itemLabelsStore.isRead(article.guid)}
+          isSaved={itemLabelsStore.isSaved(article.guid)}
+          isShared={linkblogStore.isShared(article.url)}
+          shareNote={linkblogStore.getNote(article.url)}
+          onToggleSave={() => onToggleSave(article)}
+          onToggleRead={() => handleToggleRead(article)}
+          onUnshare={() => onUnshare(article.url)}
+          onOpenFullscreen={() => openReader({ type: 'article', item: article, key: article.guid })}
+        />
+      </div>
+    {/each}
+
+    <div class="archive-footer">
+      {#if feedArchiveStore.error}
+        <p class="archive-note">{feedArchiveStore.error}</p>
+      {:else}
+        <p class="archive-note">
+          Showing the newest {MAX_ARTICLES_PER_FEED} — older items stay in your archive.
+        </p>
+      {/if}
+      {#if !feedArchiveStore.exhausted}
+        <button
+          class="btn btn-secondary"
+          disabled={feedArchiveStore.loading}
+          onclick={() => feedArchiveStore.loadMore(archiveSub)}
+        >
+          {feedArchiveStore.loading ? 'Loading…' : 'Show older'}
+        </button>
+      {/if}
+    </div>
+  {/if}
+
   {#if preferences.scrollToMarkAsRead && !feedViewStore.hasMore && feedViewStore.currentItems.length > 0}
     <div class="scroll-mark-overscroll"></div>
   {/if}
@@ -327,5 +399,22 @@
   .scroll-mark-overscroll {
     height: 100vh;
     pointer-events: none;
+  }
+
+  /* Quiet by construction: one line of explanation and one button, at the end
+     of the list where someone has already run out of reading. No banner. */
+  .archive-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1.5rem 0;
+  }
+
+  .archive-note {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    text-align: center;
   }
 </style>

--- a/frontend/src/lib/components/feed/FeedPage.svelte
+++ b/frontend/src/lib/components/feed/FeedPage.svelte
@@ -157,6 +157,14 @@
   // Tab visibility state
   let lastVisibleTime = $state(Date.now());
   const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+  // Floor between delta-only pulls, so a flapping tab doesn't poll.
+  const DELTA_MIN_INTERVAL_MS = 60 * 1000;
+  // Gentle while-open cadence. A tab left open all afternoon used to observe
+  // nothing another device did; this is what makes read state converge without
+  // adding a push channel (deliberately out of scope — the delta is cheap and
+  // the product is calm).
+  const DELTA_POLL_INTERVAL_MS = 5 * 60 * 1000;
+  let deltaPollTimer: ReturnType<typeof setInterval> | null = null;
 
   // Reference to FeedListView or SavedListView component for accessing article elements
   let feedListView = $state<ReturnType<typeof FeedListView> | null>(null);
@@ -325,7 +333,17 @@
       []
     );
 
-    await itemLabelsStore.markAllAsRead(articlesToMark);
+    // Scoped to the feed so the server marks its whole canonical window, not
+    // just the slice this device happens to hold — otherwise another device
+    // holding older items would still show them unread after this. Only RSS:
+    // atproto sources aren't in the archive and reconcile by digest instead.
+    const isRss = !sub.sourceType || sub.sourceType === 'rss';
+    await itemLabelsStore.markAllAsRead(
+      articlesToMark,
+      isRss && sub.feedUrl
+        ? { feedUrl: sub.feedUrl, beforeSeq: unreadCounts.serverCountsHead }
+        : undefined
+    );
   }
 
   async function markAllAsReadInCurrentView() {
@@ -398,7 +416,21 @@
     // Mark all using bulk operations
     const promises: Promise<void>[] = [];
     if (articlesToMark.length > 0) {
-      promises.push(itemLabelsStore.markAllAsRead(articlesToMark));
+      // The all-feeds server variant only applies to the unfiltered view: a
+      // channel or source filter means the user asked to clear THAT set, and
+      // marking every subscribed feed would read as the action doing far more
+      // than it said. Filtered views keep the per-item path.
+      const wholeView =
+        !feedViewStore.feedFilter &&
+        !feedViewStore.viewFilter &&
+        !feedViewStore.sharerFilter &&
+        !feedViewStore.categoryFilter;
+      promises.push(
+        itemLabelsStore.markAllAsRead(
+          articlesToMark,
+          wholeView ? { beforeSeq: unreadCounts.serverCountsHead } : undefined
+        )
+      );
     }
     if (socialItemsToMark.length > 0) {
       promises.push(itemLabelsStore.markAllSocialAsRead(socialItemsToMark));
@@ -428,6 +460,12 @@
         console.log('Data is stale, refreshing...');
         await appManager.refreshFromBackend();
         feedViewStore.clearReadThisSession();
+      } else {
+        // Not stale enough for a full refresh, but coming back to this tab is
+        // exactly when someone expects their phone's reading to be here. A
+        // delta-only pull is two indexed queries that usually return nothing,
+        // so it gets a one-minute gate rather than the full refresh's thirty.
+        void itemLabelsStore.pullDelta(DELTA_MIN_INTERVAL_MS);
       }
     }
     lastVisibleTime = Date.now();
@@ -461,6 +499,15 @@
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     lastVisibleTime = Date.now();
+
+    deltaPollTimer = setInterval(() => {
+      // Skipped when hidden or offline — pullDelta no-ops offline, and a hidden
+      // tab has no one to show the result to (visibilitychange covers the
+      // return). Same scheduling shape as the notifications timer.
+      if (!auth.isAuthenticated) return;
+      if (document.visibilityState !== 'visible') return;
+      void itemLabelsStore.pullDelta(DELTA_MIN_INTERVAL_MS);
+    }, DELTA_POLL_INTERVAL_MS);
   });
 
   // The linkblog stream carries unposted drafts alongside published entries, so
@@ -511,6 +558,7 @@
     // pre-applied (and silently emptying the list) on the next visit.
     savedSearchStore.setSurfaceActive(false);
     document.removeEventListener('visibilitychange', handleVisibilityChange);
+    if (deltaPollTimer) clearInterval(deltaPollTimer);
   });
 </script>
 

--- a/frontend/src/lib/components/settings/Diagnostics.svelte
+++ b/frontend/src/lib/components/settings/Diagnostics.svelte
@@ -59,6 +59,10 @@
       value: syncStore.pendingCount === 0 ? 'None' : String(syncStore.pendingCount),
     },
     {
+      // Now moves on a successful PULL as well as a queue drain, so a device
+      // with nothing of its own to push still reports when it last caught up
+      // with the others — which is the actual question behind "is my reading
+      // synced?".
       label: 'Last sync',
       value: syncStore.lastSyncedAt
         ? formatTime(syncStore.lastSyncedAt)

--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.test.ts
@@ -1,13 +1,16 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { setReadProgress, getReadProgress } = vi.hoisted(() => ({
+const { setReadProgress, getReadProgress, getLabel } = vi.hoisted(() => ({
   setReadProgress: vi.fn(),
   getReadProgress: vi.fn(),
+  // The flush-time re-check: whatever is stored when the debounce fires, which
+  // a delta may have replaced with another device's newer position since.
+  getLabel: vi.fn(),
 }));
 
 vi.mock('$lib/stores/itemLabels.svelte', () => ({
-  itemLabelsStore: { setReadProgress, getReadProgress },
+  itemLabelsStore: { setReadProgress, getReadProgress, getLabel },
 }));
 
 vi.mock('svelte', () => ({ onDestroy: vi.fn() }));
@@ -56,6 +59,8 @@ describe('useParagraphTracking', () => {
     vi.useFakeTimers();
     setReadProgress.mockReset();
     getReadProgress.mockReset();
+    getLabel.mockReset();
+    getLabel.mockReturnValue(undefined);
     getReadProgress.mockReturnValue({ paragraphIndex: 8, totalParagraphs: 20 });
     vi.stubGlobal('$state', <T>(value: T) => value);
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
@@ -176,6 +181,25 @@ describe('useParagraphTracking', () => {
     tracking.nextParagraph();
     vi.advanceTimersByTime(600);
     expect(setReadProgress).toHaveBeenCalledWith('article-key', 'article', 13, 40);
+
+    tracking.cleanup();
+  });
+  // A delta can land during the 500 ms debounce and replace the stored position
+  // with another device's newer one. Publishing the queued position afterwards
+  // would rewind that device AND republish the older position as authoritative,
+  // so the flush re-checks what is actually stored before writing.
+  it('abandons a queued save when a newer position arrived while it waited', () => {
+    getReadProgress.mockReturnValue({ paragraphIndex: 12, totalParagraphs: 40 });
+    const content = renderBody(40);
+    const tracking = track(content);
+
+    tracking.setupObserver();
+    window.dispatchEvent(new Event('scroll'));
+    // Another device's progress, recorded after this save was queued.
+    getLabel.mockReturnValue({ props: { lastReadAt: Date.now() + 10_000 } });
+    vi.advanceTimersByTime(600);
+
+    expect(setReadProgress).not.toHaveBeenCalled();
 
     tracking.cleanup();
   });

--- a/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
+++ b/frontend/src/lib/hooks/useParagraphTracking.svelte.ts
@@ -186,11 +186,19 @@ export function useParagraphTracking(params: ParagraphTrackingParams) {
 
   function debouncedSave() {
     if (saveTimer) clearTimeout(saveTimer);
+    // Whose scroll this is, captured when the save was QUEUED. A delta arriving
+    // during the debounce may replace the stored progress with another device's
+    // newer position; publishing this one afterwards would rewind that device
+    // and, worse, republish the older position as authoritative.
+    const queuedAt = Date.now();
     saveTimer = setTimeout(() => {
       saveTimer = null;
       // Re-checked at flush time rather than when the save was queued: the full
       // body may have arrived in the meantime, which makes the position real.
       if (bodyIsPartial()) return;
+      const stored = itemLabelsStore.getLabel(params.itemKey(), 'readProgress');
+      const storedAt = stored?.props.lastReadAt as number | undefined;
+      if (typeof storedAt === 'number' && storedAt > queuedAt) return;
       itemLabelsStore.setReadProgress(
         params.itemKey(),
         params.itemType(),

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -29,6 +29,19 @@ import type {
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
+/** One `item_labels_cache` row as `GET /api/labels` serves it. */
+export interface LabelRowDTO {
+  itemKey: string;
+  itemType: string;
+  label: string;
+  props: Record<string, unknown>;
+  rkey?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt?: number | null;
+  clientUpdatedAt?: number | null;
+}
+
 export class RateLimitError extends Error {
   retryAfter: number;
 
@@ -181,6 +194,14 @@ export interface TimelineResponse {
   // communicated. Present on every cold start and whenever `healthRev` moved.
   // Absent entirely on a backend that predates feed-health reporting.
   feedHealth?: Record<string, TimelineFeedHealth>;
+  // Server-computed unread counts per feed URL, over the canonical newest-K
+  // window. Requested with `include_counts=1` on the first page of a refresh.
+  // These are what makes two devices agree: a locally-derived count is taken
+  // over whatever slice THIS device holds, and no two devices hold the same one.
+  unreadCounts?: Record<string, number>;
+  // The archive head as of the counts response — passed back as `beforeSeq` when
+  // marking a feed read, so items ingested after the press stay unread.
+  head?: number;
 }
 
 /** One broken feed as the timeline reports it. Timestamps are unix ms. */
@@ -417,6 +438,24 @@ class ApiClient {
   }
 
   /**
+   * One page of a feed's archive BELOW the local window.
+   *
+   * D1 never pruned anything, but each device only keeps the newest K per feed
+   * and trims oldest-first — so an older unread item simply disappeared from the
+   * only copy the reader could see, which reads as data loss. This is the read
+   * that gets it back. Deliberately separate from `fetchFeedV2`: the result is a
+   * transient archive view, never merged into the capped local set.
+   */
+  async fetchFeedArchive(url: string, offset: number, limit: number): Promise<ParsedFeed> {
+    const params = new URLSearchParams({
+      url,
+      offset: String(offset),
+      limit: String(limit),
+    });
+    return this.fetch(`/api/v2/feeds/fetch?${params}`);
+  }
+
+  /**
    * The whole feed refresh in one request: every new item across every
    * subscription, with read state already stamped on. `since_seq` + `generation`
    * are the client's global cursor into the server-side archive; `hasMore` drives
@@ -428,6 +467,7 @@ class ApiClient {
     limit?: number;
     cold_offset?: number;
     health_rev?: string;
+    include_counts?: boolean;
   }): Promise<TimelineResponse> {
     const search = new URLSearchParams();
     if (params.since_seq !== undefined) search.set('since_seq', String(params.since_seq));
@@ -435,6 +475,7 @@ class ApiClient {
     if (params.limit) search.set('limit', String(params.limit));
     if (params.cold_offset) search.set('cold_offset', String(params.cold_offset));
     if (params.health_rev) search.set('health_rev', params.health_rev);
+    if (params.include_counts) search.set('include_counts', '1');
     const query = search.toString();
     return this.fetch(`/api/v2/timeline${query ? `?${query}` : ''}`);
   }
@@ -842,17 +883,24 @@ class ApiClient {
   // AND tombstones (deleted=true) — across articles and documents. Bootstrap read
   // state arrives via inline annotation on the fetch response, not here, so this
   // is always a delta. Returns the new cursor to send next time.
-  async getReadPositions(since?: number): Promise<{
+  // `since` is the opaque compound cursor (`nextSince` from the previous call);
+  // a legacy numeric cursor is still accepted by the backend. Pages are bounded
+  // now — drain while `hasMore`, and only persist `nextSince` once the batch is
+  // durable, or a failed write loses rows the cursor has already moved past.
+  async getReadPositions(since?: number | string): Promise<{
     positions: Array<{
       item_guid: string;
       item_type: 'article' | 'document';
       read_at: number | string | null;
       rkey: string | null;
       deleted: boolean;
+      client_updated_at?: number | null;
     }>;
     cursor: number;
+    nextSince?: string;
+    hasMore?: boolean;
   }> {
-    const params = since ? `?since=${since}` : '';
+    const params = since ? `?since=${encodeURIComponent(String(since))}` : '';
     return this.fetch(`/api/reading/positions${params}`);
   }
 
@@ -863,6 +911,10 @@ class ApiClient {
     itemTitle?: string;
     rkey?: string;
     authorDid?: string;
+    // When the USER acted, unix ms — the last-write-wins key. Without it the
+    // server falls back to arrival time, which is what let a late queue drain
+    // resurrect stale intent.
+    updatedAt?: number;
   }): Promise<{ success: boolean; rkey?: string; alreadyRead?: boolean }> {
     return this.fetch('/api/reading/mark-read', {
       method: 'POST',
@@ -870,10 +922,10 @@ class ApiClient {
     });
   }
 
-  async markAsUnread(itemGuid: string): Promise<{ success: boolean }> {
+  async markAsUnread(itemGuid: string, updatedAt?: number): Promise<{ success: boolean }> {
     return this.fetch('/api/reading/mark-unread', {
       method: 'POST',
-      body: JSON.stringify({ itemGuid }),
+      body: JSON.stringify({ itemGuid, updatedAt }),
     });
   }
 
@@ -885,11 +937,32 @@ class ApiClient {
       itemTitle?: string;
       rkey?: string;
       authorDid?: string;
-    }>
+      updatedAt?: number;
+    }>,
+    updatedAt?: number
   ): Promise<{ success: boolean; marked: number; skipped: number }> {
     return this.fetch('/api/reading/mark-read-bulk', {
       method: 'POST',
-      body: JSON.stringify({ items }),
+      body: JSON.stringify({ items, updatedAt }),
+    });
+  }
+
+  /**
+   * Mark a feed's canonical window read on the SERVER.
+   *
+   * The client-side loop could only mark what this device happened to hold, so
+   * items another device held below this device's window stayed unread there.
+   * Omit `feedUrl` for every subscribed feed. `beforeSeq` is the archive head
+   * the client saw, so anything ingested after the press stays unread.
+   */
+  async markFeedRead(options: {
+    feedUrl?: string;
+    beforeSeq?: number;
+    updatedAt?: number;
+  }): Promise<{ success: boolean; marked: number }> {
+    return this.fetch('/api/reading/mark-feed-read', {
+      method: 'POST',
+      body: JSON.stringify(options),
     });
   }
 
@@ -901,7 +974,7 @@ class ApiClient {
       itemType?: ItemLabelType;
       cursor?: string;
       limit?: number;
-      since?: number;
+      since?: number | string;
     } = {}
   ): Promise<{
     labels: Array<{
@@ -915,8 +988,14 @@ class ApiClient {
       // Tombstone marker: set (unix seconds) when the label was deleted; only
       // appears in delta (`since`) responses. Live snapshots never include it.
       deletedAt?: number | null;
+      // When the USER made this change, unix ms. Absent on an older backend.
+      clientUpdatedAt?: number | null;
     }>;
     cursor?: string;
+    // The compound delta cursor to persist once this batch is durable — the
+    // last row DELIVERED, never a clock reading. Delta responses only.
+    nextSince?: string;
+    hasMore?: boolean;
   }> {
     const params = new URLSearchParams();
     if (options.label) params.set('label', options.label);
@@ -929,43 +1008,33 @@ class ApiClient {
     return this.fetch(`/api/labels${query ? `?${query}` : ''}`);
   }
 
+  /**
+   * Drain every page of a labels fetch.
+   *
+   * Returns the rows AND the compound cursor to persist. The caller must only
+   * persist that cursor once the rows are durable locally — the whole point of
+   * the compound form is that a cursor can never sit past a row the client
+   * never applied.
+   */
   async getAllLabels(
     options: {
       label?: string;
       labels?: string[];
       itemType?: ItemLabelType;
-      since?: number;
+      since?: number | string;
     } = {}
-  ): Promise<
-    Array<{
-      itemKey: string;
-      itemType: string;
-      label: string;
-      props: Record<string, unknown>;
-      rkey?: string;
-      createdAt: number;
-      updatedAt: number;
-      deletedAt?: number | null;
-    }>
-  > {
-    const all: Array<{
-      itemKey: string;
-      itemType: string;
-      label: string;
-      props: Record<string, unknown>;
-      rkey?: string;
-      createdAt: number;
-      updatedAt: number;
-      deletedAt?: number | null;
-    }> = [];
+  ): Promise<{ labels: LabelRowDTO[]; nextSince?: string }> {
+    const all: LabelRowDTO[] = [];
     let cursor: string | undefined;
+    let nextSince: string | undefined;
     do {
       // Use the backend max page size to minimise round-trips when paginating.
       const response = await this.getLabels({ ...options, cursor, limit: 500 });
       all.push(...response.labels);
       cursor = response.cursor;
+      if (response.nextSince) nextSince = response.nextSince;
     } while (cursor);
-    return all;
+    return { labels: all, nextSince };
   }
 
   async addLabel(data: {
@@ -973,6 +1042,7 @@ class ApiClient {
     itemType: ItemLabelType;
     label: string;
     props?: Record<string, unknown>;
+    updatedAt?: number;
   }): Promise<{ success: boolean }> {
     return this.fetch('/api/labels', {
       method: 'POST',
@@ -980,10 +1050,14 @@ class ApiClient {
     });
   }
 
-  async deleteLabel(itemKey: string, label: string): Promise<{ success: boolean }> {
+  async deleteLabel(
+    itemKey: string,
+    label: string,
+    updatedAt?: number
+  ): Promise<{ success: boolean }> {
     return this.fetch('/api/labels', {
       method: 'DELETE',
-      body: JSON.stringify({ itemKey, label }),
+      body: JSON.stringify({ itemKey, label, updatedAt }),
     });
   }
 
@@ -993,6 +1067,7 @@ class ApiClient {
       itemType: ItemLabelType;
       label: string;
       props?: Record<string, unknown>;
+      updatedAt?: number;
     }>
   ): Promise<{ success: boolean; added: number }> {
     return this.fetch('/api/labels/bulk', {

--- a/frontend/src/lib/services/articleMerge.test.ts
+++ b/frontend/src/lib/services/articleMerge.test.ts
@@ -175,6 +175,38 @@ describe('computeArticleLimitDeletions', () => {
     const { ids } = computeArticleLimitDeletions(articles, new Set([1]), new Set());
     expect(ids).toHaveLength(2);
   });
+
+  // Evicting an item that carries a tag or a highlight leaves the annotation in
+  // the label store with nothing to attach it to. Starred was already exempt;
+  // labelled is the same argument.
+  it('preserves labelled articles alongside starred ones', () => {
+    const articles = feedArticles(1, 5);
+    const labelled = new Set(['g3']);
+    const { dropByFeed } = computeArticleLimitDeletions(
+      articles,
+      new Set([1]),
+      new Set(['g4']),
+      3,
+      (guid) => labelled.has(guid)
+    );
+    // g4 starred + g3 labelled kept, plus the newest evictable (g0) => drop g1, g2
+    expect([...(dropByFeed.get(1) ?? [])].sort()).toEqual(['g1', 'g2']);
+  });
+
+  // Read/unread stays recency-governed on purpose: exempting unread items would
+  // let each device's set grow past K and diverge, which is exactly what the
+  // canonical window exists to prevent.
+  it('still evicts unread articles — only annotations are pinned', () => {
+    const articles = feedArticles(1, 5);
+    const { dropByFeed } = computeArticleLimitDeletions(
+      articles,
+      new Set([1]),
+      new Set(),
+      3,
+      () => false
+    );
+    expect([...(dropByFeed.get(1) ?? [])].sort()).toEqual(['g3', 'g4']);
+  });
 });
 
 describe('computeContentStats', () => {

--- a/frontend/src/lib/services/articleMerge.ts
+++ b/frontend/src/lib/services/articleMerge.ts
@@ -1,5 +1,13 @@
 import type { Article, FeedItem } from '$lib/types';
 
+/**
+ * K — the canonical per-feed window. Must equal `ARTICLE_WINDOW_PER_FEED` in
+ * `backend/src/config/window.ts`: the server cold-starts a device with exactly
+ * this many per feed and computes its unread counts over exactly this many, so
+ * a mismatch here is a device that counts over a different set than every other
+ * device — which is the whole cross-device divergence bug. Change both or
+ * neither.
+ */
 export const MAX_ARTICLES_PER_FEED = 100;
 
 /**
@@ -96,8 +104,17 @@ export function selectNewArticles(
 
 /**
  * Compute which articles to drop to keep each affected feed within
- * `maxPerFeed`. Starred articles (guid in `savedGuids`) are always kept; among
- * the rest the newest are kept.
+ * `maxPerFeed`. Articles the reader has invested something in — starred (guid
+ * in `savedGuids`), tagged, or highlighted (`isLabeled`) — are always kept;
+ * among the rest the newest are kept.
+ *
+ * Eviction from a cache is fine. Eviction that orphans a highlight or a tag is
+ * not: the annotation survives in the label store with nothing left to attach
+ * it to. Read/unread stays recency-governed on purpose — exempting unread items
+ * would let a device's local set grow without bound and diverge from every
+ * other device's, which is precisely what the canonical window exists to stop.
+ * Older items are not lost either way; D1 never prunes, and the feed view pages
+ * back into it on demand.
  *
  * `articles` must be sorted newest-first — each feed's slice inherits that
  * order, so keeping the head keeps the newest.
@@ -109,7 +126,8 @@ export function computeArticleLimitDeletions(
   articles: Article[],
   subscriptionIds: Set<number>,
   savedGuids: Set<string>,
-  maxPerFeed: number = MAX_ARTICLES_PER_FEED
+  maxPerFeed: number = MAX_ARTICLES_PER_FEED,
+  isLabeled: (guid: string) => boolean = () => false
 ): { ids: number[]; dropByFeed: Map<number, Set<string>> } {
   const byFeed = new Map<number, Article[]>();
   for (const a of articles) {
@@ -128,13 +146,14 @@ export function computeArticleLimitDeletions(
   for (const [subscriptionId, feedArticles] of byFeed) {
     if (feedArticles.length <= maxPerFeed) continue;
 
-    const starred = feedArticles.filter((a) => savedGuids.has(a.guid));
-    const nonStarred = feedArticles.filter((a) => !savedGuids.has(a.guid));
+    const isPinned = (a: Article) => savedGuids.has(a.guid) || isLabeled(a.guid);
+    const pinned = feedArticles.filter(isPinned);
+    const evictable = feedArticles.filter((a) => !isPinned(a));
 
-    const keepCount = Math.max(0, maxPerFeed - starred.length);
+    const keepCount = Math.max(0, maxPerFeed - pinned.length);
     const toKeep = new Set([
-      ...starred.map((a) => a.guid),
-      ...nonStarred.slice(0, keepCount).map((a) => a.guid),
+      ...pinned.map((a) => a.guid),
+      ...evictable.slice(0, keepCount).map((a) => a.guid),
     ]);
 
     const drop = feedArticles.filter((a) => !toKeep.has(a.guid));

--- a/frontend/src/lib/services/feedFetcher.ts
+++ b/frontend/src/lib/services/feedFetcher.ts
@@ -128,6 +128,11 @@ async function fetchTimeline(
   let coldRounds = 0;
   // Set when we stop because of a round cap rather than because we're done.
   let cappedOut = false;
+  // The server's per-feed unread counts, held until the drain finishes. Adopting
+  // them mid-drain would compare the server's numbers against a local set this
+  // sync hasn't finished merging into, which is drift we manufactured ourselves.
+  let serverCounts: Record<string, number> | undefined;
+  let serverHead: number | undefined;
 
   for (;;) {
     if (
@@ -141,6 +146,11 @@ async function fetchTimeline(
     if (coldOffset === undefined) incrementalRounds++;
     else coldRounds++;
 
+    // Counts ride the FIRST page of a refresh only: they're per-feed index seeks
+    // over the whole subscription list, and they don't change between drain
+    // pages of the same sync.
+    const includeCounts = incrementalRounds + coldRounds === 1;
+
     let page;
     try {
       page = await api.fetchTimeline(
@@ -150,8 +160,14 @@ async function fetchTimeline(
               generation,
               limit: TIMELINE_PAGE_LIMIT,
               health_rev: feedHealthRev,
+              include_counts: includeCounts,
             }
-          : { cold_offset: coldOffset, limit: TIMELINE_PAGE_LIMIT, health_rev: feedHealthRev }
+          : {
+              cold_offset: coldOffset,
+              limit: TIMELINE_PAGE_LIMIT,
+              health_rev: feedHealthRev,
+              include_counts: includeCounts,
+            }
       );
     } catch (e) {
       if (e instanceof ApiError && e.status === 404) {
@@ -167,6 +183,11 @@ async function fetchTimeline(
     if (shouldFallBackToBatch(page, rssSubs.length)) return null;
 
     if (page.readCursor) await itemLabelsStore.seedReadCursor(page.readCursor);
+
+    if (page.unreadCounts) {
+      serverCounts = page.unreadCounts;
+      serverHead = page.head;
+    }
 
     const { toMerge, readGuids, feedUrls } = groupTimelineItems(page.items, subIdByUrl);
 
@@ -245,6 +266,19 @@ async function fetchTimeline(
   // Subscriptions that arrived from another device sit below the global cursor,
   // so only the per-feed endpoint can deliver their history.
   result.newArticles += await backfillMissingSubscriptions(rssSubs, savedGuids);
+
+  // Adopt the server's counts only once every page has merged and its read
+  // annotations have been applied — comparing them against a half-merged local
+  // set would report drift this sync created and hasn't finished resolving.
+  // A capped-out drain is a half-merged set by definition, so it keeps the
+  // local numbers until the next sync completes.
+  if (serverCounts && !cappedOut) {
+    // Imported lazily: unreadCounts reaches the subscriptions store, which
+    // imports this module. A dynamic import keeps that cycle out of the static
+    // graph rather than relying on evaluation order to make it harmless.
+    const { unreadCounts } = await import('$lib/stores/unreadCounts.svelte');
+    unreadCounts.applyServerCounts(serverCounts, serverHead);
+  }
 
   result.successfulFeeds = rssSubs.length;
   return result;
@@ -326,6 +360,11 @@ export async function fetchAllFeeds(
     }
   }
 
+  // The legacy path has no server-side counts, so anything we're still holding
+  // is about to go stale. Drop back to the local derivation rather than let a
+  // frozen number sit in the sidebar looking authoritative.
+  const { unreadCounts } = await import('$lib/stores/unreadCounts.svelte');
+  unreadCounts.clearServerCounts();
   return fetchAllFeedsViaBatch(subscriptions, savedGuids);
 }
 

--- a/frontend/src/lib/services/liveDb.svelte.ts
+++ b/frontend/src/lib/services/liveDb.svelte.ts
@@ -276,7 +276,18 @@ class LiveDatabase {
 
     // One limit-enforcement pass across every feed we touched. _articles is
     // sorted newest-first, which computeArticleLimitDeletions relies on.
-    const { ids, dropByFeed } = computeArticleLimitDeletions(this._articles, affected, savedGuids);
+    // Items carrying a tag or a highlight are exempt alongside starred ones:
+    // evicting them would leave the annotation in the label store with nothing
+    // to attach it to. Imported lazily to keep this module free of the label
+    // store's import cycle.
+    const { itemLabelsStore } = await import('$lib/stores/itemLabels.svelte');
+    const { ids, dropByFeed } = computeArticleLimitDeletions(
+      this._articles,
+      affected,
+      savedGuids,
+      undefined,
+      (guid) => itemLabelsStore.hasLabel(guid, 'tagged') || itemLabelsStore.hasHighlights(guid)
+    );
     if (ids.length > 0) {
       // One delete from IndexedDB.
       await db.articles.bulkDelete(ids);

--- a/frontend/src/lib/services/readDelta.test.ts
+++ b/frontend/src/lib/services/readDelta.test.ts
@@ -3,6 +3,7 @@ import {
   planReadDelta,
   planAnnotatedReads,
   advanceCursor,
+  mergeReadProgress,
   type ReadDeltaPosition,
 } from './readDelta';
 
@@ -137,5 +138,95 @@ describe('advanceCursor', () => {
     expect(advanceCursor(100, 0)).toBeNull();
     expect(advanceCursor(100, null)).toBeNull();
     expect(advanceCursor(100, undefined)).toBeNull();
+  });
+});
+
+// Generalizing the in-flight guard to user time. The in-flight set only covers
+// the seconds a push is in the air; the same race exists whenever this device's
+// intent is simply newer than the row the server is offering back.
+describe('planReadDelta newer-local-intent guard', () => {
+  const never = () => false;
+
+  it('drops a tombstone older than the local read label', () => {
+    const { deletes } = planReadDelta(
+      [pos({ item_guid: 'a', deleted: true, client_updated_at: NOW - 10_000 })],
+      { isInFlight: never, now: NOW, localReadAt: () => NOW }
+    );
+    expect(deletes).toEqual([]);
+  });
+
+  it('applies a tombstone newer than the local read label', () => {
+    const { deletes } = planReadDelta(
+      [pos({ item_guid: 'a', deleted: true, client_updated_at: NOW })],
+      { isInFlight: never, now: NOW, localReadAt: () => NOW - 10_000 }
+    );
+    expect(deletes).toEqual([['a', 'read']]);
+  });
+
+  // The mirror case: removing a label locally leaves nothing to compare, so the
+  // un-read intent has to be remembered separately or the server's older read
+  // row silently re-reads the item.
+  it('drops a live row older than a local un-read', () => {
+    const { puts } = planReadDelta(
+      [pos({ item_guid: 'a', read_at: 1, client_updated_at: NOW - 10_000 })],
+      { isInFlight: never, now: NOW, unreadIntentAt: () => NOW }
+    );
+    expect(puts).toEqual([]);
+  });
+
+  it('applies a live row newer than a local un-read', () => {
+    const { puts } = planReadDelta([pos({ item_guid: 'a', read_at: 1, client_updated_at: NOW })], {
+      isInFlight: never,
+      now: NOW,
+      unreadIntentAt: () => NOW - 10_000,
+    });
+    expect(puts.map((p) => p.itemKey)).toEqual(['a']);
+  });
+
+  // A backend that predates user-time LWW sends no client_updated_at. Guessing
+  // would be worse than the old behaviour, so it degrades to exactly that.
+  it('degrades to in-flight-only when the server reports no user time', () => {
+    const { deletes } = planReadDelta([pos({ item_guid: 'a', deleted: true })], {
+      isInFlight: never,
+      now: NOW,
+      localReadAt: () => NOW,
+    });
+    expect(deletes).toEqual([['a', 'read']]);
+  });
+
+  it('stamps a put with the server-reported user time so later comparisons line up', () => {
+    const { puts } = planReadDelta(
+      [pos({ item_guid: 'a', read_at: 5, client_updated_at: NOW - 500 })],
+      { isInFlight: never, now: NOW }
+    );
+    expect(puts[0].updatedAt).toBe(NOW - 500);
+  });
+});
+
+describe('mergeReadProgress', () => {
+  it('keeps whichever side was read more recently', () => {
+    expect(mergeReadProgress({ lastReadAt: 200 }, { lastReadAt: 100 })).toBe('local');
+    expect(mergeReadProgress({ lastReadAt: 100 }, { lastReadAt: 200 })).toBe('remote');
+  });
+
+  // Position is not the ordering: re-reading an article legitimately moves it
+  // backwards, and treating "further along" as "newer" would make a re-read
+  // impossible to sync.
+  it('ignores paragraphIndex entirely', () => {
+    expect(
+      mergeReadProgress(
+        { paragraphIndex: 90, lastReadAt: 100 },
+        { paragraphIndex: 2, lastReadAt: 200 }
+      )
+    ).toBe('remote');
+  });
+
+  it('takes remote on a tie so a re-pull is idempotent', () => {
+    expect(mergeReadProgress({ lastReadAt: 100 }, { lastReadAt: 100 })).toBe('remote');
+  });
+
+  it('takes remote when there is nothing local, and local when remote is unstamped', () => {
+    expect(mergeReadProgress(undefined, { lastReadAt: 100 })).toBe('remote');
+    expect(mergeReadProgress({ lastReadAt: 100 }, {})).toBe('local');
   });
 });

--- a/frontend/src/lib/services/readDelta.ts
+++ b/frontend/src/lib/services/readDelta.ts
@@ -18,6 +18,9 @@ export interface ReadDeltaPosition {
   read_at: number | string | null;
   rkey: string | null;
   deleted: boolean;
+  // When the USER made this change, unix ms (absent on a backend that predates
+  // user-time LWW). Compared against local intent before the row is applied.
+  client_updated_at?: number | null;
 }
 
 export interface ReadDeltaPlan {
@@ -30,10 +33,23 @@ export interface ReadDeltaPlan {
 /**
  * Reconcile a forward read-delta batch into add/remove operations.
  *
- * Live rows become `read` label puts. Tombstones become removals — EXCEPT for
- * any key with an in-flight local mark-read: a stale tombstone from the delta
- * must not clear a fresh local read whose push hasn't reached the server yet
- * (the optimistic-UI race). Such removals are dropped; the local read stands.
+ * Live rows become `read` label puts. Tombstones become removals — EXCEPT where
+ * this device holds NEWER intent for the same item, in which case the remote row
+ * is dropped and the local state stands. "Newer intent" generalizes the original
+ * in-flight guard from "a push is still in the air" to the honest comparison —
+ * user-action time — because the two devices' writes are ordered by when the
+ * user acted, not by which HTTP request the server saw last:
+ *
+ *  - a tombstone is dropped when a local mark-read is in flight, OR when the
+ *    local `read` label's own timestamp is newer than the tombstone's
+ *    `client_updated_at`;
+ *  - a live row is dropped when this device recorded an un-read for that item
+ *    more recently than the row's `client_updated_at` (`unreadIntentAt`), which
+ *    is the mirror case: the server hasn't seen our un-read yet, so its copy is
+ *    stale by definition.
+ *
+ * A backend that doesn't send `client_updated_at` degrades to the old
+ * in-flight-only behaviour rather than guessing.
  *
  * Each (user, item, 'read') is a single backend row, so a given item_guid
  * appears at most once per batch — puts and deletes never collide on a key, and
@@ -41,27 +57,43 @@ export interface ReadDeltaPlan {
  */
 export function planReadDelta(
   positions: ReadDeltaPosition[],
-  opts: { isInFlight: (key: string) => boolean; now: number }
+  opts: {
+    isInFlight: (key: string) => boolean;
+    now: number;
+    // Local `read` label's updatedAt (unix ms), or undefined when unlabeled.
+    localReadAt?: (key: string) => number | undefined;
+    // When this device last marked the item unread (unix ms), if recently.
+    unreadIntentAt?: (key: string) => number | undefined;
+  }
 ): ReadDeltaPlan {
   const puts: ItemLabel[] = [];
   const deletes: Array<[string, string]> = [];
 
   for (const p of positions) {
     const itemType: ItemLabelType = p.item_type === 'document' ? 'document' : 'article';
+    const remoteAt = typeof p.client_updated_at === 'number' ? p.client_updated_at : undefined;
+
     if (p.deleted) {
       // Optimistic-race guard: skip removals for items with an in-flight local
       // mark-read (covers both the article debounce buffer and in-flight
       // document pushes — see isMarkReadInFlight in the store).
       if (opts.isInFlight(p.item_guid)) continue;
+      const localAt = opts.localReadAt?.(p.item_guid);
+      if (remoteAt !== undefined && localAt !== undefined && localAt > remoteAt) continue;
       deletes.push([p.item_guid, 'read']);
     } else {
+      const unreadAt = opts.unreadIntentAt?.(p.item_guid);
+      if (remoteAt !== undefined && unreadAt !== undefined && unreadAt > remoteAt) continue;
       puts.push({
         itemKey: p.item_guid,
         itemType,
         label: 'read',
         props: { readAt: p.read_at ?? opts.now },
         createdAt: typeof p.read_at === 'number' ? p.read_at : opts.now,
-        updatedAt: opts.now,
+        // The user's action time when the server knows it, so a later comparison
+        // against another device's row is apples-to-apples. Falls back to
+        // arrival time on a backend that doesn't report it.
+        updatedAt: remoteAt ?? opts.now,
       });
     }
   }
@@ -101,8 +133,44 @@ export function planAnnotatedReads(
  * Forward-only cursor advance: returns the cursor to persist, or null if the
  * incoming cursor does not move strictly past the current one (so the delta
  * cursor never rewinds, even if a stale/empty response comes back).
+ *
+ * Only used for the legacy numeric cursor. The compound `(updated_at, id)`
+ * cursor is opaque to the client, so its monotonicity is the server's
+ * guarantee: an empty page echoes back the caller's own cursor rather than a
+ * clock reading, and the client persists it only after the batch is durable.
  */
 export function advanceCursor(current: number, incoming: number | null | undefined): number | null {
   if (incoming && incoming > current) return incoming;
   return null;
+}
+
+/** The subset of a `readProgress` label's props this merge is ordered by. */
+export interface ReadProgressProps {
+  paragraphIndex?: number;
+  totalParagraphs?: number;
+  lastReadAt?: number;
+}
+
+/**
+ * Which of {local, remote} `readProgress` to keep.
+ *
+ * The delta used to overwrite local progress unconditionally, so a device that
+ * had just scrolled — with its 500 ms debounce still pending — was silently
+ * rewound to another device's older position, and then republished that older
+ * position as authoritative when the debounce fired.
+ *
+ * `lastReadAt` is the ordering, never `paragraphIndex`: position may legitimately
+ * move backwards when someone re-reads, and treating "further along" as "newer"
+ * would make a re-read impossible to sync. Ties go to the remote row so a
+ * re-pull is idempotent.
+ */
+export function mergeReadProgress(
+  local: ReadProgressProps | undefined,
+  remote: ReadProgressProps
+): 'local' | 'remote' {
+  const localAt = local?.lastReadAt;
+  const remoteAt = remote.lastReadAt;
+  if (typeof localAt !== 'number') return 'remote';
+  if (typeof remoteAt !== 'number') return 'local';
+  return localAt > remoteAt ? 'local' : 'remote';
 }

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -290,6 +290,10 @@ class SyncQueue {
             itemGuid: payload.articleGuid,
             itemUrl: payload.articleUrl,
             itemTitle: payload.articleTitle,
+            // The enqueue time IS the user's action time. Sending it is what
+            // stops a queue draining an hour late from overwriting what the
+            // user has since done on another device.
+            updatedAt: item.timestamp,
           };
         });
 
@@ -341,9 +345,10 @@ class SyncQueue {
       }
 
       try {
-        const bulkItems = batch.map((item) =>
-          toUnifiedReadItem(JSON.parse(item.payload) as SocialReadingPayload)
-        );
+        const bulkItems = batch.map((item) => ({
+          ...toUnifiedReadItem(JSON.parse(item.payload) as SocialReadingPayload),
+          updatedAt: item.timestamp,
+        }));
 
         // Document reads are unified onto the article read path (/api/reading).
         await api.markAsReadBulk(bulkItems);
@@ -414,13 +419,21 @@ class SyncQueue {
 
     switch (entry.collection) {
       case 'reading':
-        await this.executeReadingOperation(entry.operation, payload as ReadingPayload);
+        await this.executeReadingOperation(
+          entry.operation,
+          payload as ReadingPayload,
+          entry.timestamp
+        );
         break;
       case 'socialReading':
-        await this.executeSocialReadingOperation(entry.operation, payload as SocialReadingPayload);
+        await this.executeSocialReadingOperation(
+          entry.operation,
+          payload as SocialReadingPayload,
+          entry.timestamp
+        );
         break;
       case 'label':
-        await this.executeLabelOperation(entry.operation, payload as LabelPayload);
+        await this.executeLabelOperation(entry.operation, payload as LabelPayload, entry.timestamp);
         break;
       case 'saved':
         await this.executeSavedOperation(entry.operation, payload as SavedPayload);
@@ -465,9 +478,14 @@ class SyncQueue {
     }
   }
 
+  // `queuedAt` is the entry's own enqueue time — the moment the USER acted. It
+  // rides every write as the last-write-wins key, so a queue that drains long
+  // after the fact loses to anything the user did more recently elsewhere
+  // instead of winning on arrival order.
   private async executeReadingOperation(
     operation: SyncOperation,
-    payload: ReadingPayload
+    payload: ReadingPayload,
+    queuedAt: number
   ): Promise<void> {
     switch (operation) {
       case 'create':
@@ -476,32 +494,35 @@ class SyncQueue {
           itemGuid: payload.articleGuid,
           itemUrl: payload.articleUrl,
           itemTitle: payload.articleTitle,
+          updatedAt: queuedAt,
         });
         break;
       case 'delete':
-        await api.markAsUnread(payload.articleGuid);
+        await api.markAsUnread(payload.articleGuid, queuedAt);
         break;
     }
   }
 
   private async executeSocialReadingOperation(
     operation: SyncOperation,
-    payload: SocialReadingPayload
+    payload: SocialReadingPayload,
+    queuedAt: number
   ): Promise<void> {
     switch (operation) {
       case 'create':
         // Document reads are unified onto the article read path (/api/reading).
-        await api.markAsRead(toUnifiedReadItem(payload));
+        await api.markAsRead({ ...toUnifiedReadItem(payload), updatedAt: queuedAt });
         break;
       case 'delete':
-        await api.markAsUnread(payload.itemUri);
+        await api.markAsUnread(payload.itemUri, queuedAt);
         break;
     }
   }
 
   private async executeLabelOperation(
     operation: SyncOperation,
-    payload: LabelPayload
+    payload: LabelPayload,
+    queuedAt: number
   ): Promise<void> {
     switch (operation) {
       case 'create':
@@ -510,10 +531,11 @@ class SyncQueue {
           itemType: payload.itemType as 'article' | 'document',
           label: payload.label,
           props: payload.props,
+          updatedAt: queuedAt,
         });
         break;
       case 'delete':
-        await api.deleteLabel(payload.itemKey, payload.label);
+        await api.deleteLabel(payload.itemKey, payload.label, queuedAt);
         break;
     }
   }

--- a/frontend/src/lib/services/telemetry.ts
+++ b/frontend/src/lib/services/telemetry.ts
@@ -33,7 +33,8 @@ const MAX_REPORTS_PER_LOAD = 5;
 const MAX_MESSAGE_CHARS = 300;
 const MAX_STACK_CHARS = 2000;
 
-export type ClientErrorKind = 'render' | 'uncaught' | 'rejection' | 'preload_recovery_failed';
+export type ClientErrorKind =
+  'render' | 'uncaught' | 'rejection' | 'preload_recovery_failed' | 'unread_count_drift';
 
 /**
  * Kinds that bypass sampling: the app told us it tried to recover from a bad

--- a/frontend/src/lib/stores/feedArchive.svelte.ts
+++ b/frontend/src/lib/stores/feedArchive.svelte.ts
@@ -1,0 +1,120 @@
+import { api } from '$lib/services/api';
+import { itemLabelsStore } from './itemLabels.svelte';
+import { MAX_ARTICLES_PER_FEED } from '$lib/services/articleMerge';
+import type { Article, Subscription } from '$lib/types';
+
+/**
+ * Older items for one feed, read straight from the server-side archive.
+ *
+ * Each device keeps only the newest K articles per feed and trims oldest-first,
+ * so an unread item older than that simply vanished from the only copy the
+ * reader could see. D1 never pruned it — "D1 is the archive … no pruning" — but
+ * that is cold comfort to someone who watched an article disappear and
+ * reasonably called it lost data.
+ *
+ * These items are deliberately TRANSIENT: they are never merged into the capped
+ * Dexie set. This is an archive view, not new membership — merging would push
+ * the local set past K again and re-open the divergence the canonical window
+ * closes. Read state still applies (the server annotates it, and marking one
+ * read goes through the normal path), so the view is live, just not resident.
+ */
+const PAGE_SIZE = 30;
+
+function createFeedArchiveStore() {
+  // The subscription these items belong to. Switching feeds resets everything —
+  // nothing here is worth keeping across a navigation.
+  let subscriptionId = $state<number | null>(null);
+  let items = $state<Article[]>([]);
+  let loading = $state(false);
+  let exhausted = $state(false);
+  let error = $state<string | null>(null);
+
+  function reset(nextSubscriptionId: number | null) {
+    subscriptionId = nextSubscriptionId;
+    items = [];
+    loading = false;
+    exhausted = false;
+    error = null;
+  }
+
+  /**
+   * Load the next page below the local window.
+   *
+   * The first page starts at offset K — exactly where the local set stops — so
+   * the archive picks up where the list left off with nothing repeated and
+   * nothing skipped.
+   */
+  async function loadMore(sub: Subscription) {
+    if (!sub.id || !sub.feedUrl) return;
+    if (sub.sourceType && sub.sourceType !== 'rss') return;
+    if (loading || exhausted) return;
+    if (subscriptionId !== sub.id) reset(sub.id);
+
+    loading = true;
+    error = null;
+    try {
+      const offset = MAX_ARTICLES_PER_FEED + items.length;
+      const feed = await api.fetchFeedArchive(sub.feedUrl, offset, PAGE_SIZE);
+      const fetched = feed.items ?? [];
+
+      const seen = new Set(items.map((a) => a.guid));
+      const fresh: Article[] = [];
+      for (const item of fetched) {
+        if (seen.has(item.guid)) continue;
+        seen.add(item.guid);
+        fresh.push({
+          subscriptionId: sub.id,
+          guid: item.guid,
+          url: item.url,
+          title: item.title,
+          author: item.author,
+          content: item.content,
+          summary: item.summary,
+          imageUrl: item.imageUrl,
+          publishedAt: item.publishedAt,
+          fetchedAt: Date.now(),
+          contentTruncated: item.contentTruncated || undefined,
+        });
+      }
+
+      // Read state rides the response; apply it additively, same as the timeline
+      // path, so an item read on another device doesn't come back looking unread.
+      const readGuids = fetched.filter((i) => i.read).map((i) => i.guid);
+      if (readGuids.length > 0) {
+        await itemLabelsStore.applyAnnotatedReads(readGuids, 'article');
+      }
+
+      items = [...items, ...fresh];
+      // A short page is the bottom of the archive. A full page that was entirely
+      // duplicates would otherwise loop forever, so treat that as the end too.
+      if (fetched.length < PAGE_SIZE || fresh.length === 0) exhausted = true;
+    } catch (e) {
+      console.error('Failed to load older items:', e);
+      error = 'Could not load older items';
+    } finally {
+      loading = false;
+    }
+  }
+
+  return {
+    get items() {
+      return subscriptionId === null ? [] : items;
+    },
+    get loading() {
+      return loading;
+    },
+    get exhausted() {
+      return exhausted;
+    },
+    get error() {
+      return error;
+    },
+    get subscriptionId() {
+      return subscriptionId;
+    },
+    reset,
+    loadMore,
+  };
+}
+
+export const feedArchiveStore = createFeedArchiveStore();

--- a/frontend/src/lib/stores/itemLabels.svelte.ts
+++ b/frontend/src/lib/stores/itemLabels.svelte.ts
@@ -1,7 +1,13 @@
 import { api } from '$lib/services/api';
 import { db, getMetadata, setMetadata } from '$lib/services/db';
 import { safePut, safeBulkPut } from '$lib/services/safeDb.svelte';
-import { planReadDelta, planAnnotatedReads, advanceCursor } from '$lib/services/readDelta';
+import {
+  planReadDelta,
+  planAnnotatedReads,
+  advanceCursor,
+  mergeReadProgress,
+  type ReadProgressProps,
+} from '$lib/services/readDelta';
 import {
   syncQueue,
   type ReadingPayload,
@@ -37,28 +43,34 @@ function createItemLabelsStore() {
   let isLoading = $state(true);
   let hasLoaded = false;
 
-  // Forward-read-delta cursor (max updated_at seen, in unix seconds), persisted
-  // across sessions in IndexedDB (same pattern as the managed-labels cursor).
-  // Bootstrap read state arrives via inline annotation on the fetch response, so
-  // there is no full/windowed snapshot: the cursor is *seeded* from the batch
-  // fetch's `readCursor`, then every refresh fetches only the read changes since
-  // it (live rows + tombstones), for both articles and documents. A client with
-  // no seeded cursor yet skips the delta (annotation covers it) until the next
-  // refresh, by which point the batch fetch has seeded it.
+  // Forward-read-delta cursor, persisted across sessions in IndexedDB (same
+  // pattern as the managed-labels cursor). Bootstrap read state arrives via
+  // inline annotation on the fetch response, so there is no full/windowed
+  // snapshot: the cursor is *seeded* from the batch fetch's `readCursor`, then
+  // every refresh fetches only the read changes since it (live rows +
+  // tombstones), for both articles and documents. A client with no seeded cursor
+  // yet skips the delta (annotation covers it) until the next refresh, by which
+  // point the batch fetch has seeded it.
+  //
+  // The value is the server's opaque compound `(updated_at, id)` cursor — a bare
+  // unix-seconds number only at seeding, and after the first delta always the
+  // string the server handed back. Seconds alone couldn't express "everything
+  // after this row", so any row written in the cursor's own second was dropped
+  // and never asked for again.
   const READ_CURSOR_KEY = 'readPositionsCursor';
-  let readPositionsCursor = 0;
+  let readPositionsCursor: number | string = 0;
   let readPositionsCursorLoaded = false;
   let readPositionsCursorHasValue = false;
 
-  // Managed-labels (tagged/archived/readProgress) delta-sync cursor (max
-  // updated_at seen, in unix seconds). Unlike read positions, this cursor is
-  // PERSISTED across sessions in IndexedDB: the backend tombstones deletions, so
-  // the delta is lossless and a cold start can resume from the saved cursor
-  // instead of re-fetching the whole label history. A brand-new client (no saved
-  // cursor) does one full snapshot to bootstrap; every sync after that is a
-  // delta. Hydrated once per session from `MANAGED_LABELS_CURSOR_KEY`.
+  // Managed-labels (tagged/archived/readProgress) delta-sync cursor, same
+  // compound form. Unlike read positions, this cursor is PERSISTED across
+  // sessions in IndexedDB: the backend tombstones deletions, so the delta is
+  // lossless and a cold start can resume from the saved cursor instead of
+  // re-fetching the whole label history. A brand-new client (no saved cursor)
+  // does one full snapshot to bootstrap; every sync after that is a delta.
+  // Hydrated once per session from `MANAGED_LABELS_CURSOR_KEY`.
   const MANAGED_LABELS_CURSOR_KEY = 'managedLabelsCursor';
-  let managedLabelsCursor = 0;
+  let managedLabelsCursor: number | string = 0;
   let managedLabelsCursorLoaded = false;
   let managedLabelsCursorHasValue = false;
 
@@ -67,6 +79,9 @@ function createItemLabelsStore() {
     articleGuid: string;
     articleUrl: string;
     articleTitle?: string;
+    // When the user actually read it, not when the debounce happened to flush.
+    // Carried all the way to the server as the last-write-wins key.
+    readAt: number;
   }> = [];
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   const DEBOUNCE_MS = 300;
@@ -86,6 +101,35 @@ function createItemLabelsStore() {
     return (
       pendingDocumentMarkRead.has(key) || pendingMarkRead.some((item) => item.articleGuid === key)
     );
+  }
+
+  // When this device last marked an item UNREAD, unix ms. The mirror of the
+  // in-flight read guard: removing the local `read` label leaves nothing behind
+  // to compare a stale remote row against, so a delta carrying another device's
+  // older read would silently re-read the item. Bounded and expiring — this is a
+  // race window, not a second source of truth, and the server's own user-time
+  // LWW settles the durable answer once the push lands.
+  const UNREAD_INTENT_TTL_MS = 10 * 60 * 1000;
+  const MAX_UNREAD_INTENTS = 500;
+  const unreadIntent = new Map<string, number>();
+
+  function recordUnreadIntent(key: string, at: number) {
+    unreadIntent.set(key, at);
+    if (unreadIntent.size > MAX_UNREAD_INTENTS) {
+      // Map iterates in insertion order, so the head is the oldest.
+      const oldest = unreadIntent.keys().next();
+      if (!oldest.done) unreadIntent.delete(oldest.value);
+    }
+  }
+
+  function unreadIntentAt(key: string): number | undefined {
+    const at = unreadIntent.get(key);
+    if (at === undefined) return undefined;
+    if (Date.now() - at > UNREAD_INTENT_TTL_MS) {
+      unreadIntent.delete(key);
+      return undefined;
+    }
+    return at;
   }
 
   // --- Internal helpers ---
@@ -124,6 +168,24 @@ function createItemLabelsStore() {
     labelsByItem = new Map(labelsByItem);
   }
 
+  /**
+   * Convert a server label row's timestamps to the store's unit at the boundary.
+   *
+   * The invariant is MILLISECONDS everywhere in the label store — that is what
+   * every local write (`Date.now()`) already produced. Rows arriving from the
+   * delta carried unix SECONDS, so a delta-written label and a locally-written
+   * one were being compared across a factor of a thousand: `getReadActivity`
+   * ranked any locally-touched item above every synced one, and the highlight
+   * union's per-row recency ordering was decided by which device wrote last
+   * rather than when. Converting here, once, is what makes the invariant true.
+   */
+  function localTimestamps(raw: { createdAt: number; updatedAt: number }): {
+    createdAt: number;
+    updatedAt: number;
+  } {
+    return { createdAt: raw.createdAt * 1000, updatedAt: raw.updatedAt * 1000 };
+  }
+
   async function putLabel(lbl: ItemLabel) {
     addToState(lbl);
     await safePut(db.itemLabels, lbl);
@@ -153,6 +215,7 @@ function createItemLabelsStore() {
           itemGuid: item.articleGuid,
           itemUrl: item.articleUrl,
           itemTitle: item.articleTitle,
+          updatedAt: item.readAt,
         }));
         for (let i = 0; i < bulkItems.length; i += BULK_BATCH_SIZE) {
           await api.markAsReadBulk(bulkItems.slice(i, i + BULK_BATCH_SIZE));
@@ -179,6 +242,45 @@ function createItemLabelsStore() {
   }
 
   // --- Load ---
+
+  // Delta-only pull state. A full `load()` re-reads the whole Dexie table; this
+  // is the cheap path the freshness triggers use — two indexed queries that
+  // usually return zero rows.
+  let deltaPullInFlight: Promise<void> | null = null;
+  let lastDeltaPullAt = 0;
+
+  /**
+   * Pull both deltas without the local cache rebuild.
+   *
+   * Labels used to be pulled only at app init, on a manual refresh, on
+   * tab-visible-and-≥30-minutes-stale, or through Chromium's periodic background
+   * sync — so an open tab never observed another device's changes, and
+   * "phone → laptop" felt broken even though the sync itself worked. There is no
+   * push channel and deliberately none planned; a delta that finds nothing is
+   * one indexed query returning zero rows, which is cheap enough to just ask.
+   *
+   * `minIntervalMs` lets a noisy trigger (visibility flapping) stay quiet
+   * without each caller keeping its own timestamp. Concurrent calls share the
+   * in-flight promise rather than racing two drains against one cursor.
+   */
+  async function pullDelta(minIntervalMs = 0): Promise<void> {
+    if (!syncStore.isOnline) return;
+    if (deltaPullInFlight) return deltaPullInFlight;
+    if (minIntervalMs > 0 && Date.now() - lastDeltaPullAt < minIntervalMs) return;
+
+    deltaPullInFlight = (async () => {
+      try {
+        await Promise.all([loadReadDeltaFromBackend(), loadManagedLabelsFromBackend()]);
+        lastDeltaPullAt = Date.now();
+        syncStore.markSynced();
+      } catch (e) {
+        console.error('Failed to pull label delta:', e);
+      } finally {
+        deltaPullInFlight = null;
+      }
+    })();
+    return deltaPullInFlight;
+  }
 
   async function load() {
     isLoading = true;
@@ -232,8 +334,8 @@ function createItemLabelsStore() {
   async function seedReadCursor(cursor: number) {
     if (!cursor) return;
     if (!readPositionsCursorLoaded) {
-      const persisted = await getMetadata<number>(READ_CURSOR_KEY);
-      if (typeof persisted === 'number') {
+      const persisted = await getMetadata<number | string>(READ_CURSOR_KEY);
+      if (typeof persisted === 'number' || typeof persisted === 'string') {
         readPositionsCursor = persisted;
         readPositionsCursorHasValue = true;
       }
@@ -277,10 +379,15 @@ function createItemLabelsStore() {
   // see isMarkReadInFlight, which covers both articles and documents). Closes the
   // only gap annotation can't: an already-cached item read or un-read on another
   // device, which this device won't re-fetch.
+  // Rounds of the read-delta drain. A page is 500 rows, so this covers 5 000
+  // read changes in one pull; anything beyond continues on the next one, in
+  // order, because the cursor only ever sits on a row we actually applied.
+  const MAX_READ_DELTA_PAGES = 10;
+
   async function loadReadDeltaFromBackend() {
     if (!readPositionsCursorLoaded) {
-      const persisted = await getMetadata<number>(READ_CURSOR_KEY);
-      if (typeof persisted === 'number') {
+      const persisted = await getMetadata<number | string>(READ_CURSOR_KEY);
+      if (typeof persisted === 'number' || typeof persisted === 'string') {
         readPositionsCursor = persisted;
         readPositionsCursorHasValue = true;
       }
@@ -291,40 +398,58 @@ function createItemLabelsStore() {
     // cursor this cycle, and the next refresh runs the delta from there.
     if (!readPositionsCursorHasValue) return;
 
-    const { positions, cursor } = await api.getReadPositions(readPositionsCursor);
+    for (let round = 0; round < MAX_READ_DELTA_PAGES; round++) {
+      const { positions, cursor, nextSince, hasMore } =
+        await api.getReadPositions(readPositionsCursor);
 
-    // Reconcile the delta into adds/removes — the optimistic-race guard (skip
-    // tombstone removals for in-flight local reads) lives in planReadDelta.
-    const { puts: dbPuts, deletes: dbDeletes } = planReadDelta(positions, {
-      isInFlight: isMarkReadInFlight,
-      now: Date.now(),
-    });
+      // Reconcile the delta into adds/removes. The race guards — an in-flight
+      // local mark-read, a newer local read, a newer local un-read — all live in
+      // planReadDelta.
+      const { puts: dbPuts, deletes: dbDeletes } = planReadDelta(positions, {
+        isInFlight: isMarkReadInFlight,
+        now: Date.now(),
+        localReadAt: (key) => getLabel(key, 'read')?.updatedAt,
+        unreadIntentAt,
+      });
 
-    for (const readLabel of dbPuts) addToState(readLabel);
-    for (const [itemKey, label] of dbDeletes) removeFromState(itemKey, label);
+      for (const readLabel of dbPuts) addToState(readLabel);
+      for (const [itemKey, label] of dbDeletes) removeFromState(itemKey, label);
 
-    triggerReactivity();
+      triggerReactivity();
 
-    try {
-      for (const [itemKey, label] of dbDeletes) {
-        await db.itemLabels.where('[itemKey+label]').equals([itemKey, label]).delete();
+      // The cursor moves only after the batch is DURABLE. It used to advance in
+      // a separate try, so a failed IndexedDB write lost the batch and still
+      // skipped past it — permanently, since the delta is forward-only.
+      try {
+        for (const [itemKey, label] of dbDeletes) {
+          await db.itemLabels.where('[itemKey+label]').equals([itemKey, label]).delete();
+        }
+        if (dbPuts.length > 0) {
+          await safeBulkPut(db.itemLabels, dbPuts);
+        }
+      } catch (e) {
+        console.error('Failed to sync read delta to cache; keeping cursor for retry:', e);
+        return;
       }
-      if (dbPuts.length > 0) {
-        await safeBulkPut(db.itemLabels, dbPuts);
-      }
-    } catch (e) {
-      console.error('Failed to sync read delta to cache:', e);
-    }
 
-    const nextCursor = advanceCursor(readPositionsCursor, cursor);
-    if (nextCursor !== null) {
-      readPositionsCursor = nextCursor;
+      // Prefer the compound cursor. `advanceCursor` still guards the legacy
+      // numeric one, whose forward-only comparison is all it ever had.
+      let next: number | string | null = nextSince ?? null;
+      if (next === null && typeof readPositionsCursor === 'number') {
+        next = advanceCursor(readPositionsCursor, cursor);
+      }
+      if (next === null || next === readPositionsCursor) return;
+
+      readPositionsCursor = next;
       try {
         await setMetadata(READ_CURSOR_KEY, readPositionsCursor);
       } catch (e) {
         console.error('Failed to persist read cursor:', e);
       }
+
+      if (!hasMore) return;
     }
+    console.warn('[itemLabels] Read delta page cap reached; the rest continues on the next pull.');
   }
 
   // The backend-managed (non-read) label types stored in item_labels_cache.
@@ -347,8 +472,8 @@ function createItemLabelsStore() {
     // Hydrate the persisted cursor once per session. A saved value means a prior
     // session already bootstrapped the full snapshot, so we can delta from here.
     if (!managedLabelsCursorLoaded) {
-      const persisted = await getMetadata<number>(MANAGED_LABELS_CURSOR_KEY);
-      if (typeof persisted === 'number') {
+      const persisted = await getMetadata<number | string>(MANAGED_LABELS_CURSOR_KEY);
+      if (typeof persisted === 'number' || typeof persisted === 'string') {
         managedLabelsCursor = persisted;
         managedLabelsCursorHasValue = true;
       }
@@ -361,21 +486,17 @@ function createItemLabelsStore() {
     // enough batch could spill into extra pagination round-trips.
     const labels = [...MANAGED_LABELS];
     const isFull = !managedLabelsCursorHasValue;
-    const fetched = await api.getAllLabels(
+    const { labels: fetched, nextSince } = await api.getAllLabels(
       isFull ? { labels } : { since: managedLabelsCursor, labels }
     );
 
-    // Walk the fetched rows: track the newest updated_at (unix seconds) for the
-    // next cursor, apply tombstones as removals, and group live rows by type.
-    // Only the server-sourced timestamp is used — local labels store updatedAt
-    // in ms. (A full snapshot never contains tombstones — the backend filters
+    // Walk the fetched rows: apply tombstones as removals and group live rows by
+    // type. (A full snapshot never contains tombstones — the backend filters
     // them — so the deletedAt branch only fires on deltas.)
-    let maxUpdatedAt = managedLabelsCursor;
     const removed: Array<[string, string]> = [];
     const byLabel = new Map<string, typeof fetched>();
     for (const raw of fetched) {
       if (!managed.has(raw.label)) continue;
-      if (raw.updatedAt > maxUpdatedAt) maxUpdatedAt = raw.updatedAt;
       if (raw.deletedAt != null) {
         removeFromState(raw.itemKey, raw.label);
         removed.push([raw.itemKey, raw.label]);
@@ -404,8 +525,7 @@ function createItemLabelsStore() {
         itemType: raw.itemType as ItemLabelType,
         label: 'tagged',
         props: { tags },
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt,
+        ...localTimestamps(raw),
       };
       addToState(lbl);
       dbOps.push(lbl);
@@ -416,20 +536,28 @@ function createItemLabelsStore() {
         itemType: (raw.itemType as ItemLabelType) || 'article',
         label: 'archived',
         props: raw.props || {},
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt,
+        ...localTimestamps(raw),
       };
       addToState(lbl);
       dbOps.push(lbl);
     }
     for (const raw of byLabel.get('readProgress') || []) {
+      // Progress is merged by `lastReadAt`, not overwritten. The delta used to
+      // clobber it unconditionally, so a device mid-scroll — its 500 ms debounce
+      // still pending — was rewound to another device's older position and then
+      // republished that older position as authoritative when the debounce
+      // fired. Position may legitimately move backwards on a re-read, so
+      // `lastReadAt` is the ordering and `paragraphIndex` never is.
+      const remoteProps = (raw.props || {}) as ReadProgressProps;
+      const localProps = getLabel(raw.itemKey, 'readProgress')?.props as
+        ReadProgressProps | undefined;
+      if (mergeReadProgress(localProps, remoteProps) === 'local') continue;
       const lbl: ItemLabel = {
         itemKey: raw.itemKey,
         itemType: (raw.itemType as ItemLabelType) || 'article',
         label: 'readProgress',
         props: raw.props || {},
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt,
+        ...localTimestamps(raw),
       };
       addToState(lbl);
       dbOps.push(lbl);
@@ -461,8 +589,7 @@ function createItemLabelsStore() {
         itemType: (raw.itemType as ItemLabelType) || 'article',
         label: 'highlights',
         props: { highlights: merged },
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt,
+        ...localTimestamps(raw),
       };
       addToState(lbl);
       dbOps.push(lbl);
@@ -470,7 +597,10 @@ function createItemLabelsStore() {
 
     triggerReactivity();
 
-    // Sync to IndexedDB: delete removed labels, then bulk-put the changed set.
+    // Sync to IndexedDB, THEN move the cursor — never the other way round. The
+    // cursor used to be committed in its own try, so a failed Dexie write lost
+    // the batch and still advanced past it, permanently: the delta is
+    // forward-only and never re-offers a row it has already delivered.
     try {
       for (const [itemKey, label] of removed) {
         await db.itemLabels.where('[itemKey+label]').equals([itemKey, label]).delete();
@@ -479,11 +609,21 @@ function createItemLabelsStore() {
         await safeBulkPut(db.itemLabels, dbOps);
       }
     } catch (e) {
-      console.error('Failed to sync managed labels to cache:', e);
+      console.error('Failed to sync managed labels to cache; keeping cursor for retry:', e);
+      return;
     }
 
-    // Advance and persist the cursor so the next cold start resumes as a delta.
-    managedLabelsCursor = maxUpdatedAt;
+    // The cursor is the last row the server DELIVERED — compound `(updated_at,
+    // id)`, so the next delta resumes strictly after it without dropping
+    // same-second siblings. `nextSince` is absent only on an older backend; the
+    // legacy max-updatedAt fallback keeps that case working.
+    const nextCursor =
+      nextSince ??
+      fetched.reduce(
+        (max, raw) => (raw.updatedAt > max ? raw.updatedAt : max),
+        typeof managedLabelsCursor === 'number' ? managedLabelsCursor : 0
+      );
+    managedLabelsCursor = nextCursor;
     managedLabelsCursorHasValue = true;
     try {
       await setMetadata(MANAGED_LABELS_CURSOR_KEY, managedLabelsCursor);
@@ -656,18 +796,30 @@ function createItemLabelsStore() {
     triggerReactivity();
     safePut(db.itemLabels, readLabel);
 
-    pendingMarkRead.push({ articleGuid, articleUrl, articleTitle });
+    pendingMarkRead.push({ articleGuid, articleUrl, articleTitle, readAt: now });
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(flushPendingMarkRead, DEBOUNCE_MS);
   }
 
+  /**
+   * Mark a set of articles read.
+   *
+   * `scope` turns this into a SERVER operation over the canonical per-feed
+   * window rather than a loop over whatever this device happens to hold. That
+   * distinction is the whole point: the local list stops at this device's
+   * window, so items another device holds below it stayed unread there — the one
+   * action that should force every device to agree didn't. The optimistic local
+   * pass still runs first (the UI must not wait on a round trip), and the
+   * per-item queue path is still the offline fallback.
+   */
   async function markAllAsRead(
     articles: Array<{
       subscriptionRkey: string;
       articleGuid: string;
       articleUrl: string;
       articleTitle?: string;
-    }>
+    }>,
+    scope?: { feedUrl?: string; beforeSeq?: number }
   ) {
     const unreadArticles = articles.filter((a) => !isRead(a.articleGuid));
     if (unreadArticles.length === 0) return;
@@ -699,13 +851,21 @@ function createItemLabelsStore() {
 
     if (syncStore.isOnline) {
       try {
-        const bulkItems = unreadArticles.map((a) => ({
-          itemGuid: a.articleGuid,
-          itemUrl: a.articleUrl,
-          itemTitle: a.articleTitle,
-        }));
-        for (let i = 0; i < bulkItems.length; i += BULK_BATCH_SIZE) {
-          await api.markAsReadBulk(bulkItems.slice(i, i + BULK_BATCH_SIZE));
+        if (scope) {
+          // One call covers the whole window, including items this device never
+          // held; the resulting rows ride the existing forward delta out to
+          // every other device.
+          await api.markFeedRead({ ...scope, updatedAt: now });
+        } else {
+          const bulkItems = unreadArticles.map((a) => ({
+            itemGuid: a.articleGuid,
+            itemUrl: a.articleUrl,
+            itemTitle: a.articleTitle,
+            updatedAt: now,
+          }));
+          for (let i = 0; i < bulkItems.length; i += BULK_BATCH_SIZE) {
+            await api.markAsReadBulk(bulkItems.slice(i, i + BULK_BATCH_SIZE));
+          }
         }
       } catch (e) {
         console.error('Failed to mark all as read, queueing for retry:', e);
@@ -731,7 +891,11 @@ function createItemLabelsStore() {
   async function markAsUnread(articleGuid: string) {
     if (!isRead(articleGuid)) return;
 
+    const now = Date.now();
     removeFromState(articleGuid, 'read');
+    // Removing the label leaves nothing for the delta to compare against, so
+    // remember the intent for the length of the race window.
+    recordUnreadIntent(articleGuid, now);
     triggerReactivity();
 
     try {
@@ -742,7 +906,7 @@ function createItemLabelsStore() {
 
     if (syncStore.isOnline) {
       try {
-        await api.markAsUnread(articleGuid);
+        await api.markAsUnread(articleGuid, now);
       } catch (e) {
         console.error('Failed to mark as unread, queueing for retry:', e);
         await syncQueue.enqueue('delete', 'reading', articleGuid, {
@@ -1248,7 +1412,11 @@ function createItemLabelsStore() {
     const rkey = (readLabel.props.rkey as string) || '';
     const authorDid = (readLabel.props.authorDid as string) || '';
 
+    const now = Date.now();
     removeFromState(itemUri, 'read');
+    // Same guard as articles: the removed label leaves nothing for the delta to
+    // compare against, so the un-read intent is remembered for the race window.
+    recordUnreadIntent(itemUri, now);
     triggerReactivity();
 
     try {
@@ -1269,7 +1437,7 @@ function createItemLabelsStore() {
     // un-read carries on the forward read delta to other devices.
     if (syncStore.isOnline) {
       try {
-        await api.markAsUnread(itemUri);
+        await api.markAsUnread(itemUri, now);
       } catch (e) {
         console.error('Failed to mark social item as unread, queueing for retry:', e);
         await syncQueue.enqueue('delete', 'socialReading', itemUri, payload);
@@ -1311,6 +1479,7 @@ function createItemLabelsStore() {
           itemType,
           label: 'readProgress',
           props,
+          updatedAt: now,
         });
       } catch (e) {
         console.error('Failed to sync read progress, queueing for retry:', e);
@@ -1387,9 +1556,18 @@ function createItemLabelsStore() {
     paragraphIndex: number,
     totalParagraphs: number
   ) {
-    // Skip if position hasn't changed
+    // Skip only when NOTHING changed. Comparing paragraphIndex alone dropped
+    // updates that carried a corrected `totalParagraphs` — the reader learns the
+    // real total after layout, so the first write for an article was usually the
+    // one with the wrong denominator, and it was the one that stuck.
     const current = getReadProgress(itemKey);
-    if (current && paragraphIndex === current.paragraphIndex) return;
+    if (
+      current &&
+      paragraphIndex === current.paragraphIndex &&
+      totalParagraphs === current.totalParagraphs
+    ) {
+      return;
+    }
 
     // Debounce the actual persist
     if (readProgressDebounceTimer) clearTimeout(readProgressDebounceTimer);
@@ -1775,9 +1953,15 @@ function createItemLabelsStore() {
     },
     // Lifecycle
     load,
+    // Cheap mid-session freshness: both deltas, no cache rebuild.
+    pullDelta,
     // Inline read annotation (called by feedFetcher after a batch fetch)
     seedReadCursor,
     applyAnnotatedReads,
+    // Raw label access — the eviction guard needs "does this item carry a tag",
+    // and the count reconciliation needs a label's own timestamp.
+    hasLabel,
+    getLabel,
     // Article read
     isRead,
     markAsRead,

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -19,8 +19,14 @@ function createSyncStore() {
 
     window.addEventListener('online', async () => {
       isOnline = true;
-      // Process queue when coming back online
+      // Process queue when coming back online, THEN pull. Draining first means
+      // our own offline writes reach the server before we ask what changed, so
+      // the delta we get back already reflects them and can't briefly revert the
+      // UI to the pre-offline state. This event used to only drain — coming back
+      // online showed our own changes and none of anyone else's.
       await triggerSync();
+      const { itemLabelsStore } = await import('./itemLabels.svelte');
+      await itemLabelsStore.pullDelta();
     });
 
     window.addEventListener('offline', () => {
@@ -60,6 +66,18 @@ function createSyncStore() {
     pendingCount = await syncQueue.getPendingCount();
   }
 
+  /**
+   * Record that this device is up to date with the server.
+   *
+   * `lastSyncedAt` used to move only when the outbound queue drained, so a
+   * device that had nothing to push reported "not since this page opened"
+   * however much it had pulled — the one number a reader looks at to answer
+   * "did my other device's reading arrive?" said nothing.
+   */
+  function markSynced() {
+    lastSyncedAt = Date.now();
+  }
+
   return {
     get isOnline() {
       return isOnline;
@@ -72,6 +90,7 @@ function createSyncStore() {
     },
     triggerSync,
     updatePendingCount,
+    markSynced,
   };
 }
 

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -13,6 +13,7 @@ import {
   matchesReadingLength,
 } from './feedView.svelte';
 import { liveDb } from '$lib/services/liveDb.svelte';
+import { reportClientError } from '$lib/services/telemetry';
 import {
   isRssSource,
   isDocumentsSource,
@@ -26,6 +27,38 @@ import {
  * Used by Sidebar, NavigationDropdown, and page title.
  */
 function createUnreadCountsStore() {
+  // Server-computed per-feed unread counts, keyed by feed URL, over the
+  // canonical newest-K window (see backend/src/config/window.ts).
+  //
+  // The local derivations below count over whatever articles THIS device holds,
+  // and no two devices hold the same slice — a fresh device cold-started with
+  // one window while an established one had accumulated another, so the same
+  // feed showed different numbers on a phone and a laptop no matter how well
+  // read state synced. That is the user-visible bug. When the server has told us
+  // its number, that is what we display; offline (or on a backend that doesn't
+  // send them) we fall back to the local count, which looks identical.
+  let serverCounts = $state<Record<string, number> | null>(null);
+  let serverCountsAt = $state(0);
+  let serverCountsHead = $state<number | undefined>(undefined);
+
+  // Local reads since the server's snapshot. The server number is a photograph;
+  // between refreshes the reader keeps reading, and a badge that ignored that
+  // would sit still while items visibly grey out. Counting our own marks off it
+  // keeps the display live without giving up the cross-device anchor.
+  let localReadsSince = $derived.by(() => {
+    itemLabelsStore.readPositions;
+    liveDb.articlesVersion;
+    const since = serverCountsAt;
+    const perFeed = new Map<number, number>();
+    if (!serverCounts || since === 0) return perFeed;
+    for (const article of articlesStore.allArticles) {
+      const lbl = itemLabelsStore.getLabel(article.guid, 'read');
+      if (!lbl || lbl.updatedAt < since) continue;
+      perFeed.set(article.subscriptionId, (perFeed.get(article.subscriptionId) ?? 0) + 1);
+    }
+    return perFeed;
+  });
+
   // Per-source unread counts. RSS sources count unread feed articles; ATProto sources
   // count unread social records scoped to the subscribed author/publication.
   let feedCounts = $derived.by(() => {
@@ -38,7 +71,13 @@ function createUnreadCountsStore() {
       if (!sub.id) continue;
 
       if (!sub.sourceType || sub.sourceType === 'rss') {
-        counts.set(sub.id, articlesStore.getUnreadCount(sub.id));
+        const fromServer = sub.feedUrl ? serverCounts?.[sub.feedUrl] : undefined;
+        counts.set(
+          sub.id,
+          fromServer === undefined
+            ? articlesStore.getUnreadCount(sub.id)
+            : Math.max(0, fromServer - (localReadsSince.get(sub.id) ?? 0))
+        );
         continue;
       }
 
@@ -68,6 +107,23 @@ function createUnreadCountsStore() {
   let totalArticles = $derived.by(() => {
     liveDb.articlesVersion;
     itemLabelsStore.readPositions; // Access for reactivity
+
+    // Sum the per-source counts when the server supplied them, so the header
+    // total and the sidebar rows can never disagree with each other — a total
+    // derived locally while the rows came from the server would be its own
+    // small version of the bug this is fixing. The local path still dedupes by
+    // GUID; the server path can double-count a GUID that appears in two
+    // subscribed feeds, which is rare and self-consistent with the rows.
+    if (serverCounts) {
+      let total = 0;
+      for (const sub of subscriptionsStore.subscriptions) {
+        if (!sub.id) continue;
+        if (sub.sourceType && sub.sourceType !== 'rss') continue;
+        total += feedCounts.get(sub.id) ?? 0;
+      }
+      return total;
+    }
+
     const seen = new Set<string>();
     let count = 0;
     for (const article of articlesStore.allArticles) {
@@ -268,10 +324,58 @@ function createUnreadCountsStore() {
     return counts;
   });
 
+  /**
+   * Adopt the server's per-feed counts (called once per completed refresh).
+   *
+   * Divergence between the server number and the locally-derived one is now a
+   * reconciliation SIGNAL rather than something only a user can notice: a
+   * sampled report makes drift observable in the same place client errors land,
+   * so the next version of this bug shows up in telemetry before it shows up in
+   * a discussion thread.
+   */
+  function applyServerCounts(counts: Record<string, number>, head?: number) {
+    const drifted: string[] = [];
+    for (const sub of subscriptionsStore.subscriptions) {
+      if (!sub.id || !sub.feedUrl) continue;
+      if (sub.sourceType && sub.sourceType !== 'rss') continue;
+      const server = counts[sub.feedUrl];
+      if (server === undefined) continue;
+      if (server !== articlesStore.getUnreadCount(sub.id)) drifted.push(sub.feedUrl);
+    }
+
+    serverCounts = counts;
+    serverCountsHead = head;
+    serverCountsAt = Date.now();
+
+    if (drifted.length > 0) {
+      // No feed URLs in the payload — the reporter sends no identifiers, and
+      // which feeds someone reads is exactly that. Two numbers are enough to
+      // tell "one feed off by a bit" from "the window rule is wrong".
+      reportClientError(
+        'unread_count_drift',
+        new Error(`unread counts diverged on ${drifted.length}/${Object.keys(counts).length} feeds`)
+      );
+    }
+  }
+
+  /** Forget the server's numbers — used when the timeline path isn't in play. */
+  function clearServerCounts() {
+    serverCounts = null;
+    serverCountsHead = undefined;
+    serverCountsAt = 0;
+  }
+
   return {
     get feedCounts() {
       return feedCounts;
     },
+    // The archive head the server's counts were taken at — the `beforeSeq` a
+    // mark-feed-read should use so items ingested since stay unread.
+    get serverCountsHead() {
+      return serverCountsHead;
+    },
+    applyServerCounts,
+    clearServerCounts,
     get totalArticles() {
       return totalArticles;
     },


### PR DESCRIPTION
### Review follow-up

Fixes the final read-identity edge case in the shared user-time LWW upsert. Existing live reads retain their durable `rkey`, while resurrected tombstones adopt the new `rkey` reported by the API.

Regression coverage verifies that a single-item resurrection updates the persisted identity and keeps the response consistent with D1. Existing bulk-resurrection and repeated feed-wide identity tests cover the other shared-upsert callers.

This continues the broader cross-device sync convergence work already present on the branch: canonical article windows, server unread counts, lossless compound deltas, user-time LWW, delta freshness, and archive paging.

Checks:

- `backend/npm run test -- --run test/reading-positions.spec.ts` — 32 passed.
- `backend/npm run check` — TypeScript and Prettier passed.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-7q32xbm2lr4s4cevigh2xx4w)
