### PR TITLE
Linkblog: differentiated titles, contextual cards, optional attribution

### DIFF
--- a/.github/workflows/pwa.yml
+++ b/.github/workflows/pwa.yml
@@ -46,8 +46,17 @@ jobs:
 
       # webkit is the closest iOS Safari engine proxy; --with-deps pulls the OS
       # libraries it needs on Ubuntu. The config builds the frontend + serves preview.
+      #
+      # The runner image ships Google's Chrome apt source, and --with-deps runs
+      # `apt-get update` over every source it finds. When that repo serves a
+      # Packages.gz whose hash disagrees with its InRelease, apt exits 100 and
+      # takes the browser install down with it. Nothing here needs Chrome, so the
+      # source goes before apt runs.
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium webkit
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list \
+                     /etc/apt/sources.list.d/google-chrome*.sources
+          npx playwright install --with-deps chromium webkit
 
       - name: Run PWA tests
         run: npm run test:pwa

--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -2,3 +2,5 @@ dist/
 node_modules/
 .wrangler/
 worker-configuration.d.ts
+.impeccable/
+test-results/

--- a/backend/migrations/0076_linkblog_formatting.sql
+++ b/backend/migrations/0076_linkblog_formatting.sql
@@ -1,0 +1,13 @@
+-- Per-user linkblog post formatting.
+--
+-- How a link post reads on someone else's site is a matter of taste, so the two
+-- answers to the "external linkblog formatting" feedback land as preferences
+-- rather than hardcoded changes:
+--   linkblog_title_style   'link' (🔗 <title>, default) | 'quoted' (“<title>”) | 'plain'
+--   linkblog_card_position 'context' (after the quote, default) | 'top' | 'bottom'
+--
+-- Both are nullable and NULL means "the default", so a deploy that lands ahead of
+-- this migration keeps working: getLinkblogFormatting wraps the read in a catch
+-- and falls back to the same defaults.
+ALTER TABLE user_settings ADD COLUMN linkblog_title_style TEXT;
+ALTER TABLE user_settings ADD COLUMN linkblog_card_position TEXT;

--- a/backend/migrations/0078_linkblog_publication_rkey.sql
+++ b/backend/migrations/0078_linkblog_publication_rkey.sql
@@ -1,0 +1,12 @@
+-- The record key of the user's own Skyreader linkblog publication.
+--
+-- `site.standard.publication` declares `"key": "tid"`, and Bluesky PDS lexicon
+-- resolution now enforces it: a putRecord at our old fixed rkey `skyreader-links`
+-- fails with `Invalid TID string`. New publications are therefore minted at a
+-- real TID, and the one we minted has to be remembered — a fixed constant was
+-- previously the only thing that made the URI computable from a DID.
+--
+-- NULL means "the legacy `skyreader-links` rkey", which is where every
+-- publication created before this lives and where it stays: the documents that
+-- point at it are immutable until edited, so moving it would strand them.
+ALTER TABLE user_settings ADD COLUMN linkblog_rkey TEXT;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,6 +49,7 @@ import {
   handleConnectPublication,
   handleResolvePublication,
   handleSetPageVisibility,
+  handleSetLinkblogFormatting,
   handleDeletePublication,
   handleRestorePublication,
 } from './routes/linkblog';
@@ -488,6 +489,10 @@ async function route(
       } else {
         response = await handleUpdatePublication(request, env);
       }
+      break;
+    case url.pathname === '/api/linkblog/formatting':
+      if (!session) return unauthorizedResponse(headers);
+      response = await handleSetLinkblogFormatting(request, env);
       break;
     case url.pathname === '/api/linkblog/publications':
       if (!session) return unauthorizedResponse(headers);

--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -18,10 +18,7 @@ import { log, serializeError } from '../utils/logger';
 import { chunkArray, getReadKeys } from './reading';
 import { clearFeedHealth, ingestProxyFeed } from './ingest';
 import { readFeedMetadata, readFeedSlice, type FeedHealth } from './timeline';
-import {
-  getLinkblogTargets,
-  publicationUri as linkblogPublicationUri,
-} from '../services/linkblog-sync';
+import { getLinkblogTargets } from '../services/linkblog-sync';
 
 interface V2FeedResponse {
   title: string;
@@ -540,7 +537,7 @@ async function correctLinkblogScopes(
     if (!target || target.siteUri === entry.siteUri) return entry;
     const rows = subscribed.get(entry.did);
     const stale =
-      entry.siteUri === linkblogPublicationUri(entry.did) ||
+      entry.siteUri === target.defaultSiteUri ||
       (!!rows && !rows.has(entry.siteUri) && rows.has(target.siteUri));
     // Don't collapse two requested scopes onto one — the client asked for both.
     if (!stale || requested.has(`${entry.did}\n${target.siteUri}`)) return entry;

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -19,6 +19,7 @@ import {
   DOCUMENT_COLLECTION,
   FOREIGN_RECORD_ERROR,
   getPublicationMeta,
+  getLinkblogFormatting,
   getLinkblogTarget,
   getLinkblogVisibility,
   isLinkblogDisabled,
@@ -31,8 +32,13 @@ import {
   updateLinkblogShareNote,
   updatePublication,
   writeLinkblogShare,
+  setLinkblogFormatting,
+  TITLE_STYLES,
+  CARD_POSITIONS,
   type LinkblogShareInput,
   type ContentFormat,
+  type LinkblogTitleStyle,
+  type LinkblogCardPosition,
 } from '../services/linkblog-sync';
 import { appForContentType, appForUrl, type PublicationApp } from '../services/publication-app';
 import { createPDSClient } from '../services/pds-client';
@@ -134,6 +140,9 @@ export async function handleCreateLinkblogShare(request: Request, env: Env): Pro
   if (body.repostUri !== undefined && !isAtUri(body.repostUri)) {
     return json({ error: 'repostUri must be an at:// URI' }, 400);
   }
+  if (body.attribution !== undefined && typeof body.attribution !== 'boolean') {
+    return json({ error: 'attribution must be a boolean' }, 400);
+  }
 
   const target = await getLinkblogTarget(env, session.did);
   if (missingCompanionScopes(session, target.format)) return insufficientScopesResponse();
@@ -148,6 +157,7 @@ export async function handleCreateLinkblogShare(request: Request, env: Env): Pro
     note: body.note,
     tags: body.tags,
     repostUri: body.repostUri,
+    attribution: body.attribution,
   };
 
   const result = await writeLinkblogShare(session, env, rkey, input);
@@ -236,6 +246,47 @@ export async function handleDeleteLinkblogShare(request: Request, env: Env): Pro
     return json({ error: result.error }, result.retryable ? 503 : 502);
   }
   return json({ success: true });
+}
+
+// PUT /api/linkblog/formatting — { titleStyle?, cardPosition? }
+//
+// How this user's link posts are written. A D1-only pair of settings, but gated
+// like every other linkblog mutation (see handleSetPageVisibility): a session
+// that can't write is one whose next share fails, so send it to re-auth here
+// rather than let it configure a linkblog it can't publish to.
+//
+// Partial updates are allowed; an omitted field keeps its stored value. Returns
+// the publication meta so the settings page refreshes from one response.
+export async function handleSetLinkblogFormatting(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return json({ error: 'Unauthorized' }, 401);
+  if (request.method !== 'PUT') return json({ error: 'Method not allowed' }, 405);
+  if (!hasRequiredScopes(session.grantedScopes, LINKBLOG_SCOPES)) {
+    return insufficientScopesResponse();
+  }
+
+  let body: { titleStyle?: unknown; cardPosition?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+  if (body.titleStyle !== undefined && !TITLE_STYLES.has(body.titleStyle as LinkblogTitleStyle)) {
+    return json({ error: 'titleStyle must be one of: link, quoted, plain' }, 400);
+  }
+  if (
+    body.cardPosition !== undefined &&
+    !CARD_POSITIONS.has(body.cardPosition as LinkblogCardPosition)
+  ) {
+    return json({ error: 'cardPosition must be one of: context, top, bottom' }, 400);
+  }
+
+  const current = await getLinkblogFormatting(env, session.did);
+  await setLinkblogFormatting(env, session.did, {
+    titleStyle: (body.titleStyle as LinkblogTitleStyle) ?? current.titleStyle,
+    cardPosition: (body.cardPosition as LinkblogCardPosition) ?? current.cardPosition,
+  });
+  return json(await getPublicationMeta(session, env));
 }
 
 // GET /api/linkblog/discover/friends — people the user follows on Bluesky who

--- a/backend/src/routes/linkblog.ts
+++ b/backend/src/routes/linkblog.ts
@@ -26,7 +26,6 @@ import {
   httpUrlOrUndefined,
   linkblogBaseUrl,
   PUBLICATION_COLLECTION,
-  publicationUri,
   restoreLinkblog,
   setLinkblogPageHidden,
   updateLinkblogShareNote,
@@ -361,6 +360,12 @@ export async function handleUpdatePublication(request: Request, env: Env): Promi
     return json({ error: result.error }, result.retryable ? 503 : 502);
   }
 
+  // A rename on a legacy publication moves it (see migrateLegacyPublication), so
+  // followers pointing at the old URI have to come along.
+  if (result.data.move) {
+    await migrateLinkblogFollowers(env, session.did, result.data.move.from, result.data.move.to);
+  }
+
   const meta = await getPublicationMeta(session, env);
   return json(meta);
 }
@@ -390,8 +395,11 @@ export async function migrateLinkblogFollowers(
   // links land *after* this migration: coming back to the default publication
   // makes the page live again even if the flag is still set. A null binding
   // makes every COALESCE below a no-op, so the graph moves and the URL doesn't.
-  const { pageHidden } = await getLinkblogVisibility(env, subjectDid);
-  const pageServed = !(pageHidden && nextSiteUri !== publicationUri(subjectDid));
+  const [{ pageHidden }, subjectTarget] = await Promise.all([
+    getLinkblogVisibility(env, subjectDid),
+    getLinkblogTarget(env, subjectDid),
+  ]);
+  const pageServed = !(pageHidden && nextSiteUri !== subjectTarget.defaultSiteUri);
   const linkblogPage = pageServed ? linkblogBaseUrl(env, subjectDid) : null;
 
   // A follower may already subscribe to the destination publication. Keep that
@@ -588,7 +596,7 @@ export async function handleListPublications(request: Request, env: Env): Promis
     documents.success ? documents.data.map((record) => record.value) : []
   );
 
-  const defaultUri = publicationUri(session.did);
+  const defaultUri = (await getLinkblogTarget(env, session.did)).defaultSiteUri;
   const publications = result.data.map((record) => {
     const evidence = evidenceBySite.get(record.uri);
     const url = httpUrlOrUndefined(record.value.url);
@@ -649,7 +657,7 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
   const now = Math.floor(Date.now() / 1000);
   if (request.method === 'DELETE') {
     const previousTarget = await getLinkblogTarget(env, session.did);
-    const nextSiteUri = publicationUri(session.did);
+    const nextSiteUri = previousTarget.defaultSiteUri;
     // Coming back to the Skyreader linkblog also clears "don't serve my page":
     // that page is now the only public address these links have, and a linkblog
     // silently published nowhere is worse than one the user has to hide again.
@@ -712,7 +720,7 @@ export async function handleConnectPublication(request: Request, env: Env): Prom
   // Selecting the default publication here is a disconnect by another name (the
   // UI routes it to DELETE, but the API is open), so clear the page-hidden choice
   // the same way that path does — see the note there.
-  const backToDefault = selectedPublicationUri === publicationUri(session.did) ? 1 : 0;
+  const backToDefault = selectedPublicationUri === previousTarget.defaultSiteUri ? 1 : 0;
   await env.DB.prepare(
     `INSERT INTO user_settings (user_did, linkblog_publication, linkblog_content_format, linkblog_page_hidden, created_at, updated_at)
     VALUES (?, ?, ?, 0, ?, ?) ON CONFLICT(user_did) DO UPDATE SET linkblog_publication=excluded.linkblog_publication,
@@ -742,7 +750,7 @@ export async function handleDeletePublication(request: Request, env: Env): Promi
     env,
     session.did,
     result.data.previousSiteUri,
-    publicationUri(session.did)
+    (await getLinkblogTarget(env, session.did)).defaultSiteUri
   );
   return json({ success: true, deletedPosts: result.data.deletedPosts });
 }
@@ -771,7 +779,11 @@ export async function handleResolvePublication(request: Request, env: Env): Prom
   return new Response(
     JSON.stringify({
       siteUri: target.siteUri,
-      defaultSiteUri: publicationUri(did),
+      defaultSiteUri: target.defaultSiteUri,
+      // Present only for an author whose own publication has moved off the
+      // legacy rkey — the public page scopes to it too, so a move interrupted
+      // partway still shows every post (see migrateLegacyPublication).
+      legacySiteUri: target.legacySiteUri,
       // One flag for the public site: it renders the page or it doesn't, and the
       // reason (deleted vs. page turned off) isn't the reader's business. Deleted
       // linkblogs have no posts left to show anyway, but saying so here means the

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -23,7 +23,6 @@ import {
   getLinkblogTarget,
   getPageHiddenAuthors,
   linkblogBaseUrl,
-  publicationUri as defaultLinkblogPublicationUri,
 } from '../services/linkblog-sync';
 
 /**
@@ -580,9 +579,7 @@ export async function ensureLocalDocumentSubscription(
     getLinkblogTarget(env, subjectDid),
     getPageHiddenAuthors(env, [subjectDid]).then((h) => h.length > 0),
   ]);
-  const isLinkblog =
-    publicationUri === target.siteUri ||
-    publicationUri === defaultLinkblogPublicationUri(subjectDid);
+  const isLinkblog = publicationUri === target.siteUri || publicationUri === target.defaultSiteUri;
   const siteUrl = isLinkblog && !pageHidden ? linkblogBaseUrl(env, subjectDid) : null;
 
   const rkey = generateTid();

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -118,6 +118,73 @@ export interface LinkblogTarget {
   external: boolean;
 }
 
+// ── Per-user post formatting ─────────────────────────────────────────────────
+//
+// How a link post reads on someone ELSE's site (leaflet.pub, pckt, Offprint) is
+// a matter of taste, so it's a preference rather than a constant: the maintainer's
+// note on the feedback was "probably need a general way for users to customize how
+// external linkblogs are formatted". The defaults are the answers to the feedback;
+// the other values keep the old behavior available.
+
+/** How the document's top-level `title` is written. */
+export type LinkblogTitleStyle = 'link' | 'quoted' | 'plain';
+/** Where the article's link card sits among the note blocks. */
+export type LinkblogCardPosition = 'context' | 'top' | 'bottom';
+
+export interface LinkblogFormatting {
+  titleStyle: LinkblogTitleStyle;
+  cardPosition: LinkblogCardPosition;
+}
+
+export const TITLE_STYLES = new Set<LinkblogTitleStyle>(['link', 'quoted', 'plain']);
+export const CARD_POSITIONS = new Set<LinkblogCardPosition>(['context', 'top', 'bottom']);
+
+export const DEFAULT_FORMATTING: LinkblogFormatting = {
+  titleStyle: 'link',
+  cardPosition: 'context',
+};
+
+// The decoration that separates "I linked this" from "I wrote this" on a foreign
+// site, where a byte-identical title made a share indistinguishable from a repost
+// of the article itself. Exported so every reader can strip it back off — the
+// card keeps the plain title, but pre-card records only have this one.
+export const TITLE_LINK_PREFIX = '🔗 ';
+
+export function decorateTitle(title: string, style: LinkblogTitleStyle): string {
+  const trimmed = title.trim();
+  if (!trimmed) return trimmed;
+  if (style === 'link') return `${TITLE_LINK_PREFIX}${trimmed}`;
+  if (style === 'quoted') return `“${trimmed}”`;
+  return trimmed;
+}
+
+// The inverse, for surfaces that want the article's own title back out of a
+// decorated one. Only the decorations we write are stripped — typographic quotes
+// and the link emoji — so a title the author really did wrap in "straight quotes"
+// survives untouched.
+export function stripTitleDecoration(title: string): string {
+  let out = title.trim();
+  if (out.startsWith(TITLE_LINK_PREFIX)) out = out.slice(TITLE_LINK_PREFIX.length).trim();
+  else if (out.startsWith('\u{1f517}')) out = out.slice('\u{1f517}'.length).trim();
+  const quoted = /^“([\s\S]*)”$/.exec(out);
+  if (quoted) out = quoted[1].trim();
+  return out;
+}
+
+// The optional "this came from Skyreader" line, opt-in per share.
+//
+// Deliberately PLAIN text rather than a hyperlink: a link inside a
+// pub.leaflet/pckt/Offprint text block needs a richtext facet whose shape we have
+// not verified against those published lexicons, and Leaflet's appview silently
+// drops a post that fails validation. Spelling the domain keeps the pointer
+// without betting a whole post on an unverified field. Every note parser excludes
+// this exact string, so keep it stable.
+export const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
+
+function isAttributionText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() === ATTRIBUTION_TEXT;
+}
+
 const CONTENT_FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
 
 export function defaultLinkblogTarget(did: string): LinkblogTarget {
@@ -157,6 +224,58 @@ export async function getLinkblogTarget(env: Env, did: string): Promise<Linkblog
     // Deploys remain usable while a migration is rolling out.
     return defaultLinkblogTarget(did);
   }
+}
+
+// The user's post-formatting choices, or the defaults.
+//
+// Kept OUT of getLinkblogTarget's SELECT on purpose (same reasoning as
+// getPageHiddenAuthors): that query is what every share write depends on, and its
+// catch exists so a deploy landing ahead of a migration still resolves a target.
+// A separate statement keeps migration 0076's columns out of that blast radius —
+// pre-migration this throws on its own and degrades to the defaults.
+export async function getLinkblogFormatting(env: Env, did: string): Promise<LinkblogFormatting> {
+  try {
+    const row = await env.DB.prepare(
+      'SELECT linkblog_title_style, linkblog_card_position FROM user_settings WHERE user_did = ?'
+    )
+      .bind(did)
+      .first<{ linkblog_title_style: string | null; linkblog_card_position: string | null }>();
+    return formattingFromRow(row?.linkblog_title_style, row?.linkblog_card_position);
+  } catch {
+    return { ...DEFAULT_FORMATTING };
+  }
+}
+
+// NULL (never set) and anything unrecognized both mean "the default" — a stored
+// value from a future version must not produce an undecorated title by accident.
+export function formattingFromRow(
+  titleStyle: string | null | undefined,
+  cardPosition: string | null | undefined
+): LinkblogFormatting {
+  return {
+    titleStyle: TITLE_STYLES.has(titleStyle as LinkblogTitleStyle)
+      ? (titleStyle as LinkblogTitleStyle)
+      : DEFAULT_FORMATTING.titleStyle,
+    cardPosition: CARD_POSITIONS.has(cardPosition as LinkblogCardPosition)
+      ? (cardPosition as LinkblogCardPosition)
+      : DEFAULT_FORMATTING.cardPosition,
+  };
+}
+
+export async function setLinkblogFormatting(
+  env: Env,
+  did: string,
+  formatting: LinkblogFormatting
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO user_settings (user_did, linkblog_title_style, linkblog_card_position, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_did) DO UPDATE SET linkblog_title_style=excluded.linkblog_title_style,
+     linkblog_card_position=excluded.linkblog_card_position, updated_at=excluded.updated_at`
+  )
+    .bind(did, formatting.titleStyle, formatting.cardPosition, now, now)
+    .run();
 }
 
 // D1 caps bound parameters per statement; chunk the IN (...) list well under it.
@@ -306,6 +425,10 @@ export interface PublicationMeta {
   // connected publication; `url` still describes where the page WOULD be, so the
   // setting can be undone.
   pageHidden: boolean;
+  // How this user's posts are written: title decoration and where the link card
+  // sits. Rides along here because the settings page and the composer already
+  // load publication meta, so both get the state without a second request.
+  formatting: LinkblogFormatting;
 }
 
 // PDS records are user-controlled, so a `url` can be any string. Only surface it
@@ -328,9 +451,10 @@ function iconUrlFromBlob(did: string, icon: BlobRef | undefined): string | undef
 // Read the current linkblog publication, or synthesize sensible defaults when it
 // doesn't exist yet (so the settings UI can render before the first share).
 export async function getPublicationMeta(session: Session, env: Env): Promise<PublicationMeta> {
-  const [target, visibility] = await Promise.all([
+  const [target, visibility, formatting] = await Promise.all([
     getLinkblogTarget(env, session.did),
     getLinkblogVisibility(env, session.did),
+    getLinkblogFormatting(env, session.did),
   ]);
   const disabled = visibility.disabled;
   // Hiding the page is only offered alongside a connected publication, so a stored
@@ -353,6 +477,7 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
       format: target.format,
       disabled,
       pageHidden,
+      formatting,
     };
   }
 
@@ -374,6 +499,7 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
     format: target.format,
     disabled,
     pageHidden,
+    formatting,
   };
 }
 
@@ -488,6 +614,9 @@ export interface LinkblogShareInput {
   // `links` as a `rel: "repost"` ref for provenance, alongside the article ref,
   // so the quote is its own linkblog entry that still credits the source.
   repostUri?: string;
+  // Opt-in, per share: append the ATTRIBUTION_TEXT line after the card. The
+  // composer offers it as a checkbox; nothing is added unless it's ticked.
+  attribution?: boolean;
 }
 
 interface DocumentRecord {
@@ -512,6 +641,12 @@ interface DocumentRecord {
   // Absent on documents in the default publication written before the marker
   // existed; those are covered by the publication check instead.
   skyreaderLinkblog?: string;
+  // The author ticked "Posted from Skyreader" on this share. Top-level (the
+  // extension mechanism standard.site sanctions, and the one `skyreaderLinkblog`
+  // already proves safe) so readers can exclude the attribution block without
+  // relying on a string match — a user whose last line happens to BE that string
+  // keeps their words.
+  skyreaderAttribution?: boolean;
 }
 
 // Whether a `site.standard.document` is one of OUR link posts: it carries the
@@ -636,20 +771,26 @@ export async function getDisabledLinkblogAuthors(env: Env, dids: string[]): Prom
   }
 }
 
