### PR TITLE
Add Currents image saves

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -74,7 +74,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 | `src/routes/reading.ts`       | Article + document read positions (forward delta)      |
 | `src/routes/labels.ts`        | Unified item labels (read/starred/archived/tags)       |
 | `src/routes/saved.ts`         | Saved articles CRUD                                    |
-| `src/routes/integrations.ts`  | Semble/Margin writes to the user's PDS                 |
+| `src/routes/integrations.ts`  | Semble/Margin/Currents writes to the user's PDS        |
 | `src/routes/settings.ts`      | User settings                                          |
 | `src/routes/sync.ts`          | PDS full sync, subscription sync, sync status          |
 | `src/routes/lexicons.ts`      | Serve lexicon schemas at /.well-known/lexicons         |

--- a/backend/src/config/scopes.ts
+++ b/backend/src/config/scopes.ts
@@ -36,6 +36,11 @@ export const MARGIN_SCOPES = [
   'repo:at.margin.collection',
   'repo:at.margin.collectionItem',
 ];
+export const CURRENTS_SCOPES = [
+  'repo:is.currents.feed.save',
+  'repo:is.currents.feed.collection',
+  'blob:image/*',
+];
 
 // Linkblog scopes — sharing writes standard.site records to the user's PDS.
 export const LINKBLOG_SCOPES = ['repo:site.standard.publication', 'repo:site.standard.document'];
