### PR TITLE
Fix standard.site discovery for handle-authority publication URIs

### DIFF
--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -80,6 +80,11 @@ async function callerSubscribes(env: Env, userDid: string, feedUrl: string): Pro
 // a generic one.
 const FEED_FETCH_FALLBACK_ERROR = 'Failed to fetch feed';
 
+// How many of a page's advertised standard.site hints URL discovery will try
+// before giving up. The proxy already caps what it reports at 5; this bounds the
+// serial resolve work behind one /discover call.
+const MAX_STANDARD_SITE_ATTEMPTS = 3;
+
 /**
  * The queryable half of a `FeedProxyError`, for a log line. `serializeError`
  * covers name/message/stack; these are the fields that say WHICH failure it was
@@ -1092,13 +1097,21 @@ export async function handleV2FeedDiscover(request: Request, env: Env): Promise<
     const client = new FeedProxyClient(env);
     const { feeds, standardSites } = await client.discoverFeeds(siteUrl);
 
-    // Resolve + verify the first advertised standard.site into a subscribable
+    // Resolve + verify an advertised standard.site into a subscribable
     // publication (the HTML <link> is only a hint; resolveStandardSite confirms it
     // via the domain's .well-known endpoint). Preferred over RSS/Atom in the UI.
+    //
+    // Try the hints in the order the page listed them and keep the first that
+    // resolves, rather than giving up after one: an article page commonly
+    // advertises its document *and* its publication, and either alone may fail to
+    // resolve (an unpublished document record, a publication whose binding is
+    // broken). Bounded so a page full of at:// links can't fan out — each attempt
+    // is a DID resolve plus two fetches.
     let standardSite = null;
-    if (standardSites.length > 0) {
+    for (const uri of standardSites.slice(0, MAX_STANDARD_SITE_ATTEMPTS)) {
       try {
-        standardSite = await resolveStandardSite(standardSites[0], env);
+        standardSite = await resolveStandardSite(uri, env);
+        if (standardSite) break;
       } catch (error) {
         console.error('Standard.site resolution error:', error);
       }

--- a/backend/src/utils/canonical-url.ts
+++ b/backend/src/utils/canonical-url.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Env } from '../types';
+import { resolveHandle } from '../services/oauth';
 import { resolvePdsUrl } from './did-resolver';
 
 interface ParsedAtUri {
@@ -44,10 +45,11 @@ function resolveBlobUrl(did: string, blob: BlobRef | undefined): string | null {
 }
 
 /**
- * Parse an AT URI into its components
- * Format: at://did/collection/rkey
+ * Split an AT URI into authority / collection / rkey without requiring the
+ * authority to be a DID. An at:// URI may be written with either a DID or a
+ * handle as its authority; both spell the same record.
  */