-// The article excerpt stored on a record's website link-card block. The card is
-// the durable home of the excerpt now that the top-level `description` is reserved
-// as the legacy-quote marker, so the note-update path reads it back from here to
-// rebuild the card without dropping it.
-function websiteCardExcerpt(content: unknown): string {
+// The article title and excerpt stored on a record's website link-card block. The
+// card is the durable home of both: the excerpt because the top-level
+// `description` is reserved as the legacy-quote marker, and the title because the
+// document's own `title` may carry a user-chosen decoration (🔗 …, “…”) that must
+// never be baked into a card. The note-update path reads them back from here to
+// rebuild a missing card without dropping or corrupting either.
+export function websiteCardMeta(content: unknown): { title?: string; excerpt: string } {
   const c = content as {
     pages?: Array<{ blocks?: Array<{ block?: Record<string, unknown> }> }>;
-    items?: Array<{ $type?: string; description?: unknown }>;
+    items?: Array<{ $type?: string; title?: unknown; description?: unknown }>;
   };
   for (const page of c?.pages ?? []) {
     for (const wrapper of page.blocks ?? []) {
       if (wrapper.block?.$type === 'pub.leaflet.blocks.website') {
+        const title = wrapper.block.title;
         const desc = wrapper.block.description;
-        if (typeof desc === 'string') return desc;
+        return {
+          title: typeof title === 'string' && title.trim() ? title : undefined,
+          excerpt: typeof desc === 'string' ? desc : '',
+        };
       }
     }
   }
@@ -658,9 +799,14 @@ function websiteCardExcerpt(content: unknown): string {
   for (const item of c?.items ?? []) {
     const isCard =
       item?.$type === 'blog.pckt.block.website' || item?.$type === 'app.offprint.block.webBookmark';
-    if (isCard && typeof item.description === 'string') return item.description;
+    if (isCard) {
+      return {
+        title: typeof item.title === 'string' && item.title.trim() ? item.title : undefined,
+        excerpt: typeof item.description === 'string' ? item.description : '',
+      };
+    }
   }
-  return '';
+  return { excerpt: '' };
 }
 
 // Build the rich, interoperable body: the user's note as native text/blockquote
@@ -715,6 +861,56 @@ function noteRuns(note: string | undefined): NoteRun[] {
   return runs;
 }
 
+// Where the article's link card goes among the note blocks, as an index into the
+// per-run block list. `noteToLeafletBlocks` / `noteToBlockItems` map one block per
+// run, so a run index is a block index.
+//
+// 'context' is the answer to the feedback: the card sits where the quote does —
+// after the quoted passage, before the commentary — so a reader meets "this is a
+// link post, responding to X" before the response. With nothing quoted there is
+// no passage to sit under, and the card leads instead, which lands the same
+// context in the same place.
+export function cardIndexFor(runs: NoteRun[], position: LinkblogCardPosition): number {
+  if (position === 'top') return 0;
+  if (position === 'bottom') return runs.length;
+  let leadingQuotes = 0;
+  while (leadingQuotes < runs.length && runs[leadingQuotes].quote) leadingQuotes++;
+  return leadingQuotes;
+}
+
+// The layout an EXISTING record was written in, read back from where its card
+// actually sits. An edit rebuilds in the layout it found rather than the author's
+// current setting: changing a preference must not silently reformat old posts.
+//
+// A record with no note carries no evidence, and 'bottom' is what every such
+// record was written as before this existed — so an edit that adds the first note
+// keeps behaving exactly as it used to.
+function layoutFromCardSplit(notesBefore: number, noteCount: number): LinkblogCardPosition {
+  if (noteCount === 0) return 'bottom';
+  if (notesBefore <= 0) return 'top';
+  if (notesBefore >= noteCount) return 'bottom';
+  return 'context';
+}
+
+// Splice a card (and, when present, the attribution line) into a rebuilt block
+// list. `extras` are the non-note blocks found on an existing record — the card
+// plus anything the home app added alongside it — re-emitted as one contiguous
+// run so a connected publication's own content is never dropped.
+function withCardAndAttribution<T>(
+  notes: T[],
+  extras: T[],
+  index: number,
+  attribution: T | null
+): T[] {
+  const at = Math.max(0, Math.min(index, notes.length));
+  return [
+    ...notes.slice(0, at),
+    ...extras,
+    ...notes.slice(at),
+    ...(attribution ? [attribution] : []),
+  ];
+}
+
 // Parse the note into native Leaflet text/blockquote blocks, one per run.
 export function noteToLeafletBlocks(
   note: string | undefined,
@@ -734,6 +930,29 @@ export function noteToLeafletBlocks(
   });
 }
 
+function leafletAttributionBlock(): NoteBlock {
+  return { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } };
+}
+
+// Is this wrapper part of the note (as opposed to the card, a home-app block, or
+// the attribution line)?
+function isLeafletNoteBlock(wrapper: { block?: Record<string, unknown> }): boolean {
+  const type = wrapper.block?.$type;
+  if (type === 'pub.leaflet.blocks.blockquote') return true;
+  if (type !== 'pub.leaflet.blocks.text') return false;
+  return !isAttributionText(wrapper.block?.plaintext);
+}
+
+/**
+ * Swap the note region of a Leaflet body, keeping the card exactly where it was
+ * found and preserving every block that isn't ours.
+ *
+ * The card is no longer guaranteed to close the post, so "the note is the leading
+ * run and everything past it is preserved" no longer holds. Instead the blocks are
+ * sorted into note / not-note, the not-note run is re-inserted at the same
+ * layout position it occupied, and an attribution line found on the record is
+ * carried through (v1 offers no way to remove one on edit — delete and reshare).
+ */
 export function replaceLeafletNoteRegion(
   existing: unknown,
   note: string,
@@ -744,18 +963,38 @@ export function replaceLeafletNoteRegion(
     pages?: Array<{ $type?: string; blocks?: Array<{ block?: Record<string, unknown> }> }>;
   };
   const oldBlocks = oldContent?.pages?.[0]?.blocks ?? [];
-  const firstPreserved = oldBlocks.findIndex(
-    (wrapper) =>
-      wrapper.block?.$type !== 'pub.leaflet.blocks.text' &&
-      wrapper.block?.$type !== 'pub.leaflet.blocks.blockquote'
-  );
-  const preserved = firstPreserved < 0 ? [] : oldBlocks.slice(firstPreserved);
+
+  const extras: Array<{ block?: Record<string, unknown> }> = [];
+  let hadAttribution = false;
+  let oldNotes = 0;
+  let notesBeforeExtras = -1;
+  for (const wrapper of oldBlocks) {
+    if (isAttributionText(wrapper.block?.plaintext)) {
+      hadAttribution = true;
+      continue;
+    }
+    if (isLeafletNoteBlock(wrapper)) {
+      oldNotes++;
+      continue;
+    }
+    if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+    extras.push(wrapper);
+  }
+  if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+
+  const runs = noteRuns(note);
+  const index = cardIndexFor(runs, layoutFromCardSplit(notesBeforeExtras, oldNotes));
   return {
     $type: oldContent?.$type || 'pub.leaflet.content',
     pages: [
       {
         $type: oldContent?.pages?.[0]?.$type || 'pub.leaflet.pages.linearDocument',
-        blocks: [...noteToLeafletBlocks(note, resolvedHandles), ...preserved],
+        blocks: withCardAndAttribution(
+          noteToLeafletBlocks(note, resolvedHandles),
+          extras,
+          index,
+          hadAttribution ? leafletAttributionBlock() : null
+        ),
       },
       ...(oldContent?.pages?.slice(1) ?? []),
     ],
@@ -765,9 +1004,10 @@ export function replaceLeafletNoteRegion(
 function buildLeafletContent(
   input: LinkblogShareInput,
   excerpt: string,
-  resolvedHandles?: Map<string, string>
+  resolvedHandles: Map<string, string> | undefined,
+  formatting: LinkblogFormatting
 ): unknown {
-  const blocks: Array<{ block: unknown }> = noteToLeafletBlocks(input.note, resolvedHandles);
+  const noteBlocks: NoteBlock[] = noteToLeafletBlocks(input.note, resolvedHandles);
 
   // `src` is the field name pub.leaflet.blocks.website requires. Getting it
   // wrong is silent and total: Leaflet's appview runs every site.standard.document
@@ -777,9 +1017,17 @@ function buildLeafletContent(
     $type: 'pub.leaflet.blocks.website',
     src: input.articleUrl,
   };
+  // The card keeps the article's OWN title, undecorated, whatever the document
+  // title style is — it's the source of truth Skyreader's own surfaces read back.
   if (input.articleTitle) website.title = input.articleTitle;
   if (excerpt) website.description = excerpt;
-  blocks.push({ block: website });
+
+  const blocks = withCardAndAttribution(
+    noteBlocks,
+    [{ block: website }],
+    cardIndexFor(noteRuns(input.note), formatting.cardPosition),
+    input.attribution ? leafletAttributionBlock() : null
+  );
 
   return {
     $type: 'pub.leaflet.content',
@@ -793,7 +1041,8 @@ export function buildLinkblogDocument(
   input: LinkblogShareInput,
   resolvedHandles?: Map<string, string>,
   siteUri = publicationUri(did),
-  format: ContentFormat = 'leaflet'
+  format: ContentFormat = 'leaflet',
+  formatting: LinkblogFormatting = DEFAULT_FORMATTING
 ): DocumentRecord {
   const now = new Date().toISOString();
   const excerpt = input.excerpt ? truncate(input.excerpt, MAX_EXCERPT_CHARS) : '';
@@ -806,7 +1055,11 @@ export function buildLinkblogDocument(
   return {
     $type: DOCUMENT_COLLECTION,
     site: siteUri,
-    title: input.articleTitle?.trim() || input.articleUrl,
+    // Decorated per the author's title style, so a link post on someone else's
+    // site doesn't read as a repost of the article. The article's own title stays
+    // plain on the website card, which is what Skyreader's surfaces and the RSS
+    // feed prefer — see stripTitleDecoration for the legacy fallback.
+    title: decorateTitle(input.articleTitle?.trim() || input.articleUrl, formatting.titleStyle),
     path: `/${rkey}`,
     publishedAt: input.articlePublishedAt || now,
     createdAt: now,
@@ -820,10 +1073,13 @@ export function buildLinkblogDocument(
     textContent,
     tags: input.tags && input.tags.length > 0 ? input.tags : undefined,
     links,
-    content: buildContent(format, input, excerpt, resolvedHandles),
+    content: buildContent(format, input, excerpt, resolvedHandles, formatting),
     // See DocumentRecord.skyreaderLinkblog — the tell that separates a Skyreader
     // share from a post the connected publication's home app wrote.
     skyreaderLinkblog: LINKBLOG_MARKER_URL,
+    // Only stamped when asked for, so its mere presence means "this record opted
+    // into the attribution line" (see DocumentRecord.skyreaderAttribution).
+    skyreaderAttribution: input.attribution ? true : undefined,
   };
 }
 
@@ -882,17 +1138,58 @@ function articleItem(
   };
 }
 
+function itemsAttributionBlock(prefix: string): Record<string, unknown> {
+  return { $type: `${prefix}text`, plaintext: ATTRIBUTION_TEXT };
+}
+
 function markpubLinkLine(url: string, title?: string): string {
   return `[${(title || url).replace(/([\\[\]()])/g, '\\$1')}](${url})`;
+}
+
+// The note as Markdown, split around the link line. Only the mid-note case
+// reflows the note text: with the link at either end the note is emitted exactly
+// as the user typed it, so the default-layout output of every pre-existing record
+// is byte-identical to what it was.
+function assembleMarkpub(
+  note: string | undefined,
+  linkLine: string,
+  position: LinkblogCardPosition,
+  attribution: boolean
+): string {
+  const runs = noteRuns(note);
+  const index = cardIndexFor(runs, position);
+  const render = (from: number, to: number) =>
+    runs
+      .slice(from, to)
+      .map((run) =>
+        run.quote
+          ? run.plaintext
+              .split('\n')
+              .map((line) => `> ${line}`)
+              .join('\n')
+          : run.plaintext
+      )
+      .join('\n\n');
+
+  const trimmed = note?.trim();
+  const parts =
+    index <= 0
+      ? [linkLine, trimmed]
+      : index >= runs.length
+        ? [trimmed, linkLine]
+        : [render(0, index), linkLine, render(index, runs.length)];
+  if (attribution) parts.push(ATTRIBUTION_TEXT);
+  return parts.filter(Boolean).join('\n\n');
 }
 
 function buildContent(
   format: ContentFormat,
   input: LinkblogShareInput,
   excerpt: string,
-  handles?: Map<string, string>
+  handles: Map<string, string> | undefined,
+  formatting: LinkblogFormatting
 ): unknown {
-  if (format === 'leaflet') return buildLeafletContent(input, excerpt, handles);
+  if (format === 'leaflet') return buildLeafletContent(input, excerpt, handles, formatting);
   if (format === 'markpub') {
     // No companion record here, and none needed: at.markpub.* is a content
     // lexicon designed to sit inside someone else's record (its own docs say so),
@@ -904,16 +1201,22 @@ function buildContent(
       flavor: 'commonmark',
       text: {
         $type: 'at.markpub.text',
-        markdown: [input.note?.trim(), markpubLinkLine(input.articleUrl, input.articleTitle)]
-          .filter(Boolean)
-          .join('\n\n'),
+        markdown: assembleMarkpub(
+          input.note,
+          markpubLinkLine(input.articleUrl, input.articleTitle),
+          formatting.cardPosition,
+          Boolean(input.attribution)
+        ),
       },
     };
   }
-  const items = [
-    ...noteToBlockItems(ITEM_PREFIX[format], input.note),
-    articleItem(format, { url: input.articleUrl, title: input.articleTitle, excerpt }),
-  ];
+  const prefix = ITEM_PREFIX[format];
+  const items = withCardAndAttribution(
+    noteToBlockItems(prefix, input.note),
+    [articleItem(format, { url: input.articleUrl, title: input.articleTitle, excerpt })],
+    cardIndexFor(noteRuns(input.note), formatting.cardPosition),
+    input.attribution ? itemsAttributionBlock(prefix) : null
+  );
   return { $type: ITEM_CONTENT_TYPE[format], items };
 }
 
@@ -933,20 +1236,21 @@ export function contentFormatOf(content: unknown): ContentFormat | null {
   }
 }
 
-// Is this item part of the leading note region (as opposed to the article that
-// closes the post)? A link card ends the region by not being a text block. Older
-// Offprint shares closed with an ordinary text line instead, so a text block
-// carrying the article URL ends it too.
+// Is this item part of the note (as opposed to the article card, a home-app
+// block, or the attribution line)? Older Offprint shares carried the article as
+// an ordinary text line rather than a card, so a text block holding the article
+// URL is the card too.
 function isNoteItem(item: unknown, prefix: string, articleUrl: string | undefined): boolean {
   const block = item as { $type?: string; plaintext?: unknown } | undefined;
   if (block?.$type === `${prefix}blockquote`) return true;
   if (block?.$type !== `${prefix}text`) return false;
   const plaintext = typeof block.plaintext === 'string' ? block.plaintext : '';
+  if (isAttributionText(plaintext)) return false;
   return !(articleUrl && plaintext.includes(articleUrl));
 }
 
-// Swap the note region of a pckt/Offprint body, preserving the article block and
-// anything the home app appended after it.
+// Swap the note region of a pckt/Offprint body, keeping the article block where
+// it was found and preserving anything the home app added alongside it.
 export function replaceItemsNoteRegion(
   existing: unknown,
   format: 'pckt' | 'offprint',
@@ -956,26 +1260,51 @@ export function replaceItemsNoteRegion(
   const content = existing as { $type?: string; items?: unknown[] } | undefined;
   const prefix = ITEM_PREFIX[format];
   const items = Array.isArray(content?.items) ? content.items : [];
-  const firstPreserved = items.findIndex((item) => !isNoteItem(item, prefix, article.url));
-  const preserved = firstPreserved < 0 ? [] : items.slice(firstPreserved);
+
+  const extras: unknown[] = [];
+  let hadAttribution = false;
+  let oldNotes = 0;
+  let notesBeforeExtras = -1;
+  for (const item of items) {
+    const plaintext = (item as { plaintext?: unknown } | undefined)?.plaintext;
+    if (isAttributionText(plaintext)) {
+      hadAttribution = true;
+      continue;
+    }
+    if (isNoteItem(item, prefix, article.url)) {
+      oldNotes++;
+      continue;
+    }
+    if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+    extras.push(item);
+  }
+  if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+
+  // The article block should always be there; rebuild it if the record somehow
+  // arrived without one, so an edit can't drop the link itself.
+  const card =
+    extras.length > 0
+      ? extras
+      : article.url
+        ? [articleItem(format, { url: article.url, title: article.title })]
+        : [];
+
+  const runs = noteRuns(note);
   return {
     ...content,
     $type: content?.$type || ITEM_CONTENT_TYPE[format],
-    items: [
-      ...noteToBlockItems(prefix, note),
-      // The article block should always be there; rebuild it if the record somehow
-      // arrived without one, so an edit can't drop the link itself.
-      ...(preserved.length > 0
-        ? preserved
-        : article.url
-          ? [articleItem(format, { url: article.url, title: article.title })]
-          : []),
-    ],
+    items: withCardAndAttribution(
+      noteToBlockItems(prefix, note),
+      card,
+      cardIndexFor(runs, layoutFromCardSplit(notesBeforeExtras, oldNotes)),
+      hadAttribution ? itemsAttributionBlock(prefix) : null
+    ),
   };
 }
 
-// Swap the note in a Markdown body: everything before the trailing article link,
-// which is kept verbatim when present.
+// Swap the note in a Markdown body, keeping the article link line verbatim and in
+// the same place, and preserving an attribution line. (The old implementation
+// rebuilt the body as `[note, linkLine]` and so dropped anything after the link.)
 export function replaceMarkpubNote(
   existing: unknown,
   note: string,
@@ -983,22 +1312,49 @@ export function replaceMarkpubNote(
 ): unknown {
   const content = existing as { text?: { markdown?: string } } | undefined;
   const markdown = content?.text?.markdown ?? '';
-  let tail = article.url ? markpubLinkLine(article.url, article.title) : '';
+  const lines = markdown.split('\n');
+
+  let linkIndex = -1;
   if (article.url) {
-    const lines = markdown.split('\n');
     for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i].includes(`](${article.url})`)) {
-        tail = lines[i].trim();
+        linkIndex = i;
         break;
       }
     }
   }
+  const linkLine =
+    linkIndex >= 0
+      ? lines[linkIndex].trim()
+      : article.url
+        ? markpubLinkLine(article.url, article.title)
+        : '';
+  const hadAttribution = lines.some((line) => isAttributionText(line));
+
+  // Where the link sat relative to the note text is the layout to preserve. With
+  // no link line found there's no evidence, and 'bottom' is what such a record was
+  // written as.
+  const noteText = (from: number, to: number) =>
+    lines
+      .slice(from, to)
+      .filter((line) => !isAttributionText(line))
+      .join('\n')
+      .trim();
+  const position: LinkblogCardPosition =
+    linkIndex < 0
+      ? 'bottom'
+      : !noteText(0, linkIndex)
+        ? 'top'
+        : !noteText(linkIndex + 1, lines.length)
+          ? 'bottom'
+          : 'context';
+
   return {
     ...content,
     $type: 'at.markpub.markdown',
     text: {
       ...(content?.text ?? {}),
-      markdown: [note.trim(), tail].filter(Boolean).join('\n\n'),
+      markdown: assembleMarkpub(note, linkLine, position, hadAttribution),
     },
   };
 }
@@ -1089,7 +1445,10 @@ export async function writeLinkblogShare(
   rkey: string,
   input: LinkblogShareInput
 ): Promise<PDSResult<PutRecordResponse>> {
-  const target = await getLinkblogTarget(env, session.did);
+  const [target, formatting] = await Promise.all([
+    getLinkblogTarget(env, session.did),
+    getLinkblogFormatting(env, session.did),
+  ]);
   if (!target.external) {
     const ensured = await ensureLinkblogPublication(session, env);
     if (!ensured.success) return ensured;
@@ -1102,7 +1461,8 @@ export async function writeLinkblogShare(
     input,
     resolvedHandles,
     target.siteUri,
-    target.format
+    target.format,
+    formatting
   );
   const client = createPDSClient(session);
   const written = await client.putRecord(DOCUMENT_COLLECTION, rkey, record);
@@ -1464,11 +1824,15 @@ export async function updateLinkblogShareNote(
   // comes from the website card (its durable home); `rec.description` is the
   // fallback for legacy records that still carry it at the top level. `...rec`
   // preserves that legacy `description` as-is — we never add one to a new record.
-  const excerpt = websiteCardExcerpt(rec.content) || rec.description || '';
+  const card = websiteCardMeta(rec.content);
+  const excerpt = card.excerpt || rec.description || '';
   const trimmedNote = note.trim();
   const article = {
     url: rec.links?.find((l) => /^https?:\/\//i.test(l.uri))?.uri,
-    title: rec.title,
+    // The card's own title first: `rec.title` may carry a decoration (🔗 …, “…”)
+    // that must never become a card title if the card has to be rebuilt. Stripping
+    // is the fallback for a record whose card is genuinely missing.
+    title: card.title ?? stripTitleDecoration(rec.title),
   };
   // Re-resolve mentions on edit so added/removed @handles re-encode; recipients
   // pick up the change on their next Constellation poll. (Facets are a Leaflet

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -185,6 +185,21 @@ function isAttributionText(value: unknown): boolean {
   return typeof value === 'string' && value.trim() === ATTRIBUTION_TEXT;
 }
 
+/**
+ * Is this block the attribution line WE added, as opposed to an author who wrote
+ * that same sentence themselves?
+ *
+ * Only the record's own `skyreaderAttribution` flag can tell those apart, so an
+ * edit must consult it rather than string-match alone. Without the flag the
+ * sentence is the author's words like any other line: it belongs to the note,
+ * gets rebuilt from the submitted note, and can be edited away. Lifting it out on
+ * the string match alone re-appended it beside the rebuilt copy — duplicating the
+ * author's sentence and making it impossible to remove.
+ */
+function isGeneratedAttribution(value: unknown, hasAttribution: boolean): boolean {
+  return hasAttribution && isAttributionText(value);
+}
+
 const CONTENT_FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
 
 export function defaultLinkblogTarget(did: string): LinkblogTarget {
@@ -935,12 +950,15 @@ function leafletAttributionBlock(): NoteBlock {
 }
 
 // Is this wrapper part of the note (as opposed to the card, a home-app block, or
-// the attribution line)?
-function isLeafletNoteBlock(wrapper: { block?: Record<string, unknown> }): boolean {
+// an attribution line we added)?
+function isLeafletNoteBlock(
+  wrapper: { block?: Record<string, unknown> },
+  hasAttribution: boolean
+): boolean {
   const type = wrapper.block?.$type;
   if (type === 'pub.leaflet.blocks.blockquote') return true;
   if (type !== 'pub.leaflet.blocks.text') return false;
-  return !isAttributionText(wrapper.block?.plaintext);
+  return !isGeneratedAttribution(wrapper.block?.plaintext, hasAttribution);
 }
 
 /**
@@ -952,11 +970,16 @@ function isLeafletNoteBlock(wrapper: { block?: Record<string, unknown> }): boole
  * sorted into note / not-note, the not-note run is re-inserted at the same
  * layout position it occupied, and an attribution line found on the record is
  * carried through (v1 offers no way to remove one on edit — delete and reshare).
+ *
+ * `hasAttribution` is the record's own `skyreaderAttribution` flag: only a record
+ * that says so has a generated attribution line to carry. On any other record the
+ * same sentence is the author's, and stays part of the note.
  */
 export function replaceLeafletNoteRegion(
   existing: unknown,
   note: string,
-  resolvedHandles: Map<string, string> = new Map()
+  resolvedHandles: Map<string, string> = new Map(),
+  hasAttribution = false
 ): unknown {
   const oldContent = existing as {
     $type?: string;
@@ -969,11 +992,11 @@ export function replaceLeafletNoteRegion(
   let oldNotes = 0;
   let notesBeforeExtras = -1;
   for (const wrapper of oldBlocks) {
-    if (isAttributionText(wrapper.block?.plaintext)) {
+    if (isGeneratedAttribution(wrapper.block?.plaintext, hasAttribution)) {
       hadAttribution = true;
       continue;
     }
-    if (isLeafletNoteBlock(wrapper)) {
+    if (isLeafletNoteBlock(wrapper, hasAttribution)) {
       oldNotes++;
       continue;
     }
@@ -1237,25 +1260,33 @@ export function contentFormatOf(content: unknown): ContentFormat | null {
 }
 
 // Is this item part of the note (as opposed to the article card, a home-app
-// block, or the attribution line)? Older Offprint shares carried the article as
-// an ordinary text line rather than a card, so a text block holding the article
-// URL is the card too.
-function isNoteItem(item: unknown, prefix: string, articleUrl: string | undefined): boolean {
+// block, or an attribution line we added)? Older Offprint shares carried the
+// article as an ordinary text line rather than a card, so a text block holding
+// the article URL is the card too.
+function isNoteItem(
+  item: unknown,
+  prefix: string,
+  articleUrl: string | undefined,
+  hasAttribution: boolean
+): boolean {
   const block = item as { $type?: string; plaintext?: unknown } | undefined;
   if (block?.$type === `${prefix}blockquote`) return true;
   if (block?.$type !== `${prefix}text`) return false;
   const plaintext = typeof block.plaintext === 'string' ? block.plaintext : '';
-  if (isAttributionText(plaintext)) return false;
+  if (isGeneratedAttribution(plaintext, hasAttribution)) return false;
   return !(articleUrl && plaintext.includes(articleUrl));
 }
 
 // Swap the note region of a pckt/Offprint body, keeping the article block where
 // it was found and preserving anything the home app added alongside it.
+// `hasAttribution` is the record's `skyreaderAttribution` flag — see
+// replaceLeafletNoteRegion.
 export function replaceItemsNoteRegion(
   existing: unknown,
   format: 'pckt' | 'offprint',
   note: string,
-  article: { url?: string; title?: string }
+  article: { url?: string; title?: string },
+  hasAttribution = false
 ): unknown {
   const content = existing as { $type?: string; items?: unknown[] } | undefined;
   const prefix = ITEM_PREFIX[format];
@@ -1267,11 +1298,11 @@ export function replaceItemsNoteRegion(
   let notesBeforeExtras = -1;
   for (const item of items) {
     const plaintext = (item as { plaintext?: unknown } | undefined)?.plaintext;
-    if (isAttributionText(plaintext)) {
+    if (isGeneratedAttribution(plaintext, hasAttribution)) {
       hadAttribution = true;
       continue;
     }
-    if (isNoteItem(item, prefix, article.url)) {
+    if (isNoteItem(item, prefix, article.url, hasAttribution)) {
       oldNotes++;
       continue;
     }
@@ -1303,12 +1334,15 @@ export function replaceItemsNoteRegion(
 }
 
 // Swap the note in a Markdown body, keeping the article link line verbatim and in
-// the same place, and preserving an attribution line. (The old implementation
-// rebuilt the body as `[note, linkLine]` and so dropped anything after the link.)
+// the same place, and preserving an attribution line we added. (The old
+// implementation rebuilt the body as `[note, linkLine]` and so dropped anything
+// after the link.) `hasAttribution` is the record's `skyreaderAttribution` flag —
+// see replaceLeafletNoteRegion.
 export function replaceMarkpubNote(
   existing: unknown,
   note: string,
-  article: { url?: string; title?: string }
+  article: { url?: string; title?: string },
+  hasAttribution = false
 ): unknown {
   const content = existing as { text?: { markdown?: string } } | undefined;
   const markdown = content?.text?.markdown ?? '';
@@ -1329,7 +1363,7 @@ export function replaceMarkpubNote(
       : article.url
         ? markpubLinkLine(article.url, article.title)
         : '';
-  const hadAttribution = lines.some((line) => isAttributionText(line));
+  const hadAttribution = lines.some((line) => isGeneratedAttribution(line, hasAttribution));
 
   // Where the link sat relative to the note text is the layout to preserve. With
   // no link line found there's no evidence, and 'bottom' is what such a record was
@@ -1337,7 +1371,7 @@ export function replaceMarkpubNote(
   const noteText = (from: number, to: number) =>
     lines
       .slice(from, to)
-      .filter((line) => !isAttributionText(line))
+      .filter((line) => !isGeneratedAttribution(line, hasAttribution))
       .join('\n')
       .trim();
   const position: LinkblogCardPosition =
@@ -1839,6 +1873,10 @@ export async function updateLinkblogShareNote(
   // richtext feature; the other formats store the note as plain text.)
   const resolvedHandles =
     format === 'leaflet' ? await resolveNoteMentionHandles(trimmedNote) : new Map<string, string>();
+  // Only a record that opted into attribution has a generated line to carry
+  // through. On every other record that sentence is the author's own — rebuilt
+  // from the submitted note like any other line, and removable.
+  const hasAttribution = rec.skyreaderAttribution === true;
 
   const updated: DocumentRecord = {
     ...rec,
@@ -1848,10 +1886,10 @@ export async function updateLinkblogShareNote(
     textContent: [trimmedNote, excerpt].filter(Boolean).join('\n\n') || undefined,
     content:
       format === 'leaflet'
-        ? replaceLeafletNoteRegion(rec.content, trimmedNote, resolvedHandles)
+        ? replaceLeafletNoteRegion(rec.content, trimmedNote, resolvedHandles, hasAttribution)
         : format === 'markpub'
-          ? replaceMarkpubNote(rec.content, trimmedNote, article)
-          : replaceItemsNoteRegion(rec.content, format, trimmedNote, article),
+          ? replaceMarkpubNote(rec.content, trimmedNote, article, hasAttribution)
+          : replaceItemsNoteRegion(rec.content, format, trimmedNote, article, hasAttribution),
   };
 
   const written = await pdsClient.putRecord(DOCUMENT_COLLECTION, rkey, updated);

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -111,6 +111,72 @@ export const LINKBLOG_RKEY = 'skyreader-links';
 // See LINKBLOG_PLAN.md Phase 6.
 export const LINKBLOG_MARKER_URL = 'https://skyreader.app/linkblog';
 
+// ── The `links` field, and why it is not an array ────────────────────────────
+//
+// `site.standard.document.links` is where a link post carries the article it
+// points at. Until recently the lexicon declared an ARRAY of `{uri, rel}`, which
+// is what every record in the wild holds and what Constellation indexes at
+// `.links[].uri`.
+//
+// standard.site now declares it as a BARE OPEN UNION — a single object that must
+// carry a `$type` — while the description still reads "Array of values" and no
+// member type is published (`refs` is empty). Writers only noticed when Bluesky
+// PDS lexicon resolution began enforcing it: array-form writes that succeeded on
+// 2026-08-24 now fail validation with
+//
+//   Expected an object which includes the "$type" property ... at $.record.links
+//
+// Reported upstream as standard.site/lexicons#17 (filed by snarfed.org, no
+// maintainer reply as of 2026-09-09).
+//
+// So we wrap the refs in one object of our own type. An open union accepts any
+// `$type` it does not know, which is the mechanism `skyreaderLinkblog` already
+// proves in production. This is a WORKAROUND, not a shape anyone else reads:
+// when upstream restores the array, new records should go back to it and this
+// constant retires. Readers stay tolerant of both either way, because records
+// written under each shape are immutable until edited.
+export const DOCUMENT_LINKS_TYPE = 'app.skyreader.linkblog.links';
+
+export interface DocumentLinkRef {
+  uri: string;
+  rel?: string;
+}
+
+/** The union-object form we write. */
+export interface DocumentLinksUnion {
+  $type: string;
+  refs: DocumentLinkRef[];
+}
+
+/** Either shape, as a record read back off the PDS may hold. */
+export type DocumentLinksField = DocumentLinksUnion | DocumentLinkRef[];
+
+/**
+ * Flatten whichever shape a record holds into plain refs.
+ *
+ * Tolerating both is permanent, not transitional: every record written before
+ * the lexicon changed still holds the array, and an old record only takes the
+ * new shape if the author happens to edit it.
+ */
+export function readDocumentLinks(links: unknown): DocumentLinkRef[] {
+  const raw = Array.isArray(links)
+    ? links
+    : Array.isArray((links as DocumentLinksUnion | undefined)?.refs)
+      ? (links as DocumentLinksUnion).refs
+      : [];
+  return raw
+    .filter((l): l is DocumentLinkRef => typeof (l as DocumentLinkRef)?.uri === 'string')
+    .filter((l) => !!l.uri)
+    .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }));
+}
+
+/** Wrap refs for writing. Undefined when there is nothing to link, so we never
+ *  put an empty object where the lexicon expects a value. */
+export function buildDocumentLinks(refs: DocumentLinkRef[]): DocumentLinksUnion | undefined {
+  if (refs.length === 0) return undefined;
+  return { $type: DOCUMENT_LINKS_TYPE, refs };
+}
+
 export type ContentFormat = 'leaflet' | 'pckt' | 'offprint' | 'markpub';
 export interface LinkblogTarget {
   siteUri: string;
@@ -644,7 +710,9 @@ interface DocumentRecord {
   description?: string;
   textContent?: string;
   tags?: string[];
-  links?: Array<{ uri: string; rel: string }>;
+  // Either shape — see DOCUMENT_LINKS_TYPE. We write the union; records
+  // predating the lexicon change hold the array.
+  links?: DocumentLinksField;
   content?: unknown;
   // Provenance marker: "Skyreader wrote this link post" (same constant the
   // publication carries — see LINKBLOG_MARKER_URL). Load-bearing once a linkblog
@@ -1072,8 +1140,8 @@ export function buildLinkblogDocument(
   const note = input.note?.trim();
   const textContent = [note, excerpt].filter(Boolean).join('\n\n') || undefined;
 
-  const links: Array<{ uri: string; rel: string }> = [{ uri: input.articleUrl, rel: 'related' }];
-  if (input.repostUri) links.push({ uri: input.repostUri, rel: 'repost' });
+  const linkRefs: DocumentLinkRef[] = [{ uri: input.articleUrl, rel: 'related' }];
+  if (input.repostUri) linkRefs.push({ uri: input.repostUri, rel: 'repost' });
 
   return {
     $type: DOCUMENT_COLLECTION,
@@ -1095,7 +1163,7 @@ export function buildLinkblogDocument(
     description: undefined,
     textContent,
     tags: input.tags && input.tags.length > 0 ? input.tags : undefined,
-    links,
+    links: buildDocumentLinks(linkRefs),
     content: buildContent(format, input, excerpt, resolvedHandles, formatting),
     // See DocumentRecord.skyreaderLinkblog — the tell that separates a Skyreader
     // share from a post the connected publication's home app wrote.
@@ -1862,7 +1930,7 @@ export async function updateLinkblogShareNote(
   const excerpt = card.excerpt || rec.description || '';
   const trimmedNote = note.trim();
   const article = {
-    url: rec.links?.find((l) => /^https?:\/\//i.test(l.uri))?.uri,
+    url: readDocumentLinks(rec.links).find((l) => /^https?:\/\//i.test(l.uri))?.uri,
     // The card's own title first: `rec.title` may carry a decoration (🔗 …, “…”)
     // that must never become a card title if the card has to be rebuilt. Stripping
     // is the fallback for a record whose card is genuinely missing.
@@ -1881,6 +1949,10 @@ export async function updateLinkblogShareNote(
   const updated: DocumentRecord = {
     ...rec,
     $type: DOCUMENT_COLLECTION,
+    // Re-wrap the refs on the way out. `...rec` would otherwise put back the
+    // array an older record holds, which the lexicon now rejects — so editing
+    // any pre-existing post would fail. Same refs, current shape.
+    links: buildDocumentLinks(readDocumentLinks(rec.links)),
     // Backfill the marker onto pre-marker shares while we're rewriting anyway.
     skyreaderLinkblog: LINKBLOG_MARKER_URL,
     textContent: [trimmedNote, excerpt].filter(Boolean).join('\n\n') || undefined,

--- a/backend/src/services/linkblog-sync.ts
+++ b/backend/src/services/linkblog-sync.ts
@@ -17,6 +17,7 @@ import {
 import { resolveHandle } from './oauth';
 import { OFFPRINT_SCOPES, PCKT_SCOPES } from '../config/scopes';
 import { parseHandleTokens, buildMentionFacet, type MentionFacet } from '../utils/mention-facets';
+import { generateTid } from '../utils/tid';
 
 // Cap on the number of distinct handles we resolve per note. Each unique handle
 // costs up to a few sequential network round-trips (resolveHandle), all on the
@@ -93,8 +94,35 @@ export const COMPANION_COLLECTIONS: Partial<Record<ContentFormat, string>> = {
   offprint: OFFPRINT_ARTICLE_COLLECTION,
 };
 
-// One dedicated linkblog publication per user, at a fixed rkey.
-export const LINKBLOG_RKEY = 'skyreader-links';
+// The rkey every Skyreader linkblog publication used to live at, and where every
+// one created before 2026-09 still lives.
+//
+// `site.standard.publication` declares `"key": "tid"`. Bluesky PDS lexicon
+// resolution now enforces that — a write here fails with `Invalid TID string
+// (got "skyreader-links")` — so new publications are minted at a real TID
+// instead (see `ensureLinkblogPublication`). This constant is not dead: it is
+// what a user with no stored rkey resolves to, which is every user who had a
+// linkblog before the change. Their publication stays put, because the documents
+// pointing at it are immutable until edited and moving it would strand them.
+export const LEGACY_LINKBLOG_RKEY = 'skyreader-links';
+
+const TID_RE = /^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$/;
+
+/**
+ * Can we still write a publication record at this rkey?
+ *
+ * Only a spec TID passes the lexicon now. A legacy publication is therefore
+ * READ-ONLY on the PDS: it renders, it keeps receiving documents (a document's
+ * `site` is a plain string the lexicon doesn't police), but its own record can
+ * never be rewritten again.
+ */
+export function isWritablePublicationRkey(rkey: string): boolean {
+  return TID_RE.test(rkey);
+}
+
+export function rkeyFromPublicationUri(uri: string): string {
+  return uri.split('/').pop() || LEGACY_LINKBLOG_RKEY;
+}
 
 // Discovery marker. Every linkblog publication carries this single constant URL
 // so Constellation indexes them all under one target — turning the backlink
@@ -182,6 +210,17 @@ export interface LinkblogTarget {
   siteUri: string;
   format: ContentFormat;
   external: boolean;
+  // The user's OWN Skyreader publication, whether or not they publish there
+  // right now. Carried on the target because it is no longer computable from a
+  // DID: publications minted since the TID change each have their own rkey (see
+  // LEGACY_LINKBLOG_RKEY). Equals `siteUri` unless a foreign one is connected.
+  defaultSiteUri: string;
+  // The `skyreader-links` publication, when this user's own publication is
+  // somewhere else. Readers scope to it as well so that a move interrupted
+  // partway (see migrateLegacyPublication) still shows every post, wherever it
+  // currently lives. Empty for a user who never had a legacy publication, at the
+  // cost of one scope that always comes back empty.
+  legacySiteUri?: string;
 }
 
 // ── Per-user post formatting ─────────────────────────────────────────────────
@@ -268,8 +307,18 @@ function isGeneratedAttribution(value: unknown, hasAttribution: boolean): boolea
 
 const CONTENT_FORMATS = new Set<ContentFormat>(['leaflet', 'pckt', 'offprint', 'markpub']);
 
-export function defaultLinkblogTarget(did: string): LinkblogTarget {
-  return { siteUri: publicationUri(did), format: 'leaflet', external: false };
+export function defaultLinkblogTarget(did: string, rkey?: string | null): LinkblogTarget {
+  const resolved = rkey || LEGACY_LINKBLOG_RKEY;
+  const siteUri = publicationUriFor(did, resolved);
+  return {
+    siteUri,
+    format: 'leaflet',
+    external: false,
+    defaultSiteUri: siteUri,
+    ...(resolved === LEGACY_LINKBLOG_RKEY
+      ? {}
+      : { legacySiteUri: publicationUriFor(did, LEGACY_LINKBLOG_RKEY) }),
+  };
 }
 
 // Turn a stored `linkblog_publication` setting into a target, ignoring anything
@@ -277,9 +326,10 @@ export function defaultLinkblogTarget(did: string): LinkblogTarget {
 function targetFromRow(
   did: string,
   publication: string | null | undefined,
-  contentFormat: string | null | undefined
+  contentFormat: string | null | undefined,
+  rkey?: string | null
 ): LinkblogTarget {
-  const fallback = defaultLinkblogTarget(did);
+  const fallback = defaultLinkblogTarget(did, rkey);
   if (!publication) return fallback;
   const match = publication.match(/^at:\/\/([^/]+)\/site\.standard\.publication\/([^/]+)$/);
   if (!match || match[1] !== did) return fallback;
@@ -290,17 +340,28 @@ function targetFromRow(
     siteUri: publication,
     format,
     external: publication !== fallback.siteUri,
+    defaultSiteUri: fallback.defaultSiteUri,
+    ...(fallback.legacySiteUri ? { legacySiteUri: fallback.legacySiteUri } : {}),
   };
 }
 
 export async function getLinkblogTarget(env: Env, did: string): Promise<LinkblogTarget> {
   try {
     const row = await env.DB.prepare(
-      'SELECT linkblog_publication, linkblog_content_format FROM user_settings WHERE user_did = ?'
+      'SELECT linkblog_publication, linkblog_content_format, linkblog_rkey FROM user_settings WHERE user_did = ?'
     )
       .bind(did)
-      .first<{ linkblog_publication: string | null; linkblog_content_format: string | null }>();
-    return targetFromRow(did, row?.linkblog_publication, row?.linkblog_content_format);
+      .first<{
+        linkblog_publication: string | null;
+        linkblog_content_format: string | null;
+        linkblog_rkey: string | null;
+      }>();
+    return targetFromRow(
+      did,
+      row?.linkblog_publication,
+      row?.linkblog_content_format,
+      row?.linkblog_rkey
+    );
   } catch {
     // Deploys remain usable while a migration is rolling out.
     return defaultLinkblogTarget(did);
@@ -379,7 +440,7 @@ export async function getLinkblogTargets(
       const chunk = unique.slice(i, i + TARGET_LOOKUP_CHUNK);
       const placeholders = chunk.map(() => '?').join(',');
       const rows = await env.DB.prepare(
-        `SELECT user_did, linkblog_publication, linkblog_content_format
+        `SELECT user_did, linkblog_publication, linkblog_content_format, linkblog_rkey
          FROM user_settings WHERE user_did IN (${placeholders})`
       )
         .bind(...chunk)
@@ -387,11 +448,17 @@ export async function getLinkblogTargets(
           user_did: string;
           linkblog_publication: string | null;
           linkblog_content_format: string | null;
+          linkblog_rkey: string | null;
         }>();
       for (const row of rows.results ?? []) {
         out.set(
           row.user_did,
-          targetFromRow(row.user_did, row.linkblog_publication, row.linkblog_content_format)
+          targetFromRow(
+            row.user_did,
+            row.linkblog_publication,
+            row.linkblog_content_format,
+            row.linkblog_rkey
+          )
         );
       }
     }
@@ -457,8 +524,20 @@ interface PublicationRecord {
   skyreaderLinkblog?: string;
 }
 
+export function publicationUriFor(did: string, rkey: string): string {
+  return `at://${did}/${PUBLICATION_COLLECTION}/${rkey}`;
+}
+
+/**
+ * The Skyreader publication URI for a user we know nothing else about.
+ *
+ * Only correct for a user whose rkey is the legacy one — which is every user who
+ * predates the TID change, but not one whose publication was minted after it.
+ * Prefer `LinkblogTarget.defaultSiteUri`, which carries the user's actual rkey;
+ * this is the fallback the target itself is built from.
+ */
 export function publicationUri(did: string): string {
-  return `at://${did}/${PUBLICATION_COLLECTION}/${LINKBLOG_RKEY}`;
+  return publicationUriFor(did, LEGACY_LINKBLOG_RKEY);
 }
 
 // The canonical public base for a user's linkblog. DID-based so it survives
@@ -544,7 +623,7 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
   // with no visible control to turn it back on.
   const pageHidden = visibility.pageHidden && target.external;
   const pdsClient = createPDSClient(session);
-  const rkey = target.siteUri.split('/').pop() || LINKBLOG_RKEY;
+  const rkey = rkeyFromPublicationUri(target.siteUri);
   const result = await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, rkey);
 
   const url = linkblogBaseUrl(env, session.did);
@@ -584,6 +663,43 @@ export async function getPublicationMeta(session: Session, env: Env): Promise<Pu
   };
 }
 
+/**
+ * The rkey of the user's OWN publication, and whether we actually read it.
+ *
+ * `getLinkblogTarget` folds a failed settings read into the legacy default,
+ * which is the right answer for a reader — fail open, show something — and the
+ * wrong one for a writer. A writer that mints at the legacy fallback because the
+ * real rkey merely couldn't be READ orphans the publication that rkey names, so
+ * the write paths take the rkey from here and refuse to mint on `trusted: false`.
+ *
+ * The one failure that is still trustworthy is a pre-0078 deploy window, where
+ * the column doesn't exist yet: nobody has a stored rkey then, so legacy is the
+ * true answer rather than a guess.
+ */
+async function readPublicationRkey(
+  env: Env,
+  did: string
+): Promise<{ rkey: string; trusted: boolean }> {
+  try {
+    const row = await env.DB.prepare('SELECT linkblog_rkey FROM user_settings WHERE user_did = ?')
+      .bind(did)
+      .first<{ linkblog_rkey: string | null }>();
+    return { rkey: row?.linkblog_rkey || LEGACY_LINKBLOG_RKEY, trusted: true };
+  } catch (error) {
+    const missingColumn = /no such column/i.test(String(error));
+    if (!missingColumn) {
+      console.warn(`[linkblog] could not read publication rkey for ${did}: ${error}`);
+    }
+    return { rkey: LEGACY_LINKBLOG_RKEY, trusted: missingColumn };
+  }
+}
+
+const UNTRUSTED_RKEY_ERROR = {
+  success: false,
+  error: 'Could not read linkblog settings',
+  retryable: true,
+} as const;
+
 // Create the linkblog publication if it doesn't already exist. Idempotent and
 // non-destructive: if a record is already there (possibly user-customized), it's
 // left untouched. Returns the publication AT URI.
@@ -592,10 +708,8 @@ export async function ensureLinkblogPublication(
   env: Env
 ): Promise<PDSResult<{ uri: string; created: boolean }>> {
   const pdsClient = createPDSClient(session);
-  const existing = await pdsClient.getRecord<PublicationRecord>(
-    PUBLICATION_COLLECTION,
-    LINKBLOG_RKEY
-  );
+  const { rkey, trusted } = await readPublicationRkey(env, session.did);
+  const existing = await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, rkey);
 
   if (existing.success) {
     // Lazy backfill on each share — non-destructive (preserves user-customized
@@ -612,21 +726,38 @@ export async function ensureLinkblogPublication(
     const expectedUrl = linkblogBaseUrl(env, session.did);
     const needsMarker = value.skyreaderLinkblog !== LINKBLOG_MARKER_URL;
     const needsUrl = value.url !== expectedUrl;
-    if (needsMarker || needsUrl) {
+    // A legacy publication can never be rewritten again (see
+    // isWritablePublicationRkey), and this heal is cosmetic by design. Skipping
+    // it keeps the share going; failing it would take every share down with a
+    // 502 for the sake of a `url` field nobody's read path depends on.
+    if ((needsMarker || needsUrl) && isWritablePublicationRkey(rkey)) {
       const updated: PublicationRecord = {
         ...value,
         $type: PUBLICATION_COLLECTION,
         url: expectedUrl,
         skyreaderLinkblog: LINKBLOG_MARKER_URL,
       };
-      const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY, updated);
+      const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, rkey, updated);
       if (!put.success) return put;
     }
     return {
       success: true,
-      data: { uri: publicationUri(session.did), created: false },
+      data: { uri: publicationUriFor(session.did, rkey), created: false },
     };
   }
+
+  // Only "no such record" means there is nothing here. Any other read failure is
+  // an answer we don't have: treating it as absent would mint a SECOND
+  // publication and repoint the stored rkey, orphaning the real one and every
+  // document in it. Better to fail the share and let the client retry.
+  if (!isNotFoundError(existing.error)) return existing;
+  if (!trusted) return UNTRUSTED_RKEY_ERROR;
+
+  // Nothing there yet. If the rkey we resolved is the legacy one, this user has
+  // no publication at all — mint a real TID and remember it, because a fixed
+  // constant is exactly what the lexicon now rejects. A stored TID whose record
+  // has gone missing is recreated where it was.
+  const writeRkey = isWritablePublicationRkey(rkey) ? rkey : generateTid();
 
   const record: PublicationRecord = {
     $type: PUBLICATION_COLLECTION,
@@ -635,12 +766,37 @@ export async function ensureLinkblogPublication(
     skyreaderLinkblog: LINKBLOG_MARKER_URL,
   };
 
-  const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY, record);
+  const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, writeRkey, record);
   if (!put.success) return put;
+  if (writeRkey !== rkey) await persistPublicationRkey(env, session.did, writeRkey);
   return {
     success: true,
-    data: { uri: publicationUri(session.did), created: true },
+    data: { uri: publicationUriFor(session.did, writeRkey), created: true },
   };
+}
+
+/**
+ * Remember the rkey of a freshly minted publication.
+ *
+ * Best-effort on purpose: the record is already written, and losing this row
+ * would only make the next resolve fall back to the legacy rkey and mint a
+ * second publication. Worth a warning, not worth failing the share that just
+ * succeeded.
+ */
+async function persistPublicationRkey(env: Env, did: string, rkey: string): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  try {
+    await env.DB.prepare(
+      `INSERT INTO user_settings (user_did, linkblog_rkey, created_at, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(user_did) DO UPDATE SET linkblog_rkey = excluded.linkblog_rkey,
+       updated_at = excluded.updated_at`
+    )
+      .bind(did, rkey, now, now)
+      .run();
+  } catch (error) {
+    console.warn(`[linkblog] could not persist publication rkey for ${did}: ${error}`);
+  }
 }
 
 // Update the publication's name/description, preserving url + icon. Creates the
@@ -649,12 +805,23 @@ export async function updatePublication(
   session: Session,
   env: Env,
   updates: { name?: string; description?: string }
-): Promise<PDSResult<PutRecordResponse>> {
+): Promise<PDSResult<PutRecordResponse & { move?: PublicationMove }>> {
   const pdsClient = createPDSClient(session);
-  const existing = await pdsClient.getRecord<PublicationRecord>(
-    PUBLICATION_COLLECTION,
-    LINKBLOG_RKEY
-  );
+  const { rkey, trusted } = await readPublicationRkey(env, session.did);
+  const existing = await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, rkey);
+  // As in ensureLinkblogPublication: only a genuine absence may be written over.
+  if (!existing.success && !isNotFoundError(existing.error)) return existing;
+  if (!trusted) return UNTRUSTED_RKEY_ERROR;
+
+  // A move is owed whenever a record still sits at the LEGACY rkey — not merely
+  // when the rkey we resolved is the legacy one. A move interrupted after the new
+  // rkey was stored resolves to a TID, and gating on that would strand its
+  // documents (and its followers) at the old URI with no way back in.
+  const owesMove = isWritablePublicationRkey(rkey)
+    ? (await pdsClient.getRecord<PublicationRecord>(PUBLICATION_COLLECTION, LEGACY_LINKBLOG_RKEY))
+        .success
+    : existing.success;
+  const writeRkey = isWritablePublicationRkey(rkey) ? rkey : generateTid();
 
   const base: PublicationRecord = existing.success
     ? existing.data.value
@@ -677,7 +844,169 @@ export async function updatePublication(
     else delete record.description;
   }
 
-  return pdsClient.putRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY, record);
+  // A legacy publication can't be rewritten where it stands, so the edit becomes
+  // a move: the same record, written at a TID, with every document repointed.
+  // `writeRkey` is the destination either way — a fresh TID on the first attempt,
+  // the one already stored when this run is finishing an interrupted move.
+  if (owesMove) {
+    const moved = await migrateLegacyPublication(session, env, record, writeRkey);
+    if (!moved.success) return moved;
+    return { success: true, data: { uri: moved.data.to, cid: '', move: moved.data } };
+  }
+
+  const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, writeRkey, record);
+  if (!put.success) return put;
+  if (writeRkey !== rkey) await persistPublicationRkey(env, session.did, writeRkey);
+  return { success: true, data: put.data };
+}
+
+// ── Moving a legacy publication onto a TID rkey ──────────────────────────────
+//
+// A publication at `skyreader-links` can never be rewritten again, which means
+// its owner can't rename their linkblog. The fix is to move it: mint the record
+// at a real TID and repoint every document that named the old one.
+//
+// The documents are the reason this is a move and not a fresh start — `site` is
+// what binds a post to a publication, so leaving them behind would split the
+// linkblog in two, with foreign readers of either publication seeing half the
+// posts. Skyreader-owned publications are always `leaflet` format, which has no
+// companion record (see COMPANION_COLLECTIONS), so the documents are the whole
+// job.
+//
+// Ordering is chosen so an interrupted run is never visibly broken: the new rkey
+// is stored BEFORE the walk, and readers scope to the legacy publication as well
+// as the current one (see LinkblogTarget.legacySiteUri), so posts on either side
+// of a half-finished move still render.
+//
+// The legacy publication RECORD is what says a move is still owed, so it is
+// deleted last and only on a walk that reached the end — including the walk
+// running out of pages, which is a partial move wearing a success. `owesMove` in
+// updatePublication looks for that record rather than at the resolved rkey, so
+// the next rename picks the move back up and the walk only touches documents
+// that still name the old URI.
+const MOVE_BATCH_SIZE = 200;
+const MAX_MOVE_PAGES = 100;
+
+async function movePublicationDocuments(
+  client: PDSClient,
+  did: string,
+  fromUri: string,
+  toUri: string
+): Promise<PDSResult<{ moved: number; complete: boolean }>> {
+  let cursor: string | undefined;
+  let moved = 0;
+  let complete = false;
+
+  for (let page = 0; page < MAX_MOVE_PAGES; page++) {
+    const listed = await client.listRecords<DocumentRecord>(DOCUMENT_COLLECTION, cursor);
+    if (!listed.success) {
+      return { success: false, error: listed.error, retryable: !!listed.retryable };
+    }
+    const ours = listed.data.records
+      .filter(
+        (record) => record.value?.site === fromUri && isSkyreaderShareRecord(did, record.value)
+      )
+      .map((record) => ({ rkey: record.uri.split('/').pop() ?? '', value: record.value }))
+      .filter((record) => record.rkey);
+
+    for (let i = 0; i < ours.length; i += MOVE_BATCH_SIZE) {
+      const chunk = ours.slice(i, i + MOVE_BATCH_SIZE);
+      const batch = await client.applyWrites(
+        chunk.map(({ rkey, value }) => ({
+          $type: 'com.atproto.repo.applyWrites#update' as const,
+          collection: DOCUMENT_COLLECTION,
+          rkey,
+          value: {
+            ...value,
+            $type: DOCUMENT_COLLECTION,
+            site: toUri,
+            // The whole record goes back to the PDS, so a legacy array `links`
+            // would fail validation on the way — re-wrap it (see
+            // DOCUMENT_LINKS_TYPE). Same refs, current shape.
+            links: buildDocumentLinks(readDocumentLinks(value.links)),
+          },
+        }))
+      );
+      if (!batch.success) {
+        return { success: false, error: batch.error, retryable: !!batch.retryable };
+      }
+      moved += chunk.length;
+    }
+
+    cursor = listed.data.cursor || undefined;
+    if (!cursor || listed.data.records.length === 0) {
+      complete = true;
+      break;
+    }
+  }
+
+  return { success: true, data: { moved, complete } };
+}
+
+export interface PublicationMove {
+  from: string;
+  to: string;
+  movedPosts: number;
+  /**
+   * Every document that named the old publication now names the new one. False
+   * when the walk ran out of pages with records still to visit — the linkblog is
+   * whole to a Skyreader reader either way (legacySiteUri covers both), and the
+   * next rename resumes from where this one stopped.
+   */
+  complete: boolean;
+}
+
+/**
+ * Move the user's legacy publication onto `toRkey`, carrying its fields (and any
+ * pending edits) across.
+ *
+ * `toRkey` is a fresh TID on the first attempt and the rkey already stored when
+ * this run is finishing an interrupted move — re-minting there would leave a
+ * third publication behind and lose the documents the first attempt did move.
+ *
+ * The old publication record is deleted only once every document has been
+ * repointed — while it exists, it is the marker that a move is unfinished.
+ */
+export async function migrateLegacyPublication(
+  session: Session,
+  env: Env,
+  record: PublicationRecord,
+  toRkey: string
+): Promise<PDSResult<PublicationMove>> {
+  const pdsClient = createPDSClient(session);
+  const fromUri = publicationUriFor(session.did, LEGACY_LINKBLOG_RKEY);
+  const toUri = publicationUriFor(session.did, toRkey);
+
+  const put = await pdsClient.putRecord(PUBLICATION_COLLECTION, toRkey, record);
+  if (!put.success) return put;
+
+  // Before the walk: a crash from here on leaves new shares landing in the new
+  // publication and the reader still seeing both (legacySiteUri).
+  await persistPublicationRkey(env, session.did, toRkey);
+
+  const moved = await movePublicationDocuments(pdsClient, session.did, fromUri, toUri);
+  if (!moved.success) return moved;
+
+  if (moved.data.complete) {
+    // Best-effort: an orphaned empty publication is untidy, not broken, and the
+    // rename that triggered this has already succeeded.
+    const removed = await pdsClient.deleteRecord(PUBLICATION_COLLECTION, LEGACY_LINKBLOG_RKEY);
+    if (!removed.success && !isNotFoundError(removed.error)) {
+      console.warn(
+        `[linkblog] legacy publication left in place for ${session.did}: ${removed.error}`
+      );
+    }
+  } else {
+    // Keep it: it's the marker the next rename resumes from.
+    console.warn(
+      `[linkblog] move for ${session.did} hit the page cap with documents still at ${fromUri}`
+    );
+  }
+
+  return {
+    success: true,
+    data: { from: fromUri, to: toUri, movedPosts: moved.data.moved, complete: moved.data.complete },
+  };
 }
 
 // ── Document (a share) ───────────────────────────────────────────────────────
@@ -1551,9 +1880,14 @@ export async function writeLinkblogShare(
     getLinkblogTarget(env, session.did),
     getLinkblogFormatting(env, session.did),
   ]);
+  // The ensured URI, not `target.siteUri`: a first-ever share mints the
+  // publication at a fresh TID, and the target was read before that happened. A
+  // document pointing at the rkey we no longer use would be orphaned.
+  let siteUri = target.siteUri;
   if (!target.external) {
     const ensured = await ensureLinkblogPublication(session, env);
     if (!ensured.success) return ensured;
+    siteUri = ensured.data.uri;
   }
 
   const resolvedHandles = await resolveNoteMentionHandles(input.note);
@@ -1562,21 +1896,14 @@ export async function writeLinkblogShare(
     rkey,
     input,
     resolvedHandles,
-    target.siteUri,
+    siteUri,
     target.format,
     formatting
   );
   const client = createPDSClient(session);
   const written = await client.putRecord(DOCUMENT_COLLECTION, rkey, record);
   if (written.success) {
-    await syncCompanionRecord(
-      client,
-      session.did,
-      target.format,
-      target.siteUri,
-      rkey,
-      written.data
-    );
+    await syncCompanionRecord(client, session.did, target.format, siteUri, rkey, written.data);
   }
   return written;
 }
@@ -1709,7 +2036,10 @@ type PurgeResult =
   | { success: true; deletedPosts: number }
   | { success: false; error: string; retryable: boolean; deletedPosts: number };
 
-async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
+async function purgeLinkblogRecords(
+  session: Session,
+  publicationRkey: string
+): Promise<PurgeResult> {
   const client = createPDSClient(session);
   let cursor: string | undefined;
   let deletedPosts = 0;
@@ -1747,7 +2077,7 @@ async function purgeLinkblogRecords(session: Session): Promise<PurgeResult> {
 
     const nextCursor = listed.data.cursor || undefined;
     if (!nextCursor || listed.data.records.length === 0) {
-      const publication = await client.deleteRecord(PUBLICATION_COLLECTION, LINKBLOG_RKEY);
+      const publication = await client.deleteRecord(PUBLICATION_COLLECTION, publicationRkey);
       if (!publication.success && !isNotFoundError(publication.error)) {
         return {
           success: false,
@@ -1783,6 +2113,9 @@ export async function deleteLinkblog(
     getLinkblogTarget(env, session.did),
     isLinkblogDisabled(env, session.did),
   ]);
+  // Delete the publication we actually own, legacy rkey or minted TID.
+  // deleteRecord doesn't validate the key, so this works on both.
+  const publicationRkey = rkeyFromPublicationUri(previous.defaultSiteUri);
 
   // Disable first: every write path checks the flag, so this is what stops a
   // share racing the walk and landing a document behind it. The connected
@@ -1799,7 +2132,7 @@ export async function deleteLinkblog(
 
   let purged: PurgeResult;
   try {
-    purged = await purgeLinkblogRecords(session);
+    purged = await purgeLinkblogRecords(session, publicationRkey);
   } catch (e) {
     // purgeLinkblogRecords reports PDS failures as values, but an unexpected
     // throw (a D1 error, a client it couldn't build) would escape past the

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -81,7 +81,8 @@ export interface DocumentRecord {
   createdAt?: string;
   updatedAt?: string;
   content?: unknown;
-  links?: Array<{ uri?: string; rel?: string }>;
+  // Either the legacy array or the union object — see readRecordLinks.
+  links?: unknown;
   // Skyreader's provenance marker on a link post it wrote.
   skyreaderLinkblog?: string;
 }
@@ -326,6 +327,24 @@ export function publishedAtMs(doc: DocumentRecord, fallbackMs: number): number {
   return Number.isFinite(ms) ? ms : fallbackMs;
 }
 
+// `site.standard.document.links` comes in two shapes. It was an array of
+// `{uri, rel}` until standard.site redeclared it as a bare open union (a single
+// `$type`-bearing object); Skyreader now writes `{$type, refs: [...]}` so PDS
+// validation accepts the write (see backend linkblog-sync DOCUMENT_LINKS_TYPE,
+// and standard.site/lexicons#17). Every record written before that still holds
+// the array, so both are read here and flattened to one array — which is what
+// `ProxyDocument.links` has always been, so nothing downstream changes.
+function readRecordLinks(raw: unknown): Array<{ uri: string; rel?: string }> {
+  const entries = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { refs?: unknown } | undefined)?.refs)
+      ? (raw as { refs: Array<{ uri?: string; rel?: string }> }).refs
+      : [];
+  return entries
+    .filter((l): l is { uri: string; rel?: string } => typeof l?.uri === 'string' && !!l.uri)
+    .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }));
+}
+
 /**
  * Map a raw `site.standard.document` record into the wire shape the frontend
  * consumes, given already-resolved publication metadata. Pure: every network- or
@@ -362,11 +381,7 @@ export function recordToDocument(
 
   // Surface external resource refs (the shared article URL for link posts),
   // keeping only entries with a real uri.
-  const links = Array.isArray(doc.links)
-    ? doc.links
-        .filter((l): l is { uri: string; rel?: string } => typeof l?.uri === 'string' && !!l.uri)
-        .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }))
-    : [];
+  const links = readRecordLinks(doc.links);
 
   return {
     authorDid,

--- a/backend/test/linkblog-formatting.spec.ts
+++ b/backend/test/linkblog-formatting.spec.ts
@@ -1,0 +1,176 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import worker from '../src/index';
+import { GRANULAR_SCOPES, LINKBLOG_SCOPES } from '../src/config/scopes';
+import { getLinkblogFormatting } from '../src/services/linkblog-sync';
+
+// How a link post is formatted on someone else's site is a per-user preference
+// (see migration 0076): the title decoration that keeps a share from reading as a
+// repost of the article, and where the link card sits relative to the note.
+//
+// What matters here:
+//  - Defaults come back for a user who has never chosen ('link' + 'context').
+//  - Only the known enum values are accepted; a bad value is a 400, not a stored
+//    string that would silently mean "the default" forever after.
+//  - A partial update leaves the other field alone.
+//  - The choices ride back on the publication meta the settings page already loads.
+
+const GRANTED_SCOPES = [GRANULAR_SCOPES, ...LINKBLOG_SCOPES].join(' ');
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+const TEST_DPOP_KEY = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+  y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+  d: 'jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI',
+};
+
+const TEST_DID = 'did:plc:formattingtest';
+const TEST_SESSION_ID = 'test-session-formatting';
+
+function makeAuthRequest(path: string, opts?: { method?: string; body?: unknown }) {
+  return new IncomingRequest(`http://localhost${path}`, {
+    method: opts?.method ?? 'GET',
+    headers: {
+      Cookie: `session_id=${TEST_SESSION_ID}`,
+      'Content-Type': 'application/json',
+      Origin: env.FRONTEND_URL,
+    },
+    body: opts?.body ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+async function send(request: Request) {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request as never, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function setFormatting(body: unknown) {
+  return send(makeAuthRequest('/api/linkblog/formatting', { method: 'PUT', body }));
+}
+
+interface Meta {
+  formatting: { titleStyle: string; cardPosition: string };
+}
+
+// The publication record doesn't exist yet (nothing has been shared), which is
+// exactly the state the settings page renders in before a first share.
+function stubPds() {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('getRecord')) {
+      return new Response(JSON.stringify({ error: 'RecordNotFound' }), { status: 404 });
+    }
+    if (url.includes('listRecords')) {
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+describe('linkblog post formatting', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    for (const [table, column] of [
+      ['user_settings', 'user_did'],
+      ['sessions', 'did'],
+      ['users', 'did'],
+    ]) {
+      await env.DB.prepare(`DELETE FROM ${table} WHERE ${column} = ?`).bind(TEST_DID).run();
+    }
+    await env.DB.prepare(
+      'INSERT INTO users (did, handle, pds_url, created_at) VALUES (?, ?, ?, unixepoch())'
+    )
+      .bind(TEST_DID, 'formatting.test', 'https://test.pds.example')
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO sessions (session_id, did, handle, pds_url, access_token, refresh_token, dpop_private_key, expires_at, granted_scopes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+      .bind(
+        TEST_SESSION_ID,
+        TEST_DID,
+        'formatting.test',
+        'https://test.pds.example',
+        'test-access-token',
+        'test-refresh-token',
+        JSON.stringify(TEST_DPOP_KEY),
+        Date.now() + 3600000,
+        GRANTED_SCOPES
+      )
+      .run();
+    stubPds();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('reports the new defaults for a user who has never chosen', async () => {
+    expect(await getLinkblogFormatting(env, TEST_DID)).toEqual({
+      titleStyle: 'link',
+      cardPosition: 'context',
+    });
+    const res = await send(makeAuthRequest('/api/linkblog/publication'));
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Meta).formatting).toEqual({
+      titleStyle: 'link',
+      cardPosition: 'context',
+    });
+  });
+
+  it('stores both choices and reports them on the publication meta', async () => {
+    const res = await setFormatting({ titleStyle: 'quoted', cardPosition: 'bottom' });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Meta).formatting).toEqual({
+      titleStyle: 'quoted',
+      cardPosition: 'bottom',
+    });
+    expect(await getLinkblogFormatting(env, TEST_DID)).toEqual({
+      titleStyle: 'quoted',
+      cardPosition: 'bottom',
+    });
+  });
+
+  it('leaves the other field alone on a partial update', async () => {
+    await setFormatting({ titleStyle: 'plain', cardPosition: 'top' });
+    const res = await setFormatting({ cardPosition: 'context' });
+    expect(((await res.json()) as Meta).formatting).toEqual({
+      titleStyle: 'plain',
+      cardPosition: 'context',
+    });
+  });
+
+  it.each([{ titleStyle: 'emoji' }, { cardPosition: 'middle' }, { titleStyle: 42 }])(
+    'rejects %o rather than storing it',
+    async (body) => {
+      const res = await setFormatting(body);
+      expect(res.status).toBe(400);
+      expect(await getLinkblogFormatting(env, TEST_DID)).toEqual({
+        titleStyle: 'link',
+        cardPosition: 'context',
+      });
+    }
+  );
+
+  it('needs a session', async () => {
+    const res = await send(
+      new IncomingRequest('http://localhost/api/linkblog/formatting', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Origin: env.FRONTEND_URL },
+        body: JSON.stringify({ titleStyle: 'plain' }),
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/test/linkblog-publication-rkey.spec.ts
+++ b/backend/test/linkblog-publication-rkey.spec.ts
@@ -1,0 +1,382 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ensureLinkblogPublication,
+  getLinkblogTarget,
+  isWritablePublicationRkey,
+  updatePublication,
+  LEGACY_LINKBLOG_RKEY,
+  publicationUriFor,
+} from '../src/services/linkblog-sync';
+import { generateTid } from '../src/utils/tid';
+import type { Env, Session } from '../src/types';
+
+// `site.standard.publication` declares `"key": "tid"`, and the PDS enforces it
+// now. Our old fixed rkey `skyreader-links` is not a TID, so:
+//   · a publication already there can never be rewritten — but it still renders,
+//     and documents may still point at it (a document's `site` is a plain string)
+//   · a new one has to be minted at a real TID, and remembered, because a fixed
+//     constant was the only thing making the URI computable from a DID
+const DID = 'did:plc:rkeytest';
+
+const TEST_DPOP_KEY = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+  y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+  d: 'jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI',
+};
+
+const SESSION: Session = {
+  did: DID,
+  handle: 'rkey.test',
+  pdsUrl: 'https://test.pds.example',
+  accessToken: 'test-access-token',
+  refreshToken: 'test-refresh-token',
+  dpopPrivateKey: JSON.stringify(TEST_DPOP_KEY),
+  expiresAt: Date.now() + 3_600_000,
+} as Session;
+
+type Listed = { uri: string; value: Record<string, unknown> };
+type Call = { endpoint: string; rkey?: string; body?: Record<string, unknown> };
+
+// A share document as it sits on the PDS before a move: our marker, and the
+// legacy array `links` every record written before the lexicon change carries.
+function shareRecord(rkey: string, site: string): Listed {
+  return {
+    uri: `at://${DID}/site.standard.document/${rkey}`,
+    value: {
+      $type: 'site.standard.document',
+      site,
+      title: 'A share',
+      skyreaderLinkblog: 'https://skyreader.app/linkblog',
+      links: [{ uri: 'https://example.com/an-article', rel: 'related' }],
+    },
+  };
+}
+
+// getRecord answers for the rkeys in `records`, listRecords returns `documents`
+// in one page, and every write is captured so a test can assert on it.
+//
+// `opts.endless` makes listRecords always hand back a cursor, so the move walk
+// runs out of pages instead of records. `opts.readError` makes every getRecord
+// fail with something that is NOT "no such record".
+function stubPds(
+  records: Record<string, Record<string, unknown>>,
+  documents: Listed[] = [],
+  opts: { endless?: boolean; readError?: boolean } = {}
+) {
+  const calls: Call[] = [];
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    const endpoint = url.pathname.split('/xrpc/')[1] ?? url.pathname;
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ endpoint, rkey: url.searchParams.get('rkey') ?? body?.rkey, body });
+    if (endpoint === 'com.atproto.repo.getRecord') {
+      if (opts.readError) {
+        return new Response(JSON.stringify({ error: 'InternalServerError' }), { status: 500 });
+      }
+      const record = records[url.searchParams.get('rkey') ?? ''];
+      if (!record) {
+        return new Response(
+          JSON.stringify({ error: 'RecordNotFound', message: 'Could not locate record' }),
+          { status: 400 }
+        );
+      }
+      return new Response(JSON.stringify({ uri: 'at://x', cid: 'bafy', value: record }), {
+        status: 200,
+      });
+    }
+    if (endpoint === 'com.atproto.repo.listRecords') {
+      const page: Record<string, unknown> = { records: documents };
+      if (opts.endless) page.cursor = 'more';
+      return new Response(JSON.stringify(page), { status: 200 });
+    }
+    return new Response(JSON.stringify({ uri: 'at://x', cid: 'bafy', commit: {} }), {
+      status: 200,
+    });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+// The write batches sent to applyWrites, in order.
+const applyWrites = (calls: Call[]) =>
+  calls
+    .filter((c) => c.endpoint === 'com.atproto.repo.applyWrites')
+    .map((c) => (c.body?.writes ?? []) as Array<{ $type: string; rkey: string; value?: unknown }>);
+
+const puts = (calls: Call[]) => calls.filter((c) => c.endpoint === 'com.atproto.repo.putRecord');
+
+// A publication record shaped like one written before the change: it will always
+// look like it needs the url/marker heal.
+const STALE_PUBLICATION = {
+  $type: 'site.standard.publication',
+  name: 'My links',
+  url: 'https://an-old-origin.example/blogs/did/',
+};
+
+async function storedRkey(): Promise<string | null> {
+  const row = await env.DB.prepare('SELECT linkblog_rkey FROM user_settings WHERE user_did = ?')
+    .bind(DID)
+    .first<{ linkblog_rkey: string | null }>();
+  return row?.linkblog_rkey ?? null;
+}
+
+describe('publication rkeys', () => {
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM user_settings WHERE user_did = ?').bind(DID).run();
+    await env.DB.prepare('DELETE FROM users WHERE did = ?').bind(DID).run();
+    await env.DB.prepare(
+      'INSERT INTO users (did, handle, pds_url, created_at) VALUES (?, ?, ?, unixepoch())'
+    )
+      .bind(DID, 'rkey.test', 'https://test.pds.example')
+      .run();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a spec TID and rejects the legacy fixed rkey', () => {
+    expect(isWritablePublicationRkey(LEGACY_LINKBLOG_RKEY)).toBe(false);
+    expect(isWritablePublicationRkey(generateTid())).toBe(true);
+    // 'l' is not in the TID alphabet's first position, and length is exact.
+    expect(isWritablePublicationRkey('3skyreaderlnk1')).toBe(false);
+  });
+
+  // The heal is cosmetic. Attempting it on a legacy publication is a guaranteed
+  // 400, which used to take the whole share down with it.
+  it('skips the url/marker heal on a legacy publication instead of failing', async () => {
+    const calls = stubPds({ [LEGACY_LINKBLOG_RKEY]: STALE_PUBLICATION });
+
+    const result = await ensureLinkblogPublication(SESSION, env as unknown as Env);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.uri).toBe(publicationUriFor(DID, LEGACY_LINKBLOG_RKEY));
+    expect(puts(calls)).toHaveLength(0);
+  });
+
+  it('mints a TID for a first publication and remembers it', async () => {
+    const calls = stubPds({});
+
+    const result = await ensureLinkblogPublication(SESSION, env as unknown as Env);
+
+    expect(result.success).toBe(true);
+    const written = puts(calls);
+    expect(written).toHaveLength(1);
+    const rkey = written[0].body?.rkey as string;
+    expect(isWritablePublicationRkey(rkey)).toBe(true);
+    expect(await storedRkey()).toBe(rkey);
+    expect(result.success && result.data.uri).toBe(publicationUriFor(DID, rkey));
+  });
+
+  it('resolves the stored rkey as the default publication, and heals there', async () => {
+    const rkey = generateTid();
+    await env.DB.prepare(
+      `INSERT INTO user_settings (user_did, linkblog_rkey, created_at, updated_at)
+       VALUES (?, ?, unixepoch(), unixepoch())`
+    )
+      .bind(DID, rkey)
+      .run();
+
+    const target = await getLinkblogTarget(env as unknown as Env, DID);
+    expect(target.defaultSiteUri).toBe(publicationUriFor(DID, rkey));
+    expect(target.siteUri).toBe(target.defaultSiteUri);
+    expect(target.external).toBe(false);
+
+    const calls = stubPds({ [rkey]: STALE_PUBLICATION });
+    const result = await ensureLinkblogPublication(SESSION, env as unknown as Env);
+    expect(result.success).toBe(true);
+    // Writable, so the heal it skips on a legacy publication does happen here.
+    expect(puts(calls).map((c) => c.body?.rkey)).toEqual([rkey]);
+  });
+
+  // Renaming would mean rewriting a record the lexicon won't let us write, so
+  // the rename becomes a move: same publication, minted at a TID, with every
+  // document repointed at it.
+  it('moves a legacy publication to a TID on rename, carrying its posts', async () => {
+    const calls = stubPds({ [LEGACY_LINKBLOG_RKEY]: STALE_PUBLICATION }, [
+      // Ours, at the legacy publication — both must move.
+      shareRecord('3kaaa', publicationUriFor(DID, LEGACY_LINKBLOG_RKEY)),
+      shareRecord('3kbbb', publicationUriFor(DID, LEGACY_LINKBLOG_RKEY)),
+      // Someone else's essay in a publication of their own — never touched.
+      {
+        uri: `at://${DID}/site.standard.document/3kccc`,
+        value: {
+          $type: 'site.standard.document',
+          site: `at://${DID}/site.standard.publication/3mstjk7sct22d`,
+          title: 'An essay',
+        },
+      },
+    ]);
+
+    const result = await updatePublication(SESSION, env as unknown as Env, { name: 'New name' });
+
+    expect(result.success).toBe(true);
+    const newRkey = await storedRkey();
+    expect(newRkey && isWritablePublicationRkey(newRkey)).toBe(true);
+    const newUri = publicationUriFor(DID, newRkey!);
+    expect(result.success && result.data.move).toEqual({
+      from: publicationUriFor(DID, LEGACY_LINKBLOG_RKEY),
+      to: newUri,
+      movedPosts: 2,
+      complete: true,
+    });
+
+    // The publication was written at the TID, with the new name.
+    const written = puts(calls);
+    expect(written).toHaveLength(1);
+    expect(written[0].body?.rkey).toBe(newRkey);
+    expect((written[0].body?.record as { name?: string })?.name).toBe('New name');
+
+    // Both of ours were repointed in one applyWrites, and the foreign essay
+    // wasn't among them.
+    const writes = applyWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].map((w) => w.rkey)).toEqual(['3kaaa', '3kbbb']);
+    for (const write of writes[0]) {
+      expect(write.$type).toBe('com.atproto.repo.applyWrites#update');
+      expect((write.value as { site: string }).site).toBe(newUri);
+      // The whole record goes back to the PDS, so a legacy array `links` has to
+      // be re-wrapped on the way or the move itself would fail validation.
+      expect((write.value as { links: unknown }).links).toEqual({
+        $type: 'app.skyreader.linkblog.links',
+        refs: [{ uri: 'https://example.com/an-article', rel: 'related' }],
+      });
+    }
+
+    // The emptied publication is cleaned up last.
+    expect(
+      calls.some(
+        (c) => c.endpoint === 'com.atproto.repo.deleteRecord' && c.rkey === LEGACY_LINKBLOG_RKEY
+      )
+    ).toBe(true);
+  });
+
+  // Readers scope to the old publication too, so a move that dies partway still
+  // shows every post — whichever side of the move it currently sits on.
+  it('exposes the legacy publication as a scope once the rkey has moved', async () => {
+    const rkey = generateTid();
+    await env.DB.prepare(
+      `INSERT INTO user_settings (user_did, linkblog_rkey, created_at, updated_at)
+       VALUES (?, ?, unixepoch(), unixepoch())`
+    )
+      .bind(DID, rkey)
+      .run();
+
+    const target = await getLinkblogTarget(env as unknown as Env, DID);
+    expect(target.legacySiteUri).toBe(publicationUriFor(DID, LEGACY_LINKBLOG_RKEY));
+  });
+
+  it('has no legacy scope for a user who never had a legacy publication', async () => {
+    const target = await getLinkblogTarget(env as unknown as Env, DID);
+    expect(target.defaultSiteUri).toBe(publicationUriFor(DID, LEGACY_LINKBLOG_RKEY));
+    expect(target.legacySiteUri).toBeUndefined();
+  });
+
+  it('creates at a TID when settings are saved before a first share', async () => {
+    const calls = stubPds({});
+
+    const result = await updatePublication(SESSION, env as unknown as Env, { name: 'New name' });
+
+    expect(result.success).toBe(true);
+    const written = puts(calls);
+    expect(written).toHaveLength(1);
+    expect(isWritablePublicationRkey(written[0].body?.rkey as string)).toBe(true);
+    expect(await storedRkey()).toBe(written[0].body?.rkey);
+  });
+
+  // The new rkey is stored BEFORE the walk, so a move that dies partway resolves
+  // to a TID on the next attempt. What says a move is still owed is the record
+  // sitting at the legacy rkey — reading the resolved rkey instead would leave
+  // the stragglers (and the followers) at the old URI with no way back in.
+  it('finishes a move that was interrupted after the rkey was stored', async () => {
+    const rkey = generateTid();
+    await env.DB.prepare(
+      `INSERT INTO user_settings (user_did, linkblog_rkey, created_at, updated_at)
+       VALUES (?, ?, unixepoch(), unixepoch())`
+    )
+      .bind(DID, rkey)
+      .run();
+
+    const legacyUri = publicationUriFor(DID, LEGACY_LINKBLOG_RKEY);
+    const newUri = publicationUriFor(DID, rkey);
+    const calls = stubPds(
+      {
+        // Both publications exist: the first attempt wrote the new one and never
+        // got as far as deleting the old.
+        [rkey]: { $type: 'site.standard.publication', name: 'My links', url: 'https://x.example/' },
+        [LEGACY_LINKBLOG_RKEY]: STALE_PUBLICATION,
+      },
+      [
+        shareRecord('3kaaa', newUri), // already moved
+        shareRecord('3kbbb', legacyUri), // stranded
+      ]
+    );
+
+    const result = await updatePublication(SESSION, env as unknown as Env, { name: 'New name' });
+
+    expect(result.success).toBe(true);
+    // Resumed onto the rkey already stored — a fresh mint would strand the posts
+    // the first attempt did move.
+    expect(await storedRkey()).toBe(rkey);
+    expect(result.success && result.data.move).toEqual({
+      from: legacyUri,
+      to: newUri,
+      movedPosts: 1,
+      complete: true,
+    });
+
+    const written = puts(calls);
+    expect(written).toHaveLength(1);
+    expect(written[0].body?.rkey).toBe(rkey);
+
+    // Only the straggler is rewritten; the one already at the new URI is left be.
+    const writes = applyWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].map((w) => w.rkey)).toEqual(['3kbbb']);
+    expect(
+      calls.some(
+        (c) => c.endpoint === 'com.atproto.repo.deleteRecord' && c.rkey === LEGACY_LINKBLOG_RKEY
+      )
+    ).toBe(true);
+  });
+
+  // The legacy record IS the resume marker, so a walk that ran out of pages must
+  // leave it standing — deleting it would orphan every document it didn't reach.
+  it('keeps the legacy publication when the walk runs out of pages', async () => {
+    const legacyUri = publicationUriFor(DID, LEGACY_LINKBLOG_RKEY);
+    const calls = stubPds(
+      { [LEGACY_LINKBLOG_RKEY]: STALE_PUBLICATION },
+      [shareRecord('3kaaa', legacyUri)],
+      { endless: true }
+    );
+
+    const result = await updatePublication(SESSION, env as unknown as Env, { name: 'New name' });
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.move?.complete).toBe(false);
+    expect(
+      calls.some(
+        (c) => c.endpoint === 'com.atproto.repo.deleteRecord' && c.rkey === LEGACY_LINKBLOG_RKEY
+      )
+    ).toBe(false);
+  });
+
+  // A read that merely failed is not a publication that isn't there. Minting on
+  // one would put a second publication over a perfectly good one and repoint the
+  // stored rkey at it, orphaning every document in the original.
+  it('refuses to mint when the publication read fails for any other reason', async () => {
+    const calls = stubPds({}, [], { readError: true });
+
+    const ensured = await ensureLinkblogPublication(SESSION, env as unknown as Env);
+    expect(ensured.success).toBe(false);
+    expect(puts(calls)).toHaveLength(0);
+    expect(await storedRkey()).toBeNull();
+
+    const updated = await updatePublication(SESSION, env as unknown as Env, { name: 'New name' });
+    expect(updated.success).toBe(false);
+    expect(puts(calls)).toHaveLength(0);
+    expect(await storedRkey()).toBeNull();
+  });
+});

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  ATTRIBUTION_TEXT,
   deleteLinkblog,
   deleteLinkblogShare,
   updateLinkblogShareNote,
@@ -199,6 +200,93 @@ describe('linkblog share guards', () => {
     expect((put?.body as { record: { skyreaderLinkblog?: string } }).record.skyreaderLinkblog).toBe(
       LINKBLOG_MARKER_URL
     );
+  });
+
+  // Whether that trailing sentence is ours or the author's is a property of the
+  // RECORD (`skyreaderAttribution`), not of the string. Read it off the record, or
+  // an author who wrote it themselves gets it duplicated on every edit and can
+  // never delete it.
+  it('does not duplicate an author’s own attribution-shaped line on edit', async () => {
+    const calls = stubPds(
+      documentRecord({
+        site: publicationUri(DID),
+        content: {
+          $type: 'pub.leaflet.content',
+          pages: [
+            {
+              $type: 'pub.leaflet.pages.linearDocument',
+              blocks: [
+                { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Worth reading.' } },
+                { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
+                {
+                  block: {
+                    $type: 'pub.leaflet.blocks.website',
+                    src: 'https://example.com/an-article',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await updateLinkblogShareNote(
+      SESSION,
+      '3kabc',
+      `Worth reading, still.\n\n${ATTRIBUTION_TEXT}`
+    );
+
+    expect(result.success).toBe(true);
+    const put = calls.find((c) => c.endpoint === 'com.atproto.repo.putRecord');
+    const blocks = (
+      put?.body as {
+        record: {
+          content: { pages: Array<{ blocks: Array<{ block: { plaintext?: string } }> }> };
+        };
+      }
+    ).record.content.pages[0].blocks;
+    expect(blocks.filter((b) => b.block.plaintext === ATTRIBUTION_TEXT)).toHaveLength(1);
+  });
+
+  it('carries the attribution line it added, once, when the record flag says so', async () => {
+    const calls = stubPds(
+      documentRecord({
+        site: publicationUri(DID),
+        skyreaderAttribution: true,
+        content: {
+          $type: 'pub.leaflet.content',
+          pages: [
+            {
+              $type: 'pub.leaflet.pages.linearDocument',
+              blocks: [
+                { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Worth reading.' } },
+                {
+                  block: {
+                    $type: 'pub.leaflet.blocks.website',
+                    src: 'https://example.com/an-article',
+                  },
+                },
+                { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await updateLinkblogShareNote(SESSION, '3kabc', 'Revised.');
+
+    expect(result.success).toBe(true);
+    const put = calls.find((c) => c.endpoint === 'com.atproto.repo.putRecord');
+    const blocks = (
+      put?.body as {
+        record: {
+          content: { pages: Array<{ blocks: Array<{ block: { plaintext?: string } }> }> };
+        };
+      }
+    ).record.content.pages[0].blocks;
+    expect(blocks.map((b) => b.block.plaintext)).toEqual(['Revised.', undefined, ATTRIBUTION_TEXT]);
   });
 
   it('walks the collection once, deleting as it pages', async () => {

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -235,8 +235,9 @@ describe('linkblog share guards', () => {
 
     expect(result.success).toBe(true);
     const put = calls.find((c) => c.endpoint === 'com.atproto.repo.putRecord');
-    const record = (put?.body as { record: { links: unknown; content: { text: { markdown: string } } } })
-      .record;
+    const record = (
+      put?.body as { record: { links: unknown; content: { text: { markdown: string } } } }
+    ).record;
     expect(record.content.text.markdown).toContain('https://example.com/an-article');
     expect(record.links).toEqual({
       $type: DOCUMENT_LINKS_TYPE,

--- a/backend/test/linkblog-share-guard.spec.ts
+++ b/backend/test/linkblog-share-guard.spec.ts
@@ -4,6 +4,7 @@ import {
   deleteLinkblog,
   deleteLinkblogShare,
   updateLinkblogShareNote,
+  DOCUMENT_LINKS_TYPE,
   LINKBLOG_MARKER_URL,
   publicationUri,
 } from '../src/services/linkblog-sync';
@@ -200,6 +201,47 @@ describe('linkblog share guards', () => {
     expect((put?.body as { record: { skyreaderLinkblog?: string } }).record.skyreaderLinkblog).toBe(
       LINKBLOG_MARKER_URL
     );
+  });
+
+  // `...rec` would put back whatever shape the record holds, and the array form
+  // every pre-existing share carries is what the lexicon now rejects. Without the
+  // re-wrap, editing any post written before the change 400s.
+  it('rewrites a legacy array `links` into the union shape on edit', async () => {
+    const calls = stubPds(documentRecord({ site: publicationUri(DID) }));
+    const result = await updateLinkblogShareNote(SESSION, '3kabc', 'my commentary');
+
+    expect(result.success).toBe(true);
+    const put = calls.find((c) => c.endpoint === 'com.atproto.repo.putRecord');
+    expect((put?.body as { record: { links: unknown } }).record.links).toEqual({
+      $type: DOCUMENT_LINKS_TYPE,
+      refs: [{ uri: 'https://example.com/an-article', rel: 'related' }],
+    });
+  });
+
+  // The article URL the rebuilt link card needs comes out of `links`, so a reader
+  // that only understood one shape would drop the card on edit.
+  it('finds the article URL in a union-shaped `links` when rebuilding the card', async () => {
+    const calls = stubPds(
+      documentRecord({
+        site: publicationUri(DID),
+        links: {
+          $type: DOCUMENT_LINKS_TYPE,
+          refs: [{ uri: 'https://example.com/an-article', rel: 'related' }],
+        },
+        content: { $type: 'at.markpub.markdown', text: { markdown: 'Old note.' } },
+      })
+    );
+    const result = await updateLinkblogShareNote(SESSION, '3kabc', 'New note.');
+
+    expect(result.success).toBe(true);
+    const put = calls.find((c) => c.endpoint === 'com.atproto.repo.putRecord');
+    const record = (put?.body as { record: { links: unknown; content: { text: { markdown: string } } } })
+      .record;
+    expect(record.content.text.markdown).toContain('https://example.com/an-article');
+    expect(record.links).toEqual({
+      $type: DOCUMENT_LINKS_TYPE,
+      refs: [{ uri: 'https://example.com/an-article', rel: 'related' }],
+    });
   });
 
   // Whether that trailing sentence is ours or the author's is a property of the

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ATTRIBUTION_TEXT,
   buildLinkblogDocument,
   contentFormatOf,
+  formattingFromRow,
   noteToLeafletBlocks,
   replaceItemsNoteRegion,
   replaceLeafletNoteRegion,
   replaceMarkpubNote,
   publicationUri,
+  stripTitleDecoration,
+  websiteCardMeta,
   LINKBLOG_RKEY,
 } from '../src/services/linkblog-sync';
 
@@ -74,7 +78,7 @@ describe('buildLinkblogDocument', () => {
     const bare = buildLinkblogDocument(DID, RKEY, {
       articleUrl: 'https://example.com/x',
     });
-    expect(bare.title).toBe('https://example.com/x');
+    expect(bare.title).toBe('🔗 https://example.com/x');
     const content = bare.content as {
       pages: Array<{ blocks: Array<{ block: { $type: string } }> }>;
     };
@@ -99,24 +103,24 @@ describe('connected publication formats', () => {
     expect(doc.links).toEqual([{ uri: input.articleUrl, rel: 'related' }]);
   });
 
-  it('closes a pckt post with its flat website card', () => {
+  it('gives a pckt post its flat website card', () => {
     const pckt = buildLinkblogDocument(DID, RKEY, input, undefined, target, 'pckt').content as {
       items: Array<{ $type: string; src?: string; attrs?: unknown }>;
     };
-    const card = pckt.items.at(-1);
+    const card = pckt.items.find((i) => i.$type === 'blog.pckt.block.website');
     // Top level, not nested under `attrs` — the shape pckt's lexicon requires and
     // its own posts use.
-    expect(card?.$type).toBe('blog.pckt.block.website');
+    expect(card).toBeDefined();
     expect(card?.src).toBe(input.articleUrl);
     expect(card?.attrs).toBeUndefined();
   });
 
-  it('closes an Offprint post with its native bookmark card, not a text line', () => {
+  it('gives an Offprint post its native bookmark card, not a text line', () => {
     const offprint = buildLinkblogDocument(DID, RKEY, input, undefined, target, 'offprint')
       .content as { items: Array<{ $type: string; href?: string; title?: string }> };
-    const card = offprint.items.at(-1);
+    const card = offprint.items.find((i) => i.$type === 'app.offprint.block.webBookmark');
     // `href`, and a title that's required rather than optional.
-    expect(card?.$type).toBe('app.offprint.block.webBookmark');
+    expect(card).toBeDefined();
     expect(card?.href).toBe(input.articleUrl);
     expect(card?.title).toBe(input.articleTitle);
   });
@@ -247,32 +251,299 @@ describe('note runs in the block-item formats', () => {
     const prefix = format === 'pckt' ? 'blog.pckt.block.' : 'app.offprint.block.';
     const card = format === 'pckt' ? `${prefix}website` : `${prefix}webBookmark`;
 
+    // The card lands between the quote and the commentary under the default
+    // 'context' layout — the reader meets what's being responded to before the
+    // response.
     it(`${format}: a quote followed by commentary on the next line stays two blocks`, () => {
       const items = build(format, '> A quoted sentence.\nMy commentary.');
-      expect(items.map((i) => i.$type)).toEqual([`${prefix}blockquote`, `${prefix}text`, card]);
+      expect(items.map((i) => i.$type)).toEqual([`${prefix}blockquote`, card, `${prefix}text`]);
       expect(items[0].content).toEqual([
         { $type: `${prefix}text`, plaintext: 'A quoted sentence.' },
       ]);
-      expect(items[1].plaintext).toBe('My commentary.');
+      expect(items[2].plaintext).toBe('My commentary.');
     });
 
     it(`${format}: commentary followed by a quote on the next line keeps the quote`, () => {
       const items = build(format, 'My commentary.\n> A quoted sentence.');
-      expect(items.map((i) => i.$type)).toEqual([`${prefix}text`, `${prefix}blockquote`, card]);
-      expect(items[0].plaintext).toBe('My commentary.');
-      expect(items[1].content).toEqual([
+      // Nothing is quoted up front, so the card leads instead.
+      expect(items.map((i) => i.$type)).toEqual([card, `${prefix}text`, `${prefix}blockquote`]);
+      expect(items[1].plaintext).toBe('My commentary.');
+      expect(items[2].content).toEqual([
         { $type: `${prefix}text`, plaintext: 'A quoted sentence.' },
       ]);
     });
 
     it(`${format}: a multiline quote stays one block with its markers stripped`, () => {
       const items = build(format, '> line one\n> line two\n\nAfter.');
-      expect(items.map((i) => i.$type)).toEqual([`${prefix}blockquote`, `${prefix}text`, card]);
+      expect(items.map((i) => i.$type)).toEqual([`${prefix}blockquote`, card, `${prefix}text`]);
       expect(items[0].content).toEqual([
         { $type: `${prefix}text`, plaintext: 'line one\nline two' },
       ]);
     });
   }
+});
+
+// ── Formatting preferences ───────────────────────────────────────────────────
+//
+// The two answers to the external-formatting feedback are per-user settings with
+// new defaults, not hardcoded changes: 'link' + 'context'.
+
+describe('title style', () => {
+  const input = { articleUrl: 'https://example.com/a', articleTitle: 'The Article' };
+  const titleFor = (style: 'link' | 'quoted' | 'plain') =>
+    buildLinkblogDocument(DID, RKEY, input, undefined, publicationUri(DID), 'leaflet', {
+      titleStyle: style,
+      cardPosition: 'context',
+    }).title;
+
+  it('decorates the document title so a link post is not a repost of the article', () => {
+    expect(titleFor('link')).toBe('🔗 The Article');
+    expect(titleFor('quoted')).toBe('“The Article”');
+    expect(titleFor('plain')).toBe('The Article');
+  });
+
+  it('leaves the website card title plain whatever the document title says', () => {
+    const content = buildLinkblogDocument(
+      DID,
+      RKEY,
+      input,
+      undefined,
+      publicationUri(DID),
+      'leaflet',
+      { titleStyle: 'link', cardPosition: 'context' }
+    ).content as { pages: Array<{ blocks: Array<{ block: { $type: string; title?: string } }> }> };
+    const card = content.pages[0].blocks.find(
+      (b) => b.block.$type === 'pub.leaflet.blocks.website'
+    );
+    expect(card?.block.title).toBe('The Article');
+  });
+
+  it('round-trips through stripTitleDecoration', () => {
+    expect(stripTitleDecoration('🔗 The Article')).toBe('The Article');
+    expect(stripTitleDecoration('“The Article”')).toBe('The Article');
+    expect(stripTitleDecoration('The Article')).toBe('The Article');
+    // A title the author really did wrap in straight quotes is left alone.
+    expect(stripTitleDecoration('"Quoted" for real')).toBe('"Quoted" for real');
+  });
+});
+
+describe('card position', () => {
+  const NOTE = '> A quoted sentence.\n\nMy commentary.';
+  const blocksFor = (cardPosition: 'context' | 'top' | 'bottom', note = NOTE) =>
+    (
+      buildLinkblogDocument(
+        DID,
+        RKEY,
+        { articleUrl: 'https://example.com/a', articleTitle: 'A', note },
+        undefined,
+        publicationUri(DID),
+        'leaflet',
+        { titleStyle: 'link', cardPosition }
+      ).content as { pages: Array<{ blocks: Array<{ block: { $type: string } }> }> }
+    ).pages[0].blocks.map((b) => b.block.$type);
+
+  it('puts the card between the quote and the commentary by default', () => {
+    expect(blocksFor('context')).toEqual([
+      'pub.leaflet.blocks.blockquote',
+      'pub.leaflet.blocks.website',
+      'pub.leaflet.blocks.text',
+    ]);
+  });
+
+  it('leads with the card when nothing is quoted', () => {
+    expect(blocksFor('context', 'Just commentary.')).toEqual([
+      'pub.leaflet.blocks.website',
+      'pub.leaflet.blocks.text',
+    ]);
+  });
+
+  it('honors top and bottom', () => {
+    expect(blocksFor('top')[0]).toBe('pub.leaflet.blocks.website');
+    expect(blocksFor('bottom').at(-1)).toBe('pub.leaflet.blocks.website');
+  });
+
+  it('splits markpub markdown around the link line', () => {
+    const markpub = (cardPosition: 'context' | 'top' | 'bottom') =>
+      (
+        buildLinkblogDocument(
+          DID,
+          RKEY,
+          { articleUrl: 'https://example.com/a', articleTitle: 'A', note: NOTE },
+          undefined,
+          publicationUri(DID),
+          'markpub',
+          { titleStyle: 'link', cardPosition }
+        ).content as { text: { markdown: string } }
+      ).text.markdown;
+    expect(markpub('context')).toBe(
+      '> A quoted sentence.\n\n[A](https://example.com/a)\n\nMy commentary.'
+    );
+    // With the link at either end the note text is emitted verbatim.
+    expect(markpub('bottom')).toBe(`${NOTE}\n\n[A](https://example.com/a)`);
+    expect(markpub('top')).toBe(`[A](https://example.com/a)\n\n${NOTE}`);
+  });
+});
+
+describe('attribution', () => {
+  const input = {
+    articleUrl: 'https://example.com/a',
+    articleTitle: 'A',
+    note: '> Quoted.\n\nMine.',
+    attribution: true,
+  };
+
+  it('is opt-in and absent by default', () => {
+    const doc = buildLinkblogDocument(DID, RKEY, { ...input, attribution: undefined });
+    expect(doc.skyreaderAttribution).toBeUndefined();
+    expect(JSON.stringify(doc.content)).not.toContain(ATTRIBUTION_TEXT);
+  });
+
+  it.each(['leaflet', 'pckt', 'offprint', 'markpub'] as const)(
+    'appends a trailing %s attribution block and stamps the flag',
+    (format) => {
+      const doc = buildLinkblogDocument(DID, RKEY, input, undefined, publicationUri(DID), format, {
+        titleStyle: 'link',
+        cardPosition: 'context',
+      });
+      expect(doc.skyreaderAttribution).toBe(true);
+      const content = doc.content as {
+        pages?: Array<{ blocks: Array<{ block: { plaintext?: string } }> }>;
+        items?: Array<{ plaintext?: string }>;
+        text?: { markdown: string };
+      };
+      const last =
+        content.pages?.[0].blocks.at(-1)?.block.plaintext ??
+        content.items?.at(-1)?.plaintext ??
+        content.text?.markdown.split('\n').at(-1);
+      expect(last).toBe(ATTRIBUTION_TEXT);
+      // The user's words + excerpt are what textContent is for; the attribution
+      // is ours and stays out of it.
+      expect(doc.textContent ?? '').not.toContain(ATTRIBUTION_TEXT);
+    }
+  );
+
+  it('survives a note edit without being duplicated', () => {
+    const doc = buildLinkblogDocument(DID, RKEY, input);
+    const edited = replaceLeafletNoteRegion(doc.content, '> Quoted.\n\nRevised.') as {
+      pages: Array<{ blocks: Array<{ block: { $type: string; plaintext?: string } }> }>;
+    };
+    const plaintexts = edited.pages[0].blocks.map((b) => b.block.plaintext);
+    expect(plaintexts.filter((t) => t === ATTRIBUTION_TEXT)).toHaveLength(1);
+    expect(edited.pages[0].blocks.at(-1)?.block.plaintext).toBe(ATTRIBUTION_TEXT);
+    // …and the note the reader sees never contains it.
+    expect(plaintexts).toContain('Revised.');
+  });
+});
+
+describe('edits preserve the layout they find', () => {
+  const card = { $type: 'pub.leaflet.blocks.website', src: 'https://example.com/a' };
+  const wrap = (blocks: Array<Record<string, unknown>>) => ({
+    $type: 'pub.leaflet.content',
+    pages: [
+      { $type: 'pub.leaflet.pages.linearDocument', blocks: blocks.map((b) => ({ block: b })) },
+    ],
+  });
+  const typesAfterEdit = (blocks: Array<Record<string, unknown>>, note: string) =>
+    (
+      replaceLeafletNoteRegion(wrap(blocks), note) as {
+        pages: Array<{ blocks: Array<{ block: { $type: string } }> }>;
+      }
+    ).pages[0].blocks.map((b) => b.block.$type);
+
+  it('keeps a legacy note-leads/card-closes record at the bottom', () => {
+    expect(
+      typesAfterEdit(
+        [{ $type: 'pub.leaflet.blocks.text', plaintext: 'old' }, card],
+        '> quote\n\nnew'
+      )
+    ).toEqual([
+      'pub.leaflet.blocks.blockquote',
+      'pub.leaflet.blocks.text',
+      'pub.leaflet.blocks.website',
+    ]);
+  });
+
+  it('keeps a context-layout record in context layout', () => {
+    expect(
+      typesAfterEdit(
+        [
+          { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'old quote' },
+          card,
+          { $type: 'pub.leaflet.blocks.text', plaintext: 'old' },
+        ],
+        '> quote\n\nnew'
+      )
+    ).toEqual([
+      'pub.leaflet.blocks.blockquote',
+      'pub.leaflet.blocks.website',
+      'pub.leaflet.blocks.text',
+    ]);
+  });
+
+  it('keeps commentary that sits after a mid-post card', () => {
+    const content = replaceLeafletNoteRegion(
+      wrap([
+        { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'q' },
+        card,
+        { $type: 'pub.leaflet.blocks.text', plaintext: 'old' },
+      ]),
+      '> q\n\nnew commentary'
+    ) as { pages: Array<{ blocks: Array<{ block: { plaintext?: string } }> }> };
+    expect(content.pages[0].blocks.at(-1)?.block.plaintext).toBe('new commentary');
+  });
+
+  it('keeps a card-first record card-first', () => {
+    expect(
+      typesAfterEdit([card, { $type: 'pub.leaflet.blocks.text', plaintext: 'old' }], 'new')
+    ).toEqual(['pub.leaflet.blocks.website', 'pub.leaflet.blocks.text']);
+  });
+});
+
+describe('websiteCardMeta', () => {
+  it('reads the plain article title back off the card', () => {
+    const doc = buildLinkblogDocument(DID, RKEY, {
+      articleUrl: 'https://example.com/a',
+      articleTitle: 'The Article',
+      excerpt: 'An excerpt.',
+    });
+    expect(doc.title).toBe('🔗 The Article');
+    expect(websiteCardMeta(doc.content)).toEqual({
+      title: 'The Article',
+      excerpt: 'An excerpt.',
+    });
+  });
+
+  it.each(['pckt', 'offprint'] as const)('reads a %s card', (format) => {
+    const doc = buildLinkblogDocument(
+      DID,
+      RKEY,
+      { articleUrl: 'https://example.com/a', articleTitle: 'The Article', excerpt: 'An excerpt.' },
+      undefined,
+      publicationUri(DID),
+      format
+    );
+    expect(websiteCardMeta(doc.content).title).toBe('The Article');
+  });
+});
+
+describe('formattingFromRow', () => {
+  it('treats NULL and anything unrecognized as the defaults', () => {
+    expect(formattingFromRow(null, null)).toEqual({
+      titleStyle: 'link',
+      cardPosition: 'context',
+    });
+    expect(formattingFromRow('nonsense', 'nonsense')).toEqual({
+      titleStyle: 'link',
+      cardPosition: 'context',
+    });
+  });
+
+  it('takes stored values it recognizes', () => {
+    expect(formattingFromRow('plain', 'bottom')).toEqual({
+      titleStyle: 'plain',
+      cardPosition: 'bottom',
+    });
+  });
 });
 
 describe('replaceItemsNoteRegion', () => {

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -424,7 +424,12 @@ describe('attribution', () => {
 
   it('survives a note edit without being duplicated', () => {
     const doc = buildLinkblogDocument(DID, RKEY, input);
-    const edited = replaceLeafletNoteRegion(doc.content, '> Quoted.\n\nRevised.') as {
+    const edited = replaceLeafletNoteRegion(
+      doc.content,
+      '> Quoted.\n\nRevised.',
+      undefined,
+      doc.skyreaderAttribution === true
+    ) as {
       pages: Array<{ blocks: Array<{ block: { $type: string; plaintext?: string } }> }>;
     };
     const plaintexts = edited.pages[0].blocks.map((b) => b.block.plaintext);
@@ -432,6 +437,110 @@ describe('attribution', () => {
     expect(edited.pages[0].blocks.at(-1)?.block.plaintext).toBe(ATTRIBUTION_TEXT);
     // …and the note the reader sees never contains it.
     expect(plaintexts).toContain('Revised.');
+  });
+});
+
+// The attribution sentence is only OURS when the record says so. Without the flag
+// an identical last line is the author's own words: an edit rebuilds it from the
+// submitted note like any other line — it must not be lifted out and re-appended
+// (which duplicated the sentence), and deleting it from the note must delete it.
+describe("an author's own attribution-shaped line", () => {
+  const ARTICLE = { url: 'https://example.com/post', title: 'Post' };
+  const CARD = { $type: 'pub.leaflet.blocks.website', src: ARTICLE.url, title: 'Post' };
+  const NOTE = `Worth reading.\n\n${ATTRIBUTION_TEXT}`;
+
+  it('is kept once, not duplicated, when a leaflet note is edited', () => {
+    const existing = {
+      $type: 'pub.leaflet.content',
+      pages: [
+        {
+          $type: 'pub.leaflet.pages.linearDocument',
+          blocks: [
+            { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Worth reading.' } },
+            { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
+            { block: CARD },
+          ],
+        },
+      ],
+    };
+    const edited = replaceLeafletNoteRegion(existing, NOTE) as {
+      pages: Array<{ blocks: Array<{ block: { $type: string; plaintext?: string } }> }>;
+    };
+    const plaintexts = edited.pages[0].blocks.map((b) => b.block.plaintext);
+    expect(plaintexts.filter((t) => t === ATTRIBUTION_TEXT)).toHaveLength(1);
+    // The card still closes the post: the author's line is note text, so the
+    // layout the record was written in is unchanged.
+    expect(edited.pages[0].blocks.at(-1)?.block.$type).toBe('pub.leaflet.blocks.website');
+  });
+
+  it('can be removed by editing it out of a leaflet note', () => {
+    const existing = {
+      $type: 'pub.leaflet.content',
+      pages: [
+        {
+          $type: 'pub.leaflet.pages.linearDocument',
+          blocks: [
+            { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Worth reading.' } },
+            { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
+            { block: CARD },
+          ],
+        },
+      ],
+    };
+    const edited = replaceLeafletNoteRegion(existing, 'Worth reading.') as {
+      pages: Array<{ blocks: Array<{ block: { plaintext?: string } }> }>;
+    };
+    expect(edited.pages[0].blocks.map((b) => b.block.plaintext)).not.toContain(ATTRIBUTION_TEXT);
+  });
+
+  it.each(['pckt', 'offprint'] as const)('is kept once when a %s note is edited', (format) => {
+    const prefix = format === 'pckt' ? 'blog.pckt.block.' : 'app.offprint.block.';
+    const card =
+      format === 'pckt'
+        ? { $type: `${prefix}website`, src: ARTICLE.url }
+        : { $type: `${prefix}webBookmark`, href: ARTICLE.url, title: 'Post' };
+    const existing = {
+      $type: format === 'pckt' ? 'blog.pckt.content' : 'app.offprint.content',
+      items: [
+        { $type: `${prefix}text`, plaintext: 'Worth reading.' },
+        { $type: `${prefix}text`, plaintext: ATTRIBUTION_TEXT },
+        card,
+      ],
+    };
+    const edited = replaceItemsNoteRegion(existing, format, NOTE, ARTICLE) as {
+      items: Array<{ $type: string; plaintext?: string }>;
+    };
+    expect(edited.items.filter((i) => i.plaintext === ATTRIBUTION_TEXT)).toHaveLength(1);
+    expect(edited.items.at(-1)?.$type).toBe(card.$type);
+    // …and editing it out removes it.
+    const cleared = replaceItemsNoteRegion(existing, format, 'Worth reading.', ARTICLE) as {
+      items: Array<{ plaintext?: string }>;
+    };
+    expect(cleared.items.map((i) => i.plaintext)).not.toContain(ATTRIBUTION_TEXT);
+  });
+
+  it('is kept once when a markpub note is edited', () => {
+    const existing = {
+      $type: 'at.markpub.markdown',
+      text: { markdown: `Worth reading.\n\n${ATTRIBUTION_TEXT}\n\n[Post](${ARTICLE.url})` },
+    };
+    const edited = replaceMarkpubNote(existing, NOTE, ARTICLE) as { text: { markdown: string } };
+    expect(edited.text.markdown).toBe(`${NOTE}\n\n[Post](${ARTICLE.url})`);
+    const cleared = replaceMarkpubNote(existing, 'Worth reading.', ARTICLE) as {
+      text: { markdown: string };
+    };
+    expect(cleared.text.markdown).toBe(`Worth reading.\n\n[Post](${ARTICLE.url})`);
+  });
+
+  it('is still ours to carry when the record flag says we added it', () => {
+    const existing = {
+      $type: 'at.markpub.markdown',
+      text: { markdown: `Worth reading.\n\n[Post](${ARTICLE.url})\n\n${ATTRIBUTION_TEXT}` },
+    };
+    const edited = replaceMarkpubNote(existing, 'Revised.', ARTICLE, true) as {
+      text: { markdown: string };
+    };
+    expect(edited.text.markdown).toBe(`Revised.\n\n[Post](${ARTICLE.url})\n\n${ATTRIBUTION_TEXT}`);
   });
 });
 

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -3,6 +3,8 @@ import {
   ATTRIBUTION_TEXT,
   buildLinkblogDocument,
   contentFormatOf,
+  DOCUMENT_LINKS_TYPE,
+  readDocumentLinks,
   formattingFromRow,
   noteToLeafletBlocks,
   replaceItemsNoteRegion,
@@ -40,8 +42,26 @@ describe('buildLinkblogDocument', () => {
     expect(doc.path).toBe(`/${RKEY}`);
   });
 
+  // `links` is a bare open union upstream now, so the refs ride inside one
+  // $type-bearing object rather than a top-level array — see DOCUMENT_LINKS_TYPE.
+  // A PDS rejects the array outright, so this is the difference between a share
+  // that publishes and a 400.
   it('carries the external URL in the machine-readable links field', () => {
-    expect(doc.links).toEqual([{ uri: 'https://example.com/the-article', rel: 'related' }]);
+    expect(doc.links).toEqual({
+      $type: DOCUMENT_LINKS_TYPE,
+      refs: [{ uri: 'https://example.com/the-article', rel: 'related' }],
+    });
+  });
+
+  it('carries a quote-reshare ref alongside the article ref', () => {
+    const quote = buildLinkblogDocument(DID, RKEY, {
+      articleUrl: 'https://example.com/the-article',
+      repostUri: 'at://did:plc:someone/site.standard.document/3kxyz',
+    });
+    expect(readDocumentLinks(quote.links)).toEqual([
+      { uri: 'https://example.com/the-article', rel: 'related' },
+      { uri: 'at://did:plc:someone/site.standard.document/3kxyz', rel: 'repost' },
+    ]);
   });
 
   it('reserves the top-level description (the legacy-quote marker) and keeps the excerpt durable', () => {
@@ -100,7 +120,7 @@ describe('connected publication formats', () => {
     const doc = buildLinkblogDocument(DID, RKEY, input, undefined, target, format);
     expect(doc.site).toBe(target);
     expect(doc.content).toMatchObject({ $type: type });
-    expect(doc.links).toEqual([{ uri: input.articleUrl, rel: 'related' }]);
+    expect(readDocumentLinks(doc.links)).toEqual([{ uri: input.articleUrl, rel: 'related' }]);
   });
 
   it('gives a pckt post its flat website card', () => {
@@ -747,5 +767,25 @@ describe('replaceMarkpubNote', () => {
       ARTICLE
     ) as { text: { markdown: string } };
     expect(content.text.markdown).toBe(`new note\n\n[Post](${ARTICLE.url})`);
+  });
+});
+
+// Both shapes stay readable for good: every record written before the lexicon
+// changed holds the array, and only an edit rewrites one.
+describe('readDocumentLinks', () => {
+  const refs = [{ uri: 'https://example.com/a', rel: 'related' }];
+
+  it('reads the legacy array form', () => {
+    expect(readDocumentLinks(refs)).toEqual(refs);
+  });
+
+  it('reads the union form', () => {
+    expect(readDocumentLinks({ $type: DOCUMENT_LINKS_TYPE, refs })).toEqual(refs);
+  });
+
+  it('drops entries without a usable uri, and tolerates absence', () => {
+    expect(readDocumentLinks(undefined)).toEqual([]);
+    expect(readDocumentLinks({ $type: DOCUMENT_LINKS_TYPE })).toEqual([]);
+    expect(readDocumentLinks([{ rel: 'related' }, { uri: '' }, ...refs])).toEqual(refs);
   });
 });

--- a/backend/test/linkblog-sync.spec.ts
+++ b/backend/test/linkblog-sync.spec.ts
@@ -13,7 +13,7 @@ import {
   publicationUri,
   stripTitleDecoration,
   websiteCardMeta,
-  LINKBLOG_RKEY,
+  LEGACY_LINKBLOG_RKEY,
 } from '../src/services/linkblog-sync';
 
 const DID = 'did:plc:linkblogtest123';
@@ -35,7 +35,7 @@ describe('buildLinkblogDocument', () => {
   it('is a site.standard.document scoped to the skyreader-links publication', () => {
     expect(doc.$type).toBe('site.standard.document');
     expect(doc.site).toBe(publicationUri(DID));
-    expect(doc.site).toBe(`at://${DID}/site.standard.publication/${LINKBLOG_RKEY}`);
+    expect(doc.site).toBe(`at://${DID}/site.standard.publication/${LEGACY_LINKBLOG_RKEY}`);
   });
 
   it('uses the rkey as its path for canonical-URL building', () => {

--- a/backend/test/linkblog-targets.spec.ts
+++ b/backend/test/linkblog-targets.spec.ts
@@ -52,6 +52,9 @@ describe('getLinkblogTargets', () => {
       siteUri: `at://${CONNECTED}/site.standard.publication/my-leaflet`,
       format: 'pckt',
       external: true,
+      // Their own Skyreader publication rides along even while they publish
+      // elsewhere — it's what a disconnect comes back to.
+      defaultSiteUri: publicationUri(CONNECTED),
     });
   });
 
@@ -62,6 +65,7 @@ describe('getLinkblogTargets', () => {
         siteUri: publicationUri(did),
         format: 'leaflet',
         external: false,
+        defaultSiteUri: publicationUri(did),
       });
     }
   });

--- a/backend/test/mention-facets.spec.ts
+++ b/backend/test/mention-facets.spec.ts
@@ -56,8 +56,11 @@ describe('buildLinkblogDocument with mention facets', () => {
     const content = doc.content as {
       pages: Array<{ blocks: Array<{ block: Record<string, unknown> }> }>;
     };
-    const textBlock = content.pages[0].blocks[0].block;
-    expect(textBlock.$type).toBe('pub.leaflet.blocks.text');
+    // Nothing is quoted here, so the default 'context' layout leads with the
+    // card and the note follows it.
+    const textBlock = content.pages[0].blocks
+      .map((b) => b.block)
+      .find((b) => b.$type === 'pub.leaflet.blocks.text')!;
     expect(textBlock.facets).toEqual([facet]);
   });
 
@@ -71,6 +74,9 @@ describe('buildLinkblogDocument with mention facets', () => {
     const content = doc.content as {
       pages: Array<{ blocks: Array<{ block: Record<string, unknown> }> }>;
     };
-    expect(content.pages[0].blocks[0].block.facets).toBeUndefined();
+    const textBlock = content.pages[0].blocks
+      .map((b) => b.block)
+      .find((b) => b.$type === 'pub.leaflet.blocks.text')!;
+    expect(textBlock.facets).toBeUndefined();
   });
 });

--- a/feed-proxy/src/constellation.test.ts
+++ b/feed-proxy/src/constellation.test.ts
@@ -20,11 +20,17 @@ function createTestApp(config: Partial<AppConfig> = {}) {
 }
 
 // Mock the one Constellation endpoint the context still reads.
-function mockConstellationFetch(opts: { quoteCount?: number } = {}) {
+//
+// It's asked once per `links` shape: the legacy array (`.links[].uri`) and the
+// union object Skyreader writes now (`.links.refs[].uri`). A given reshare is
+// indexed at exactly one of them, so the mock answers them separately and the
+// context sums.
+function mockConstellationFetch(opts: { legacy?: number; union?: number } = {}) {
   return spyOn(globalThis, 'fetch').mockImplementation((async (input: unknown) => {
     const url = String(input);
     if (url.includes('/links/count')) {
-      return new Response(JSON.stringify({ total: opts.quoteCount ?? 0 }));
+      const isUnion = decodeURIComponent(url).includes('.links.refs[].uri');
+      return new Response(JSON.stringify({ total: (isUnion ? opts.union : opts.legacy) ?? 0 }));
     }
     throw new Error(`Unexpected fetch: ${url}`);
   }) as unknown as typeof fetch);
@@ -43,24 +49,37 @@ describe('getSocialContext', () => {
 
   it('counts the posts quoting this one', async () => {
     const { db } = createTestApp();
-    mockConstellationFetch({ quoteCount: 1 });
+    mockConstellationFetch({ legacy: 1 });
 
     const ctx = await getSocialContext(db, { docUri: DOC_URI });
     expect(ctx).toEqual({ quoteCount: 1 });
   });
 
+  // Reshares written before the lexicon change are indexed under the array path
+  // and newer ones under the union path. Asking only one would undercount a post
+  // quoted on both sides of the change.
+  it('sums quotes across both `links` shapes', async () => {
+    const { db } = createTestApp();
+    mockConstellationFetch({ legacy: 2, union: 3 });
+
+    const ctx = await getSocialContext(db, { docUri: DOC_URI });
+    expect(ctx).toEqual({ quoteCount: 5 });
+  });
+
   // The context used to fan out to every linker's PDS for their note. Nothing
-  // renders that now, so nothing should fetch it: one call, to /links/count.
+  // renders that now, so nothing should fetch it: the only calls are the
+  // /links/count pair, one per `links` shape.
   it('reads only the quote count — no per-linker PDS fan-out', async () => {
     const { db } = createTestApp();
-    const spy = mockConstellationFetch({ quoteCount: 2 });
+    const spy = mockConstellationFetch({ legacy: 2 });
     await getSocialContext(db, { docUri: DOC_URI });
-    expect(spy.mock.calls.length).toBe(1);
+    expect(spy.mock.calls.length).toBe(2);
+    expect(spy.mock.calls.every(([input]) => String(input).includes('/links/count'))).toBe(true);
   });
 
   it('serves a cached bundle on the second call (no extra fetches)', async () => {
     const { db } = createTestApp();
-    const spy = mockConstellationFetch({ quoteCount: 5 });
+    const spy = mockConstellationFetch({ legacy: 5 });
     await getSocialContext(db, { docUri: DOC_URI });
     const callsAfterFirst = spy.mock.calls.length;
     await getSocialContext(db, { docUri: DOC_URI });
@@ -92,7 +111,7 @@ describe('POST /social-context', () => {
 
   it('returns a per-item context keyed back to the request', async () => {
     const { app } = createTestApp();
-    mockConstellationFetch({ quoteCount: 2 });
+    mockConstellationFetch({ legacy: 2 });
     const res = await post(app, { items: [{ key: 'a', docUri: DOC_URI }] });
     expect(res.status).toBe(200);
     const json = (await res.json()) as {

--- a/feed-proxy/src/constellation.ts
+++ b/feed-proxy/src/constellation.ts
@@ -21,8 +21,15 @@ import { Database } from 'bun:sqlite';
 import { constellationGet } from './constellation-client';
 
 const DOCUMENT_COLLECTION = 'site.standard.document';
-// JSON path of the external/at-uri ref in a link-post document's `links` array.
-const LINKS_PATH = '.links[].uri';
+// JSON paths of the external/at-uri ref in a link-post document's `links`.
+//
+// Two of them, permanently. `links` was an array of `{uri, rel}` until
+// standard.site redeclared it as a bare open union; Skyreader now writes
+// `{$type, refs: [...]}` (see backend linkblog-sync DOCUMENT_LINKS_TYPE and
+// standard.site/lexicons#17), which Constellation indexes one level deeper.
+// Records written under each shape are immutable until edited, so a count that
+// asked only the new path would silently drop every reshare of an older post.
+const LINKS_PATHS = ['.links[].uri', '.links.refs[].uri'];
 
 // Firehose-fresh index → keep the assembled bundle only briefly.
 const CONTEXT_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -48,14 +55,20 @@ interface CacheRow {
 
 const EMPTY: SocialContext = { quoteCount: 0 };
 
-// Count of documents whose `links` ref points at this doc (quote-reshares of it).
+// Count of documents whose `links` ref points at this doc (quote-reshares of it),
+// summed over both link shapes. A reshare lives at exactly one of the two paths,
+// so the sum double-counts nothing.
 async function fetchQuoteCount(docUri: string): Promise<number> {
-  const data = await constellationGet<ConstellationCountResponse>('/links/count', {
-    target: docUri,
-    collection: DOCUMENT_COLLECTION,
-    path: LINKS_PATH,
-  });
-  return data?.total ?? 0;
+  const counts = await Promise.all(
+    LINKS_PATHS.map((path) =>
+      constellationGet<ConstellationCountResponse>('/links/count', {
+        target: docUri,
+        collection: DOCUMENT_COLLECTION,
+        path,
+      })
+    )
+  );
+  return counts.reduce((sum, data) => sum + (data?.total ?? 0), 0);
 }
 
 // Namespaced like the table's other tenants (`lane-items:`, `profile:`), which

--- a/feed-proxy/src/document-content.test.ts
+++ b/feed-proxy/src/document-content.test.ts
@@ -120,6 +120,49 @@ describe('extractContentText', () => {
     expect(extractContentText(content)).toBe('Title');
   });
 
+  // Skyreader's opt-in "Posted from skyreader.app" line is a plain text block in
+  // every format, so a bare share — a quote and that line — would otherwise
+  // yield the attribution as if it were the linker's own prose.
+  it('never takes the Skyreader attribution line as the snippet', () => {
+    expect(
+      extractContentText({
+        $type: 'pub.leaflet.content',
+        pages: [
+          {
+            blocks: [
+              { block: { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'quoted lead' } },
+              { block: { $type: 'pub.leaflet.blocks.website', src: 'https://example.com/a' } },
+              {
+                block: {
+                  $type: 'pub.leaflet.blocks.text',
+                  plaintext: 'Posted from skyreader.app',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe('quoted lead');
+    expect(
+      extractContentText({
+        $type: 'at.markpub.markdown',
+        text: { markdown: 'Posted from skyreader.app\n' },
+      })
+    ).toBeNull();
+  });
+
+  // The card can lead the post now (see the card-position preference), so a
+  // markpub link post can open with its own link line. That's the link, not the
+  // linker's words, and as a snippet it reads as an empty label.
+  it('skips a bare markdown link line and takes the prose after it', () => {
+    expect(
+      extractContentText({
+        $type: 'at.markpub.markdown',
+        text: { markdown: '[The Article](https://example.com/a)\n\nWorth reading.\n' },
+      })
+    ).toBe('Worth reading.');
+  });
+
   it('returns null for a markpub record with no inline markdown', () => {
     const content = {
       $type: 'at.markpub.markdown',

--- a/feed-proxy/src/document-content.ts
+++ b/feed-proxy/src/document-content.ts
@@ -58,6 +58,12 @@ const MAX_DEPTH = 4;
 // text block in every format, so without this the snippet for a bare share —
 // no commentary, just a quote and the line — would read as the linker's prose.
 // Keep in sync with the backend constant.
+//
+// The string alone is the tell here, unlike the note parsers, which require the
+// record's `skyreaderAttribution` flag before treating that sentence as ours.
+// This is a snippet, not a note: nothing is rewritten from it, so an author whose
+// lead line happens to be that sentence loses one snippet candidate to the next
+// block rather than losing the line itself.
 const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
 
 function isAttributionText(text: string): boolean {

--- a/feed-proxy/src/document-content.ts
+++ b/feed-proxy/src/document-content.ts
@@ -54,6 +54,16 @@ const QUOTE_BLOCK_TYPES = new Set([
 // text) without chasing pathologically deep trees.
 const MAX_DEPTH = 4;
 
+// Skyreader's opt-in "posted from" line (backend ATTRIBUTION_TEXT). It's a plain
+// text block in every format, so without this the snippet for a bare share —
+// no commentary, just a quote and the line — would read as the linker's prose.
+// Keep in sync with the backend constant.
+const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
+
+function isAttributionText(text: string): boolean {
+  return text === ATTRIBUTION_TEXT;
+}
+
 function firstTextInBlocks(blocks: unknown, depth: number, quotes: 'skip' | 'take'): string | null {
   if (depth > MAX_DEPTH || !Array.isArray(blocks)) return null;
   for (const entry of blocks) {
@@ -67,7 +77,7 @@ function firstTextInBlocks(blocks: unknown, depth: number, quotes: 'skip' | 'tak
     if (isQuote && quotes === 'skip') continue;
     if (isQuote || (typeof block.$type === 'string' && TEXT_BLOCK_TYPES.has(block.$type))) {
       const text = block.plaintext?.trim();
-      if (text) return text;
+      if (text && !isAttributionText(text)) return text;
     }
     // Descend into container blocks (blockquote / list item / table cell).
     const nested = firstTextInBlocks(block.content, depth + 1, quotes);
@@ -81,13 +91,19 @@ function firstSnippetInBlocks(blocks: unknown): string | null {
   return firstTextInBlocks(blocks, 0, 'skip') ?? firstTextInBlocks(blocks, 0, 'take');
 }
 
+// A line that is nothing but a markdown link — the shared article's own link
+// line in a markpub link post, which can now lead the body rather than close it
+// (see the card-position preference). It's the link, not the linker's words, and
+// as a snippet it would read as an empty label.
+const BARE_LINK_LINE = /^\[[^\]]*\]\([^)]*\)$/;
+
 // The first non-empty markdown line, stripped of leading heading/quote/list
 // markers. Shared by the markdown-bodied formats (greengale, markpub).
 function firstMarkdownLine(markdown: unknown): string | null {
   if (typeof markdown !== 'string') return null;
   for (const line of markdown.split('\n')) {
     const cleaned = line.replace(/^\s*(#{1,6}\s+|>\s?|[-*+]\s+)/, '').trim();
-    if (cleaned) return cleaned;
+    if (cleaned && !isAttributionText(cleaned) && !BARE_LINK_LINE.test(cleaned)) return cleaned;
   }
   return null;
 }

--- a/feed-proxy/src/documents.test.ts
+++ b/feed-proxy/src/documents.test.ts
@@ -279,6 +279,36 @@ describe('POST /documents', () => {
     expect(doc.links).toEqual([{ uri: 'https://example.com/the-article', rel: 'related' }]);
   });
 
+  // Same field, the shape standard.site's lexicon now demands: one $type-bearing
+  // object wrapping the refs (see backend linkblog-sync DOCUMENT_LINKS_TYPE).
+  // Both flatten to the same `ProxyDocument.links` array, so the frontend, the
+  // reader and linkblogs.skyreader.app never learn the difference.
+  it('reads the union-shaped links field a new record carries', async () => {
+    const { app } = createTestApp();
+    fetchMock = mockAtprotoFetch({
+      docs: [
+        docRecord('hello', {
+          site: PUB_URI,
+          title: 'Hello',
+          publishedAt: '2024-01-02T00:00:00Z',
+          createdAt: '2024-01-02T00:00:00Z',
+          links: {
+            $type: 'app.skyreader.linkblog.links',
+            refs: [{ uri: 'https://example.com/the-article', rel: 'related' }, { rel: 'nouri' }],
+          },
+        }),
+      ],
+    });
+
+    const res = await postDocuments(app, [{ did: AUTHOR, siteUri: PUB_URI }]);
+    const json = (await res.json()) as {
+      authors: Array<{ status: string; documents: ProxyDocument[] }>;
+    };
+    expect(json.authors[0].documents[0].links).toEqual([
+      { uri: 'https://example.com/the-article', rel: 'related' },
+    ]);
+  });
+
   it('applies the publication filter and returns newest first', async () => {
     const { app } = createTestApp();
     fetchMock = mockAtprotoFetch({

--- a/feed-proxy/src/standard-site.ts
+++ b/feed-proxy/src/standard-site.ts
@@ -73,6 +73,10 @@ export interface ProxyDocument {
   // Passed through verbatim from the record (see DocumentRecord). Clients use it
   // to decide whether a document is theirs to edit or delete.
   skyreaderLinkblog?: string;
+  // The author opted into the trailing "Posted from skyreader.app" line. Passed
+  // through so note parsers can exclude that block by the flag rather than by
+  // string match alone — someone whose own last line reads exactly that keeps it.
+  skyreaderAttribution?: boolean;
 }
 
 /**
@@ -175,6 +179,9 @@ export interface DocumentRecord {
   // publication shares that publication with the posts its home app writes, so
   // this is the only thing separating "a share" from "an essay that links out".
   skyreaderLinkblog?: string;
+  // Set when the author asked for the "Posted from skyreader.app" line, so
+  // readers can tell that trailing block from the author's own last paragraph.
+  skyreaderAttribution?: boolean;
 }
 
 interface PublicationRecord {
@@ -630,6 +637,7 @@ export async function recordToProxyDocument(
     readerCollection: readerCollection || undefined,
     skyreaderLinkblog:
       typeof doc.skyreaderLinkblog === 'string' ? doc.skyreaderLinkblog : undefined,
+    skyreaderAttribution: doc.skyreaderAttribution === true ? true : undefined,
   };
 }
 

--- a/feed-proxy/src/standard-site.ts
+++ b/feed-proxy/src/standard-site.ts
@@ -173,7 +173,8 @@ export interface DocumentRecord {
   createdAt?: string;
   updatedAt?: string;
   content?: unknown;
-  links?: Array<{ uri?: string; rel?: string }>;
+  // Either the legacy array or the union object — see readRecordLinks.
+  links?: unknown;
   // Skyreader's provenance marker on a link post it wrote (a constant URL, the
   // same one its publications carry). A linkblog connected to an existing
   // publication shares that publication with the posts its home app writes, so
@@ -565,6 +566,24 @@ async function resolveReaderCollection(
   };
 }
 
+// `site.standard.document.links` comes in two shapes. It was an array of
+// `{uri, rel}` until standard.site redeclared it as a bare open union (a single
+// `$type`-bearing object); Skyreader now writes `{$type, refs: [...]}` so PDS
+// validation accepts the write (see backend linkblog-sync DOCUMENT_LINKS_TYPE,
+// and standard.site/lexicons#17). Every record written before that still holds
+// the array, so both are read here and flattened to one array — which is what
+// `ProxyDocument.links` has always been, so nothing downstream changes.
+function readRecordLinks(raw: unknown): Array<{ uri: string; rel?: string }> {
+  const entries = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { refs?: unknown } | undefined)?.refs)
+      ? (raw as { refs: Array<{ uri?: string; rel?: string }> }).refs
+      : [];
+  return entries
+    .filter((l): l is { uri: string; rel?: string } => typeof l?.uri === 'string' && !!l.uri)
+    .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }));
+}
+
 /**
  * Map a single raw `site.standard.document` record into a `ProxyDocument`,
  * resolving its publication's base URL + icon (SQLite-cached via
@@ -595,11 +614,7 @@ export async function recordToProxyDocument(
 
   // Surface external resource refs (the shared article URL for link posts),
   // keeping only entries with a real uri.
-  const links = Array.isArray(doc.links)
-    ? doc.links
-        .filter((l): l is { uri: string; rel?: string } => typeof l?.uri === 'string' && !!l.uri)
-        .map((l) => ({ uri: l.uri, ...(l.rel ? { rel: l.rel } : {}) }))
-    : [];
+  const links = readRecordLinks(doc.links);
 
   // Resolve the paired curated edition (if any) to renderable item previews. The
   // edition's own publication name + theme (colors) + fonts + author handle drive

--- a/frontend/src/lib/components/feed/LinkblogEntry.svelte
+++ b/frontend/src/lib/components/feed/LinkblogEntry.svelte
@@ -49,6 +49,7 @@
     getExternalArticleLink,
     getLinkPostNote,
     getLinkPostNoteMentions,
+    getLinkPostTitle,
     isSkyreaderShare,
     linkifyNoteMentions,
   } from '$lib/utils/linkPost';
@@ -74,8 +75,11 @@
   let articleUrl = $derived(
     draft ? draft.articleUrl : doc ? (getExternalArticleLink(doc) ?? doc.canonicalUrl ?? '') : ''
   );
+  // The article's own title, undecorated. The record's `title` may carry the 🔗 /
+  // “…” decoration that exists for foreign sites; on your own linkblog the
+  // headline is the article, so read it off the card (see getLinkPostTitle).
   let articleTitle = $derived(
-    draft ? (draft.articleTitle ?? draft.articleUrl) : (doc?.title ?? '')
+    draft ? (draft.articleTitle ?? draft.articleUrl) : doc ? getLinkPostTitle(doc) : ''
   );
   let faviconUrl = $derived(articleUrl ? getFaviconUrl(articleUrl) : '');
   let domain = $derived.by(() => {

--- a/frontend/src/lib/components/feed/ShareComposer.svelte
+++ b/frontend/src/lib/components/feed/ShareComposer.svelte
@@ -20,6 +20,7 @@
   import { bottomBarInset } from '$lib/stores/bottomBarInset.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { preferences } from '$lib/stores/preferences.svelte';
+  import { myLinkblogStore } from '$lib/stores/myLinkblog.svelte';
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { formatQuoteSeed } from '$lib/utils/linkPost';
   import { positionFloating } from '$lib/utils/floating';
@@ -45,6 +46,44 @@
   let noteLength = $derived(composer.note.length);
   let nearLimit = $derived(noteLength > MAX - 200);
   let overLimit = $derived(noteLength > MAX);
+
+  // ── Where the link card sits ────────────────────────────────────────────────
+  // The published post puts the article's card wherever the user's card-position
+  // setting says, so the draft shows it there too — the composer and the post
+  // agree instead of the composer implying one layout and the post publishing
+  // another. Mirrors the backend's cardIndexFor: 'context' (the default) drops
+  // the card after the opening quote block(s), before the first commentary.
+  let cardPosition = $derived(myLinkblogStore.publication?.formatting?.cardPosition ?? 'context');
+  // Offered only when the user turned the feature on, and only on a new share —
+  // v1 doesn't add or remove the line on an edit (the backend preserves whatever
+  // the record already has).
+  let showAttribution = $derived(!isEdit && preferences.linkblogAttributionOffered);
+
+  // The composer needs the publication's formatting to draw the card where the
+  // post will put it. Unforced, so it piggybacks on whatever is already loaded.
+  $effect(() => {
+    if (session && !myLinkblogStore.publication) void myLinkblogStore.load();
+  });
+
+  let cardIndex = $derived.by(() => {
+    // The composer's block list and the published note's runs line up one-to-one
+    // once empty blocks (the trailing "type here" text block) are discounted.
+    const filled = composer.blocks.map((b) => b.text.trim() !== '');
+    const runs = composer.blocks.filter((_, i) => filled[i]);
+    if (cardPosition === 'top') return 0;
+    if (cardPosition === 'bottom') return composer.blocks.length;
+    let leadingQuotes = 0;
+    while (leadingQuotes < runs.length && runs[leadingQuotes].kind === 'quote') leadingQuotes++;
+    if (leadingQuotes === 0) return 0;
+    // Translate a run index back to a block index (skipping the empty blocks).
+    let seen = 0;
+    for (let i = 0; i < composer.blocks.length; i++) {
+      if (!filled[i]) continue;
+      if (seen === leadingQuotes) return i;
+      seen++;
+    }
+    return composer.blocks.length;
+  });
 
   // ── Quote picker ────────────────────────────────────────────────────────────
   // Saved highlights on the article, shown in full with their surrounding
@@ -593,8 +632,19 @@
         </div>
       </header>
 
+      <!-- What the post carries besides your words: the article's link card,
+           drawn where the published post will actually put it. -->
+      {#snippet linkCard()}
+        <div class="link-card" title={article.url}>
+          {#if faviconUrl}<img src={faviconUrl} alt="" class="link-card-favicon" />{/if}
+          <span class="link-card-title">{article.title}</span>
+          {#if domain}<span class="link-card-domain">{domain}</span>{/if}
+        </div>
+      {/snippet}
+
       <div class="composer-blocks" class:picking={quotesOpen}>
         {#each composer.blocks as block, i (i)}
+          {#if i === cardIndex}{@render linkCard()}{/if}
           {#if block.kind === 'quote'}
             <div class="quote-block">
               <textarea
@@ -637,13 +687,11 @@
             </div>
           {/if}
         {/each}
+        {#if cardIndex >= composer.blocks.length}{@render linkCard()}{/if}
 
-        <!-- What the post carries besides your words: the article's link card. -->
-        <div class="link-card" title={article.url}>
-          {#if faviconUrl}<img src={faviconUrl} alt="" class="link-card-favicon" />{/if}
-          <span class="link-card-title">{article.title}</span>
-          {#if domain}<span class="link-card-domain">{domain}</span>{/if}
-        </div>
+        {#if showAttribution && composer.attribution}
+          <p class="attribution-preview">Posted from skyreader.app</p>
+        {/if}
       </div>
 
       <footer class="composer-foot">
@@ -712,6 +760,19 @@
                 </div>
               {/if}
             </div>
+          {/if}
+          {#if showAttribution}
+            <!-- Off unless the user turned the feature on in Settings → Shared
+                 links: a checkbox in the way of every draft is exactly the kind
+                 of thing that stops being useful and starts being noise. -->
+            <label class="attribution-toggle">
+              <input
+                type="checkbox"
+                checked={composer.attribution}
+                onchange={(e) => composer.setAttribution(e.currentTarget.checked)}
+              />
+              <span class="foot-btn-label">Posted from Skyreader</span>
+            </label>
           {/if}
           {#if isEdit}
             <!-- Taking the share down lives here: the Share control opens this
@@ -1076,8 +1137,9 @@
     color: var(--color-error, #f44336);
   }
 
-  /* The trailing link card every share carries — shown so the draft reads as
-     the finished post: your words, then the article. */
+  /* The link card every share carries, drawn at the position the published post
+     will use — so the draft reads as the finished post rather than implying a
+     layout the post won't have. */
   .link-card {
     display: flex;
     align-items: center;
@@ -1108,6 +1170,30 @@
   .link-card-domain {
     flex-shrink: 0;
     color: var(--color-text-secondary);
+  }
+
+  /* The attribution line as it will appear in the post — quiet, because it is
+     the one line here that isn't the user's writing. */
+  .attribution-preview {
+    margin: 0.125rem 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .attribution-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.3125rem 0.5rem;
+    color: var(--color-text-secondary);
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+  }
+
+  .attribution-toggle input {
+    margin: 0;
+    cursor: pointer;
   }
 
   /* ── Footer ─────────────────────────────────────────────────────────────── */
@@ -1362,6 +1448,12 @@
     }
 
     .foot-btn.discard.confirming .foot-btn-label {
+      display: inline;
+    }
+
+    /* The checkbox's label is the only thing that says what it does, so unlike
+       the icon buttons beside it, it keeps its words on a phone. */
+    .attribution-toggle .foot-btn-label {
       display: inline;
     }
 

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -26,6 +26,7 @@ import type {
   SocialDocument,
   User,
 } from '$lib/types';
+import { getLinkPostTitle, isLinkPost } from '$lib/utils/linkPost';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
@@ -40,6 +41,45 @@ export interface LabelRowDTO {
   updatedAt: number;
   deletedAt?: number | null;
   clientUpdatedAt?: number | null;
+}
+
+export interface DocumentsBatchV2Response {
+  authors: Array<{
+    did: string;
+    siteUri?: string;
+    // Present only on `ready`; absent on `unchanged` (bodyless) and `error`.
+    documents?: SocialDocument[];
+    status: 'ready' | 'unchanged' | 'error';
+    error?: string;
+    errorCount?: number;
+    nextRetryAt?: number;
+    // Per-scope content hash to store and echo as `since_digest` next poll.
+    digest?: string;
+    // True when `documents` is the author's complete set (fit under the proxy's
+    // per-author cap) — lets a client treat an absent record as deleted.
+    complete?: boolean;
+  }>;
+  // See fetchFeedsBatchV2 — documents ride the identical read delta.
+  readCursor?: number;
+}
+
+/**
+ * Give a link post back the article's own title.
+ *
+ * A share's record title carries the author's chosen decoration (🔗 …, “…”), and
+ * that decoration is FOR foreign sites — on leaflet.pub or pckt an undecorated
+ * title made the post indistinguishable from a repost of the article. Inside
+ * Skyreader the headline is the article, so the decoration is stripped once here,
+ * at the one boundary every document read crosses, rather than at each of the
+ * dozen surfaces that render `doc.title` (feed card, saves, reader, linkblog).
+ *
+ * Non-link-post documents — someone's essay — are untouched: their title is their
+ * own, decorations and all.
+ */
+function undecorateLinkPostTitle(doc: SocialDocument): SocialDocument {
+  if (!isLinkPost(doc)) return doc;
+  const title = getLinkPostTitle(doc);
+  return title && title !== doc.title ? { ...doc, title } : doc;
 }
 
 export class RateLimitError extends Error {
@@ -632,29 +672,15 @@ class ApiClient {
 
   async fetchDocumentsBatchV2(
     documents: Array<{ did: string; siteUri?: string; since_digest?: string }>
-  ): Promise<{
-    authors: Array<{
-      did: string;
-      siteUri?: string;
-      // Present only on `ready`; absent on `unchanged` (bodyless) and `error`.
-      documents?: SocialDocument[];
-      status: 'ready' | 'unchanged' | 'error';
-      error?: string;
-      errorCount?: number;
-      nextRetryAt?: number;
-      // Per-scope content hash to store and echo as `since_digest` next poll.
-      digest?: string;
-      // True when `documents` is the author's complete set (fit under the proxy's
-      // per-author cap) — lets a client treat an absent record as deleted.
-      complete?: boolean;
-    }>;
-    // See fetchFeedsBatchV2 — documents ride the identical read delta.
-    readCursor?: number;
-  }> {
-    return this.fetch('/api/v2/documents/batch', {
+  ): Promise<DocumentsBatchV2Response> {
+    const res = await this.fetch<DocumentsBatchV2Response>('/api/v2/documents/batch', {
       method: 'POST',
       body: JSON.stringify({ documents }),
     });
+    for (const author of res.authors ?? []) {
+      author.documents = author.documents?.map(undecorateLinkPostTitle);
+    }
+    return res;
   }
 
   // On-demand fetch of a single standard.site document by at:// URI — the in-app
@@ -664,7 +690,7 @@ class ApiClient {
     const res = await this.fetch<{ document?: SocialDocument }>(
       `/api/v2/documents/get?uri=${encodeURIComponent(uri)}`
     );
-    return res.document ?? null;
+    return res.document ? undecorateLinkPostTitle(res.document) : null;
   }
 
   async discoverFeedsV2(url: string): Promise<{
@@ -844,6 +870,8 @@ class ApiClient {
     tags?: string[];
     // Quote-reshare: the AT URI of the original link post being quoted.
     repostUri?: string;
+    // Append the "Posted from skyreader.app" line to the post.
+    attribution?: boolean;
   }): Promise<{ uri: string; cid: string; rkey: string; publication: string }> {
     return this.fetch('/api/linkblog/share', {
       method: 'POST',
@@ -999,6 +1027,18 @@ class ApiClient {
     return this.fetch('/api/linkblog/publication/visibility', {
       method: 'PUT',
       body: JSON.stringify({ pageHidden }),
+    });
+  }
+
+  // How this user's link posts are written on other people's sites: the title
+  // decoration and where the article's link card sits. Partial updates are fine;
+  // the response is the refreshed publication meta.
+  async setLinkblogFormatting(
+    formatting: Partial<LinkblogPublication['formatting']>
+  ): Promise<LinkblogPublication> {
+    return this.fetch('/api/linkblog/formatting', {
+      method: 'PUT',
+      body: JSON.stringify(formatting),
     });
   }
 

--- a/frontend/src/lib/services/socialGraph.test.ts
+++ b/frontend/src/lib/services/socialGraph.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { scanPublications } from './socialGraph';
+
+const DID = 'did:plc:someone';
+const PDS = 'https://pds.example';
+const FOLLOW = { did: DID, handle: 'someone.test', displayName: 'Someone' };
+
+const publication = (rkey: string, value: Record<string, unknown>) => ({
+  uri: `at://${DID}/site.standard.publication/${rkey}`,
+  value: { url: `https://${rkey}.example/`, ...value },
+});
+
+// Answers the DID document, then the publication listing.
+function stubPds(records: Array<{ uri: string; value: Record<string, unknown> }>) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.startsWith('https://plc.directory/')) {
+      return new Response(
+        JSON.stringify({ service: [{ id: '#atproto_pds', serviceEndpoint: PDS }] }),
+        { status: 200 }
+      );
+    }
+    return new Response(JSON.stringify({ records }), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe('scanPublications', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // A Skyreader linkblog belongs to the Linkblogs section on /discover, so
+  // listing it here too would show the same account twice. Publications minted
+  // since the TID change each sit at their own rkey, so the marker — not the old
+  // fixed rkey — is what identifies them.
+  it('skips a linkblog minted at a TID, on its marker', async () => {
+    stubPds([
+      publication('3mstjk7sct22d', {
+        name: 'My links',
+        skyreaderLinkblog: 'https://skyreader.app/linkblog',
+      }),
+      publication('3mv4qfo5qj2zu', { name: 'An essay collection' }),
+    ]);
+
+    const out = await scanPublications(FOLLOW);
+    expect(out.map((p) => p.name)).toEqual(['An essay collection']);
+  });
+
+  it('still skips a linkblog left at the legacy rkey', async () => {
+    stubPds([
+      // Created before the marker existed, so the rkey is the only tell.
+      publication('skyreader-links', { name: 'My links' }),
+      publication('3mv4qfo5qj2zu', { name: 'An essay collection' }),
+    ]);
+
+    const out = await scanPublications(FOLLOW);
+    expect(out.map((p) => p.name)).toEqual(['An essay collection']);
+  });
+});

--- a/frontend/src/lib/services/socialGraph.ts
+++ b/frontend/src/lib/services/socialGraph.ts
@@ -12,13 +12,20 @@
 // CORS is silently skipped — discovery is an adornment, never load-bearing.
 
 import type { FollowingPublication } from '$lib/types';
+import { LINKBLOG_MARKER_URL } from '$lib/utils/linkPost';
 
 const APPVIEW_BASE = 'https://public.api.bsky.app';
 const PLC_DIRECTORY = 'https://plc.directory';
 const PUBLICATION_COLLECTION = 'site.standard.publication';
-// The Skyreader linkblog publication — surfaced in the Linkblogs section, so we
-// exclude it here to avoid listing the same account twice on /discover.
-const LINKBLOG_RKEY = 'skyreader-links';
+// A Skyreader linkblog is surfaced in the Linkblogs section, so it's excluded
+// here to avoid listing the same account twice on /discover. The marker is the
+// durable tell: publications minted since the TID change each sit at their own
+// rkey, so the fixed one only identifies the ones created before it.
+const LEGACY_LINKBLOG_RKEY = 'skyreader-links';
+
+function isSkyreaderLinkblog(uri: string, value: PublicationRecord): boolean {
+  return value.skyreaderLinkblog === LINKBLOG_MARKER_URL || rkeyOf(uri) === LEGACY_LINKBLOG_RKEY;
+}
 
 export interface FollowLite {
   did: string;
@@ -105,6 +112,8 @@ interface PublicationRecord {
   url?: string;
   description?: string;
   icon?: { ref?: { $link?: string } };
+  // Skyreader's provenance marker on the publications it creates.
+  skyreaderLinkblog?: string;
 }
 interface ListRecordsResponse {
   records?: Array<{ uri: string; value: PublicationRecord }>;
@@ -116,7 +125,7 @@ function rkeyOf(uri: string): string {
 
 /**
  * List one followed account's standard.site publications straight from their
- * PDS. Skips the Skyreader linkblog (skyreader-links). Returns [] on any
+ * PDS. Skips the account's Skyreader linkblog. Returns [] on any
  * failure (unresolved PDS, CORS block, network error) — never throws.
  */
 export async function scanPublications(follow: FollowLite): Promise<FollowingPublication[]> {
@@ -139,8 +148,8 @@ export async function scanPublications(follow: FollowLite): Promise<FollowingPub
 
   const out: FollowingPublication[] = [];
   for (const record of data.records) {
-    if (rkeyOf(record.uri) === LINKBLOG_RKEY) continue;
     const value = record.value || {};
+    if (isSkyreaderLinkblog(record.uri, value)) continue;
 
     let iconUrl: string | undefined;
     if (value.icon?.ref?.$link) {

--- a/frontend/src/lib/stores/linkblog.svelte.ts
+++ b/frontend/src/lib/stores/linkblog.svelte.ts
@@ -135,7 +135,9 @@ function createLinkblogStore() {
   async function shareLink(
     article: Article,
     note?: string,
-    repostUri?: string
+    repostUri?: string,
+    // Ticked in the composer: append the "Posted from skyreader.app" line.
+    attribution?: boolean
   ): Promise<ShareLinkResult> {
     // Guard against both a local duplicate and one already shared on another
     // device (surfaced via the overlay) — re-sharing would create a second copy.
@@ -172,6 +174,7 @@ function createLinkblogStore() {
         articlePublishedAt: article.publishedAt,
         note,
         repostUri,
+        attribution,
       });
       const stored = shares.get(article.url);
       if (stored) {

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -229,9 +229,16 @@ function createMyLinkblogStore() {
   // Mirrors the backend's replaceLeafletNoteRegion, which this is the optimistic
   // preview of: the card no longer closes the post, so "everything from the first
   // non-note block onward" is no longer the tail — it's whatever isn't the note,
-  // re-inserted at the same layout position it was found in. The attribution line
-  // is carried through as-is (the edit path never adds or removes one).
-  function rebuildContentWithNote(existing: unknown, note: string): unknown {
+  // re-inserted at the same layout position it was found in. An attribution line
+  // WE added — the record's `skyreaderAttribution` flag is the only thing that
+  // says so — is carried through as-is (the edit path never adds or removes one);
+  // on any other record that same sentence is the author's, and belongs to the
+  // note like any other line.
+  function rebuildContentWithNote(
+    existing: unknown,
+    note: string,
+    hasAttribution: boolean
+  ): unknown {
     const pages =
       (
         existing as {
@@ -249,7 +256,7 @@ function createMyLinkblogStore() {
       const type = wrapper.block.$type;
       const isNoteType =
         type === 'pub.leaflet.blocks.text' || type === 'pub.leaflet.blocks.blockquote';
-      if (isNoteType && isAttributionText(wrapper.block.plaintext ?? '')) {
+      if (isNoteType && isAttributionText(wrapper.block.plaintext ?? '', hasAttribution)) {
         attribution = { block: wrapper.block };
         continue;
       }
@@ -301,7 +308,7 @@ function createMyLinkblogStore() {
     const doc = documents[idx];
     const next: SocialDocument = {
       ...doc,
-      content: rebuildContentWithNote(doc.content, note.trim()),
+      content: rebuildContentWithNote(doc.content, note.trim(), doc.skyreaderAttribution === true),
     };
     documents = [...documents.slice(0, idx), next, ...documents.slice(idx + 1)];
   }

--- a/frontend/src/lib/stores/myLinkblog.svelte.ts
+++ b/frontend/src/lib/stores/myLinkblog.svelte.ts
@@ -16,7 +16,7 @@
 import { api } from '$lib/services/api';
 import { auth } from '$lib/stores/auth.svelte';
 import { buildOptimisticLinkPost, getExternalArticleLink } from '$lib/utils/linkPost';
-import { noteToLeafletBlocks } from '$lib/utils/linkPostNote';
+import { isAttributionText, noteToLeafletBlocks } from '$lib/utils/linkPostNote';
 import { loadDigests, saveDigests, scopeKey } from '$lib/services/documentDigests';
 import type { LinkblogPublication, SocialDocument } from '$lib/types';
 import { preferences } from '$lib/stores/preferences.svelte';
@@ -223,30 +223,72 @@ function createMyLinkblogStore() {
     documents = [doc, ...documents.filter((d) => getExternalArticleLink(d) !== input.articleUrl)];
   }
 
-  // Rebuild a document's pub.leaflet body with new leading text/blockquote
-  // blocks, preserving the website card and everything after it.
+  // Rebuild a document's pub.leaflet body with new note blocks, keeping the
+  // website card (and anything else that isn't ours) exactly where it sits.
+  //
+  // Mirrors the backend's replaceLeafletNoteRegion, which this is the optimistic
+  // preview of: the card no longer closes the post, so "everything from the first
+  // non-note block onward" is no longer the tail — it's whatever isn't the note,
+  // re-inserted at the same layout position it was found in. The attribution line
+  // is carried through as-is (the edit path never adds or removes one).
   function rebuildContentWithNote(existing: unknown, note: string): unknown {
     const pages =
-      (existing as { pages?: Array<{ blocks?: Array<{ block?: { $type?: string } }> }> })?.pages ??
-      [];
-    const blocks: Array<{ block: unknown }> = [];
-    blocks.push(...noteToLeafletBlocks(note));
+      (
+        existing as {
+          pages?: Array<{ blocks?: Array<{ block?: { $type?: string; plaintext?: string } }> }>;
+        }
+      )?.pages ?? [];
     const oldBlocks = pages[0]?.blocks ?? [];
-    const firstPreserved = oldBlocks.findIndex(
-      (wrapper) =>
-        wrapper.block?.$type !== 'pub.leaflet.blocks.text' &&
-        wrapper.block?.$type !== 'pub.leaflet.blocks.blockquote'
-    );
-    if (firstPreserved >= 0) {
-      for (const wrapper of oldBlocks.slice(firstPreserved)) {
-        if (wrapper.block) blocks.push({ block: wrapper.block });
+
+    const extras: Array<{ block: unknown }> = [];
+    let attribution: { block: unknown } | null = null;
+    let oldNotes = 0;
+    let notesBeforeExtras = -1;
+    for (const wrapper of oldBlocks) {
+      if (!wrapper.block) continue;
+      const type = wrapper.block.$type;
+      const isNoteType =
+        type === 'pub.leaflet.blocks.text' || type === 'pub.leaflet.blocks.blockquote';
+      if (isNoteType && isAttributionText(wrapper.block.plaintext ?? '')) {
+        attribution = { block: wrapper.block };
+        continue;
       }
+      if (isNoteType) {
+        oldNotes++;
+        continue;
+      }
+      if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+      extras.push({ block: wrapper.block });
     }
+    if (notesBeforeExtras < 0) notesBeforeExtras = oldNotes;
+
+    const noteBlocks = noteToLeafletBlocks(note);
+    // Same rule as the backend: no note on the old record means no evidence, and
+    // 'bottom' is what such a record was written as.
+    const at =
+      oldNotes === 0 || notesBeforeExtras >= oldNotes
+        ? noteBlocks.length
+        : notesBeforeExtras <= 0
+          ? 0
+          : Math.min(leadingQuoteRuns(noteBlocks), noteBlocks.length);
+    const blocks: Array<{ block: unknown }> = [
+      ...noteBlocks.slice(0, at),
+      ...extras,
+      ...noteBlocks.slice(at),
+      ...(attribution ? [attribution] : []),
+    ];
     if (blocks.length === 0) return undefined;
     return {
       $type: 'pub.leaflet.content',
       pages: [{ $type: 'pub.leaflet.pages.linearDocument', blocks }],
     };
+  }
+
+  // How many blocks the note opens with that are quotes — the 'context' split.
+  function leadingQuoteRuns(blocks: Array<{ block: { $type?: string } }>): number {
+    let n = 0;
+    while (n < blocks.length && blocks[n].block.$type === 'pub.leaflet.blocks.blockquote') n++;
+    return n;
   }
 
   // Update the note on an already-listed document (keyed by record URI), so the

--- a/frontend/src/lib/stores/preferences.component.test.ts
+++ b/frontend/src/lib/stores/preferences.component.test.ts
@@ -1,0 +1,84 @@
+// Named `.component.test.ts` so it runs in the project that compiles runes —
+// the store is a `.svelte.ts` module and `$state` needs the Svelte plugin.
+//
+// Regression suite for the "Posted from Skyreader" kill-switch: disabling the
+// offer in Settings must actually stop the attribution line, even when the
+// checkbox was ticked (and persisted sticky) beforehand. See the review finding
+// on the linkblog-formatting change: the sticky on-value used to outlive the
+// offer, seed a fresh composer to a hidden `true`, and keep publishing.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'skyreader-preferences';
+const DID = 'did:plc:reader';
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+  auth: {
+    get user() {
+      return {
+        did: DID,
+        handle: 'reader.bsky.social',
+        displayName: 'The Reader',
+        avatarUrl: null,
+        pdsUrl: 'https://pds.test',
+      };
+    },
+  },
+}));
+
+// The store restores from localStorage at module-init, so every test seeds
+// storage first and imports a fresh copy.
+async function freshPreferences() {
+  vi.resetModules();
+  const { preferences } = await import('./preferences.svelte');
+  return preferences;
+}
+
+function storedDids(key: 'linkblogAttributionOfferedDids' | 'linkblogAttributionOnDids'): string[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? (JSON.parse(raw)[key] ?? []) : [];
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('linkblog attribution kill-switch', () => {
+  it('disabling the offer after the box was ticked turns attribution off', async () => {
+    const preferences = await freshPreferences();
+    preferences.setLinkblogAttributionOffered(true);
+    preferences.setLinkblogAttributionOn(true);
+    expect(preferences.linkblogAttributionOn).toBe(true);
+
+    preferences.setLinkblogAttributionOffered(false);
+
+    expect(preferences.linkblogAttributionOffered).toBe(false);
+    expect(preferences.linkblogAttributionOn).toBe(false);
+    // The sticky value is gone from storage too, not merely masked: a fresh
+    // session (or a later re-enable) must start from an unticked box.
+    expect(storedDids('linkblogAttributionOnDids')).not.toContain(DID);
+  });
+
+  it('re-enabling the offer starts from an unticked box', async () => {
+    const preferences = await freshPreferences();
+    preferences.setLinkblogAttributionOffered(true);
+    preferences.setLinkblogAttributionOn(true);
+    preferences.setLinkblogAttributionOffered(false);
+
+    preferences.setLinkblogAttributionOffered(true);
+
+    expect(preferences.linkblogAttributionOffered).toBe(true);
+    expect(preferences.linkblogAttributionOn).toBe(false);
+  });
+
+  it('a persisted ticked state never reads as on while the offer is off', async () => {
+    // What a build without the clearing fix left behind: ticked, offer off.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ linkblogAttributionOfferedDids: [], linkblogAttributionOnDids: [DID] })
+    );
+    const preferences = await freshPreferences();
+
+    expect(preferences.linkblogAttributionOffered).toBe(false);
+    expect(preferences.linkblogAttributionOn).toBe(false);
+  });
+});

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -312,6 +312,13 @@ function createPreferencesStore() {
     const next = setDidFlag(state.linkblogAttributionOfferedDids, offered);
     if (!next) return;
     state.linkblogAttributionOfferedDids = next;
+    // Disabling is a kill-switch: also drop the sticky ticked state. Left in
+    // place, it would seed the next draft's (now invisible) checkbox to true
+    // and keep publishing the line. Re-enabling starts from an unticked box.
+    if (!offered) {
+      const on = setDidFlag(state.linkblogAttributionOnDids, false);
+      if (on) state.linkblogAttributionOnDids = on;
+    }
     save();
   }
 
@@ -397,9 +404,16 @@ function createPreferencesStore() {
       const did = auth.user?.did;
       return !!did && state.linkblogAttributionOfferedDids.includes(did);
     },
+    // Gated on the offer, not just the ticked list: builds before the
+    // kill-switch cleared the sticky value on disable may have persisted a
+    // ticked state with the offer off, and that must never seed a draft.
     get linkblogAttributionOn() {
       const did = auth.user?.did;
-      return !!did && state.linkblogAttributionOnDids.includes(did);
+      return (
+        !!did &&
+        state.linkblogAttributionOfferedDids.includes(did) &&
+        state.linkblogAttributionOnDids.includes(did)
+      );
     },
     get defaultView() {
       return state.defaultView;

--- a/frontend/src/lib/stores/preferences.svelte.ts
+++ b/frontend/src/lib/stores/preferences.svelte.ts
@@ -75,6 +75,15 @@ interface PreferencesState {
   // or its deleted linkblog.
   linkblogShareConfirmedDids: string[];
   linkblogDisabledDids: string[];
+  // The "Posted from Skyreader" line: whether the composer OFFERS the checkbox
+  // at all (the settings kill-switch — a feature that would be annoying if it
+  // were always in the way), and whether the box is ticked by default. Both are
+  // per-account for the same reason as the two lists above: a second account on
+  // this browser must not inherit the first one's publishing habits. Client-side
+  // only — the server acts on the per-request flag, so this is UI state, and the
+  // tradeoff is that it doesn't follow you to another device.
+  linkblogAttributionOfferedDids: string[];
+  linkblogAttributionOnDids: string[];
   // Which surface a cold app load lands on (consumed by the `/` redirector).
   defaultView: DefaultView;
   // Whether the reader actually picked that surface. save() serializes the
@@ -116,6 +125,8 @@ function createPreferencesStore() {
     sortOrder: 'newest',
     linkblogShareConfirmedDids: [],
     linkblogDisabledDids: [],
+    linkblogAttributionOfferedDids: [],
+    linkblogAttributionOnDids: [],
     defaultView: 'home',
     defaultViewConfigured: false,
     cardDensity: 'cozy',
@@ -159,6 +170,8 @@ function createPreferencesStore() {
         // the safe direction for something that publishes publicly.
         state.linkblogShareConfirmedDids = didList(parsed.linkblogShareConfirmedDids);
         state.linkblogDisabledDids = didList(parsed.linkblogDisabledDids);
+        state.linkblogAttributionOfferedDids = didList(parsed.linkblogAttributionOfferedDids);
+        state.linkblogAttributionOnDids = didList(parsed.linkblogAttributionOnDids);
         if (
           parsed.defaultView === 'home' ||
           parsed.defaultView === 'feeds' ||
@@ -286,6 +299,30 @@ function createPreferencesStore() {
     save();
   }
 
+  // A per-account DID membership flag, the shape the four linkblog preferences
+  // share: present in the list = on for this account, logged out = off.
+  function setDidFlag(list: string[], on: boolean): string[] | null {
+    const did = auth.user?.did;
+    if (!did || on === list.includes(did)) return null;
+    return on ? [...list, did] : list.filter((d) => d !== did);
+  }
+
+  /** Whether the composer offers the "Posted from Skyreader" checkbox at all. */
+  function setLinkblogAttributionOffered(offered: boolean) {
+    const next = setDidFlag(state.linkblogAttributionOfferedDids, offered);
+    if (!next) return;
+    state.linkblogAttributionOfferedDids = next;
+    save();
+  }
+
+  /** Whether that checkbox starts ticked — sticky across drafts, per account. */
+  function setLinkblogAttributionOn(on: boolean) {
+    const next = setDidFlag(state.linkblogAttributionOnDids, on);
+    if (!next) return;
+    state.linkblogAttributionOnDids = next;
+    save();
+  }
+
   function setDefaultView(view: DefaultView) {
     state.defaultView = view;
     state.defaultViewConfigured = true;
@@ -354,6 +391,16 @@ function createPreferencesStore() {
       const did = auth.user?.did;
       return !!did && state.linkblogDisabledDids.includes(did);
     },
+    // Default OFF: the checkbox is a feature you opt into, not one that greets
+    // every draft. Turned on in Settings → Shared links.
+    get linkblogAttributionOffered() {
+      const did = auth.user?.did;
+      return !!did && state.linkblogAttributionOfferedDids.includes(did);
+    },
+    get linkblogAttributionOn() {
+      const did = auth.user?.did;
+      return !!did && state.linkblogAttributionOnDids.includes(did);
+    },
     get defaultView() {
       return state.defaultView;
     },
@@ -382,6 +429,8 @@ function createPreferencesStore() {
     setMarginHighlightImport,
     confirmLinkblogShare,
     setLinkblogDisabled,
+    setLinkblogAttributionOffered,
+    setLinkblogAttributionOn,
     setDefaultView,
     setCardDensity,
     setDailyMagazineMinutes,

--- a/frontend/src/lib/stores/shareComposer.component.test.ts
+++ b/frontend/src/lib/stores/shareComposer.component.test.ts
@@ -1,0 +1,114 @@
+// Named `.component.test.ts` so it runs in the project that compiles runes —
+// the store is a `.svelte.ts` module and `$state` needs the Svelte plugin.
+//
+// What the wire actually carries: the attribution flag handed to
+// `linkblogStore.shareLink` must obey the Settings kill-switch, whether the
+// offer was disabled before the composer opened or while the draft sat open
+// with the checkbox already hidden.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const DID = 'did:plc:reader';
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+  auth: {
+    get user() {
+      return {
+        did: DID,
+        handle: 'reader.bsky.social',
+        displayName: 'The Reader',
+        avatarUrl: null,
+        pdsUrl: 'https://pds.test',
+      };
+    },
+  },
+}));
+
+const shareLink = vi.fn();
+vi.mock('$lib/stores/linkblog.svelte', () => ({
+  linkblogStore: {
+    shareLink: (...args: unknown[]) => shareLink(...args),
+    setNote: vi.fn(),
+    unshare: vi.fn(),
+  },
+}));
+
+// The real drafts store persists to IndexedDB; the composer only needs these.
+vi.mock('$lib/stores/shareDrafts.svelte', () => ({
+  shareDraftsStore: {
+    load: () => Promise.resolve(),
+    get: () => undefined,
+    save: () => Promise.resolve(),
+    remove: () => Promise.resolve(),
+  },
+}));
+
+const ARTICLE = {
+  subscriptionId: 0,
+  guid: 'https://example.test/post',
+  url: 'https://example.test/post',
+  title: 'The Post',
+  publishedAt: '2026-01-01T00:00:00.000Z',
+  fetchedAt: 0,
+};
+
+// Both stores restore module-level $state on import; give every test a fresh
+// pair wired to a clean localStorage.
+async function freshStores() {
+  vi.resetModules();
+  const { preferences } = await import('./preferences.svelte');
+  const { shareComposerStore: shareComposer } = await import('./shareComposer.svelte');
+  return { preferences, shareComposer };
+}
+
+async function openCreate(shareComposer: { open: (o: { article: typeof ARTICLE }) => void }) {
+  shareComposer.open({ article: ARTICLE });
+  // open() resolves the drafts store before seeding the session.
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  shareLink.mockReset().mockResolvedValue('shared');
+});
+
+describe('share composer attribution', () => {
+  it('posts the sticky ticked value while the offer is on', async () => {
+    const { preferences, shareComposer } = await freshStores();
+    preferences.setLinkblogAttributionOffered(true);
+    preferences.setLinkblogAttributionOn(true);
+
+    await openCreate(shareComposer);
+    expect(shareComposer.attribution).toBe(true);
+    await shareComposer.post();
+
+    expect(shareLink).toHaveBeenCalledWith(ARTICLE, undefined, undefined, true);
+  });
+
+  it('disable-after-checked: a new composer neither seeds nor posts attribution', async () => {
+    const { preferences, shareComposer } = await freshStores();
+    preferences.setLinkblogAttributionOffered(true);
+    preferences.setLinkblogAttributionOn(true);
+    preferences.setLinkblogAttributionOffered(false);
+
+    await openCreate(shareComposer);
+    expect(shareComposer.attribution).toBe(false);
+    await shareComposer.post();
+
+    expect(shareLink).toHaveBeenCalledWith(ARTICLE, undefined, undefined, false);
+  });
+
+  it('disabling the offer while a draft is open suppresses the hidden true', async () => {
+    const { preferences, shareComposer } = await freshStores();
+    preferences.setLinkblogAttributionOffered(true);
+    preferences.setLinkblogAttributionOn(true);
+
+    await openCreate(shareComposer);
+    expect(shareComposer.attribution).toBe(true);
+    // The checkbox vanishes from the UI at this point; its stale true must
+    // not reach the record.
+    preferences.setLinkblogAttributionOffered(false);
+    await shareComposer.post();
+
+    expect(shareLink).toHaveBeenCalledWith(ARTICLE, undefined, undefined, false);
+  });
+});

--- a/frontend/src/lib/stores/shareComposer.svelte.ts
+++ b/frontend/src/lib/stores/shareComposer.svelte.ts
@@ -241,7 +241,10 @@ function createShareComposerStore() {
           article,
           noteText || undefined,
           repostUri,
-          attribution
+          // Re-check the kill-switch at post time: Settings may have disabled
+          // the offer while this draft sat open, hiding the checkbox — a value
+          // the user can no longer see must not be published.
+          attribution && preferences.linkblogAttributionOffered
         );
         if (result === 'failed') return false;
         if (result === 'duplicate') await linkblogStore.setNote(article.url, noteText);

--- a/frontend/src/lib/stores/shareComposer.svelte.ts
+++ b/frontend/src/lib/stores/shareComposer.svelte.ts
@@ -8,6 +8,7 @@
 // the live record on Update and are not drafted.
 
 import { linkblogStore } from '$lib/stores/linkblog.svelte';
+import { preferences } from '$lib/stores/preferences.svelte';
 import { shareDraftsStore } from '$lib/stores/shareDrafts.svelte';
 import { blocksToNote, noteToBlocks, draftHasContent, draftWordCount } from '$lib/utils/shareNote';
 import type { Article, ShareDraft, ShareDraftBlock } from '$lib/types';
@@ -51,6 +52,12 @@ function createShareComposerStore() {
   let blocks = $state<ShareDraftBlock[]>([]);
   let minimized = $state(false);
   let posting = $state(false);
+  // "Posted from skyreader.app" on this post. Seeded from the sticky per-account
+  // preference each time the drawer opens, so the choice carries between drafts
+  // without following the article. Create mode only — v1 offers no way to add or
+  // remove the line on an edit (delete and reshare covers it), and the backend
+  // preserves whatever the record already has.
+  let attribution = $state(false);
   let draftCreatedAt = 0;
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -124,6 +131,7 @@ function createShareComposerStore() {
     };
     minimized = false;
     posting = false;
+    attribution = mode === 'create' && preferences.linkblogAttributionOn;
 
     if (mode === 'edit') {
       blocks = noteToBlocks(options.initialNote);
@@ -229,7 +237,12 @@ function createShareComposerStore() {
         // through `isShared`, which deleted the draft without the note ever
         // being written. So act on what it reports: a failure keeps the draft, a
         // duplicate attaches these words to the entry that already exists.
-        const result = await linkblogStore.shareLink(article, noteText || undefined, repostUri);
+        const result = await linkblogStore.shareLink(
+          article,
+          noteText || undefined,
+          repostUri,
+          attribution
+        );
         if (result === 'failed') return false;
         if (result === 'duplicate') await linkblogStore.setNote(article.url, noteText);
       }
@@ -285,6 +298,14 @@ function createShareComposerStore() {
     isOpenFor,
     setMinimized(value: boolean) {
       minimized = value;
+    },
+    /** Tick or untick "Posted from Skyreader"; the choice sticks per account. */
+    setAttribution(value: boolean) {
+      attribution = value;
+      preferences.setLinkblogAttributionOn(value);
+    },
+    get attribution() {
+      return attribution;
     },
     get session() {
       return session;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -608,6 +608,10 @@ export interface SocialDocument {
   // whatever its home app publishes there, so this is what separates a share from
   // someone's essay — see isSkyreaderShare in utils/linkPost.
   skyreaderLinkblog?: string;
+  // The author opted into the trailing "Posted from skyreader.app" line. Note
+  // parsers exclude that block by this flag rather than by string match alone, so
+  // an author whose own last line reads exactly that keeps their words.
+  skyreaderAttribution?: boolean;
 }
 
 // A single curated piece in a Collection, resolved by the proxy to a renderable
@@ -934,6 +938,17 @@ export interface LinkblogPublication {
   // Informational — `url` above is always the Skyreader linkblog page, which
   // renders the connected publication's link posts too.
   externalUrl?: string;
+  // How this user's link posts are written where other people read them: whether
+  // the post title is decorated (so a share doesn't read as a repost of the
+  // article) and where the article's link card sits among the note's blocks.
+  formatting: LinkblogFormatting;
+}
+
+export interface LinkblogFormatting {
+  /** 🔗 <title> | “<title>” | the article title verbatim. */
+  titleStyle: 'link' | 'quoted' | 'plain';
+  /** After the opening quote | first | last. */
+  cardPosition: 'context' | 'top' | 'bottom';
 }
 
 // One publication the user could publish their links to, as offered by

--- a/frontend/src/lib/utils/feedbackPending.test.ts
+++ b/frontend/src/lib/utils/feedbackPending.test.ts
@@ -79,8 +79,11 @@ describe('mergePendingPosts', () => {
 
 describe('storage', () => {
   it('round-trips, and clears the key when nothing is pending', () => {
-    writePendingPosts([pending('a')]);
-    expect(readPendingPosts()).toEqual([pending('a')]);
+    // One entry, not two calls to `pending`: its default `postedAt` is `Date.now()`,
+    // so a millisecond tick between the write and the expectation fails the compare.
+    const entry = pending('a');
+    writePendingPosts([entry]);
+    expect(readPendingPosts()).toEqual([entry]);
     writePendingPosts([]);
     expect(readPendingPosts()).toEqual([]);
     expect(localStorage.getItem('skyreader-feedback-pending')).toBeNull();

--- a/frontend/src/lib/utils/linkPost.test.ts
+++ b/frontend/src/lib/utils/linkPost.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { SocialDocument } from '$lib/types';
-import { buildOptimisticLinkPost, getLinkPostNote, isSkyreaderShare } from './linkPost';
+import {
+  buildOptimisticLinkPost,
+  getLinkPostNote,
+  getLinkPostTitle,
+  isSkyreaderShare,
+  stripTitleDecoration,
+} from './linkPost';
+import { ATTRIBUTION_TEXT } from './linkPostNote';
 
 const ARTICLE = 'https://example.com/post';
 
@@ -37,6 +44,78 @@ describe('getLinkPostNote across connected publication formats', () => {
       })
     );
     expect(note).toBe('Worth reading.\n\n> A quote');
+  });
+
+  // The card can sit between the quote and the commentary now, so every format's
+  // reader has to skip it rather than treat it as the end of the note.
+  it('reads a Leaflet note around a mid-post card', () => {
+    const note = getLinkPostNote(
+      doc({
+        $type: 'pub.leaflet.content',
+        pages: [
+          {
+            blocks: [
+              { block: { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'A quote' } },
+              { block: { $type: 'pub.leaflet.blocks.website', src: ARTICLE } },
+              { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Worth reading.' } },
+            ],
+          },
+        ],
+      })
+    );
+    expect(note).toBe('> A quote\n\nWorth reading.');
+  });
+
+  it('reads a pckt note around a mid-post card', () => {
+    const note = getLinkPostNote(
+      doc({
+        $type: 'blog.pckt.content',
+        items: [
+          {
+            $type: 'blog.pckt.block.blockquote',
+            content: [{ $type: 'blog.pckt.block.text', plaintext: 'A quote' }],
+          },
+          { $type: 'blog.pckt.block.website', src: ARTICLE },
+          { $type: 'blog.pckt.block.text', plaintext: 'Worth reading.' },
+        ],
+      })
+    );
+    expect(note).toBe('> A quote\n\nWorth reading.');
+  });
+
+  it('reads a Markdown note around a mid-post link line, closing the gap', () => {
+    const note = getLinkPostNote(
+      doc({
+        $type: 'at.markpub.markdown',
+        text: { markdown: `> A quote\n\n[Post](${ARTICLE})\n\nWorth reading.` },
+      })
+    );
+    expect(note).toBe('> A quote\n\nWorth reading.');
+  });
+
+  it('excludes the attribution line from every format', () => {
+    expect(
+      getLinkPostNote({
+        ...doc({
+          $type: 'app.offprint.content',
+          items: [
+            { $type: 'app.offprint.block.text', plaintext: 'Worth reading.' },
+            { $type: 'app.offprint.block.webBookmark', href: ARTICLE, title: 'Post' },
+            { $type: 'app.offprint.block.text', plaintext: ATTRIBUTION_TEXT },
+          ],
+        }),
+        skyreaderAttribution: true,
+      })
+    ).toBe('Worth reading.');
+    expect(
+      getLinkPostNote({
+        ...doc({
+          $type: 'at.markpub.markdown',
+          text: { markdown: `Worth reading.\n\n[Post](${ARTICLE})\n\n${ATTRIBUTION_TEXT}` },
+        }),
+        skyreaderAttribution: true,
+      })
+    ).toBe('Worth reading.');
   });
 
   it('reads a pckt note and stops at the website card', () => {
@@ -97,6 +176,54 @@ describe('getLinkPostNote across connected publication formats', () => {
 
   it('ignores a content shape it does not know', () => {
     expect(getLinkPostNote(doc({ $type: 'com.example.content', items: [] }))).toBeUndefined();
+  });
+});
+
+// The record title carries the author's decoration (🔗 …, “…”) so a link post
+// isn't mistaken for a repost of the article on someone else's site. Skyreader's
+// own surfaces want the article's plain name, which lives on the website card.
+describe('getLinkPostTitle', () => {
+  it('prefers the plain card title over the decorated record title', () => {
+    expect(
+      getLinkPostTitle({
+        ...doc({
+          $type: 'pub.leaflet.content',
+          pages: [
+            {
+              blocks: [
+                {
+                  block: {
+                    $type: 'pub.leaflet.blocks.website',
+                    src: ARTICLE,
+                    title: 'The Article',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        title: '🔗 The Article',
+      })
+    ).toBe('The Article');
+  });
+
+  it('falls back to stripping the record title when the card has none', () => {
+    expect(
+      getLinkPostTitle({
+        ...doc({
+          $type: 'blog.pckt.content',
+          items: [{ $type: 'blog.pckt.block.website', src: ARTICLE }],
+        }),
+        title: '“The Article”',
+      })
+    ).toBe('The Article');
+  });
+
+  it('only strips the decorations we write', () => {
+    expect(stripTitleDecoration('🔗 A')).toBe('A');
+    expect(stripTitleDecoration('“A”')).toBe('A');
+    expect(stripTitleDecoration('"Straight" quotes')).toBe('"Straight" quotes');
+    expect(stripTitleDecoration('A')).toBe('A');
   });
 });
 

--- a/frontend/src/lib/utils/linkPost.test.ts
+++ b/frontend/src/lib/utils/linkPost.test.ts
@@ -118,6 +118,32 @@ describe('getLinkPostNote across connected publication formats', () => {
     ).toBe('Worth reading.');
   });
 
+  // The flag is what makes that line ours. Without it the author wrote it, and
+  // dropping it would both hide their words and delete them on the next edit —
+  // this note is what the composer reloads.
+  it("keeps an author's own attribution-shaped line when the record isn't flagged", () => {
+    expect(
+      getLinkPostNote(
+        doc({
+          $type: 'app.offprint.content',
+          items: [
+            { $type: 'app.offprint.block.text', plaintext: 'Worth reading.' },
+            { $type: 'app.offprint.block.webBookmark', href: ARTICLE, title: 'Post' },
+            { $type: 'app.offprint.block.text', plaintext: ATTRIBUTION_TEXT },
+          ],
+        })
+      )
+    ).toBe(`Worth reading.\n\n${ATTRIBUTION_TEXT}`);
+    expect(
+      getLinkPostNote(
+        doc({
+          $type: 'at.markpub.markdown',
+          text: { markdown: `Worth reading.\n\n[Post](${ARTICLE})\n\n${ATTRIBUTION_TEXT}` },
+        })
+      )
+    ).toBe(`Worth reading.\n\n${ATTRIBUTION_TEXT}`);
+  });
+
   it('reads a pckt note and stops at the website card', () => {
     const note = getLinkPostNote(
       doc({

--- a/frontend/src/lib/utils/linkPost.ts
+++ b/frontend/src/lib/utils/linkPost.ts
@@ -1,6 +1,10 @@
 import type { LeafletContent, SocialDocument } from '$lib/types';
 import { isLeafletContent } from '$lib/utils/leaflet-renderer';
-import { noteToLeafletBlocks, reconstructLinkPostNote } from '$lib/utils/linkPostNote';
+import {
+  isAttributionText,
+  noteToLeafletBlocks,
+  reconstructLinkPostNote,
+} from '$lib/utils/linkPostNote';
 
 /**
  * Link-post helpers (Linkblog Phase 2).
@@ -126,20 +130,82 @@ export function getLinkPostNote(doc: SocialDocument): string | undefined {
   if (isLeafletContent(doc.content)) {
     const content = doc.content as LeafletContent;
     for (const page of content.pages ?? []) {
-      const note = reconstructLinkPostNote(page.blocks ?? []).note;
+      const note = reconstructLinkPostNote(page.blocks ?? [], {
+        hasAttribution: doc.skyreaderAttribution,
+      }).note;
       if (note) return note;
     }
     return undefined;
   }
-  return foreignNote(doc.content, getExternalArticleLink(doc));
+  return foreignNote(doc.content, getExternalArticleLink(doc), doc.skyreaderAttribution);
 }
+
+/**
+ * The article's own title for a link post, undecorated.
+ *
+ * The document's `title` may carry the author's chosen decoration (🔗 …, “…”) —
+ * that decoration exists for FOREIGN sites, where a byte-identical title made a
+ * share indistinguishable from a repost of the article. Skyreader's own surfaces
+ * (and the RSS feed, and og:title) want the plain one, so they read the website
+ * card, which always holds it. Stripping `doc.title` is the fallback for records
+ * that predate the card carrying a title.
+ */
+export function getLinkPostTitle(doc: SocialDocument): string {
+  return websiteCardTitle(doc.content) ?? stripTitleDecoration(doc.title ?? '');
+}
+
+/** The plain article title stored on the website link-card block, if there is one. */
+function websiteCardTitle(content: unknown): string | undefined {
+  const shape = content as
+    | {
+        pages?: Array<{ blocks?: Array<{ block?: { $type?: string; title?: unknown } }> }>;
+        items?: Array<{ $type?: string; title?: unknown }>;
+      }
+    | undefined;
+  const usable = (value: unknown) =>
+    typeof value === 'string' && value.trim() ? value : undefined;
+  for (const page of shape?.pages ?? []) {
+    for (const wrapper of page.blocks ?? []) {
+      if (wrapper.block?.$type === 'pub.leaflet.blocks.website') return usable(wrapper.block.title);
+    }
+  }
+  for (const item of shape?.items ?? []) {
+    if (
+      item?.$type === 'blog.pckt.block.website' ||
+      item?.$type === 'app.offprint.block.webBookmark'
+    ) {
+      return usable(item.title);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Strip the decorations Skyreader writes onto a link post's title. Only ours —
+ * the link emoji and typographic quotes — so a title the author really did wrap
+ * in "straight quotes" survives. MUST match the backend's stripTitleDecoration.
+ */
+export function stripTitleDecoration(title: string): string {
+  let out = title.trim();
+  if (out.startsWith(TITLE_LINK_PREFIX)) out = out.slice(TITLE_LINK_PREFIX.length).trim();
+  else if (out.startsWith('\u{1f517}')) out = out.slice('\u{1f517}'.length).trim();
+  const quoted = /^“([\s\S]*)”$/.exec(out);
+  if (quoted) out = quoted[1].trim();
+  return out;
+}
+
+/** MUST match the backend's TITLE_LINK_PREFIX. */
+export const TITLE_LINK_PREFIX = '🔗 ';
 
 // ── Notes in a connected publication's own content lexicon ───────────────────
 //
 // pckt and Offprint share an `items` array of text/blockquote blocks; Markdown
-// (at.markpub) stores one string. In each, the note leads and the shared article
-// closes the post — as a native link card (pckt, Offprint) or a trailing Markdown
-// link. Rendered back into the same small Markdown subset the Leaflet reader
+// (at.markpub) stores one string. In each, the shared article rides along as a
+// native link card (pckt, Offprint) or a Markdown link line — and, since the
+// card-position preference, it can sit before, between or after the note's runs.
+// So the card is SKIPPED wherever it appears rather than ending the note; the
+// same for the opt-in "Posted from Skyreader" line, which is ours, not the
+// author's. Rendered back into the same small Markdown subset the Leaflet reader
 // produces (`> ` for quotes).
 
 interface ForeignBlock {
@@ -153,17 +219,22 @@ function blockText(block: ForeignBlock): string {
   return (block.content ?? []).map(blockText).filter(Boolean).join('\n');
 }
 
-function itemsNote(items: ForeignBlock[], prefix: string, articleUrl?: string): string | undefined {
+function itemsNote(
+  items: ForeignBlock[],
+  prefix: string,
+  articleUrl?: string,
+  hasAttribution?: boolean
+): string | undefined {
   const parts: string[] = [];
   for (const item of items) {
     const isQuote = item?.$type === `${prefix}blockquote`;
-    if (!isQuote && item?.$type !== `${prefix}text`) break;
+    if (!isQuote && item?.$type !== `${prefix}text`) continue;
     const text = blockText(item).trim();
     if (!text) continue;
-    // A link card ends the note by not being a text block at all. Shares written
-    // before Offprint's card was used put the article in a trailing text line
-    // instead, so a text block carrying the URL ends it too.
-    if (!isQuote && articleUrl && text.includes(articleUrl)) break;
+    // Shares written before Offprint's card was used put the article in a text
+    // line instead of a card, so a text block carrying the URL is the card too.
+    if (!isQuote && articleUrl && text.includes(articleUrl)) continue;
+    if (!isQuote && isAttributionText(text, hasAttribution)) continue;
     parts.push(
       isQuote
         ? text
@@ -177,8 +248,12 @@ function itemsNote(items: ForeignBlock[], prefix: string, articleUrl?: string): 
   return note || undefined;
 }
 
-function markdownNote(markdown: string, articleUrl?: string): string | undefined {
-  const lines = markdown.split('\n');
+function markdownNote(
+  markdown: string,
+  articleUrl?: string,
+  hasAttribution?: boolean
+): string | undefined {
+  let lines = markdown.split('\n');
   if (articleUrl) {
     for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i].includes(`](${articleUrl})`)) {
@@ -187,19 +262,29 @@ function markdownNote(markdown: string, articleUrl?: string): string | undefined
       }
     }
   }
-  const note = lines.join('\n').trim();
+  lines = lines.filter((line) => !isAttributionText(line, hasAttribution));
+  // Removing a line from the middle leaves the blank lines that flanked it back
+  // to back; collapse so a mid-post link doesn't open a hole in the note.
+  const note = lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
   return note || undefined;
 }
 
-function foreignNote(content: unknown, articleUrl?: string): string | undefined {
+function foreignNote(
+  content: unknown,
+  articleUrl?: string,
+  hasAttribution?: boolean
+): string | undefined {
   const shape = content as { $type?: string; items?: ForeignBlock[]; text?: { markdown?: string } };
   switch (shape?.$type) {
     case 'blog.pckt.content':
-      return itemsNote(shape.items ?? [], 'blog.pckt.block.', articleUrl);
+      return itemsNote(shape.items ?? [], 'blog.pckt.block.', articleUrl, hasAttribution);
     case 'app.offprint.content':
-      return itemsNote(shape.items ?? [], 'app.offprint.block.', articleUrl);
+      return itemsNote(shape.items ?? [], 'app.offprint.block.', articleUrl, hasAttribution);
     case 'at.markpub.markdown':
-      return markdownNote(shape.text?.markdown ?? '', articleUrl);
+      return markdownNote(shape.text?.markdown ?? '', articleUrl, hasAttribution);
     default:
       return undefined;
   }
@@ -224,7 +309,9 @@ export function getLinkPostNoteMentions(doc: SocialDocument): MentionFacet[] {
   if (!doc.content || !isLeafletContent(doc.content)) return [];
   const content = doc.content as LeafletContent;
   for (const page of content.pages ?? []) {
-    const result = reconstructLinkPostNote(page.blocks ?? []);
+    const result = reconstructLinkPostNote(page.blocks ?? [], {
+      hasAttribution: doc.skyreaderAttribution,
+    });
     if (result.note) return result.mentions;
   }
   return [];

--- a/frontend/src/lib/utils/linkPostNote.test.ts
+++ b/frontend/src/lib/utils/linkPostNote.test.ts
@@ -78,9 +78,10 @@ describe('link post note conversion', () => {
       { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
     ];
     expect(reconstructLinkPostNote(blocks, { hasAttribution: true }).note).toBe('commentary');
-    // Absent the record's flag, the constant string is the fallback tell…
-    expect(reconstructLinkPostNote(blocks).note).toBe('commentary');
-    // …but a record that says it has no attribution keeps the author's line.
+    // …but only the record's flag says the line is ours. Without it, an author who
+    // wrote that exact sentence keeps their words — on the page and, because this
+    // is what the composer reloads, through a note edit.
+    expect(reconstructLinkPostNote(blocks).note).toBe(`commentary\n\n${ATTRIBUTION_TEXT}`);
     expect(reconstructLinkPostNote(blocks, { hasAttribution: false }).note).toBe(
       `commentary\n\n${ATTRIBUTION_TEXT}`
     );

--- a/frontend/src/lib/utils/linkPostNote.test.ts
+++ b/frontend/src/lib/utils/linkPostNote.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { LeafletBlockWrapper } from '$lib/types';
-import { noteToLeafletBlocks, reconstructLinkPostNote } from './linkPostNote';
+import { ATTRIBUTION_TEXT, noteToLeafletBlocks, reconstructLinkPostNote } from './linkPostNote';
 
 describe('link post note conversion', () => {
   it('round-trips mixed commentary and native blockquotes', () => {
@@ -22,18 +22,68 @@ describe('link post note conversion', () => {
     expect(reconstructLinkPostNote(blocks).note).toBe('> legacy quote');
   });
 
-  it('stops the note at the website card and handles website-only shares', () => {
+  // The card no longer closes the post — it can sit between the quote and the
+  // commentary, or lead — so it's skipped, not treated as the end of the note.
+  // Breaking at it truncated every note written in the new layout.
+  it('skips the website card wherever it sits and handles website-only shares', () => {
     const website = {
       block: { $type: 'pub.leaflet.blocks.website', src: 'https://example.com' },
     } as LeafletBlockWrapper;
     expect(reconstructLinkPostNote([website])).toEqual({ note: undefined, mentions: [] });
     expect(
       reconstructLinkPostNote([
-        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'note' } },
+        { block: { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'quoted' } },
         website,
-        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'not note' } },
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'commentary' } },
       ]).note
-    ).toBe('note');
+    ).toBe('> quoted\n\ncommentary');
+    // …and card-first.
+    expect(
+      reconstructLinkPostNote([
+        website,
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'commentary' } },
+      ]).note
+    ).toBe('commentary');
+  });
+
+  // A card between two note blocks contributes no note bytes, so the mention
+  // offsets of the block after it must be unaffected by its presence.
+  it('keeps mention offsets correct across a mid-post card', () => {
+    const feature = { $type: 'pub.leaflet.richtext.facet#didMention', did: 'did:plc:bob' };
+    const result = reconstructLinkPostNote([
+      { block: { $type: 'pub.leaflet.blocks.blockquote', plaintext: 'quoted' } },
+      {
+        block: { $type: 'pub.leaflet.blocks.website', src: 'https://example.com' },
+      } as LeafletBlockWrapper,
+      {
+        block: {
+          $type: 'pub.leaflet.blocks.text',
+          plaintext: 'hi @a.test',
+          facets: [{ index: { byteStart: 3, byteEnd: 10 }, features: [feature] }],
+        },
+      },
+    ]);
+    expect(result.note).toBe('> quoted\n\nhi @a.test');
+    const note = result.note!;
+    const [m] = result.mentions;
+    expect(
+      new TextDecoder().decode(new TextEncoder().encode(note).slice(m.byteStart, m.byteEnd))
+    ).toBe('@a.test');
+  });
+
+  // The attribution line is ours, not the author's words.
+  it('excludes the attribution line from the note', () => {
+    const blocks: LeafletBlockWrapper[] = [
+      { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'commentary' } },
+      { block: { $type: 'pub.leaflet.blocks.text', plaintext: ATTRIBUTION_TEXT } },
+    ];
+    expect(reconstructLinkPostNote(blocks, { hasAttribution: true }).note).toBe('commentary');
+    // Absent the record's flag, the constant string is the fallback tell…
+    expect(reconstructLinkPostNote(blocks).note).toBe('commentary');
+    // …but a record that says it has no attribution keeps the author's line.
+    expect(reconstructLinkPostNote(blocks, { hasAttribution: false }).note).toBe(
+      `commentary\n\n${ATTRIBUTION_TEXT}`
+    );
   });
 
   it('rebases block-local Unicode mention offsets into reconstructed Markdown', () => {

--- a/frontend/src/lib/utils/linkPostNote.ts
+++ b/frontend/src/lib/utils/linkPostNote.ts
@@ -32,6 +32,26 @@ export function noteToLeafletBlocks(note: string | null | undefined): LeafletBlo
   return blocks;
 }
 
+/**
+ * The opt-in "this came from Skyreader" line. MUST match the backend's
+ * ATTRIBUTION_TEXT — it's the fallback tell for records whose top-level
+ * `skyreaderAttribution` flag didn't survive whatever pulled them.
+ */
+export const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
+
+/**
+ * Whether a block is the attribution line rather than the author's words.
+ *
+ * `hasAttribution` (the record's own flag) is the reliable signal; the string
+ * match is the fallback, and it's why the flag exists — someone whose last line
+ * happens to be that exact sentence would otherwise lose it. Bounded to a
+ * trailing-line match either way.
+ */
+export function isAttributionText(plaintext: string, hasAttribution?: boolean): boolean {
+  if (hasAttribution === false) return false;
+  return plaintext.trim() === ATTRIBUTION_TEXT;
+}
+
 export interface ReconstructedMention {
   byteStart: number;
   byteEnd: number;
@@ -57,7 +77,23 @@ function quoteOffset(plaintext: string, byteOffset: number): number {
   return byteOffset + 2 * (newlines + 1);
 }
 
-export function reconstructLinkPostNote(blocks: LeafletBlockWrapper[]): {
+/**
+ * The user's commentary, rebuilt from the native text and blockquote blocks.
+ *
+ * The website card no longer closes the post — it can sit between the quote and
+ * the commentary, or lead — so non-note blocks are SKIPPED rather than treated as
+ * the end of the note. (Breaking at the first one silently truncated every note
+ * written in the new layout at the card.) The card contributes no note bytes, so
+ * mention byte offsets are unaffected by where it sits.
+ *
+ * The "Posted from Skyreader" line is ours, not the author's, so it's excluded —
+ * by the record's `skyreaderAttribution` flag where the caller has it, and by the
+ * constant string otherwise.
+ */
+export function reconstructLinkPostNote(
+  blocks: LeafletBlockWrapper[],
+  options: { hasAttribution?: boolean } = {}
+): {
   note?: string;
   mentions: ReconstructedMention[];
 } {
@@ -71,8 +107,9 @@ export function reconstructLinkPostNote(blocks: LeafletBlockWrapper[]): {
       block.$type !== 'pub.leaflet.blocks.text' &&
       block.$type !== 'pub.leaflet.blocks.blockquote'
     )
-      break;
+      continue;
     if (!('plaintext' in block) || !block.plaintext.trim()) continue;
+    if (isAttributionText(block.plaintext, options.hasAttribution)) continue;
     const isQuote = block.$type === 'pub.leaflet.blocks.blockquote';
     const rendered = isQuote
       ? block.plaintext

--- a/frontend/src/lib/utils/linkPostNote.ts
+++ b/frontend/src/lib/utils/linkPostNote.ts
@@ -32,24 +32,21 @@ export function noteToLeafletBlocks(note: string | null | undefined): LeafletBlo
   return blocks;
 }
 
-/**
- * The opt-in "this came from Skyreader" line. MUST match the backend's
- * ATTRIBUTION_TEXT — it's the fallback tell for records whose top-level
- * `skyreaderAttribution` flag didn't survive whatever pulled them.
- */
+/** The opt-in "this came from Skyreader" line. MUST match the backend's ATTRIBUTION_TEXT. */
 export const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
 
 /**
  * Whether a block is the attribution line rather than the author's words.
  *
- * `hasAttribution` (the record's own flag) is the reliable signal; the string
- * match is the fallback, and it's why the flag exists — someone whose last line
- * happens to be that exact sentence would otherwise lose it. Bounded to a
- * trailing-line match either way.
+ * The record's own `skyreaderAttribution` flag is what decides — the string alone
+ * can't tell our line from an author who wrote that exact sentence, and it's why
+ * the flag exists. The writer stamps it top-level on the document and every read
+ * path carries it, so an unflagged record simply has no line of ours to exclude.
+ * (Erring the other way ate the author's words; this way a flag that somehow went
+ * missing only shows a line the reader can see is there.)
  */
 export function isAttributionText(plaintext: string, hasAttribution?: boolean): boolean {
-  if (hasAttribution === false) return false;
-  return plaintext.trim() === ATTRIBUTION_TEXT;
+  return hasAttribution === true && plaintext.trim() === ATTRIBUTION_TEXT;
 }
 
 export interface ReconstructedMention {
@@ -87,8 +84,8 @@ function quoteOffset(plaintext: string, byteOffset: number): number {
  * mention byte offsets are unaffected by where it sits.
  *
  * The "Posted from Skyreader" line is ours, not the author's, so it's excluded —
- * by the record's `skyreaderAttribution` flag where the caller has it, and by the
- * constant string otherwise.
+ * on the records whose `skyreaderAttribution` flag says we added it, and only
+ * those. See isAttributionText.
  */
 export function reconstructLinkPostNote(
   blocks: LeafletBlockWrapper[],

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -32,7 +32,12 @@
   import { syncStore } from '$lib/stores/sync.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { viewTitleStore } from '$lib/stores/viewTitle.svelte';
-  import type { LinkblogPublication, LinkblogPublicationChoice, SaveBacking } from '$lib/types';
+  import type {
+    LinkblogFormatting,
+    LinkblogPublication,
+    LinkblogPublicationChoice,
+    SaveBacking,
+  } from '$lib/types';
 
   $effect(() => {
     viewTitleStore.set('Settings');
@@ -151,6 +156,59 @@
   let showLinkblogPage = $state(true);
   $effect(() => {
     showLinkblogPage = !linkblogPub?.pageHidden;
+  });
+
+  // Post formatting. Same local-mirror reasoning as the page toggle above: a
+  // select moves itself, so a failed save needs somewhere to be put back from.
+  let titleStyle = $state<LinkblogFormatting['titleStyle']>('link');
+  let cardPosition = $state<LinkblogFormatting['cardPosition']>('context');
+  $effect(() => {
+    titleStyle = linkblogPub?.formatting?.titleStyle ?? 'link';
+    cardPosition = linkblogPub?.formatting?.cardPosition ?? 'context';
+  });
+
+  // The article title a preview uses. Deliberately generic — the point is the
+  // shape of the decoration, not this user's last share.
+  const SAMPLE_TITLE = 'The article you linked';
+  const titlePreview = $derived(
+    titleStyle === 'link'
+      ? `🔗 ${SAMPLE_TITLE}`
+      : titleStyle === 'quoted'
+        ? `“${SAMPLE_TITLE}”`
+        : SAMPLE_TITLE
+  );
+
+  async function handleSaveFormatting(patch: Partial<LinkblogFormatting>) {
+    const revert = () => {
+      titleStyle = linkblogPub?.formatting?.titleStyle ?? 'link';
+      cardPosition = linkblogPub?.formatting?.cardPosition ?? 'context';
+    };
+    if (isSavingLinkblog) return revert();
+    if (!syncStore.isOnline) {
+      linkblogError = 'You are offline. Connect to the internet to change this.';
+      return revert();
+    }
+    isSavingLinkblog = true;
+    linkblogError = null;
+    linkblogSuccess = null;
+    try {
+      linkblogPub = await api.setLinkblogFormatting(patch);
+      linkblogSuccess = 'Saved. Posts you already published keep the shape they were written in.';
+    } catch (error) {
+      linkblogError = error instanceof Error ? error.message : 'Could not change this.';
+      revert();
+    } finally {
+      isSavingLinkblog = false;
+    }
+  }
+
+  // Whether the composer offers the "Posted from Skyreader" checkbox at all.
+  // Client-side and per-account (see preferences): the server only ever acts on
+  // the per-share flag, so this is about what the composer shows, not what the
+  // post carries. The trade is that it doesn't follow you to another device.
+  let offerAttribution = $state(false);
+  $effect(() => {
+    offerAttribution = preferences.linkblogAttributionOffered;
   });
 
   onMount(async () => {
@@ -893,6 +951,66 @@
           </p>
         {/if}
       {/if}
+
+      <!-- How a post reads where other people read it. These matter most on a
+           connected publication (leaflet.pub, Offprint), where a link post sits
+           beside that site's own writing — but they're written into every record,
+           so they're offered either way. -->
+      <h3 class="subhead">How your posts read</h3>
+      <div class="linkblog-field">
+        <label for="linkblog-title-style">Post title</label>
+        <select
+          id="linkblog-title-style"
+          bind:value={titleStyle}
+          disabled={isSavingLinkblog}
+          onchange={(e) =>
+            handleSaveFormatting({
+              titleStyle: e.currentTarget.value as LinkblogFormatting['titleStyle'],
+            })}
+        >
+          <option value="link">🔗 with the article title</option>
+          <option value="quoted">The article title in quotes</option>
+          <option value="plain">The article title exactly</option>
+        </select>
+      </div>
+      <p class="setting-description">
+        Marks the post as a link rather than a copy of the article. Shows as
+        <strong>{titlePreview}</strong>. Skyreader always shows the plain title.
+      </p>
+
+      <div class="linkblog-field">
+        <label for="linkblog-card-position">Link card</label>
+        <select
+          id="linkblog-card-position"
+          bind:value={cardPosition}
+          disabled={isSavingLinkblog}
+          onchange={(e) =>
+            handleSaveFormatting({
+              cardPosition: e.currentTarget.value as LinkblogFormatting['cardPosition'],
+            })}
+        >
+          <option value="context">With the quote, above your commentary</option>
+          <option value="top">First</option>
+          <option value="bottom">Last</option>
+        </select>
+      </div>
+      <p class="setting-description">
+        Where the article sits in the post. With the quote, a reader knows what you're responding to
+        before they read the response.
+      </p>
+
+      <label class="toggle-setting">
+        <input
+          type="checkbox"
+          bind:checked={offerAttribution}
+          onchange={(e) => preferences.setLinkblogAttributionOffered(e.currentTarget.checked)}
+        />
+        <span>Offer a “Posted from Skyreader” line when sharing</span>
+      </label>
+      <p class="setting-description">
+        Adds a checkbox to the composer. Nothing is added to a post unless you tick it. This switch
+        is for this device.
+      </p>
 
       <!-- Name/description belong to the Skyreader linkblog only. A connected
            publication is its home app's record; Skyreader doesn't rename it. -->
@@ -1768,6 +1886,7 @@
   }
 
   .linkblog-field input,
+  .linkblog-field select,
   .linkblog-field textarea {
     width: 100%;
     padding: 0.5rem 0.625rem;

--- a/linkblog-site/src/lib/components/BlogEntry.svelte
+++ b/linkblog-site/src/lib/components/BlogEntry.svelte
@@ -8,6 +8,7 @@
     hostnameOf,
     linkPostMentions,
     linkPostNote,
+    linkPostTitle,
     renderBodyHtml,
     rkeyFromUri,
     safeHttpUrl,
@@ -41,6 +42,9 @@
   const host = $derived(hostnameOf(articleUrl ?? undefined));
   const date = $derived(formatDate(doc.createdAt || doc.publishedAt));
   const social = $derived(socialCountsText(ctx));
+  // The article's own title, undecorated — the 🔗 / “…” decoration on the record
+  // is for foreign sites, and this page IS the linkblog (see linkPostTitle).
+  const title = $derived(linkPostTitle(doc) || 'Untitled');
 </script>
 
 <li class="entry">
@@ -49,9 +53,9 @@
        date in the meta row is raised above it as the permalink to the commentary. -->
   <h2 class="entry-title">
     {#if headlineHref}
-      <a href={headlineHref}>{doc.title || 'Untitled'}</a>
+      <a href={headlineHref}>{title}</a>
     {:else}
-      {doc.title || 'Untitled'}
+      {title}
     {/if}
   </h2>
   {#if note}

--- a/linkblog-site/src/lib/fields.ts
+++ b/linkblog-site/src/lib/fields.ts
@@ -148,14 +148,14 @@ function blockMentions(block: LeafletTextBlock, base: number, isQuote: boolean):
 }
 
 // Skyreader's opt-in "posted from" line (the backend's ATTRIBUTION_TEXT). It's
-// ours, not the author's words, so every note parser here skips it. The record's
-// own `skyreaderAttribution` flag is the reliable tell; the string match is the
-// fallback for anything that lost the flag on the way here.
+// ours, not the author's words, so every note parser here skips it — but only on
+// a record whose own `skyreaderAttribution` flag says we added it. The string
+// alone can't tell our line from an author who wrote that exact sentence, and
+// skipping theirs would drop their words from their own post.
 export const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
 
 function isAttributionLine(text: string, hasAttribution?: boolean): boolean {
-  if (hasAttribution === false) return false;
-  return text.trim() === ATTRIBUTION_TEXT;
+  return hasAttribution === true && text.trim() === ATTRIBUTION_TEXT;
 }
 
 // Rebuild the note from the text and blockquote blocks — the same restricted

--- a/linkblog-site/src/lib/fields.ts
+++ b/linkblog-site/src/lib/fields.ts
@@ -147,11 +147,30 @@ function blockMentions(block: LeafletTextBlock, base: number, isQuote: boolean):
   return out;
 }
 
-// Rebuild the note from the leading text and blockquote blocks — the same
-// restricted Markdown the user typed, with `> ` markers restored — and rebase the
-// mention facets onto it. Skyreader writes the note before the website card, so
-// the walk stops at the first block that is neither.
-function reconstructLeafletNote(blocks: Array<{ block?: LeafletTextBlock }>): {
+// Skyreader's opt-in "posted from" line (the backend's ATTRIBUTION_TEXT). It's
+// ours, not the author's words, so every note parser here skips it. The record's
+// own `skyreaderAttribution` flag is the reliable tell; the string match is the
+// fallback for anything that lost the flag on the way here.
+export const ATTRIBUTION_TEXT = 'Posted from skyreader.app';
+
+function isAttributionLine(text: string, hasAttribution?: boolean): boolean {
+  if (hasAttribution === false) return false;
+  return text.trim() === ATTRIBUTION_TEXT;
+}
+
+// Rebuild the note from the text and blockquote blocks — the same restricted
+// Markdown the user typed, with `> ` markers restored — and rebase the mention
+// facets onto it.
+//
+// The website card no longer closes the post: it can sit between the quote and
+// the commentary, or lead (see the card-position preference), so a non-note block
+// is SKIPPED rather than ending the walk. Breaking at the first one truncated
+// every note written in the new layout at the card. The card contributes no note
+// bytes, so mention offsets are unaffected by where it sits.
+function reconstructLeafletNote(
+  blocks: Array<{ block?: LeafletTextBlock }>,
+  hasAttribution?: boolean
+): {
   note: string;
   mentions: MentionFacet[];
 } {
@@ -162,9 +181,10 @@ function reconstructLeafletNote(blocks: Array<{ block?: LeafletTextBlock }>): {
   for (const wrapper of blocks) {
     const block = wrapper.block;
     const isQuote = block?.$type === 'pub.leaflet.blocks.blockquote';
-    if (!isQuote && block?.$type !== 'pub.leaflet.blocks.text') break;
+    if (!isQuote && block?.$type !== 'pub.leaflet.blocks.text') continue;
     const plaintext = block?.plaintext;
     if (!plaintext?.trim()) continue;
+    if (!isQuote && isAttributionLine(plaintext, hasAttribution)) continue;
     const rendered = isQuote
       ? plaintext
           .split('\n')
@@ -184,10 +204,12 @@ function reconstructLeafletNote(blocks: Array<{ block?: LeafletTextBlock }>): {
 // A linkblog can be an existing standard.site publication (Leaflet, pckt,
 // Offprint, Markdown), in which case its link posts carry the note in that app's
 // content shape. pckt and Offprint use an ordered `items` array of text and
-// blockquote blocks; Markdown stores one string. In each the note leads and the
-// shared article closes the post — as a native link card (pckt, Offprint) or a
-// trailing Markdown link. Older Offprint shares closed with a text line carrying
-// the URL instead, which is why a URL-bearing text block also ends the note.
+// blockquote blocks; Markdown stores one string. In each, the shared article
+// rides along as a native link card (pckt, Offprint) or a Markdown link line, and
+// since the card-position preference it can lead, close, or sit between the
+// note's runs — so it's skipped wherever it appears rather than ending the note.
+// Older Offprint shares carried the article as a text line holding the URL, which
+// is why such a text block counts as the card too.
 
 interface ForeignBlock {
   $type?: string;
@@ -200,14 +222,20 @@ function foreignBlockText(block: ForeignBlock): string {
   return (block.content ?? []).map(foreignBlockText).filter(Boolean).join('\n');
 }
 
-function foreignItemsNote(items: ForeignBlock[], prefix: string, articleUrl?: string): string {
+function foreignItemsNote(
+  items: ForeignBlock[],
+  prefix: string,
+  articleUrl?: string,
+  hasAttribution?: boolean
+): string {
   const parts: string[] = [];
   for (const item of items) {
     const isQuote = item?.$type === `${prefix}blockquote`;
-    if (!isQuote && item?.$type !== `${prefix}text`) break;
+    if (!isQuote && item?.$type !== `${prefix}text`) continue;
     const text = foreignBlockText(item).trim();
     if (!text) continue;
-    if (!isQuote && articleUrl && text.includes(articleUrl)) break;
+    if (!isQuote && articleUrl && text.includes(articleUrl)) continue;
+    if (!isQuote && isAttributionLine(text, hasAttribution)) continue;
     parts.push(
       isQuote
         ? text
@@ -220,8 +248,12 @@ function foreignItemsNote(items: ForeignBlock[], prefix: string, articleUrl?: st
   return parts.join('\n\n').trim();
 }
 
-function foreignMarkdownNote(markdown: string, articleUrl?: string): string {
-  const lines = markdown.split('\n');
+function foreignMarkdownNote(
+  markdown: string,
+  articleUrl?: string,
+  hasAttribution?: boolean
+): string {
+  let lines = markdown.split('\n');
   if (articleUrl) {
     for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i].includes(`](${articleUrl})`)) {
@@ -230,7 +262,13 @@ function foreignMarkdownNote(markdown: string, articleUrl?: string): string {
       }
     }
   }
-  return lines.join('\n').trim();
+  lines = lines.filter((line) => !isAttributionLine(line, hasAttribution));
+  // Removing a line from the middle leaves the blank lines that flanked it back
+  // to back; collapse so a mid-post link doesn't open a hole in the note.
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 }
 
 // The user's commentary on a link post, with any @mention facets rebased onto it.
@@ -241,27 +279,28 @@ function noteOf(doc: ProxyDocument): { note: string; mentions: MentionFacet[] } 
   const content = doc.content as
     (LeafletContent & { items?: ForeignBlock[]; text?: { markdown?: string } }) | undefined;
   const articleUrl = externalArticleUrl(doc);
+  const attributed = doc.skyreaderAttribution;
   switch (content?.$type) {
     case 'pub.leaflet.content': {
       for (const page of content.pages ?? []) {
-        const result = reconstructLeafletNote(page.blocks ?? []);
+        const result = reconstructLeafletNote(page.blocks ?? [], attributed);
         if (result.note) return result;
       }
       return { note: '', mentions: [] };
     }
     case 'blog.pckt.content':
       return {
-        note: foreignItemsNote(content.items ?? [], 'blog.pckt.block.', articleUrl),
+        note: foreignItemsNote(content.items ?? [], 'blog.pckt.block.', articleUrl, attributed),
         mentions: [],
       };
     case 'app.offprint.content':
       return {
-        note: foreignItemsNote(content.items ?? [], 'app.offprint.block.', articleUrl),
+        note: foreignItemsNote(content.items ?? [], 'app.offprint.block.', articleUrl, attributed),
         mentions: [],
       };
     case 'at.markpub.markdown':
       return {
-        note: foreignMarkdownNote(content.text?.markdown ?? '', articleUrl),
+        note: foreignMarkdownNote(content.text?.markdown ?? '', articleUrl, attributed),
         mentions: [],
       };
     default:
@@ -276,6 +315,55 @@ export function linkPostNote(doc: ProxyDocument): string {
 // The resolved @mention facets on the note, byte-indexed into linkPostNote(doc).
 export function linkPostMentions(doc: ProxyDocument): MentionFacet[] {
   return noteOf(doc).mentions;
+}
+
+// The article's own title for a link post, undecorated.
+//
+// A share's record title may carry the author's chosen decoration (🔗 …, “…”),
+// which exists to distinguish a link post from a repost of the article on
+// FOREIGN sites. This page IS the linkblog, and its own headline, RSS <title> and
+// og:title want the article's plain name — so read it off the website card, which
+// always carries it. Stripping the record title is the fallback for records
+// written before the card had one.
+export function linkPostTitle(doc: ProxyDocument): string {
+  return websiteCardTitle(doc.content) ?? stripTitleDecoration(doc.title || '');
+}
+
+// The decorations Skyreader writes, and only those: the link emoji and
+// typographic quotes. A title the author really did wrap in "straight quotes"
+// survives. MUST match the backend's stripTitleDecoration.
+export function stripTitleDecoration(title: string): string {
+  let out = title.trim();
+  if (out.startsWith('\u{1f517} ')) out = out.slice('\u{1f517} '.length).trim();
+  else if (out.startsWith('\u{1f517}')) out = out.slice('\u{1f517}'.length).trim();
+  const quoted = /^“([\s\S]*)”$/.exec(out);
+  if (quoted) out = quoted[1].trim();
+  return out;
+}
+
+function websiteCardTitle(content: unknown): string | undefined {
+  const shape = content as
+    | {
+        pages?: Array<{ blocks?: Array<{ block?: { $type?: string; title?: unknown } }> }>;
+        items?: Array<{ $type?: string; title?: unknown }>;
+      }
+    | undefined;
+  const usable = (value: unknown) =>
+    typeof value === 'string' && value.trim() ? value : undefined;
+  for (const page of shape?.pages ?? []) {
+    for (const wrapper of page.blocks ?? []) {
+      if (wrapper.block?.$type === 'pub.leaflet.blocks.website') return usable(wrapper.block.title);
+    }
+  }
+  for (const item of shape?.items ?? []) {
+    if (
+      item?.$type === 'blog.pckt.block.website' ||
+      item?.$type === 'app.offprint.block.webBookmark'
+    ) {
+      return usable(item.title);
+    }
+  }
+  return undefined;
 }
 
 // A snippet of the shared article itself (its first paragraph or so). LEGACY

--- a/linkblog-site/src/lib/fields.ts
+++ b/linkblog-site/src/lib/fields.ts
@@ -277,7 +277,8 @@ function foreignMarkdownNote(
 // a Leaflet richtext feature; the other formats store the note as plain text.
 function noteOf(doc: ProxyDocument): { note: string; mentions: MentionFacet[] } {
   const content = doc.content as
-    (LeafletContent & { items?: ForeignBlock[]; text?: { markdown?: string } }) | undefined;
+    | (LeafletContent & { items?: ForeignBlock[]; text?: { markdown?: string } })
+    | undefined;
   const articleUrl = externalArticleUrl(doc);
   const attributed = doc.skyreaderAttribution;
   switch (content?.$type) {

--- a/linkblog-site/src/lib/server/proxy.ts
+++ b/linkblog-site/src/lib/server/proxy.ts
@@ -14,6 +14,12 @@ export interface LinkblogTarget {
   siteUri: string;
   defaultSiteUri: string;
   /**
+   * The author's old `skyreader-links` publication, when their own publication
+   * has since moved to a TID rkey. Scoped alongside the others so a move that
+   * was interrupted partway still renders every post, wherever it sits.
+   */
+  legacySiteUri?: string;
+  /**
    * Don't render this linkblog: the user deleted it, or connected an existing
    * publication and turned this page off. The backend collapses both into one
    * flag — which it is isn't the reader's business.
@@ -68,6 +74,7 @@ export async function resolveLinkblogTarget(apiBase: string, did: string): Promi
     const data = (await res.json()) as {
       siteUri?: string;
       defaultSiteUri?: string;
+      legacySiteUri?: string;
       hidden?: boolean;
     };
     const siteUri = data.siteUri || fallback;
@@ -75,12 +82,23 @@ export async function resolveLinkblogTarget(apiBase: string, did: string): Promi
     return {
       siteUri,
       defaultSiteUri,
+      legacySiteUri: data.legacySiteUri,
       hidden: data.hidden === true,
       external: siteUri !== defaultSiteUri,
     };
   } catch {
     return unresolved;
   }
+}
+
+// Every publication a reader's view of this linkblog should cover: where the
+// author publishes now, their own Skyreader publication, and — while a move off
+// the legacy rkey is unfinished — the publication they moved from.
+// `fetchLinkblogDocuments` dedupes, so the usual one-or-two case costs nothing.
+export function linkblogScopes(target: LinkblogTarget): string[] {
+  return [target.siteUri, target.defaultSiteUri, target.legacySiteUri].filter(
+    (uri): uri is string => !!uri
+  );
 }
 
 function proxyHeaders(cfg: ProxyConfig): Record<string, string> {

--- a/linkblog-site/src/lib/server/rss.ts
+++ b/linkblog-site/src/lib/server/rss.ts
@@ -11,6 +11,7 @@ import {
   hostnameOf,
   linkPostMentions,
   linkPostNote,
+  linkPostTitle,
   renderBodyHtml,
   rkeyFromUri,
   safeHttpUrl,
@@ -90,7 +91,9 @@ function renderItem(origin: string, did: string, doc: ProxyDocument): string {
   const pubDate = toRfc822(doc.createdAt || doc.publishedAt);
 
   const tags = [
-    `<title>${escapeXml(doc.title || 'Untitled')}</title>`,
+    // The article's own title, undecorated — the 🔗 / “…” decoration a record
+    // can carry is for foreign sites, and a subscriber's reader shows the article.
+    `<title>${escapeXml(linkPostTitle(doc) || 'Untitled')}</title>`,
     `<link>${escapeXml(itemLink)}</link>`,
     `<guid isPermaLink="false">${escapeXml(doc.recordUri)}</guid>`,
     pubDate ? `<pubDate>${escapeXml(pubDate)}</pubDate>` : '',

--- a/linkblog-site/src/lib/types.ts
+++ b/linkblog-site/src/lib/types.ts
@@ -16,6 +16,10 @@ export interface ProxyDocument {
   siteIcon?: string;
   links?: Array<{ uri: string; rel?: string }>;
   content?: unknown;
+  // The author opted into the trailing "Posted from skyreader.app" line. Used to
+  // exclude that block from the note by the flag rather than by string match
+  // alone — someone whose own last line reads exactly that keeps their words.
+  skyreaderAttribution?: boolean;
 }
 
 export interface Profile {

--- a/linkblog-site/src/routes/[id]/+page.server.ts
+++ b/linkblog-site/src/routes/[id]/+page.server.ts
@@ -10,6 +10,7 @@ import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/serve
 import {
   fetchLinkblogDocuments,
   fetchSocialContext,
+  linkblogScopes,
   resolveLinkblogTarget,
   type ProxyConfig,
 } from '$lib/server/proxy';
@@ -38,7 +39,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did, target.siteUri),
-    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
+    fetchLinkblogDocuments(cfg, did, linkblogScopes(target)),
   ]);
 
   // Counts-only social context for the most recent entries (one proxy batch, no

--- a/linkblog-site/src/routes/[id]/[rkey]/+page.server.ts
+++ b/linkblog-site/src/routes/[id]/[rkey]/+page.server.ts
@@ -17,6 +17,7 @@ import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/serve
 import {
   fetchLinkblogDocuments,
   fetchSocialContext,
+  linkblogScopes,
   resolveLinkblogTarget,
   type ProxyConfig,
 } from '$lib/server/proxy';
@@ -46,7 +47,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did, target.siteUri),
-    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
+    fetchLinkblogDocuments(cfg, did, linkblogScopes(target)),
   ]);
 
   const doc = docs.find((d) => rkeyFromUri(d.recordUri) === rkey);

--- a/linkblog-site/src/routes/[id]/[rkey]/+page.svelte
+++ b/linkblog-site/src/routes/[id]/[rkey]/+page.svelte
@@ -11,6 +11,7 @@
     hostnameOf,
     linkPostMentions,
     linkPostNote,
+    linkPostTitle,
     plainBody,
     renderBodyHtml,
     rkeyFromUri,
@@ -25,7 +26,10 @@
 
   const doc = $derived(data.doc);
   const blogName = $derived(blogTitle(data.profile, data.pub));
-  const title = $derived(doc.title || 'Untitled');
+  // The article's own title, undecorated: the 🔗 / “…” decoration a record can
+  // carry exists for foreign sites, and this page IS the linkblog. Keeps the
+  // decoration out of <title>, og:title and the RSS feed (see linkPostTitle).
+  const title = $derived(linkPostTitle(doc) || 'Untitled');
   const note = $derived(linkPostNote(doc).trim());
   const mentions = $derived(linkPostMentions(doc));
   const excerpt = $derived(articleExcerpt(doc));

--- a/linkblog-site/src/routes/[id]/feed.xml/+server.ts
+++ b/linkblog-site/src/routes/[id]/feed.xml/+server.ts
@@ -8,7 +8,12 @@ import { redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { apiBaseFor, feedUrlFor, isDid } from '$lib/fields';
 import { fetchPublicationMeta, getProfile, resolveHandleToDid } from '$lib/server/identity';
-import { fetchLinkblogDocuments, resolveLinkblogTarget, type ProxyConfig } from '$lib/server/proxy';
+import {
+  fetchLinkblogDocuments,
+  linkblogScopes,
+  resolveLinkblogTarget,
+  type ProxyConfig,
+} from '$lib/server/proxy';
 import { emptyFeed, renderFeed } from '$lib/server/rss';
 import type { RequestHandler } from './$types';
 
@@ -47,7 +52,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
   const [profile, pub, docs] = await Promise.all([
     getProfile(did),
     fetchPublicationMeta(did, target.siteUri),
-    fetchLinkblogDocuments(cfg, did, [target.siteUri, target.defaultSiteUri]),
+    fetchLinkblogDocuments(cfg, did, linkblogScopes(target)),
   ]);
 
   // Cap the feed length — readers only need the recent window.


### PR DESCRIPTION
## Summary

- Differentiates external linkblog post titles from linked-article titles with a per-user style preference.
- Places the link card alongside quoted context, with configurable top/context/bottom positioning.
- Adds an opt-in “Posted from skyreader.app” composer attribution controlled from Settings.
- Preserves author-written attribution-like text unless the record explicitly marks it as Skyreader attribution.
- Merges the latest `main` and resolves the frontend API contract conflict while retaining both linkblog and cross-device sync types.
- **Review fix:** the Settings kill-switch now actually turns attribution off after the checkbox was ticked — disabling the offer clears the sticky ticked state, the `linkblogAttributionOn` getter never reports a tick that outlived the offer (covers state persisted by older builds), and `post()` re-checks the offer so a draft left open across a Settings change can't submit a hidden `true`. Regression tests cover disable-after-checked at both the preferences and composer layers.

## Checks

- `frontend: npm run check` — 0 errors
- Frontend Vitest: 680 passed (52 files), including 6 new attribution kill-switch regression tests
- Backend/linkblog-site unchanged this revision (previously: `npm run check` clean, backend Vitest 92 passed)

## Remaining risk

Live staging verification against external Leaflet/pckt appviews remains unavailable from this environment.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-aplz6amcxa6vn4jamtzpp5pa)
