### PR TITLE
Rank a document backfill by publication date, not listing order

### DIFF
--- a/backend/src/services/document-store.ts
+++ b/backend/src/services/document-store.ts
@@ -941,11 +941,11 @@ export async function backfillAuthorDocuments(
   const pds = createPdsMemo();
 
   const now = Date.now();
-  let listed: Awaited<ReturnType<typeof listAuthorDocuments>>;
+  let listing: Awaited<ReturnType<typeof listAuthorDocuments>>;
   // The listing's pages are subrequests too, spent whether or not it succeeds.
   chargeQueries(ctx.ledger, BACKFILL_LIST_SUBREQUESTS);
   try {
-    listed = await listAuthorDocuments(authorDid, pds);
+    listing = await listAuthorDocuments(authorDid, pds);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'listRecords failed';
     chargeQueries(ctx.ledger, 1);
@@ -954,8 +954,24 @@ export async function backfillAuthorDocuments(
     return refused(message);
   }
 
-  const complete = listed.length < MAX_DOCUMENTS_PER_AUTHOR;
-  const kept = listed.slice(0, MAX_DOCUMENTS_PER_AUTHOR);
+  const listed = listing.records;
+  // Only a listing that reached the end of the repo can claim the author fits under
+  // the cap; one stopped by the page bound says nothing about what lay past it.
+  const complete = listing.exhaustive && listed.length < MAX_DOCUMENTS_PER_AUTHOR;
+
+  // Rank by publication date, not by the order the PDS happened to serve. This is
+  // the same key the cap eviction and every read path order by
+  // (`ORDER BY published_at DESC, record_uri DESC`), and matching them is the whole
+  // point: when the walk kept a different 100 than the trim would, the two fought
+  // each other — a reader saw a publication's 2007 archive imports while its 2026
+  // posts sat one reconcile away from being deleted.
+  const kept = [...listed]
+    .sort((a, b) => {
+      const byPublished = publishedAtMs(b.value, now) - publishedAtMs(a.value, now);
+      if (byPublished !== 0) return byPublished;
+      return a.uri < b.uri ? 1 : a.uri > b.uri ? -1 : 0;
+    })
+    .slice(0, MAX_DOCUMENTS_PER_AUTHOR);
 
   for (const record of kept) {
     const parsed = parseAtUri(record.uri);
@@ -971,13 +987,27 @@ export async function backfillAuthorDocuments(
   // per-author constant fiction. It is also safer against a concurrent write — a
   // row the drain adds while we list carries a later stamp and survives, where a
   // set difference against the listing would have deleted it.
-  const pruned = await env.DB.prepare(
-    'DELETE FROM documents_v2 WHERE author_did = ? AND (updated_at IS NULL OR updated_at < ?)'
-  )
-    .bind(authorDid, now)
-    .run();
+  //
+  // Only against an exhaustive listing, though. A walk stopped by the page bound
+  // has no idea what it didn't see, and "absent from a partial listing" is not
+  // evidence of deletion — on a PDS that serves oldest-first, it is evidence of
+  // nothing but a large repo. Such a walk falls back to the cap eviction, which
+  // ranks by the same key over everything we hold rather than over what one listing
+  // reached, so rows the firehose delivered survive a walk that couldn't see them.
+  // One statement either way: the budget is unchanged.
+  let removed = 0;
+  if (listing.exhaustive) {
+    const pruned = await env.DB.prepare(
+      'DELETE FROM documents_v2 WHERE author_did = ? AND (updated_at IS NULL OR updated_at < ?)'
+    )
+      .bind(authorDid, now)
+      .run();
+    removed = pruned.meta?.changes ?? 0;
+  } else {
+    const trimmed = await trimAuthorDocumentsStatement(env, authorDid).run();
+    removed = trimmed.meta?.changes ?? 0;
+  }
   chargeQueries(ctx.ledger, 1);
-  const removed = pruned.meta?.changes ?? 0;
 
   const collections = await listAuthorCollections(authorDid, pds);
 
@@ -1067,6 +1097,9 @@ export async function backfillAuthorDocuments(
     deferredCollections,
     collectionAllowance,
     complete,
+    // Which of the two settle paths ran: a false here means stale rows were kept
+    // rather than pruned, which is the deliberate trade and worth being able to see.
+    exhaustive: listing.exhaustive,
     queries: ctx.ledger.spent,
   });
 

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -475,10 +475,30 @@ function resolveAuthorPds(authorDid: string, memo?: PdsMemo): Promise<string | n
   return pending;
 }
 
+/** One author's document listing, and whether it reached the end of the repo. */
+export interface AuthorDocumentListing {
+  records: Array<ListedRecord<DocumentRecord>>;
+  /**
+   * True only when the listing ran out of records, rather than stopping on
+   * `MAX_LIST_PAGES`. A caller that prunes stored rows against this set has to be
+   * able to tell those apart — the same reason `AuthorCollectionListing` carries
+   * the flag. A partial listing that looks authoritative deletes real documents.
+   */
+  exhaustive: boolean;
+}
+
 /**
- * List an author's recent `site.standard.document` records, newest-repo-order,
- * capped at `MAX_DOCUMENTS_PER_AUTHOR`. Throws on PDS resolution / fetch failure so
+ * Scan an author's `site.standard.document` records, up to `MAX_LIST_PAGES` pages,
+ * in whatever order their PDS serves. Throws on PDS resolution / fetch failure so
  * the caller records the error + backoff.
+ *
+ * Deliberately *not* capped at `MAX_DOCUMENTS_PER_AUTHOR`, and deliberately not
+ * assumed to be newest-first. `listRecords` order is per implementation: a
+ * Bluesky-hosted PDS serves newest rkey first, Bridgy Fed serves oldest first and
+ * rejects `reverse` outright — and rkey order is write order, which for a
+ * publication that imported an archive has nothing to do with publication date.
+ * So this returns what it saw and the caller ranks it by `publishedAt`, which is
+ * the order every read path already uses.
  *
  * Pass the same {@link PdsMemo} here and to {@link listAuthorCollections} to resolve
  * the author's DID once for the pair.
@@ -486,14 +506,20 @@ function resolveAuthorPds(authorDid: string, memo?: PdsMemo): Promise<string | n
 export async function listAuthorDocuments(
   authorDid: string,
   pds?: PdsMemo
-): Promise<Array<ListedRecord<DocumentRecord>>> {
+): Promise<AuthorDocumentListing> {
   const pdsUrl = await resolveAuthorPds(authorDid, pds);
   if (!pdsUrl) throw new Error(`Could not resolve PDS for ${authorDid}`);
 
   const raw: Array<ListedRecord<DocumentRecord>> = [];
   let cursor: string | undefined;
+  let exhaustive = false;
 
-  for (let page = 0; page < MAX_LIST_PAGES && raw.length < MAX_DOCUMENTS_PER_AUTHOR; page++) {
+  // Pages to `MAX_LIST_PAGES` rather than stopping at `MAX_DOCUMENTS_PER_AUTHOR`.
+  // The old early exit made the cap and the page bound the same thing, so one full
+  // page ended the walk — and *which* 100 that was depended entirely on the order
+  // the PDS chose to serve. Selecting the cap is the caller's job, and it can only
+  // do it over a set wider than the cap.
+  for (let page = 0; page < MAX_LIST_PAGES; page++) {
     const params = new URLSearchParams({
       repo: authorDid,
       collection: DOCUMENT_COLLECTION,
@@ -511,11 +537,14 @@ export async function listAuthorDocuments(
     };
     const records = data.records ?? [];
     raw.push(...records);
-    if (!data.cursor || records.length === 0) break;
+    if (!data.cursor || records.length === 0) {
+      exhaustive = true;
+      break;
+    }
     cursor = data.cursor;
   }
 
-  return raw;
+  return { records: raw, exhaustive };
 }
 
 /** One page of collection sidecars, plus whether absence from it proves deletion. */

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -570,6 +570,147 @@ describe('backfill and reconcile', () => {
     expect((await loadAuthorDocuments(env, AUTHOR)).map((d) => d.title)).toEqual(['One']);
   });
 
+  /**
+   * A PDS that pages a repo in a caller-chosen order, with a `publishedAt` per
+   * record. Both are the variables the walk used to be wrong about: `listRecords`
+   * order is per implementation, and rkey order is write order, which is not
+   * publication order for a repo that imported an archive.
+   */
+  function mockOrderedPds(
+    docs: Array<{ rkey: string; publishedAt: string }>,
+    { pageSize = 100 }: { pageSize?: number } = {}
+  ): { documentPages: number } {
+    const counts = { documentPages: 0 };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'plc.directory') {
+        return new Response(
+          JSON.stringify({
+            id: AUTHOR,
+            service: [
+              {
+                id: '#atproto_pds',
+                type: 'AtprotoPersonalDataServer',
+                serviceEndpoint: 'https://pds.example',
+              },
+            ],
+          })
+        );
+      }
+      const collection = url.searchParams.get('collection');
+      if (collection === 'site.standard.document') {
+        counts.documentPages++;
+        const page = Number(url.searchParams.get('cursor') ?? '0');
+        const start = page * pageSize;
+        const slice = docs.slice(start, start + pageSize);
+        const more = start + slice.length < docs.length;
+        return new Response(
+          JSON.stringify({
+            records: slice.map((d) => ({
+              uri: `at://${AUTHOR}/site.standard.document/${d.rkey}`,
+              cid: `cid-${d.rkey}`,
+              value: {
+                site: PUBLICATION,
+                title: d.rkey,
+                path: `/${d.rkey}`,
+                publishedAt: d.publishedAt,
+              },
+            })),
+            ...(more ? { cursor: String(page + 1) } : {}),
+          })
+        );
+      }
+      if (url.pathname.endsWith('listRecords'))
+        return new Response(JSON.stringify({ records: [] }));
+      return new Response('{}', { status: 404 });
+    });
+    return counts;
+  }
+
+  async function storedRkeys(): Promise<string[]> {
+    const rows = await env.DB.prepare(
+      'SELECT rkey FROM documents_v2 WHERE author_did = ? ORDER BY published_at DESC'
+    )
+      .bind(AUTHOR)
+      .all<{ rkey: string }>();
+    return (rows.results ?? []).map((r) => r.rkey);
+  }
+
+  /** A row the firehose delivered, stamped before the walk so a prune would take it. */
+  async function seedFirehoseDocument(rkey: string, publishedAt: string): Promise<void> {
+    const stamp = Date.now() - 60_000;
+    await env.DB.prepare(
+      `INSERT INTO documents_v2
+         (record_uri, author_did, rkey, record_cid, site_uri, published_at, canonical_url, record_json, indexed_at, updated_at)
+       VALUES (?, ?, ?, 'cid-live', ?, ?, NULL, '{"site":"","title":"Live"}', ?, ?)`
+    )
+      .bind(
+        `at://${AUTHOR}/site.standard.document/${rkey}`,
+        AUTHOR,
+        rkey,
+        PUBLICATION,
+        new Date(publishedAt).getTime(),
+        stamp,
+        stamp
+      )
+      .run();
+  }
+
+  // The Bridgy Fed shape: `listRecords` serves *oldest* first (and rejects
+  // `reverse`), so a repo past the page bound never shows the walk its newest
+  // records. Pruning against that listing deleted exactly the documents the
+  // firehose had gotten right — the reader-visible half of the bug.
+  it('keeps what a partial listing never saw instead of pruning it', async () => {
+    const total = MAX_LIST_PAGES * 100 + 100;
+    const docs = Array.from({ length: total }, (_, i) => ({
+      rkey: `asc${String(i).padStart(4, '0')}`,
+      // Ascending: the oldest publication is served first, the newest is past the
+      // page bound and unreachable.
+      publishedAt: new Date(Date.UTC(2020, 0, 1) + i * 86_400_000).toISOString(),
+    }));
+    await seedFirehoseDocument('live001', '2026-09-06T00:00:00.000Z');
+    mockOrderedPds(docs);
+
+    const result = await backfillAuthorDocuments(env, AUTHOR);
+
+    expect(result.ok).toBe(true);
+    // The walk could not prove it saw the whole repo, so it must not claim to have.
+    expect(result.complete).toBe(false);
+    const stored = await storedRkeys();
+    expect(stored).toContain('live001');
+    // The cap still holds — a walk that declines to prune falls back to eviction.
+    expect(stored.length).toBe(MAX_DOCUMENTS_PER_AUTHOR);
+  });
+
+  // The archive-import shape: one write batch, so rkey order is meaningless, and
+  // `publishedAt` spans two decades. Taking the first 100 listed kept the 2007
+  // imports and dropped everything recent.
+  it('keeps the newest by publication date, not the first page the PDS served', async () => {
+    const archive = Array.from({ length: 120 }, (_, i) => ({
+      rkey: `old${String(i).padStart(3, '0')}`,
+      publishedAt: new Date(Date.UTC(2007, 0, 1) + i * 86_400_000).toISOString(),
+    }));
+    const recent = Array.from({ length: 30 }, (_, i) => ({
+      rkey: `new${String(i).padStart(3, '0')}`,
+      publishedAt: new Date(Date.UTC(2026, 0, 1) + i * 86_400_000).toISOString(),
+    }));
+    // Served archive-first: every recent document is past the per-author cap in
+    // listing order, and inside it in publication order.
+    mockOrderedPds([...archive, ...recent]);
+
+    const result = await backfillAuthorDocuments(env, AUTHOR);
+
+    expect(result.ok).toBe(true);
+    const stored = await storedRkeys();
+    expect(stored.length).toBe(MAX_DOCUMENTS_PER_AUTHOR);
+    // Every recent post is held, and the oldest imports are the ones evicted.
+    for (const doc of recent) expect(stored).toContain(doc.rkey);
+    expect(stored).not.toContain('old000');
+    // The listing was exhaustive, so this walk is still allowed to prune and the
+    // author is genuinely past the cap.
+    expect(result.complete).toBe(false);
+  });
+
   it('records the error and leaves the stored set alone when the PDS fails', async () => {
     mockPds([{ rkey: 'one', cid: 'cid1', title: 'One' }]);
     await backfillAuthorDocuments(env, AUTHOR);
@@ -1071,23 +1212,27 @@ describe('the backfill query budget', () => {
 
   // The allowance is per author but the context is shared by a fan-out. A
   // publication starved during one author's walk must not stay starved for the next.
+  //
+  // Which document gets starved follows the walk's order, and that is publication
+  // date descending — these fixtures carry no `publishedAt`, so they all tie at the
+  // walk's `now` and the `record_uri DESC` tie-break decides, exactly as the cap
+  // eviction would. So the walk spends its resolves on doc5..doc1 and doc0 is the
+  // one left holding a bare path.
   it('gives each author in a fan-out a fresh allowance for the same publication', async () => {
     const pubs = Array.from(
       { length: MAX_SITE_RESOLVES_PER_BACKFILL + 1 },
       (_, i) => `at://${AUTHOR}/site.standard.publication/pub${i}`
     );
-    const starved = pubs[pubs.length - 1];
+    const starved = pubs[0];
     mockPdsWithPublications({ [AUTHOR]: pubs, [OTHER]: [starved] });
 
     const ctx = createDocumentApplyContext(createQueryLedger());
     await backfillAuthorDocuments(env, AUTHOR, ctx);
-    // The last publication is past the first author's allowance: path only.
-    expect(await canonicalUrlOf(AUTHOR, `doc${pubs.length - 1}`)).toBe(`/doc${pubs.length - 1}`);
+    // The lowest-ranked publication is past the first author's allowance: path only.
+    expect(await canonicalUrlOf(AUTHOR, 'doc0')).toBe('/doc0');
 
     await backfillAuthorDocuments(env, OTHER, ctx);
-    expect(await canonicalUrlOf(OTHER, 'doc0')).toBe(
-      `https://pub${MAX_SITE_RESOLVES_PER_BACKFILL}.example/doc0`
-    );
+    expect(await canonicalUrlOf(OTHER, 'doc0')).toBe('https://pub0.example/doc0');
   });
 
   // The listing term, counted against the network rather than against itself. A

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -692,6 +692,46 @@ npx wrangler d1 execute skyreader --remote --command \
    (`No proxy entry returned`) — coverage of the walk has to be a fact, not an
    assumption. Pass `{"dids":[…]}` to re-check specific authors after a fix.
 
+   **`clean` is not proof for an author at the per-author cap.** The compare diffs
+   D1 against the proxy, and both sides pick which 100 documents to keep. When they
+   pick by the same rule they agree whether or not the rule is right — so an author
+   both sides got wrong reads `clean`, and only an author one side has since
+   corrected shows up as drift at all. Only authors at the cap can disagree, which
+   makes the exposure enumerable:
+
+   ```bash
+   npx wrangler d1 execute skyreader --remote --command \
+     "SELECT author_did, COUNT(*) AS docs FROM documents_v2
+       GROUP BY author_did HAVING COUNT(*) >= 100 ORDER BY 2 DESC"
+   ```
+
+   Force those through the backfill (`{"dids":[…]}`, five at a time) before reading
+   the compare as a verdict. A repo the walk can list exhaustively — anything inside
+   `MAX_LIST_PAGES` — re-ranks itself to the true newest 100 in one pass. A larger
+   one can't be repaired by a walk and depends on the firehose rows already in D1,
+   which is what the `exhaustive` prune gate exists to protect.
+
+   **Drift that does not block the flip.** Two shapes are expected and mean D1 is
+   the better side, not the broken one:
+   - **D1 holds the newer `publishedAt`.** The proxy ranks an author's cap by the
+     order their PDS served `listRecords`; D1 ranks by publication date, which is
+     what every read path orders by. Those disagree whenever listing order isn't
+     publication order — a Bridgy Fed repo (served oldest-first, `reverse`
+     rejected), or a publication that imported a back catalogue in one write batch,
+     where rkey order is write order and says nothing about when anything was
+     published. Same counts on both sides with a symmetric difference and no
+     `cidMismatches` is the signature. Drift the other way — the **proxy** holding
+     newer content — is not this, and does stop the flip.
+   - **An author whose PDS is down.** `last_listed_at` null with a listing error
+     (§4d) means neither side has content and the flip changes nothing for their
+     subscribers. Their scopes serve `status:'error'`, which is what keeps a
+     reader's existing copy on screen.
+
+   So the gate is _every page clean, or its drift explained and D1 the better
+   side_ — recorded here rather than left to be re-derived, because a literal
+   reading of "every page clean" is unreachable while the proxy is still ranking by
+   a different key.
+
 3. **Flip reads**, after a clean compare and a soak:
 
    ```bash


### PR DESCRIPTION
The walk and the cap eviction were selecting an author's 100 documents by different keys. `trimAuthorDocumentsStatement` keeps the newest by `published_at` — the key every read path orders by — while the walk took `listed.slice(0, MAX_DOCUMENTS_PER_AUTHOR)`, the first 100 in whatever order the PDS served. Two rules over one cap, so they fought.

Listing order is not publication order, in two shapes both live in production. `listRecords` order is per implementation: a Bluesky-hosted PDS serves newest rkey first, Bridgy Fed serves oldest first and rejects `reverse` with a 400. And rkey order is *write* order, which for a publication that imported a back catalogue in one batch spans two decades of `publishedAt` in a single page.

That alone would be cosmetic. What made it reader-visible is that the walk then pruned every row it hadn't listed, so a reconcile deleted exactly the documents the firehose had gotten right — one subscribed publication was a reconcile away from losing its 2026 posts in favour of its February back catalogue, another from showing 2007 archive imports instead of the last five years.

Three changes. `listAuthorDocuments` pages to `MAX_LIST_PAGES` instead of stopping at the first full page: the old condition made the page bound and the row cap the same thing, so the constant's own "up to 500 scanned" was never true, and selecting a cap needs a set wider than the cap. It returns `exhaustive` alongside the records, the way `AuthorCollectionListing` already does. The walk ranks by `publishedAtMs` with a `record_uri` tie-break, matching the eviction's `ORDER BY published_at DESC, record_uri DESC` exactly. And the prune runs only against an exhaustive listing — a partial one falls back to cap eviction, which ranks over everything we hold rather than over what one listing reached, so firehose rows survive a walk that could not see them. One statement either way, so `BACKFILL_QUERY_COST` is unchanged.

Still open: a cold-start subscribe to an oldest-first repo larger than `MAX_LIST_PAGES` pages starts on old documents. It is no longer destructive and converges as the author publishes, but the first render is wrong; fixing it needs paging to the end for detected-ascending repos.

RUNBOOK §4e gains the two things this makes non-obvious: shadow-compare shares the proxy's selection rule, so `clean` is not proof for an author at the cap, and which drift shapes mean D1 is the better side rather than the broken one.