### PR TITLE
Keep a summary when the archive drops an oversized feed body

### DIFF
--- a/backend/src/routes/ingest.ts
+++ b/backend/src/routes/ingest.ts
@@ -121,11 +121,47 @@ function badRequest(message: string, status = 400): Response {
   });
 }
 
+// Length of the summary derived below. Matches EXCERPT_MAX_CHARS in the proxy's
+// feed-parser.ts, which normally gets there first.
+const DERIVED_SUMMARY_MAX_CHARS = 400;
+
+/**
+ * Last-resort preview for a body about to be dropped. The proxy's parser already
+ * derives one at parse time; this covers the item that arrives without it (an
+ * older proxy build, a body that grew past the cap after its summary was
+ * resolved) so "summary/title/url/image kept" is never vacuously true.
+ *
+ * Entities stay encoded — `summary` is rendered as HTML downstream, exactly like
+ * a feed-supplied one.
+ */
+function deriveSummary(content: string): string {
+  const text = content
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (text.length <= DERIVED_SUMMARY_MAX_CHARS) return text;
+  const cut = text.slice(0, DERIVED_SUMMARY_MAX_CHARS);
+  const lastSpace = cut.lastIndexOf(' ');
+  const head = (lastSpace > DERIVED_SUMMARY_MAX_CHARS / 2 ? cut.slice(0, lastSpace) : cut)
+    // Drop an `&`-run stranded by the cut, which would render as `&amp`.
+    .replace(/&[#a-z0-9]*$/i, '')
+    .trimEnd();
+  return head ? `${head}…` : '';
+}
+
 /**
  * Apply the stored-content cap. Returns the item to persist: unchanged when it
  * fits, otherwise the same item with `content` dropped and `contentTruncated`
  * set. `content_hash` is computed by the proxy over the FULL item, so truncation
  * never confuses edit detection.
+ *
+ * An item with no summary of its own gets one derived from the body being
+ * dropped. Without it such an item is stored with no text at all — the reader
+ * has nothing to preview in the list, nothing to show offline, and no word count
+ * (Atom feeds that ship a full <content> and no <summary> are the common case),
+ * and only an on-open extraction can recover the article.
  */
 export function capItemContent(item: FeedItem): FeedItem {
   const content = item.content;
@@ -134,7 +170,8 @@ export function capItemContent(item: FeedItem): FeedItem {
   const bytes = new TextEncoder().encode(content).length;
   if (bytes <= MAX_ITEM_CONTENT_BYTES) return item;
   const { content: _dropped, ...rest } = item;
-  return { ...rest, contentTruncated: true };
+  const summary = rest.summary || deriveSummary(content) || undefined;
+  return { ...rest, summary, contentTruncated: true };
 }
 
 /**

--- a/backend/test/feed-timeline.spec.ts
+++ b/backend/test/feed-timeline.spec.ts
@@ -354,6 +354,27 @@ describe('feed timeline (D1 ingest + serve)', () => {
       expect(parsedSmall.content).toBe('tiny');
       expect(parsedSmall.contentTruncated).toBeUndefined();
     });
+
+    it('derives a summary from a dropped body when the item has none', async () => {
+      // An Atom feed shipping a full <content> and no <summary> used to leave the
+      // archive with no text at all for the item — a blank card in the reader.
+      const body =
+        '<p>Opening sentence of the article body.</p>' +
+        '<script>ignore()</script>' +
+        `<p>${'and more prose '.repeat(700)}</p>`;
+      await ingest(FEED_A, [{ item: item('no-summary', { content: body }), contentHash: 'hns' }]);
+
+      const row = await env.DB.prepare('SELECT item_json FROM feed_items WHERE guid = ?')
+        .bind('no-summary')
+        .first<{ item_json: string }>();
+      const parsed = JSON.parse(row!.item_json);
+      expect(parsed.content).toBeUndefined();
+      expect(parsed.contentTruncated).toBe(true);
+      expect(parsed.summary).toContain('Opening sentence of the article body.');
+      expect(parsed.summary).not.toContain('ignore()');
+      expect(parsed.summary).not.toContain('<');
+      expect(parsed.summary.length).toBeLessThanOrEqual(401);
+    });
   });
 
   describe('pull-through ingest (proxy feed → archive)', () => {

--- a/docs/plans/D1_FEED_TIMELINE.md
+++ b/docs/plans/D1_FEED_TIMELINE.md
@@ -46,7 +46,11 @@ read state (`getReadKeys`). Now:
   authenticated by a constant-time compare against `FEED_PROXY_SECRET` and **fail-closed** when
   it is unset. Idempotent upsert (edit-in-place keeps the seq), per-item content cap
   (`MAX_ITEM_CONTENT_BYTES = 8 KB`, drops `content` and sets `contentTruncated`), and the per-feed
-  `SANITY_CAP = 5000` trim — the only pruning that ever runs. Both endpoints stamp a **crawler
+  `SANITY_CAP = 5000` trim — the only pruning that ever runs. A dropped body always leaves a
+  `summary` behind: the proxy's parser derives one for any over-cap body whose feed supplies none
+  (`CONTENT_EXCERPT_THRESHOLD_BYTES` in `feed-proxy/src/feed-parser.ts`), and `capItemContent`
+  derives one itself if the item still arrives without. Storing an item with neither content nor
+  summary is what made full-text Atom feeds render as blank cards. Both endpoints stamp a **crawler
   heartbeat** (`sync_state.crawler_heartbeat_at`); the crawl-set pull runs every 5 minutes, so the
   stamp is fresh even when no feed produced an item.
 - `routes/timeline.ts`: `GET /api/v2/timeline?since_seq=&generation=&limit=&cold_offset=` —

--- a/feed-proxy/src/app.ts
+++ b/feed-proxy/src/app.ts
@@ -364,7 +364,10 @@ const EXTRACT_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // past those items in the monotonic feed cursor.
 //   0: cache rows created before parser output was versioned
 //   1: TeX feed delimiters converted to native MathML
-export const FEED_PARSER_VERSION = 1;
+//   2: summary derived from an over-cap body when the feed supplies none —
+//      without the re-parse, items already in the archive keep the empty body
+//      they were stored with, since an unchanged hash is never re-pushed
+export const FEED_PARSER_VERSION = 2;
 
 // Version tag for extractArticle's output. A cached extraction is only reused
 // when its stored version matches this constant, so bumping it here retires

--- a/feed-proxy/src/feed-parser.test.ts
+++ b/feed-proxy/src/feed-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { parseFeed } from './feed-parser';
+import { excerptFromContent, parseFeed } from './feed-parser';
 
 describe('parseFeed', () => {
   describe('RSS 2.0', () => {
@@ -533,5 +533,121 @@ describe('parseFeed', () => {
       expect(result.items[0].title).toBe('Post 1');
       expect(result.items[99].title).toBe('Post 100');
     });
+  });
+
+  // The archive drops bodies over 8 KB and keeps "summary/title/url/image", so a
+  // feed that ships a full body and no summary of its own used to reach the
+  // reader with no text at all. See CONTENT_EXCERPT_THRESHOLD_BYTES.
+  describe('summary fallback for over-cap bodies', () => {
+    const longBody = (lead: string) => `<p>${lead}</p><p>${'padding words here. '.repeat(600)}</p>`;
+
+    function atomWith(entry: string): string {
+      return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Full Text Blog</title>
+  ${entry}
+</feed>`;
+    }
+
+    it('derives one for an Atom entry with a big content and no summary', () => {
+      const feed = atomWith(`<entry>
+        <title>Long Post</title>
+        <link href="https://example.com/long"/>
+        <id>https://example.com/long</id>
+        <content type="html"><![CDATA[${longBody('The opening line of the post.')}]]></content>
+      </entry>`);
+
+      const [parsed] = parseFeed(feed, 'https://example.com/feed.xml').items;
+
+      expect(parsed.content).toContain('padding words here.');
+      expect(parsed.summary).toContain('The opening line of the post.');
+      expect(parsed.summary).not.toContain('<p>');
+      expect(parsed.summary!.endsWith('…')).toBe(true);
+    });
+
+    it('leaves a feed-supplied summary alone', () => {
+      const feed = atomWith(`<entry>
+        <title>Long Post</title>
+        <link href="https://example.com/long"/>
+        <id>https://example.com/long</id>
+        <summary>The author's own blurb.</summary>
+        <content type="html"><![CDATA[${longBody('The opening line.')}]]></content>
+      </entry>`);
+
+      const [parsed] = parseFeed(feed, 'https://example.com/feed.xml').items;
+
+      expect(parsed.summary).toBe("The author's own blurb.");
+    });
+
+    it('derives nothing for a body the archive keeps in full', () => {
+      const feed = atomWith(`<entry>
+        <title>Short Post</title>
+        <link href="https://example.com/short"/>
+        <id>https://example.com/short</id>
+        <content type="html"><![CDATA[<p>Just a couple of sentences.</p>]]></content>
+      </entry>`);
+
+      const [parsed] = parseFeed(feed, 'https://example.com/feed.xml').items;
+
+      // Duplicating a body the reader already has would grow the archive and
+      // re-hash (so re-push) an item that was never broken.
+      expect(parsed.summary).toBeUndefined();
+      expect(parsed.content).toContain('Just a couple of sentences.');
+    });
+
+    it('derives one for an RSS item carrying only content:encoded', () => {
+      const rss = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Full Text Blog</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Long Post</title>
+      <link>https://example.com/long</link>
+      <guid>long</guid>
+      <content:encoded><![CDATA[${longBody('First sentence of the body.')}]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+
+      const [parsed] = parseFeed(rss, 'https://example.com/feed.xml').items;
+
+      expect(parsed.summary).toContain('First sentence of the body.');
+    });
+  });
+});
+
+describe('excerptFromContent', () => {
+  it('strips tags without fusing the words either side', () => {
+    expect(excerptFromContent('<p>one</p><p>two</p>')).toBe('one two');
+  });
+
+  it('drops script, style and comment bodies', () => {
+    const html =
+      '<p>Real text.</p><script>alert(1)</script><style>p{color:red}</style><!-- note -->';
+    expect(excerptFromContent(html)).toBe('Real text.');
+  });
+
+  it('leaves entities encoded, since the excerpt is rendered as HTML', () => {
+    expect(excerptFromContent('<p>Tom &amp; Jerry</p>')).toBe('Tom &amp; Jerry');
+  });
+
+  it('cuts on a word boundary', () => {
+    expect(excerptFromContent(`alpha beta gamma ${'delta '.repeat(50)}`, 20)).toBe(
+      'alpha beta gamma…'
+    );
+  });
+
+  it('cuts mid-word only when the window holds no usable boundary', () => {
+    expect(excerptFromContent('a'.repeat(50), 10)).toBe('aaaaaaaaaa…');
+  });
+
+  it('drops an entity the cut left half-written', () => {
+    // Without the trim this reads `abcdefghij&am…` — a visible `&am` in the UI.
+    expect(excerptFromContent('abcdefghij&amp;klmnopqrst', 13)).toBe('abcdefghij…');
+  });
+
+  it('returns empty for markup with no text', () => {
+    expect(excerptFromContent('<img src="x.png"><br/>')).toBe('');
   });
 });

--- a/feed-proxy/src/feed-parser.ts
+++ b/feed-proxy/src/feed-parser.ts
@@ -24,6 +24,31 @@ const HEX_ENTITY_PATTERN = /&#x([0-9a-f]+);/gi;
 // source publishes <= MAX_ITEMS_TO_PARSE items per warm-refresh interval.
 const MAX_ITEMS_TO_PARSE = 100;
 
+// Bodies above this are stored in the archive WITHOUT their content — the
+// Worker's `MAX_ITEM_CONTENT_BYTES` (backend/src/routes/ingest.ts) drops them and
+// keeps "summary/title/url/image". A feed that ships a full body and no
+// <summary>/<description> (anildash.com, and every Atom generator that omits it)
+// therefore left NOTHING behind: no preview in the list, no body offline, no word
+// count — a blank card, recoverable only by an on-open extraction. So derive a
+// summary from the body that is about to be dropped.
+//
+// The threshold mirrors that cap deliberately rather than excerpting everything:
+// an item whose body the archive keeps in full is not broken, and giving it a
+// summary would duplicate its opening paragraph in every stored copy and change
+// its content hash — re-pushing millions of healthy rows to fix nothing.
+const CONTENT_EXCERPT_THRESHOLD_BYTES = 8 * 1024;
+
+// Long enough to read as a real preview (a feed-supplied <description> is
+// typically one or two sentences), short enough that it costs nothing next to the
+// body it stands in for.
+const EXCERPT_MAX_CHARS = 400;
+
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+const SCRIPT_STYLE_PATTERN = /<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+const TAG_PATTERN = /<[^>]*>/g;
+// A `&`-run left dangling by the cut: rendering it would show `&amp` or `&#82`.
+const PARTIAL_ENTITY_PATTERN = /&[#a-z0-9]*$/i;
+
 const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
@@ -74,6 +99,58 @@ export function parseFeed(content: string, feedUrl: string): ParsedFeed {
   throw new Error(`Unknown feed format. Root elements: ${keys || 'none'}`);
 }
 
+/**
+ * A plain-text preview of an item's body. Tags become spaces so words either
+ * side of one don't fuse, script/style bodies and comments are dropped outright,
+ * and the cut lands on a word boundary.
+ *
+ * Entity sequences are left encoded on purpose: this becomes `summary`, which is
+ * rendered as HTML downstream exactly like a feed-supplied one, so `&amp;` must
+ * stay `&amp;`. Only a partial entity stranded by the cut is trimmed.
+ */
+export function excerptFromContent(content: string, maxChars = EXCERPT_MAX_CHARS): string {
+  const text = content
+    .replace(HTML_COMMENT_PATTERN, ' ')
+    .replace(SCRIPT_STYLE_PATTERN, ' ')
+    .replace(TAG_PATTERN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (text.length <= maxChars) return text;
+
+  const cut = text.slice(0, maxChars);
+  const lastSpace = cut.lastIndexOf(' ');
+  // Only honour the word boundary if one exists reasonably near the end; a body
+  // with no spaces in its first `maxChars` (CJK, a long URL) is cut where it is.
+  const head = (lastSpace > maxChars / 2 ? cut.slice(0, lastSpace) : cut)
+    .replace(PARTIAL_ENTITY_PATTERN, '')
+    .trimEnd();
+  return head ? `${head}…` : '';
+}
+
+/** Byte length without encoding the whole string when the answer is obvious. */
+function exceedsExcerptThreshold(content: string): boolean {
+  // UTF-8 never uses fewer bytes than the string has UTF-16 code units, and never
+  // more than three per unit, so only the ambiguous band needs the encoder.
+  if (content.length > CONTENT_EXCERPT_THRESHOLD_BYTES) return true;
+  if (content.length * 3 <= CONTENT_EXCERPT_THRESHOLD_BYTES) return false;
+  return new TextEncoder().encode(content).length > CONTENT_EXCERPT_THRESHOLD_BYTES;
+}
+
+/**
+ * The item's own summary when the feed supplies one, otherwise an excerpt of a
+ * body large enough that the archive will drop it (see
+ * CONTENT_EXCERPT_THRESHOLD_BYTES). Never fabricates a summary for a body that
+ * survives storage intact.
+ */
+function resolveSummary(
+  summary: string | undefined,
+  content: string | undefined
+): string | undefined {
+  if (summary) return summary;
+  if (!content || !exceedsExcerptThreshold(content)) return undefined;
+  return excerptFromContent(content) || undefined;
+}
+
 function parseJsonFeed(json: any, feedUrl: string): ParsedFeed {
   const items: FeedItem[] = [];
   const jsonItems = json.items || [];
@@ -85,7 +162,7 @@ function parseJsonFeed(json: any, feedUrl: string): ParsedFeed {
     const guid = item.id || url || generateGuid(title);
     const author = item.author?.name || item.authors?.[0]?.name;
     const content = convertLatexToMathML(item.content_html || item.content_text);
-    const summary = convertLatexToMathML(item.summary);
+    const summary = resolveSummary(convertLatexToMathML(item.summary), content);
     const imageUrl = item.image || item.banner_image;
     const pubDate = item.date_published || item.date_modified;
 
@@ -124,7 +201,7 @@ function parseRssFeed(channel: any, feedUrl: string): ParsedFeed {
     const content = convertLatexToMathML(
       getText(item['content:encoded']) || getText(item.description)
     );
-    const summary = convertLatexToMathML(getText(item.description));
+    const summary = resolveSummary(convertLatexToMathML(getText(item.description)), content);
     const pubDate = getText(item.pubDate) || getText(item['dc:date']);
     const imageUrl = extractRssItemImage(item);
 
@@ -162,7 +239,7 @@ function parseAtomFeed(feed: any, feedUrl: string): ParsedFeed {
     const guid = getText(entry.id) || url || generateGuid(title);
     const author = entry.author?.name ? getText(entry.author.name) : undefined;
     const content = convertLatexToMathML(getText(entry.content) || getText(entry.summary));
-    const summary = convertLatexToMathML(getText(entry.summary));
+    const summary = resolveSummary(convertLatexToMathML(getText(entry.summary)), content);
     const updated = getText(entry.updated) || getText(entry.published);
 
     items.push({
@@ -201,7 +278,7 @@ function parseRdfFeed(rdf: any, feedUrl: string): ParsedFeed {
     const content = convertLatexToMathML(
       getText(item['content:encoded']) || getText(item.description)
     );
-    const summary = convertLatexToMathML(getText(item.description));
+    const summary = resolveSummary(convertLatexToMathML(getText(item.description)), content);
     const pubDate = getText(item['dc:date']);
 
     items.push({


### PR DESCRIPTION
## The bug

`https://anildash.com/feed.xml` is an Atom feed that ships each post's full body in `<content type="html">` and **no `<summary>`**. Most entries are 8–19 KB.

The archive caps stored bodies at `MAX_ITEM_CONTENT_BYTES = 8 KB` (`backend/src/routes/ingest.ts`): over the cap `content` is dropped and `contentTruncated` set, on the documented basis that "summary/title/url/image" survive. For a feed with no summary, **nothing** survived — the item was stored with no text at all.

Downstream, `ArticleCard`'s `displayContent` falls through `content → lazyContent → summary` and lands on `''`, so the card renders empty. Its auto-extraction (`/api/extract`) only fires once the card is `expanded`, and is account-only — so the list preview, guest mode and offline reading all showed nothing. Verified against the live feed: 5 of the first 6 entries are over the cap and none carries a summary.

## The fix — always leave text behind

- **`feed-proxy/src/feed-parser.ts`** — `excerptFromContent()` derives a plain-text preview (400 chars, word-boundary cut, script/style/comment bodies dropped, entities left encoded because `summary` is rendered as HTML downstream). `resolveSummary()` applies it in all four parsers (JSON Feed, RSS, Atom, RDF) when the feed supplies no summary **and** the body is over the archive's cap. Bodies the archive keeps in full are left alone: giving them a summary would duplicate their opening paragraph in storage and re-hash items that were never broken.
- **`feed-proxy/src/app.ts`** — `FEED_PARSER_VERSION` 1 → 2. This is what repairs items **already in the archive**: an unchanged content hash is never re-pushed, so without the forced re-parse the fix would only reach posts published from here on. Each cached feed re-parses once, the new summary changes the item hash, the dirty-row pusher re-delivers, and ingest rewrites the row in place (seq unchanged → clients don't re-receive it).
- **`backend/src/routes/ingest.ts`** — `capItemContent` derives the same kind of excerpt itself when dropping a body from an item with no summary. Backstop for an item that arrives without one (older proxy build, pull-through path), so the "summary is kept" promise is never vacuous.
- **`docs/plans/D1_FEED_TIMELINE.md`** — records the invariant next to the cap.

With a summary present the reader shows a real preview in the list, has text offline and in guest mode, computes a word count, and — because the body now reads as a short excerpt — surfaces the prominent inline "Fetch full article" affordance instead of burying it in the overflow menu. Extraction on open is unchanged and still supplies the whole post (Defuddle returns 1,131 words for the anildash post used as the repro).

## Tests

- `feed-proxy/src/feed-parser.test.ts` — 11 new: derivation across Atom/RSS, a feed-supplied summary left untouched, nothing derived for an under-cap body, plus `excerptFromContent` unit cases (tag stripping without word fusion, script/style/comment removal, entities kept encoded, word-boundary cut, mid-word fallback, half-written entity dropped).
- `backend/test/feed-timeline.spec.ts` — 1 new: an over-cap item with no summary is stored with `content` dropped, `contentTruncated` set, and a derived summary.

## Checks

- `feed-proxy`: `bun test` — 412 pass, 0 fail (whole suite). `npm run check` clean.
- `backend`: `npx vitest run` — 63 files, 762 tests, all passing. `npm run check` clean.
- Frontend untouched.

## Operational notes

- **One-time re-push.** The parser bump makes every crawl-set feed re-parse once (~200 feeds per 60 s warm tick, so ~30 min for the set at the normal cadence — it makes those fetches unconditional, it does not add fetches). Items whose summary is newly derived become dirty and are re-pushed to D1; that is bounded to over-cap bodies with no summary, and the push loop's drain chaining exists for exactly this shape of backlog. Clients see nothing — the rewrite keeps the row's `seq`.
- **Storage:** ~400 bytes per affected item, only where an 8 KB+ body was discarded.
- `CONTENT_EXCERPT_THRESHOLD_BYTES` mirrors the Worker's `MAX_ITEM_CONTENT_BYTES`, the way `itemContentHash`/`computeContentHash` are already mirrored across the two packages. If the Worker's cap is ever lowered the proxy constant must follow; the backend's own derivation covers the gap meanwhile.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-mfyet5najdosox3bgeysvfi6)