-export function parseAtUri(uri: string): ParsedAtUri | null {
+function splitAtUri(uri: string): { authority: string; collection: string; rkey: string } | null {
   if (!uri.startsWith('at://')) {
     return null;
   }
@@ -59,15 +61,85 @@ export function parseAtUri(uri: string): ParsedAtUri | null {
     return null;
   }
 
-  const did = parts[0];
+  const authority = parts[0];
   const collection = parts[1];
   const rkey = parts.slice(2).join('/'); // rkey might contain slashes
 
-  if (!did.startsWith('did:')) {
+  if (!authority || !collection || !rkey) {
     return null;
   }
 
-  return { did, collection, rkey };
+  return { authority, collection, rkey };
+}
+
+/**
+ * Parse an AT URI into its components
+ * Format: at://did/collection/rkey
+ */
+export function parseAtUri(uri: string): ParsedAtUri | null {
+  const parts = splitAtUri(uri);
+
+  if (!parts || !parts.authority.startsWith('did:')) {
+    return null;
+  }
+
+  return { did: parts.authority, collection: parts.collection, rkey: parts.rkey };
+}
+
+/**
+ * A handle authority we're willing to resolve, applying the same shape rules the
+ * did:web SSRF guard uses: a bare public domain, no port, no IP literal, no
+ * internal TLD. The authority arrives from a third-party page's <link> hint, so
+ * it must not be able to point a fetch at internal infrastructure.
+ */
+function isResolvableHandle(authority: string): boolean {
+  const host = authority.toLowerCase();
+  if (host.includes(':') || host.includes('@') || host.includes('%')) return false;
+  if (host === 'localhost' || host.endsWith('.localhost')) return false;
+  if (host.endsWith('.local') || host.endsWith('.internal') || host.endsWith('.lan')) return false;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return false; // IPv4 literal
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(host);
+}
+
+/**
+ * Parse an AT URI, resolving a handle authority to its DID.
+ *
+ * standard.site publishers write these URIs both ways — brennan.day advertises
+ * `at://brennan.day/site.standard.publication/self` in its HTML and .well-known
+ * while its document records point at the did:plc spelling of the same record —
+ * so a discovery path that only accepted DIDs silently dropped half of them.
+ * Returns the DID form, which is what a record fetch and any later comparison
+ * need.
+ */
+async function resolveAtUri(uri: string): Promise<ParsedAtUri | null> {
+  const parts = splitAtUri(uri);
+  if (!parts) {
+    return null;
+  }
+
+  if (parts.authority.startsWith('did:')) {
+    return { did: parts.authority, collection: parts.collection, rkey: parts.rkey };
+  }
+
+  if (!isResolvableHandle(parts.authority)) {
+    return null;
+  }
+
+  try {
+    const did = await resolveHandle(parts.authority);
+    if (!did.startsWith('did:')) {
+      return null;
+    }
+    return { did, collection: parts.collection, rkey: parts.rkey };
+  } catch (error) {
+    console.warn('[canonical-url] Could not resolve at:// handle authority:', error);
+    return null;
+  }
+}
+
+/** Canonical DID-form spelling of a parsed AT URI. */
+function formatAtUri(parsed: ParsedAtUri): string {
+  return `at://${parsed.did}/${parsed.collection}/${parsed.rkey}`;
 }
 
 /**
@@ -128,11 +200,14 @@ export interface ResolvedStandardSite {
  * claim the same publication back via /.well-known/site.standard.publication.
  *
  * Returns true only when the well-known endpoint at `publicationUrl`'s origin
- * returns the `expectedUri` (the publication AT URI we resolved).
+ * names the same record as `expected` (the publication AT URI we resolved).
+ * The comparison is per-component after resolving the advertised URI's
+ * authority, not a string equality: the domain may advertise its publication
+ * with a handle authority while we hold the DID spelling of the same record.
  */
 async function verifyPublicationDomain(
   publicationUrl: string,
-  expectedUri: string
+  expected: ParsedAtUri
 ): Promise<boolean> {
   try {
     const origin = new URL(publicationUrl).origin;
@@ -146,7 +221,16 @@ async function verifyPublicationDomain(
     // The endpoint may return a bare AT URI or a JSON object containing one.
     const body = (await res.text()).trim();
     const advertisedUri = body.match(/at:\/\/[^\s"']+/)?.[0];
-    return advertisedUri === expectedUri;
+    if (!advertisedUri) {
+      return false;
+    }
+    const advertised = await resolveAtUri(advertisedUri);
+    return (
+      advertised !== null &&
+      advertised.did === expected.did &&
+      advertised.collection === expected.collection &&
+      advertised.rkey === expected.rkey
+    );
   } catch (error) {
     console.warn('[canonical-url] Publication domain verification failed:', error);
     return false;
@@ -164,7 +248,7 @@ async function verifyPublicationDomain(
 async function resolveVerifiedPublication(
   publicationUri: string
 ): Promise<ResolvedStandardSite | null> {
-  const pub = parseAtUri(publicationUri);
+  const pub = await resolveAtUri(publicationUri);
   if (!pub || pub.collection !== 'site.standard.publication') {
     return null;
   }
@@ -180,7 +264,7 @@ async function resolveVerifiedPublication(
   }
 
   // Confirm the bidirectional binding before trusting the hint.
-  const verified = await verifyPublicationDomain(record.url, publicationUri);
+  const verified = await verifyPublicationDomain(record.url, pub);
   if (!verified) {
     console.warn(`[canonical-url] Unverified standard.site, not offering: ${publicationUri}`);
     return null;
@@ -188,7 +272,10 @@ async function resolveVerifiedPublication(
 
   return {
     did: pub.did,
-    publicationUri,
+    // Always the DID spelling, whichever way the site wrote the hint — this
+    // becomes the subscription's feedUrl, so it has to be stable across a
+    // handle change and comparable to publication URIs from every other source.
+    publicationUri: formatAtUri(pub),
     name: record.name || record.url,
     url: record.url,
     description: record.description,
@@ -200,7 +287,8 @@ async function resolveVerifiedPublication(
  * Resolve a discovered standard.site URI into a *verified*, subscribable
  * publication.
  *
- * Accepts either of the at:// URIs advertised in a website's <link> hint:
+ * Accepts either of the at:// URIs advertised in a website's <link> hint, with
+ * either a DID or a handle as the authority:
  * - `at://did/site.standard.publication/rkey` (publication homepages) — used
  *   directly.
  * - `at://did/site.standard.document/rkey` (article pages) — the document record
@@ -218,7 +306,7 @@ export async function resolveStandardSite(
   uri: string,
   _env: Env
 ): Promise<ResolvedStandardSite | null> {
-  const parsed = parseAtUri(uri);
+  const parsed = await resolveAtUri(uri);
   if (!parsed) {
     return null;
   }

--- a/backend/test/feeds-v2-discover.spec.ts
+++ b/backend/test/feeds-v2-discover.spec.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleV2FeedDiscover } from '../src/routes/feeds-v2';
+import type { Env } from '../src/types';
+
+const ENV = {
+  FEED_PROXY_URL: 'https://proxy.example',
+  FEED_PROXY_SECRET: 'test-secret',
+} as Env;
+
+function request(siteUrl: string): Request {
+  return new Request(
+    `https://api.example/api/v2/feeds/discover?url=${encodeURIComponent(siteUrl)}`
+  );
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * The brennan.day shape from #435: an article page advertising its document
+ * first and its publication second, where the site writes at:// URIs with a
+ * *handle* authority while the document record points at the did:plc spelling of
+ * the same publication.
+ */
+const DOC_DID = 'did:plc:h4fm3emeptzegfs452eoiaz7';
+const PDS = 'https://scalycap.us-west.host.bsky.network';
+const DOC_URI = `at://${DOC_DID}/site.standard.document/3muhkhf6unv2x`;
+const PUB_URI_DID = `at://${DOC_DID}/site.standard.publication/self`;
+const PUB_URI_HANDLE = 'at://brennan.day/site.standard.publication/self';
+
+interface Routes {
+  standardSites?: string[];
+  feeds?: string[];
+  /** What /.well-known/site.standard.publication advertises back. */
+  wellKnown?: string;
+  /** Document records that exist, keyed by rkey. */
+  documents?: Record<string, unknown>;
+}
+
+function mockNetwork(routes: Routes = {}) {
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    calls.push(url);
+
+    if (url.startsWith('https://proxy.example/discover')) {
+      return json({
+        feeds: routes.feeds ?? [],
+        standardSites: routes.standardSites ?? [],
+      });
+    }
+    if (url === `https://plc.directory/${DOC_DID}`) {
+      return json({
+        id: DOC_DID,
+        service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: PDS }],
+      });
+    }
+    if (url.includes('com.atproto.identity.resolveHandle')) {
+      const handle = new URL(url).searchParams.get('handle');
+      return handle === 'brennan.day' ? json({ did: DOC_DID }) : json({}, 400);
+    }
+    if (url.startsWith(`${PDS}/xrpc/com.atproto.repo.getRecord`)) {
+      const params = new URL(url).searchParams;
+      const collection = params.get('collection');
+      const rkey = params.get('rkey') ?? '';
+      if (collection === 'site.standard.document') {
+        const value = (routes.documents ?? {})[rkey];
+        return value ? json({ value }) : json({ error: 'RecordNotFound' }, 400);
+      }
+      if (collection === 'site.standard.publication' && rkey === 'self') {
+        return json({
+          value: {
+            $type: 'site.standard.publication',
+            url: 'https://brennan.day',
+            name: 'brennan.day',
+          },
+        });
+      }
+      return json({ error: 'RecordNotFound' }, 400);
+    }
+    if (url === 'https://brennan.day/.well-known/site.standard.publication') {
+      return new Response(routes.wellKnown ?? PUB_URI_HANDLE, {
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return calls;
+}
+
+describe('handleV2FeedDiscover — standard.site resolution', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('verifies a publication whose domain advertises it with a handle authority', async () => {
+    mockNetwork({
+      standardSites: [DOC_URI],
+      documents: { '3muhkhf6unv2x': { site: PUB_URI_DID } },
+    });
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/some-post/'), ENV);
+    const body = (await res.json()) as { standardSite: { publicationUri: string; did: string } };
+
+    expect(res.status).toBe(200);
+    // Before #435 this was null: the well-known's handle spelling was compared
+    // as a string against the DID spelling we had resolved.
+    expect(body.standardSite).not.toBeNull();
+    expect(body.standardSite.publicationUri).toBe(PUB_URI_DID);
+    expect(body.standardSite.did).toBe(DOC_DID);
+  });
+
+  it('accepts a handle-authority publication hint and reports it in DID form', async () => {
+    mockNetwork({ standardSites: [PUB_URI_HANDLE] });
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/'), ENV);
+    const body = (await res.json()) as { standardSite: { publicationUri: string } };
+
+    expect(body.standardSite.publicationUri).toBe(PUB_URI_DID);
+  });
+
+  it('falls through to the next hint when the first one does not resolve', async () => {
+    // The page advertises a document whose record is missing, then the
+    // publication. Trying only the first hint dropped the publication entirely.
+    mockNetwork({ standardSites: [DOC_URI, PUB_URI_HANDLE], documents: {} });
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/some-post/'), ENV);
+    const body = (await res.json()) as { standardSite: { publicationUri: string } | null };
+
+    expect(body.standardSite?.publicationUri).toBe(PUB_URI_DID);
+  });
+
+  it('still rejects a publication the domain does not claim back', async () => {
+    mockNetwork({
+      standardSites: [PUB_URI_HANDLE],
+      wellKnown: 'at://did:plc:someoneelse/site.standard.publication/self',
+    });
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/'), ENV);
+    const body = (await res.json()) as { standardSite: unknown };
+
+    expect(body.standardSite).toBeNull();
+  });
+
+  it('does not try to resolve an authority that is not a public domain', async () => {
+    const calls = mockNetwork({ standardSites: ['at://localhost/site.standard.publication/self'] });
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/'), ENV);
+    const body = (await res.json()) as { standardSite: unknown };
+
+    expect(body.standardSite).toBeNull();
+    expect(calls.some((c) => c.includes('resolveHandle'))).toBe(false);
+  });
+
+  it('stops after three hints rather than fanning out over a page full of them', async () => {
+    const hints = ['a', 'b', 'c', 'd', 'e'].map(
+      (id) => `at://did:plc:${id}/site.standard.publication/self`
+    );
+    // Every DID here is unknown to plc.directory, so each attempt dies at PDS
+    // resolution — what the test reads is how many were attempted at all.
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      return url.startsWith('https://proxy.example/discover')
+        ? json({ feeds: [], standardSites: hints })
+        : json({ error: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    const res = await handleV2FeedDiscover(request('https://brennan.day/'), ENV);
+    const body = (await res.json()) as { standardSite: unknown };
+
+    expect(body.standardSite).toBeNull();
+    expect(calls.filter((c) => c.startsWith('https://plc.directory/'))).toHaveLength(3);
+  });
+});

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -1262,7 +1262,13 @@ async function runDiscover(siteUrl: string): Promise<DiscoverResult> {
           const baseUrl = new URL(siteUrl);
           feedUrl = new URL(feedUrl, baseUrl).toString();
         }
-        feeds.push(feedUrl);
+        // Dedup after resolving: a site that serves one file under both the RSS
+        // and Atom link tags (brennan.day advertises feed.xml as both) would
+        // otherwise offer the reader the same URL twice with nothing to choose
+        // between. Relative and absolute spellings of one href collapse here too.
+        if (!feeds.includes(feedUrl)) {
+          feeds.push(feedUrl);
+        }
       }
     }
 

--- a/feed-proxy/src/integration.test.ts
+++ b/feed-proxy/src/integration.test.ts
@@ -2179,6 +2179,37 @@ describe('Integration Tests', () => {
         expect(json.feeds).toContain('https://example.com/atom.xml');
       });
 
+      it('reports one feed when the RSS and Atom links point at the same file', async () => {
+        const { app } = createTestApp();
+        // brennan.day advertises feed.xml under both types, once relative and
+        // once absolute. Offering it twice asks the reader to pick between two
+        // identical rows.
+        const html = `
+					<!DOCTYPE html>
+					<html>
+					<head>
+						<link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml" title="RSS Feed">
+						<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="Atom Feed">
+					</head>
+					<body>Hello</body>
+					</html>
+				`;
+        fetchMock = mockFetch(
+          () =>
+            new Response(html, {
+              headers: { 'Content-Type': 'text/html' },
+            })
+        );
+
+        const res = await app.request('/discover?url=https://example.com/', {
+          headers: { 'X-Proxy-Secret': 'test-secret' },
+        });
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.feeds).toEqual(['https://example.com/feed.xml']);
+      });
+
       it('detects standard.site advertisements in HTML', async () => {
         const { app } = createTestApp();
         const html = `


### PR DESCRIPTION
Fixes #435.

Adding a feed from `https://brennan.day/normalized-fascism-in-open-source-12-million-given-to-dhh/` offered two identical RSS rows and no standard.site publication, though the page advertises one. Two independent causes.

### Duplicate feeds (feed-proxy)

brennan.day points both its `application/rss+xml` and `application/atom+xml` link tags at the same `feed.xml`. `runDiscover` pushed every href it matched, so the reader got two rows with nothing to choose between. Feed URLs now dedup *after* relative-URL resolution, which also collapses a relative and an absolute spelling of one href.

### Missing publication (backend)

Verification compared AT URIs as strings:

- the document record names its publication as `at://did:plc:h4fm3emeptzegfs452eoiaz7/site.standard.publication/self`
- `brennan.day/.well-known/site.standard.publication` answers `at://brennan.day/site.standard.publication/self`

Same record, two spellings of the authority — so the bidirectional check failed and a real publication was dropped as unverified. (A homepage advertising the handle form was rejected even earlier: `parseAtUri` returned null for a non-`did:` authority.)

AT URI parsing on the discovery path now resolves a handle authority to its DID, and `verifyPublicationDomain` compares did/collection/rkey instead of raw text. The returned `publicationUri` is always the DID form, so it stays stable across a handle change and comparable to publication URIs from every other source. Handle resolution is gated on the same bare-public-domain shape rules the `did:web` SSRF guard uses (no port, no IP literal, no internal TLD), since the authority comes from a third party's page. `parseAtUri` itself is unchanged for its other callers — still DID-only.

Discovery also gave up after `standardSites[0]`. An article page commonly advertises its document *and* its publication and either alone can fail to resolve, so `handleV2FeedDiscover` now tries hints in page order (capped at 3) and keeps the first that resolves.

### Tests

- `backend/test/feeds-v2-discover.spec.ts` (new, 6 cases) — the brennan.day shape end-to-end, handle-form hints, fall-through, and the two guards (unverified publication still rejected; a non-public-domain authority is never resolved). Four of them fail on `main`.
- `feed-proxy/src/integration.test.ts` — one feed reported when the RSS and Atom links name the same file.

Checks: backend `tsc --noEmit` + `prettier --check` clean, 719 tests pass; feed-proxy `tsc --noEmit` + `prettier --check` clean, 401 tests pass.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-kennwthggkqzenzb7chhdvod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
