### PR TITLE
Refresh saved articles across devices

### DIFF
--- a/frontend/src/lib/stores/app.svelte.ts
+++ b/frontend/src/lib/stores/app.svelte.ts
@@ -127,10 +127,14 @@ function createAppManager() {
     let newArticles = 0;
 
     try {
-      // Sync subscriptions and load read state, social data, and channels in parallel
+      // Sync subscriptions and reload every server-backed user collection in parallel.
+      // Saves must participate here (not only during initialize): another device can
+      // add one while this tab stays open, and an explicit refresh is the user's way
+      // to pull that new server row into this device's IndexedDB cache.
       const [syncResult] = await Promise.all([
         syncSubscriptions(),
         itemLabelsStore.load(),
+        savesStore.load(),
         magazineStore.load(),
         socialStore.loadFeed(true),
         filteredViewsStore.syncWithBackend(),


### PR DESCRIPTION
## Summary

- Reload server-backed saved articles during every global refresh.
- Pull saves made on another device into the current device’s IndexedDB-backed Saved list.

## Checks

- `cd frontend && npm test` (664 tests passed)
- `cd frontend && npm run check` (0 errors; 18 existing warnings)

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-nhk3zylskcul6fpcj77lq2mu)