@@ -70,6 +75,7 @@ export const ALL_POSSIBLE_SCOPES = [
   ...SEMBLE_SCOPES,
   ...SEMBLE_CONNECTION_SCOPES,
   ...MARGIN_SCOPES,
+  ...CURRENTS_SCOPES,
   ...LINKBLOG_SCOPES,
   ...PCKT_SCOPES,
   ...OFFPRINT_SCOPES,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -102,6 +102,8 @@ import {
   handleDeleteMarginNote,
   handleGetIntegrationMemberships,
   handleEditIntegrationMemberships,
+  handleCreateCurrentsSave,
+  handleListCurrentsCollections,
 } from './routes/integrations';
 import { handleFullSync, handleSyncSubscriptions, handleSyncStatus } from './routes/sync';
 import {
@@ -692,6 +694,26 @@ async function route(
       } else {
         response = await handleCreateMarginBookmark(request, env);
       }
+      break;
+    case url.pathname === '/api/integrations/currents/saves':
+      if (!session) return unauthorizedResponse(headers);
+      response =
+        request.method === 'POST'
+          ? await handleCreateCurrentsSave(request, env)
+          : new Response(JSON.stringify({ error: 'Method not allowed' }), {
+              status: 405,
+              headers: { 'Content-Type': 'application/json' },
+            });
+      break;
+    case url.pathname === '/api/integrations/currents/collections':
+      if (!session) return unauthorizedResponse(headers);
+      response =
+        request.method === 'GET'
+          ? await handleListCurrentsCollections(request, env)
+          : new Response(JSON.stringify({ error: 'Method not allowed' }), {
+              status: 405,
+              headers: { 'Content-Type': 'application/json' },
+            });
       break;
     case url.pathname === '/api/integrations/margin/collections':
       if (!session) return unauthorizedResponse(headers);

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -98,8 +98,12 @@ export function buildCurrentsSaveRecord(
   image: BlobRef,
   createdAt: string
 ) {
-  const alt = body.alt?.trim().slice(0, MAX_ALT_GRAPHEMES);
-  const note = body.note?.trim().slice(0, MAX_TEXT_GRAPHEMES);
+  const alt = body.alt
+    ? Array.from(body.alt.trim()).slice(0, MAX_ALT_GRAPHEMES).join('')
+    : undefined;
+  const note = body.note
+    ? Array.from(body.note.trim()).slice(0, MAX_TEXT_GRAPHEMES).join('')
+    : undefined;
   return {
     $type: 'is.currents.feed.save',
     content: {

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -10,7 +10,9 @@ import {
   type IntegrationProvider,
 } from '../services/integration-membership';
 import { SEMBLE_SCOPES, MARGIN_SCOPES } from './auth';
-import { SEMBLE_CONNECTION_SCOPES } from '../config/scopes';
+import { CURRENTS_SCOPES, SEMBLE_CONNECTION_SCOPES } from '../config/scopes';
+import { fetchImageForCurrents, ImageFetchError } from '../services/image-fetch';
+import type { BlobRef } from '../services/pds-client';
 import { listAllRecordsPublic } from '../services/backing/read';
 import { resolvePdsUrl } from '../utils/did-resolver';
 
@@ -20,11 +22,12 @@ import { resolvePdsUrl } from '../utils/did-resolver';
  * every live session, so folding it into the Semble set would break card saves
  * for everyone until they re-authed (see config/scopes.ts).
  */
-export type ScopeGate = 'semble' | 'margin' | 'semble-connections';
+export type ScopeGate = 'semble' | 'margin' | 'currents' | 'semble-connections';
 
 const SCOPE_SETS: Record<ScopeGate, string[]> = {
   semble: SEMBLE_SCOPES,
   margin: MARGIN_SCOPES,
+  currents: CURRENTS_SCOPES,
   'semble-connections': SEMBLE_CONNECTION_SCOPES,
 };
 
@@ -54,6 +57,7 @@ export async function handleIntegrationStatus(request: Request, env: Env): Promi
       scopeStatus: {
         semble: hasIntegrationScopes(session, 'semble'),
         margin: hasIntegrationScopes(session, 'margin'),
+        currents: hasIntegrationScopes(session, 'currents'),
         // Reported separately so a surface can tell "offer the control" from
         // "the control will trip the re-login banner" and say so up front.
         sembleConnections: hasIntegrationScopes(session, 'semble-connections'),
@@ -61,6 +65,85 @@ export async function handleIntegrationStatus(request: Request, env: Env): Promi
     }),
     { headers: { 'Content-Type': 'application/json' } }
   );
+}
+
+export interface CurrentsSaveBody {
+  imageUrl: string;
+  pageUrl?: string;
+  caption?: string;
+  collection?: { uri: string; cid: string };
+}
+
+export function buildCurrentsSaveRecord(
+  body: Omit<CurrentsSaveBody, 'imageUrl'>,
+  content: BlobRef,
+  createdAt: string
+) {
+  const caption = body.caption?.trim();
+  return {
+    $type: 'is.currents.feed.save',
+    content,
+    createdAt,
+    ...(body.collection ? { collection: body.collection } : {}),
+    ...(body.pageUrl ? { originUrl: body.pageUrl } : {}),
+    ...(caption ? { text: caption } : {}),
+  };
+}
+
+export async function handleListCurrentsCollections(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  const gate = checkIntegrationScopes(session, 'currents');
+  if (gate) return gate;
+  const result = await createPDSClient(session).listAllRecords<{
+    name?: string;
+    description?: string;
+    createdAt?: string;
+  }>('is.currents.feed.collection', { maxPages: 5 });
+  if (!result.success) return Response.json({ error: result.error }, { status: 502 });
+  return Response.json({
+    collections: result.data.map(({ uri, cid, value }) => ({
+      uri,
+      cid,
+      name: value.name,
+      description: value.description,
+      createdAt: value.createdAt,
+    })),
+  });
+}
+
+export async function handleCreateCurrentsSave(request: Request, env: Env): Promise<Response> {
+  const session = await getSessionFromRequest(request, env);
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  const gate = checkIntegrationScopes(session, 'currents');
+  if (gate) return gate;
+  let body: CurrentsSaveBody;
+  try {
+    body = (await request.json()) as CurrentsSaveBody;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (!body.imageUrl) return Response.json({ error: 'imageUrl is required' }, { status: 400 });
+  if (body.collection && (!body.collection.uri || !body.collection.cid)) {
+    return Response.json({ error: 'collection requires uri and cid' }, { status: 400 });
+  }
+  try {
+    const image = await fetchImageForCurrents(body.imageUrl);
+    const pds = createPDSClient(session);
+    const uploaded = await pds.uploadBlob(image.bytes, image.contentType);
+    if (!uploaded.success) return Response.json({ error: uploaded.error }, { status: 502 });
+    const rkey = generateTid();
+    const record = buildCurrentsSaveRecord(body, uploaded.data.blob, new Date().toISOString());
+    const saved = await pds.putRecord('is.currents.feed.save', rkey, record);
+    if (!saved.success) return Response.json({ error: saved.error }, { status: 502 });
+    return Response.json({ ...saved.data, rkey }, { status: 201 });
+  } catch (error) {
+    if (error instanceof ImageFetchError) {
+      const status = error.code === 'upstream_failed' ? 502 : 422;
+      return Response.json({ error: error.code, message: error.message }, { status });
+    }
+    throw error;
+  }
 }
 
 /**

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -70,23 +70,47 @@ export async function handleIntegrationStatus(request: Request, env: Env): Promi
 export interface CurrentsSaveBody {
   imageUrl: string;
   pageUrl?: string;
-  caption?: string;
+  /** Description of the image itself — rides the image content's `alt`. */
+  alt?: string;
+  /** A user-authored note about the save — rides the record's `text`. */
+  note?: string;
   collection?: { uri: string; cid: string };
 }
 
+// The lexicon's own caps (maxGraphemes on `is.currents.content.image#alt` and
+// `is.currents.feed.save#text`). Slicing by code point can only undercount
+// graphemes, so staying under the cap this way is always safe — and an alt
+// lifted from a page's markup can be arbitrarily long.
+const MAX_ALT_GRAPHEMES = 2000;
+const MAX_TEXT_GRAPHEMES = 1000;
+
+/**
+ * Build the `is.currents.feed.save` record.
+ *
+ * `content` is a **union**, not a bare blob: its only current variant is
+ * `is.currents.content.image`, and Currents' indexer skips any save whose
+ * `content.$type` it doesn't recognize (it reads the blob from `content.image`
+ * and the description from `content.alt`). See
+ * https://github.com/matteomarjanovic/currents lexicons/is/currents/{feed/save,content/image}.json.
+ */
 export function buildCurrentsSaveRecord(
   body: Omit<CurrentsSaveBody, 'imageUrl'>,
-  content: BlobRef,
+  image: BlobRef,
   createdAt: string
 ) {
-  const caption = body.caption?.trim();
+  const alt = body.alt?.trim().slice(0, MAX_ALT_GRAPHEMES);
+  const note = body.note?.trim().slice(0, MAX_TEXT_GRAPHEMES);
   return {
     $type: 'is.currents.feed.save',
-    content,
+    content: {
+      $type: 'is.currents.content.image',
+      image,
+      ...(alt ? { alt } : {}),
+    },
     createdAt,
     ...(body.collection ? { collection: body.collection } : {}),
     ...(body.pageUrl ? { originUrl: body.pageUrl } : {}),
-    ...(caption ? { text: caption } : {}),
+    ...(note ? { text: note } : {}),
   };
 }
 

--- a/backend/src/services/image-fetch.ts
+++ b/backend/src/services/image-fetch.ts
@@ -13,6 +13,9 @@ export class ImageFetchError extends Error {
 }
 
 function isBlockedHostname(hostname: string): boolean {
+  // This is a defense-in-depth literal-host check, not DNS rebinding protection:
+  // Workers egress supplies the network boundary and exposes no DNS resolution
+  // API with which to validate every resolved address before fetching.
   const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
   if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal'))
     return true;

--- a/backend/src/services/image-fetch.ts
+++ b/backend/src/services/image-fetch.ts
@@ -1,0 +1,135 @@
+export const MAX_CURRENTS_IMAGE_BYTES = 19 * 1024 * 1024;
+
+export type ImageFetchErrorCode = 'blocked' | 'too_large' | 'not_image' | 'upstream_failed';
+
+export class ImageFetchError extends Error {
+  constructor(
+    public readonly code: ImageFetchErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ImageFetchError';
+  }
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal'))
+    return true;
+  if (
+    host === '::1' ||
+    host === '::' ||
+    host.startsWith('fc') ||
+    host.startsWith('fd') ||
+    host.startsWith('fe8') ||
+    host.startsWith('fe9') ||
+    host.startsWith('fea') ||
+    host.startsWith('feb')
+  )
+    return true;
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) return false;
+  const octets = match.slice(1).map(Number);
+  if (octets.some((n) => n > 255)) return true;
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    a >= 224 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function sniffImageType(bytes: Uint8Array): string | null {
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+  if (bytes.slice(0, 8).every((v, i) => v === [137, 80, 78, 71, 13, 10, 26, 10][i]))
+    return 'image/png';
+  if (
+    String.fromCharCode(...bytes.slice(0, 6)) === 'GIF87a' ||
+    String.fromCharCode(...bytes.slice(0, 6)) === 'GIF89a'
+  )
+    return 'image/gif';
+  if (
+    String.fromCharCode(...bytes.slice(0, 4)) === 'RIFF' &&
+    String.fromCharCode(...bytes.slice(8, 12)) === 'WEBP'
+  )
+    return 'image/webp';
+  return null;
+}
+
+export async function fetchImageForCurrents(
+  imageUrl: string
+): Promise<{ bytes: ArrayBuffer; contentType: string }> {
+  let url: URL;
+  try {
+    url = new URL(imageUrl);
+  } catch {
+    throw new ImageFetchError('blocked', 'Image URL is invalid');
+  }
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    url.username ||
+    url.password ||
+    isBlockedHostname(url.hostname)
+  ) {
+    throw new ImageFetchError('blocked', 'This image address cannot be fetched');
+  }
+
+  let response: Response | undefined;
+  for (let redirects = 0; redirects <= 3; redirects += 1) {
+    try {
+      response = await fetch(url, { headers: { Accept: 'image/*' }, redirect: 'manual' });
+    } catch {
+      throw new ImageFetchError('upstream_failed', 'The image host could not be reached');
+    }
+    if (![301, 302, 303, 307, 308].includes(response.status)) break;
+    const location = response.headers.get('location');
+    if (!location || redirects === 3) {
+      throw new ImageFetchError('upstream_failed', 'The image host redirected too many times');
+    }
+    url = new URL(location, url);
+    if (
+      !['http:', 'https:'].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      isBlockedHostname(url.hostname)
+    ) {
+      throw new ImageFetchError('blocked', 'The image redirected to a blocked address');
+    }
+  }
+  if (!response)
+    throw new ImageFetchError('upstream_failed', 'The image host could not be reached');
+  if (!response.ok)
+    throw new ImageFetchError('upstream_failed', `The image host returned ${response.status}`);
+  const length = Number(response.headers.get('content-length'));
+  if (Number.isFinite(length) && length > MAX_CURRENTS_IMAGE_BYTES)
+    throw new ImageFetchError('too_large', 'Image is larger than 19 MiB');
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new ImageFetchError('upstream_failed', 'The image response was empty');
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > MAX_CURRENTS_IMAGE_BYTES) {
+      await reader.cancel();
+      throw new ImageFetchError('too_large', 'Image is larger than 19 MiB');
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const declared = response.headers.get('content-type')?.split(';')[0].trim().toLowerCase();
+  const contentType = declared?.startsWith('image/') ? declared : sniffImageType(bytes);
+  if (!contentType) throw new ImageFetchError('not_image', 'The address did not return an image');
+  return { bytes: bytes.buffer, contentType };
+}

--- a/backend/src/services/pds-client.ts
+++ b/backend/src/services/pds-client.ts
@@ -27,6 +27,15 @@ export interface PutRecordResponse {
   cid: string;
 }
 
+export interface BlobRef {
+  $type: 'blob';
+  ref: { $link: string };
+  mimeType: string;
+  size: number;
+}
+
+type RequestBody = { json: unknown } | { bytes: ArrayBuffer; contentType: string };
+
 /**
  * Write operation for applyWrites
  */
@@ -137,7 +146,7 @@ export class PDSClient {
   private async request<T>(
     method: string,
     endpoint: string,
-    body?: unknown
+    body?: RequestBody
   ): Promise<PDSResult<T>> {
     const first = await this.attemptRequest<T>(method, endpoint, body);
     if (!first.staleEndpoint || !this.recovery || this.recoveryAttempted) {
@@ -210,7 +219,7 @@ export class PDSClient {
   private async attemptRequest<T>(
     method: string,
     endpoint: string,
-    body?: unknown
+    body?: RequestBody
   ): Promise<{ result: PDSResult<T>; staleEndpoint: boolean }> {
     // A session whose stored DPoP key isn't a usable private JWK can't sign
     // anything, so there is no request to attempt. Fail closed on one line
@@ -249,14 +258,17 @@ export class PDSClient {
         DPoP: dpopProof,
       };
 
-      if (body) {
-        headers['Content-Type'] = 'application/json';
-      }
+      if (body) headers['Content-Type'] = 'json' in body ? 'application/json' : body.contentType;
+      const requestBody = body
+        ? 'json' in body
+          ? JSON.stringify(body.json)
+          : body.bytes
+        : undefined;
 
       let response = await fetch(url, {
         method,
         headers,
-        body: body ? JSON.stringify(body) : undefined,
+        body: requestBody,
       });
 
       // Handle DPoP nonce requirement
@@ -296,7 +308,7 @@ export class PDSClient {
               ...headers,
               DPoP: dpopProof,
             },
-            body: body ? JSON.stringify(body) : undefined,
+            body: requestBody,
           });
         }
       }
@@ -454,10 +466,19 @@ export class PDSClient {
     record: unknown
   ): Promise<PDSResult<PutRecordResponse>> {
     return this.request<PutRecordResponse>('POST', 'com.atproto.repo.putRecord', {
-      repo: this.session.did,
-      collection,
-      rkey,
-      record,
+      json: {
+        repo: this.session.did,
+        collection,
+        rkey,
+        record,
+      },
+    });
+  }
+
+  async uploadBlob(bytes: ArrayBuffer, contentType: string): Promise<PDSResult<{ blob: BlobRef }>> {
+    return this.request<{ blob: BlobRef }>('POST', 'com.atproto.repo.uploadBlob', {
+      bytes,
+      contentType,
     });
   }
 
@@ -490,9 +511,11 @@ export class PDSClient {
       'POST',
       'com.atproto.repo.deleteRecord',
       {
-        repo: this.session.did,
-        collection,
-        rkey,
+        json: {
+          repo: this.session.did,
+          collection,
+          rkey,
+        },
       }
     );
 
@@ -515,8 +538,10 @@ export class PDSClient {
     }
 
     return this.request<ApplyWritesResponse>('POST', 'com.atproto.repo.applyWrites', {
-      repo: this.session.did,
-      writes,
+      json: {
+        repo: this.session.did,
+        writes,
+      },
     });
   }
 

--- a/backend/src/services/rate-limit.ts
+++ b/backend/src/services/rate-limit.ts
@@ -38,6 +38,7 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
   '/api/feeds/discover': EXPENSIVE_LIMIT,
   '/api/leaflet/resolve': EXPENSIVE_LIMIT,
   '/api/extract': EXPENSIVE_LIMIT,
+  '/api/integrations/currents/saves': { limit: 10, windowMs: 60000 },
 
   // AT Intents service-auth pre-verification. Keyed by client IP (not did) and checked
   // BEFORE the signature, since verifying a service-auth JWT triggers an outbound DID

--- a/backend/test/currents.spec.ts
+++ b/backend/test/currents.spec.ts
@@ -11,12 +11,13 @@ const blob: BlobRef = {
 };
 
 describe('Currents save records', () => {
-  it('builds the third-party record shape and trims its caption', () => {
+  it('wraps the blob in the typed image content and trims its text', () => {
     expect(
       buildCurrentsSaveRecord(
         {
           pageUrl: 'https://example.com/article',
-          caption: '  A calm image  ',
+          alt: '  A calm image  ',
+          note: '  Worth revisiting  ',
           collection: { uri: 'at://did:plc:test/is.currents.feed.collection/one', cid: 'cid' },
         },
         blob,
@@ -24,10 +25,10 @@ describe('Currents save records', () => {
       )
     ).toEqual({
       $type: 'is.currents.feed.save',
-      content: blob,
+      content: { $type: 'is.currents.content.image', image: blob, alt: 'A calm image' },
       createdAt: '2026-09-02T00:00:00.000Z',
       originUrl: 'https://example.com/article',
-      text: 'A calm image',
+      text: 'Worth revisiting',
       collection: { uri: 'at://did:plc:test/is.currents.feed.collection/one', cid: 'cid' },
     });
   });
@@ -35,9 +36,19 @@ describe('Currents save records', () => {
   it('omits optional fields', () => {
     expect(buildCurrentsSaveRecord({}, blob, 'now')).toEqual({
       $type: 'is.currents.feed.save',
-      content: blob,
+      content: { $type: 'is.currents.content.image', image: blob },
       createdAt: 'now',
     });
+  });
+
+  it('caps alt and text at the lexicon graphemes limits', () => {
+    const record = buildCurrentsSaveRecord(
+      { alt: 'a'.repeat(2500), note: 'n'.repeat(1200) },
+      blob,
+      'now'
+    );
+    expect(record.content.alt).toHaveLength(2000);
+    expect(record.text).toHaveLength(1000);
   });
 });
 

--- a/backend/test/currents.spec.ts
+++ b/backend/test/currents.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildCurrentsSaveRecord } from '../src/routes/integrations';
+import { fetchImageForCurrents, ImageFetchError } from '../src/services/image-fetch';
+import type { BlobRef } from '../src/services/pds-client';
+
+const blob: BlobRef = {
+  $type: 'blob',
+  ref: { $link: 'bafkreitest' },
+  mimeType: 'image/png',
+  size: 8,
+};
+
+describe('Currents save records', () => {
+  it('builds the third-party record shape and trims its caption', () => {
+    expect(
+      buildCurrentsSaveRecord(
+        {
+          pageUrl: 'https://example.com/article',
+          caption: '  A calm image  ',
+          collection: { uri: 'at://did:plc:test/is.currents.feed.collection/one', cid: 'cid' },
+        },
+        blob,
+        '2026-09-02T00:00:00.000Z'
+      )
+    ).toEqual({
+      $type: 'is.currents.feed.save',
+      content: blob,
+      createdAt: '2026-09-02T00:00:00.000Z',
+      originUrl: 'https://example.com/article',
+      text: 'A calm image',
+      collection: { uri: 'at://did:plc:test/is.currents.feed.collection/one', cid: 'cid' },
+    });
+  });
+
+  it('omits optional fields', () => {
+    expect(buildCurrentsSaveRecord({}, blob, 'now')).toEqual({
+      $type: 'is.currents.feed.save',
+      content: blob,
+      createdAt: 'now',
+    });
+  });
+});
+
+describe('Currents image fetching', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(['http://localhost/image.png', 'http://127.0.0.1/image.png', 'ftp://example.com/a.png'])(
+    'blocks unsafe address %s',
+    async (url) => {
+      await expect(fetchImageForCurrents(url)).rejects.toMatchObject<ImageFetchError>({
+        code: 'blocked',
+      });
+    }
+  );
+
+  it('sniffs a PNG served as octet-stream', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]), {
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+      )
+    );
+    const result = await fetchImageForCurrents('https://images.example/a');
+    expect(result.contentType).toBe('image/png');
+  });
+});

--- a/backend/test/currents.spec.ts
+++ b/backend/test/currents.spec.ts
@@ -50,6 +50,16 @@ describe('Currents save records', () => {
     expect(record.content.alt).toHaveLength(2000);
     expect(record.text).toHaveLength(1000);
   });
+
+  it('does not split a surrogate pair at a text limit', () => {
+    const record = buildCurrentsSaveRecord(
+      { alt: `${'a'.repeat(1999)}😀more`, note: `${'n'.repeat(999)}😀more` },
+      blob,
+      'now'
+    );
+    expect(record.content.alt).toBe(`${'a'.repeat(1999)}😀`);
+    expect(record.text).toBe(`${'n'.repeat(999)}😀`);
+  });
 });
 
 describe('Currents image fetching', () => {

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -1024,7 +1024,7 @@
         anchorRect={linkInterception.menuState.anchorRect}
         imageUrl={linkInterception.menuState.imageUrl}
         pageUrl={linkInterception.menuState.pageUrl}
-        caption={linkInterception.menuState.caption}
+        imageAlt={linkInterception.menuState.imageAlt}
         onClose={linkInterception.closeMenu}
       />
     {/key}

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -749,6 +749,7 @@
   const linkInterception = useLinkInterception({
     contentEl: () => bodyEl,
     enabled: () => true,
+    pageUrl: () => itemUrl,
     // While the preview is clamped *and overflowing* (`isTruncated`), a footnote
     // number is visible but its list entry is below the clamp: let the tap expand
     // the card instead of jumping to something the reader can't see. A preview
@@ -1021,6 +1022,9 @@
         url={linkInterception.menuState.url}
         linkText={linkInterception.menuState.linkText}
         anchorRect={linkInterception.menuState.anchorRect}
+        imageUrl={linkInterception.menuState.imageUrl}
+        pageUrl={linkInterception.menuState.pageUrl}
+        caption={linkInterception.menuState.caption}
         onClose={linkInterception.closeMenu}
       />
     {/key}

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -749,6 +749,7 @@
   const linkInterception = useLinkInterception({
     contentEl: () => bodyEl,
     enabled: () => true,
+    interceptImages: () => expanded,
     pageUrl: () => itemUrl,
     // While the preview is clamped *and overflowing* (`isTruncated`), a footnote
     // number is visible but its list entry is below the clamp: let the tap expand

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -63,6 +63,7 @@
   let isRefreshing = $derived(collectionsStore.refreshing[integration]);
   let loadError = $derived(collectionsStore.error[integration]);
   let isOffline = $derived(loadError === 'offline');
+  let needsScopeUpgrade = $derived(loadError === 'scope_upgrade_required');
   // Nothing to list and no way to get one. The picker still opens: saving
   // without a collection is exactly the escape hatch this state needs, so the
   // notice replaces the list, not the whole body.
@@ -138,6 +139,7 @@
   let changed = $derived(addedUris.length > 0 || removedUris.length > 0);
 
   let canSave = $derived.by(() => {
+    if (needsScopeUpgrade) return false;
     if (membershipsLoading) return false;
     // Until this settles, the row whose membership IS the user's Saved entry is
     // unknown and must not be editable (or removable through "remove all").
@@ -382,7 +384,9 @@
       {:else if noListing}
         <p class="notice notice-error">
           <span class="notice-icon" aria-hidden="true"><Icon name="alert-circle" size={15} /></span>
-          <span>{loadError}</span>
+          <span>
+            {needsScopeUpgrade ? 'Log in again to grant Currents permissions.' : loadError}
+          </span>
         </p>
       {:else if isOffline}
         <p class="notice notice-warn">

--- a/frontend/src/lib/components/CollectionPicker.svelte
+++ b/frontend/src/lib/components/CollectionPicker.svelte
@@ -110,7 +110,10 @@
   let searching = $derived(searchQuery.trim().length > 0);
   let banded = $derived(!searching && recent.length > 0);
 
-  let integrationName = $derived(integration === 'semble' ? 'Semble' : 'Margin');
+  let integrationName = $derived(
+    { semble: 'Semble', margin: 'Margin', currents: 'Currents' }[integration]
+  );
+  let singleSelect = $derived(integration === 'currents');
 
   // Edit mode = this URL already has a card/note in the user's repo.
   let isEdit = $derived((memberships?.items.length ?? 0) > 0);
@@ -138,7 +141,8 @@
     if (membershipsLoading) return false;
     // Until this settles, the row whose membership IS the user's Saved entry is
     // unknown and must not be editable (or removable through "remove all").
-    if (!saveBackingStore.loaded) return false;
+    if (!singleSelect && !saveBackingStore.loaded) return false;
+    if (singleSelect) return noCollection || selectedUris.size === 1;
     if (isEdit) return changed;
     return noCollection || selectedUris.size > 0;
   });
@@ -172,7 +176,7 @@
    * without counting checkmarks. In edit mode it's the pending diff.
    */
   let summary = $derived.by(() => {
-    if (membershipsLoading || !saveBackingStore.loaded) return '';
+    if (membershipsLoading || (!singleSelect && !saveBackingStore.loaded)) return '';
     if (isEdit) {
       if (!changed) return 'No changes yet';
       const parts: string[] = [];
@@ -188,7 +192,7 @@
   $effect(() => {
     if (open) {
       collectionsStore.loadAndRefresh(integration);
-      saveBackingStore.load();
+      if (!singleSelect) saveBackingStore.load();
       loadMemberships(integration, url);
     } else {
       // Reset picker state when modal closes.
@@ -207,7 +211,7 @@
     memberships = null;
     membershipsFailed = false;
     // No URL, or offline: nothing readable, so stay in create mode.
-    if (!target || (typeof navigator !== 'undefined' && !navigator.onLine)) {
+    if (kind === 'currents' || !target || (typeof navigator !== 'undefined' && !navigator.onLine)) {
       membershipsLoading = false;
       return;
     }
@@ -234,6 +238,11 @@
 
   function toggleCollection(uri: string) {
     if (uri === lockedUri) return;
+    if (singleSelect) {
+      selectedUris = new Set([uri]);
+      noCollection = false;
+      return;
+    }
     const next = new Set(selectedUris);
     if (next.has(uri)) {
       next.delete(uri);
@@ -302,11 +311,11 @@
     class="collection-row"
     class:selected={checked}
     class:locked
-    role="checkbox"
+    role={singleSelect ? 'radio' : 'checkbox'}
     aria-checked={checked}
     aria-disabled={locked}
     onclick={() => toggleCollection(collection.uri)}
-    disabled={!saveBackingStore.loaded}
+    disabled={!singleSelect && !saveBackingStore.loaded}
     type="button"
   >
     <span class="tile" aria-hidden="true">
@@ -439,7 +448,7 @@
         role={isEdit ? undefined : 'checkbox'}
         aria-checked={isEdit ? undefined : noCollection}
         onclick={toggleNoCollection}
-        disabled={!saveBackingStore.loaded}
+        disabled={!singleSelect && !saveBackingStore.loaded}
         type="button"
       >
         <span class="tile tile-none" aria-hidden="true">

--- a/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
+++ b/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
@@ -85,6 +85,7 @@
   const linkInterception = useLinkInterception({
     contentEl: () => bodyEl,
     enabled: () => true,
+    pageUrl: () => item.url,
     // Paged mode: turn to the footnote's page rather than scrolling the paged
     // viewport (which the transform-driven paginator never resets).
     pagedController: () => pagedController,
@@ -244,6 +245,9 @@
       url={linkInterception.menuState.url}
       linkText={linkInterception.menuState.linkText}
       anchorRect={linkInterception.menuState.anchorRect}
+      imageUrl={linkInterception.menuState.imageUrl}
+      pageUrl={linkInterception.menuState.pageUrl}
+      caption={linkInterception.menuState.caption}
       onClose={linkInterception.closeMenu}
     />
   {/key}

--- a/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
+++ b/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
@@ -247,7 +247,7 @@
       anchorRect={linkInterception.menuState.anchorRect}
       imageUrl={linkInterception.menuState.imageUrl}
       pageUrl={linkInterception.menuState.pageUrl}
-      caption={linkInterception.menuState.caption}
+      imageAlt={linkInterception.menuState.imageAlt}
       onClose={linkInterception.closeMenu}
     />
   {/key}

--- a/frontend/src/lib/components/feed/LinkContextMenu.svelte
+++ b/frontend/src/lib/components/feed/LinkContextMenu.svelte
@@ -5,15 +5,19 @@
   import { toastStore } from '$lib/stores/toast.svelte';
   import { UrlSaveLimitError } from '$lib/services/api';
   import { saveLimitLine } from '$lib/utils/limitCopy';
+  import { integrationSaveStore } from '$lib/stores/integrationSave.svelte';
 
   interface Props {
     url: string;
     linkText: string;
     anchorRect: DOMRect;
     onClose: () => void;
+    imageUrl?: string;
+    pageUrl?: string;
+    caption?: string;
   }
 
-  let { url, linkText, anchorRect, onClose }: Props = $props();
+  let { url, linkText, anchorRect, onClose, imageUrl, pageUrl, caption }: Props = $props();
 
   let menuEl = $state<HTMLDivElement | null>(null);
   let copyState = $state<'idle' | 'copied'>('idle');
@@ -44,9 +48,20 @@
       });
   }
 
+  function handleSaveImage() {
+    if (!imageUrl) return;
+    integrationSaveStore.openPicker('currents', {
+      url: pageUrl || imageUrl,
+      imageUrl,
+      pageUrl,
+      caption,
+    });
+    onClose();
+  }
+
   async function handleCopy() {
     try {
-      await navigator.clipboard.writeText(url);
+      await navigator.clipboard.writeText(imageUrl || url);
       copyState = 'copied';
       setTimeout(onClose, 600);
     } catch {
@@ -110,17 +125,25 @@
 >
   <div class="link-url">{linkText || url}</div>
   <div class="menu-divider"></div>
+  {#if imageUrl}
+    <button class="menu-item" onclick={handleSaveImage}>
+      <Icon name="bookmark" size={15} />
+      <span>Save image to Currents</span>
+    </button>
+  {/if}
   <button class="menu-item" onclick={handleOpenInNewTab}>
     <Icon name="external-link" size={15} />
     <span>Open in new tab</span>
   </button>
-  <button class="menu-item" onclick={handleSave}>
-    <Icon name="bookmark" size={15} />
-    <span>Add to saved</span>
-  </button>
+  {#if !imageUrl || url !== imageUrl}
+    <button class="menu-item" onclick={handleSave}>
+      <Icon name="bookmark" size={15} />
+      <span>Add to saved</span>
+    </button>
+  {/if}
   <button class="menu-item" onclick={handleCopy}>
     <Icon name="copy" size={15} />
-    <span>{copyState === 'copied' ? 'Copied!' : 'Copy URL'}</span>
+    <span>{copyState === 'copied' ? 'Copied!' : imageUrl ? 'Copy image address' : 'Copy URL'}</span>
   </button>
 </div>
 

--- a/frontend/src/lib/components/feed/LinkContextMenu.svelte
+++ b/frontend/src/lib/components/feed/LinkContextMenu.svelte
@@ -14,10 +14,10 @@
     onClose: () => void;
     imageUrl?: string;
     pageUrl?: string;
-    caption?: string;
+    imageAlt?: string;
   }
 
-  let { url, linkText, anchorRect, onClose, imageUrl, pageUrl, caption }: Props = $props();
+  let { url, linkText, anchorRect, onClose, imageUrl, pageUrl, imageAlt }: Props = $props();
 
   let menuEl = $state<HTMLDivElement | null>(null);
   let copyState = $state<'idle' | 'copied'>('idle');
@@ -54,7 +54,7 @@
       url: pageUrl || imageUrl,
       imageUrl,
       pageUrl,
-      caption,
+      imageAlt,
     });
     onClose();
   }

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -1159,7 +1159,7 @@
           anchorRect={linkInterception.menuState.anchorRect}
           imageUrl={linkInterception.menuState.imageUrl}
           pageUrl={linkInterception.menuState.pageUrl}
-          caption={linkInterception.menuState.caption}
+          imageAlt={linkInterception.menuState.imageAlt}
           onClose={linkInterception.closeMenu}
         />
       {/key}

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -748,6 +748,7 @@
   const linkInterception = useLinkInterception({
     contentEl: () => readerBodyEl,
     enabled: () => true,
+    pageUrl: () => itemUrl,
     // Paged mode: a footnote jump turns to the target's page (scrolling would
     // slide the paged viewport sideways and desync every later page turn).
     pagedController: () => pagedController,
@@ -1156,6 +1157,9 @@
           url={linkInterception.menuState.url}
           linkText={linkInterception.menuState.linkText}
           anchorRect={linkInterception.menuState.anchorRect}
+          imageUrl={linkInterception.menuState.imageUrl}
+          pageUrl={linkInterception.menuState.pageUrl}
+          caption={linkInterception.menuState.caption}
           onClose={linkInterception.closeMenu}
         />
       {/key}

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -5,6 +5,9 @@ export interface LinkMenuState {
   url: string;
   linkText: string;
   anchorRect: DOMRect;
+  imageUrl?: string;
+  pageUrl?: string;
+  caption?: string;
 }
 
 const INTERACTIVE_MEDIA_SELECTOR = 'video, audio, iframe, embed, object';
@@ -19,6 +22,15 @@ interface LinkInterceptionParams {
   // The paginator when this content is laid out in paged mode, so a footnote
   // jump turns the page instead of scrolling (which would desync the columns).
   pagedController?: () => FootnotePagedController | null | undefined;
+  pageUrl?: () => string | undefined;
+}
+
+function imageSource(image: HTMLImageElement): string {
+  const candidates = image.srcset
+    .split(',')
+    .map((part) => part.trim().split(/\s+/)[0])
+    .filter(Boolean);
+  return candidates.at(-1) || image.currentSrc || image.src;
 }
 
 export function useLinkInterception(params: LinkInterceptionParams) {
@@ -48,20 +60,31 @@ export function useLinkInterception(params: LinkInterceptionParams) {
     // browser behavior
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
 
+    const image = target.closest('img') as HTMLImageElement | null;
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
-    if (!link) return;
+    if (!link && !image) return;
     if (!params.enabled()) return;
 
     e.preventDefault();
     e.stopPropagation();
 
-    const href = link.getAttribute('href');
+    const resolvedImageUrl = image
+      ? new URL(imageSource(image), params.pageUrl?.() || document.baseURI).href
+      : undefined;
+    const href = link?.getAttribute('href') || resolvedImageUrl;
     if (!href) return;
 
     menuState = {
       url: href,
-      linkText: link.textContent?.trim() || '',
-      anchorRect: link.getBoundingClientRect(),
+      linkText: link?.textContent?.trim() || image?.alt || '',
+      anchorRect: (link ?? image!).getBoundingClientRect(),
+      ...(image
+        ? {
+            imageUrl: resolvedImageUrl,
+            pageUrl: params.pageUrl?.(),
+            caption: image.alt || image.title || undefined,
+          }
+        : {}),
     };
   }
 

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -7,7 +7,8 @@ export interface LinkMenuState {
   anchorRect: DOMRect;
   imageUrl?: string;
   pageUrl?: string;
-  caption?: string;
+  /** The image's own description, for a Currents save's alt text. */
+  imageAlt?: string;
 }
 
 const INTERACTIVE_MEDIA_SELECTOR = 'video, audio, iframe, embed, object';
@@ -82,7 +83,7 @@ export function useLinkInterception(params: LinkInterceptionParams) {
         ? {
             imageUrl: resolvedImageUrl,
             pageUrl: params.pageUrl?.(),
-            caption: image.alt || image.title || undefined,
+            imageAlt: image.alt || image.title || undefined,
           }
         : {}),
     };

--- a/frontend/src/lib/hooks/useLinkInterception.svelte.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.svelte.ts
@@ -24,14 +24,20 @@ interface LinkInterceptionParams {
   // jump turns the page instead of scrolling (which would desync the columns).
   pagedController?: () => FootnotePagedController | null | undefined;
   pageUrl?: () => string | undefined;
+  /** Bare images are part of a preview's primary tap target until it is expanded. */
+  interceptImages?: () => boolean;
 }
 
-function imageSource(image: HTMLImageElement): string {
-  const candidates = image.srcset
-    .split(',')
-    .map((part) => part.trim().split(/\s+/)[0])
-    .filter(Boolean);
-  return candidates.at(-1) || image.currentSrc || image.src;
+/**
+ * Prefer the browser's actual responsive-image choice. The fallback parser is
+ * descriptor-aware because image transform URLs commonly contain commas.
+ */
+export function imageSource(
+  image: Pick<HTMLImageElement, 'currentSrc' | 'src' | 'srcset'>
+): string {
+  if (image.currentSrc) return image.currentSrc;
+  const candidates = [...image.srcset.matchAll(/\s*(.+?)\s+(\d+(?:\.\d+)?[wx])\s*(?:,|$)/gi)];
+  return candidates.at(-1)?.[1].trim() || image.src;
 }
 
 export function useLinkInterception(params: LinkInterceptionParams) {
@@ -65,6 +71,10 @@ export function useLinkInterception(params: LinkInterceptionParams) {
     const link = target.closest('a[href]') as HTMLAnchorElement | null;
     if (!link && !image) return;
     if (!params.enabled()) return;
+    // A bare image in a clamped river preview remains part of the card's tap
+    // target. A linked image is still intercepted because the link already has
+    // its own click affordance and the menu can offer both destinations.
+    if (image && !link && params.interceptImages && !params.interceptImages()) return;
 
     e.preventDefault();
     e.stopPropagation();

--- a/frontend/src/lib/hooks/useLinkInterception.test.ts
+++ b/frontend/src/lib/hooks/useLinkInterception.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { imageSource } from './useLinkInterception.svelte';
+
+describe('imageSource', () => {
+  it('prefers the image candidate selected by the browser', () => {
+    expect(
+      imageSource({
+        currentSrc: 'https://images.example/chosen.jpg',
+        src: 'https://images.example/fallback.jpg',
+        srcset: 'https://images.example/small.jpg 500w',
+      })
+    ).toBe('https://images.example/chosen.jpg');
+  });
+
+  it('keeps commas inside descriptor-bearing image URLs', () => {
+    expect(
+      imageSource({
+        currentSrc: '',
+        src: 'https://images.example/fallback.jpg',
+        srcset:
+          'https://img.example/format=auto,width=500/a.jpg 500w, https://img.example/format=auto,width=1000/a.jpg 1000w',
+      })
+    ).toBe('https://img.example/format=auto,width=1000/a.jpg');
+  });
+});

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -1308,7 +1308,8 @@ class ApiClient {
   async createCurrentsSave(data: {
     imageUrl: string;
     pageUrl?: string;
-    caption?: string;
+    /** Describes the image — stored as the Currents image content's alt text. */
+    alt?: string;
     collection?: { uri: string; cid: string };
   }): Promise<{ uri: string; cid: string; rkey: string }> {
     return this.fetch('/api/integrations/currents/saves', {

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -12,6 +12,7 @@ import type {
   MagazineParams,
   MagazinePosition,
   MarginCollection,
+  CurrentsCollection,
   MarginHighlightNote,
   ParsedFeed,
   SaveBacking,
@@ -1298,6 +1299,22 @@ class ApiClient {
 
   async listMarginCollections(): Promise<{ collections: MarginCollection[] }> {
     return this.fetch('/api/integrations/margin/collections');
+  }
+
+  async listCurrentsCollections(): Promise<{ collections: CurrentsCollection[] }> {
+    return this.fetch('/api/integrations/currents/collections');
+  }
+
+  async createCurrentsSave(data: {
+    imageUrl: string;
+    pageUrl?: string;
+    caption?: string;
+    collection?: { uri: string; cid: string };
+  }): Promise<{ uri: string; cid: string; rkey: string }> {
+    return this.fetch('/api/integrations/currents/saves', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
   }
 
   /** Which collections this URL is already saved to (read live from the PDS). */

--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -59,7 +59,7 @@ export interface FeedCursorEntry {
 // Cached Semble/Margin collection for the integration share picker.
 // Keyed by [integration+uri] so the same Dexie table can hold both integrations.
 export interface IntegrationCollectionCacheEntry {
-  integration: 'semble' | 'margin';
+  integration: 'semble' | 'margin' | 'currents';
   uri: string;
   cid: string;
   name?: string;

--- a/frontend/src/lib/stores/collections.component.test.ts
+++ b/frontend/src/lib/stores/collections.component.test.ts
@@ -1,0 +1,63 @@
+// Named `.component.test.ts` so the Svelte plugin compiles this rune store.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class FakeScopeUpgradeError extends Error {
+  constructor() {
+    super('scope upgrade');
+    this.name = 'ScopeUpgradeError';
+  }
+}
+
+const listCurrentsCollections = vi.fn();
+const cachedCurrents = {
+  integration: 'currents',
+  uri: 'at://did:plc:reader/is.currents.feed.collection/one',
+  cid: 'bafycollection',
+  name: 'Reference',
+  cachedAt: 1,
+};
+
+const collectionQuery = {
+  equals: vi.fn(() => collectionQuery),
+  toArray: vi.fn(async () => [cachedCurrents]),
+  delete: vi.fn(),
+};
+
+vi.mock('$lib/services/db', () => ({
+  db: {
+    integrationCollections: {
+      where: vi.fn(() => collectionQuery),
+    },
+  },
+}));
+
+vi.mock('$lib/services/api', () => ({
+  api: {
+    listCurrentsCollections: (...args: unknown[]) => listCurrentsCollections(...args),
+  },
+  ScopeUpgradeError: FakeScopeUpgradeError,
+}));
+
+const { collectionsStore } = await import('./collections.svelte');
+
+beforeEach(async () => {
+  listCurrentsCollections.mockReset();
+  collectionQuery.equals.mockClear();
+  collectionQuery.toArray.mockClear();
+  await collectionsStore.invalidate('currents');
+});
+
+describe('collectionsStore', () => {
+  it('surfaces missing Currents scopes even when cached collections exist', async () => {
+    listCurrentsCollections.mockRejectedValue(new FakeScopeUpgradeError());
+
+    await collectionsStore.loadAndRefresh('currents');
+
+    expect(collectionsStore.collections.currents).toEqual([
+      expect.objectContaining({ uri: cachedCurrents.uri, name: 'Reference' }),
+    ]);
+    expect(collectionsStore.error.currents).toBe('scope_upgrade_required');
+    expect(collectionsStore.loading.currents).toBe(false);
+    expect(collectionsStore.refreshing.currents).toBe(false);
+  });
+});

--- a/frontend/src/lib/stores/collections.svelte.ts
+++ b/frontend/src/lib/stores/collections.svelte.ts
@@ -1,5 +1,5 @@
 import { db, type IntegrationCollectionCacheEntry } from '$lib/services/db';
-import { api } from '$lib/services/api';
+import { api, ScopeUpgradeError } from '$lib/services/api';
 import type { SembleCollection, MarginCollection, CurrentsCollection } from '$lib/types';
 
 export type IntegrationKind = 'semble' | 'margin' | 'currents';
@@ -151,7 +151,12 @@ function createCollectionsStore() {
       collections[integration] = merged;
       await writeCache(integration, merged);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to load collections';
+      const msg =
+        err instanceof ScopeUpgradeError
+          ? 'scope_upgrade_required'
+          : err instanceof Error
+            ? err.message
+            : 'Failed to load collections';
       if (!hasCache) {
         error[integration] = msg;
       } else {

--- a/frontend/src/lib/stores/collections.svelte.ts
+++ b/frontend/src/lib/stores/collections.svelte.ts
@@ -157,7 +157,11 @@ function createCollectionsStore() {
           : err instanceof Error
             ? err.message
             : 'Failed to load collections';
-      if (!hasCache) {
+      // Cached collection names remain useful for transient failures, but they
+      // cannot prove that the current session is authorized. A scope failure is
+      // authoritative (including after an account/session change), so surface it
+      // even when IndexedDB still holds rows from an earlier session.
+      if (!hasCache || err instanceof ScopeUpgradeError) {
         error[integration] = msg;
       } else {
         console.error(`Background refresh of ${integration} collections failed:`, err);

--- a/frontend/src/lib/stores/collections.svelte.ts
+++ b/frontend/src/lib/stores/collections.svelte.ts
@@ -1,8 +1,8 @@
 import { db, type IntegrationCollectionCacheEntry } from '$lib/services/db';
 import { api } from '$lib/services/api';
-import type { SembleCollection, MarginCollection } from '$lib/types';
+import type { SembleCollection, MarginCollection, CurrentsCollection } from '$lib/types';
 
-export type IntegrationKind = 'semble' | 'margin';
+export type IntegrationKind = 'semble' | 'margin' | 'currents';
 
 /**
  * A collection as the picker needs it. `lastUsedAt` is local-only: neither
@@ -10,7 +10,7 @@ export type IntegrationKind = 'semble' | 'margin';
  * picker's "recently used" band is built from what this device remembers
  * (stamped by markUsed, merged forward across every cache refresh).
  */
-export type CollectionEntry = (SembleCollection | MarginCollection) & {
+export type CollectionEntry = (SembleCollection | MarginCollection | CurrentsCollection) & {
   lastUsedAt?: number;
 };
 
@@ -29,18 +29,22 @@ function createCollectionsStore() {
   const collections = $state<Record<IntegrationKind, CollectionEntry[]>>({
     semble: [],
     margin: [],
+    currents: [],
   });
   const loading = $state<Record<IntegrationKind, boolean>>({
     semble: false,
     margin: false,
+    currents: false,
   });
   const refreshing = $state<Record<IntegrationKind, boolean>>({
     semble: false,
     margin: false,
+    currents: false,
   });
   const error = $state<Record<IntegrationKind, string | null>>({
     semble: null,
     margin: null,
+    currents: null,
   });
 
   async function readCache(integration: IntegrationKind): Promise<CollectionEntry[]> {
@@ -89,10 +93,12 @@ function createCollectionsStore() {
     if (integration === 'semble') {
       const res = await api.listSembleCollections();
       return res.collections;
-    } else {
+    } else if (integration === 'margin') {
       const res = await api.listMarginCollections();
       return res.collections;
     }
+    const res = await api.listCurrentsCollections();
+    return res.collections;
   }
 
   /**
@@ -158,7 +164,7 @@ function createCollectionsStore() {
   }
 
   async function invalidate(integration?: IntegrationKind): Promise<void> {
-    const kinds: IntegrationKind[] = integration ? [integration] : ['semble', 'margin'];
+    const kinds: IntegrationKind[] = integration ? [integration] : ['semble', 'margin', 'currents'];
     for (const k of kinds) {
       collections[k] = [];
       loading[k] = false;

--- a/frontend/src/lib/stores/integrationSave.svelte.ts
+++ b/frontend/src/lib/stores/integrationSave.svelte.ts
@@ -27,6 +27,9 @@ export interface IntegrationSaveTarget {
   description?: string;
   author?: string;
   publishedAt?: string;
+  imageUrl?: string;
+  pageUrl?: string;
+  caption?: string;
 }
 
 export type CollectionChoice = CollectionSelection;
@@ -71,8 +74,40 @@ function createIntegrationSaveStore() {
     if (!data) return;
     target = null;
 
+    const label = { margin: 'Margin', semble: 'Semble', currents: 'Currents' }[integration];
+
+    if (integration === 'currents') {
+      if (!data.imageUrl) return;
+      if (!syncStore.isOnline) {
+        const id = toastStore.add('Currents needs a connection');
+        toastStore.update(id, 'error');
+        return;
+      }
+      const id = toastStore.add('Saving to Currents...');
+      try {
+        await api.createCurrentsSave({
+          imageUrl: data.imageUrl,
+          pageUrl: data.pageUrl ?? data.url,
+          caption: data.caption ?? data.title,
+          collection: collections[0],
+        });
+        toastStore.update(id, 'success', 'Saved to Currents');
+      } catch (err) {
+        if (err instanceof ScopeUpgradeError) {
+          toastStore.update(id, 'error', 'Log in again to grant Currents permissions');
+        } else {
+          console.error('Failed to save to Currents:', err);
+          toastStore.update(
+            id,
+            'error',
+            err instanceof Error ? err.message : "Couldn't save image"
+          );
+        }
+      }
+      return;
+    }
+
     const isMargin = integration === 'margin';
-    const label = isMargin ? 'Margin' : 'Semble';
 
     const payload: IntegrationPayload = {
       type: integration,
@@ -138,6 +173,7 @@ function createIntegrationSaveStore() {
     if (!data) return;
     target = null;
 
+    if (integration === 'currents') return;
     const label = integration === 'margin' ? 'Margin' : 'Semble';
     const id = toastStore.add(`Updating ${label} save...`);
     try {

--- a/frontend/src/lib/stores/integrationSave.svelte.ts
+++ b/frontend/src/lib/stores/integrationSave.svelte.ts
@@ -29,7 +29,12 @@ export interface IntegrationSaveTarget {
   publishedAt?: string;
   imageUrl?: string;
   pageUrl?: string;
-  caption?: string;
+  /**
+   * The image's own description (its `alt`/`title`), not the article's title —
+   * it lands in the Currents image content's `alt` field, so anything that
+   * doesn't describe the image itself doesn't belong here.
+   */
+  imageAlt?: string;
 }
 
 export type CollectionChoice = CollectionSelection;
@@ -88,7 +93,7 @@ function createIntegrationSaveStore() {
         await api.createCurrentsSave({
           imageUrl: data.imageUrl,
           pageUrl: data.pageUrl ?? data.url,
-          caption: data.caption ?? data.title,
+          alt: data.imageAlt,
           collection: collections[0],
         });
         toastStore.update(id, 'success', 'Saved to Currents');

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1149,6 +1149,7 @@ export interface IntegrationStatus {
   scopeStatus: {
     margin: boolean;
     semble: boolean;
+    currents?: boolean;
     /**
      * Writing a Semble *connection* needs a scope no pre-existing session holds,
      * and it's checked separately from the card/collection scopes so those keep
@@ -1252,6 +1253,14 @@ export interface SembleCard {
 }
 
 export interface MarginCollection {
+  uri: string;
+  cid: string;
+  name?: string;
+  description?: string;
+  createdAt?: string;
+}
+
+export interface CurrentsCollection {
   uri: string;
   cid: string;
   name?: string;


### PR DESCRIPTION
Adds direct image saves to Currents from reader content, including single-collection selection, guarded server-side image fetching, PDS blob upload, and Currents record creation.

The save record writes `content` as the lexicon's typed union variant — `is.currents.content.image` (`{ $type, image: <blob>, alt? }`) — which is what Currents' indexer recognizes; the image's own description rides `alt`, and the record's `text` is reserved for a user-authored note.

Cached collection data no longer masks missing Currents OAuth scopes, so the picker immediately asks the reader to log in again and keeps Save disabled.

Includes focused record-shape, image-fetch safety, reader-interaction, and cached-scope regression tests.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-roi4pvcurtcygyshdt42jt3l)
[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-x3qzk5rmjvvpcoltuv5tm6vl)
[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-6r4gu7cbf4vz4wcb5igjyhxk)
