### PR TITLE
Cut refresh latency: background the backed-saves poll, unblock the ti…

### DIFF
--- a/backend/migrations/0077_backing_successful_snapshot.sql
+++ b/backend/migrations/0077_backing_successful_snapshot.sql
@@ -1,0 +1,18 @@
+-- Distinguish "the latest complete backing snapshot is empty" from "no complete
+-- snapshot has ever landed". last_backing_poll remains the attempt timestamp
+-- used by the one-minute retry gate; this timestamp advances only after a
+-- provably-complete membership replacement.
+ALTER TABLE user_settings ADD COLUMN last_successful_backing_poll INTEGER;
+
+-- Existing non-empty membership proves that a complete snapshot landed before
+-- this marker existed. Existing empty snapshots cannot be distinguished from a
+-- failed first poll, so they safely perform one final inline poll after deploy.
+UPDATE user_settings
+SET last_successful_backing_poll = last_backing_poll
+WHERE last_backing_poll IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM backed_collection_members m
+    WHERE m.user_did = user_settings.user_did
+      AND user_settings.backing = m.external_provider || ':' || m.external_collection
+  );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -161,6 +161,9 @@ function corsHeaders(origin: string | null, env: Env): HeadersInit {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Access-Control-Allow-Credentials': 'true',
+    // Let browsers cache preflights instead of paying one per API call.
+    // (Chrome caps this at 2h, Firefox at 24h.)
+    'Access-Control-Max-Age': '86400',
     // So a browser client can read the correlation id off a failed response and
     // quote it in a bug report.
     'Access-Control-Expose-Headers': 'X-Request-Id',

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -703,15 +703,37 @@ export async function handleGetSaved(
   }
 
   try {
-    // When backing is on, the Saved list IS the foreign collection: refresh the
-    // membership snapshot (open-driven, gated) then read membership ⋈ enrichment.
-    // A failed/incomplete poll is non-fatal — we still read the last good membership.
+    // When backing is on, the Saved list IS the foreign collection: serve the
+    // last good membership ⋈ enrichment immediately and refresh the membership
+    // snapshot in the background (the poll is auth-free and session-less, so it
+    // is waitUntil-safe — the next open reads what it wrote). The poll used to
+    // run inline and a large collection held the response for many seconds,
+    // which also serialized the client's whole refresh behind it. Only an
+    // account with no successful snapshot yet (enable-time poll failed or
+    // hasn't landed) still pays for an inline poll — otherwise the list would
+    // render an unverified empty snapshot.
     const settings = await getUserSettings(env, session.did);
     if (settings.backing.provider !== 'skyreader') {
-      try {
-        await pollBackedMembership(env, session.did, settings.backing);
-      } catch (pollErr) {
-        console.error('Backed membership poll failed (serving last good snapshot):', pollErr);
+      let verified = settings.lastSuccessfulBackingPoll != null;
+      if (verified) {
+        ctx.waitUntil(
+          pollBackedMembership(env, session.did, settings.backing).catch((pollErr) => {
+            console.error('Backed membership poll failed (serving last good snapshot):', pollErr);
+          })
+        );
+      } else {
+        try {
+          // Forced past POLL_GATE_MS on purpose: the gate keys off
+          // `last_backing_poll`, which a *failed* poll stamps too, so an ordinary
+          // poll here would no-op for a minute after enable-time failed — and we'd
+          // answer `full: true` with a snapshot that was never verified.
+          const poll = await pollBackedMembership(env, session.did, settings.backing, {
+            force: true,
+          });
+          verified = poll.complete;
+        } catch (pollErr) {
+          console.error('Backed membership poll failed (serving last good snapshot):', pollErr);
+        }
       }
       // Metadata only — the body is the bulk of a saved item and the client
       // already caches it; it hydrates bodies for unseen rkeys via /api/saved/bodies.
@@ -728,7 +750,11 @@ export async function handleGetSaved(
       // Backing is a snapshot of foreign membership (items can be *removed*
       // elsewhere), so it can't be merged incrementally — `full: true` tells the
       // client to replace its cache wholesale. `cursor: null` → single page.
-      return new Response(JSON.stringify({ articles, cursor: null, full: true }), {
+      // Only claim `full` once a snapshot has actually landed: a wholesale
+      // replace from an unverified (possibly empty) membership table wipes the
+      // user's Saved list. Unverified degrades to the merge path, which keeps
+      // the client's cache and is a no-op when we have no rows to offer.
+      return new Response(JSON.stringify({ articles, cursor: null, full: verified }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -47,6 +47,12 @@ export interface UserSettings {
   lastPdsSyncSubscriptions: number | null;
   /** External-backed saves: which engine backs the Saved list (one per account). */
   backing: SaveBacking;
+  /**
+   * When the last backing poll last *completed* (ms), or null if none ever has.
+   * Null means the local membership snapshot has never been verified against the
+   * foreign collection — `GET /api/saved` won't serve it as authoritative.
+   */
+  lastSuccessfulBackingPoll: number | null;
   linkblogDisabled: boolean;
   createdAt: number;
   updatedAt: number;
@@ -57,6 +63,7 @@ interface UserSettingsRow {
   pds_sync_enabled: number;
   last_pds_sync_subscriptions: number | null;
   backing: string | null;
+  last_successful_backing_poll: number | null;
   linkblog_disabled: number;
   created_at: number;
   updated_at: number;
@@ -68,6 +75,7 @@ function rowToSettings(row: UserSettingsRow | null): UserSettings {
       pdsSyncEnabled: false,
       lastPdsSyncSubscriptions: null,
       backing: { provider: 'skyreader' },
+      lastSuccessfulBackingPoll: null,
       linkblogDisabled: false,
       createdAt: Math.floor(Date.now() / 1000),
       updatedAt: Math.floor(Date.now() / 1000),
@@ -77,6 +85,7 @@ function rowToSettings(row: UserSettingsRow | null): UserSettings {
     pdsSyncEnabled: row.pds_sync_enabled === 1,
     lastPdsSyncSubscriptions: row.last_pds_sync_subscriptions,
     backing: parseBacking(row.backing),
+    lastSuccessfulBackingPoll: row.last_successful_backing_poll,
     linkblogDisabled: row.linkblog_disabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -163,22 +172,61 @@ export async function handleUpdateSettings(request: Request, env: Env): Promise<
   }
 
   try {
+    // A backing change invalidates the local snapshot of the OLD collection: its
+    // membership rows and unsave tombstones describe a collection that no longer
+    // backs this account, and nothing else ever prunes them. Left in place, they
+    // are what `GET /api/saved` serves the moment the next poll marks the new
+    // backing verified. `disableBacking` — the other way out of a backing — does
+    // the same teardown; this is the direct-API path to the same state change.
+    // Compared through parse+serialize so a NULL or junk column reads as
+    // 'skyreader', exactly as the rest of the code sees it.
+    const before =
+      backingValue !== null
+        ? await env.DB.prepare(`SELECT backing FROM user_settings WHERE user_did = ?`)
+            .bind(session.did)
+            .first<{ backing: string | null }>()
+        : null;
+    const backingChanged =
+      backingValue !== null && backingValue !== serializeBacking(parseBacking(before?.backing));
+
     // Upsert the settings. Each column is only written when present in the body
     // (COALESCE keeps the existing value for an omitted/null bind).
-    await env.DB.prepare(
+    const upsert = env.DB.prepare(
       `INSERT INTO user_settings (user_did, pds_sync_enabled, backing, updated_at)
 			 VALUES (?, ?, ?, unixepoch())
 			 ON CONFLICT(user_did) DO UPDATE SET
 			   pds_sync_enabled = COALESCE(excluded.pds_sync_enabled, pds_sync_enabled),
+			   last_backing_poll = CASE
+			     WHEN excluded.backing IS NOT NULL AND excluded.backing IS NOT user_settings.backing
+			       THEN NULL
+			     ELSE user_settings.last_backing_poll
+			   END,
+			   last_successful_backing_poll = CASE
+			     WHEN excluded.backing IS NOT NULL AND excluded.backing IS NOT user_settings.backing
+			       THEN NULL
+			     ELSE user_settings.last_successful_backing_poll
+			   END,
 			   backing = COALESCE(excluded.backing, backing),
 			   updated_at = unixepoch()`
-    )
-      .bind(
-        session.did,
-        body.pdsSyncEnabled !== undefined ? (body.pdsSyncEnabled ? 1 : 0) : null,
-        backingValue
-      )
-      .run();
+    ).bind(
+      session.did,
+      body.pdsSyncEnabled !== undefined ? (body.pdsSyncEnabled ? 1 : 0) : null,
+      backingValue
+    );
+
+    await env.DB.batch(
+      backingChanged
+        ? [
+            upsert,
+            env.DB.prepare(`DELETE FROM backed_collection_members WHERE user_did = ?`).bind(
+              session.did
+            ),
+            env.DB.prepare(`DELETE FROM backed_unsave_tombstones WHERE user_did = ?`).bind(
+              session.did
+            ),
+          ]
+        : [upsert]
+    );
 
     // Fetch the updated settings
     const row = await env.DB.prepare(`SELECT * FROM user_settings WHERE user_did = ?`)

--- a/backend/src/services/backing/enable.ts
+++ b/backend/src/services/backing/enable.ts
@@ -71,9 +71,14 @@ export async function enableBacking(
   // Persist the setting first so the poll/export paths see backing as on. Reset the
   // poll gate so the immediate backfill isn't skipped.
   await env.DB.prepare(
-    `INSERT INTO user_settings (user_did, backing, last_backing_poll, updated_at)
-     VALUES (?, ?, NULL, unixepoch())
-     ON CONFLICT(user_did) DO UPDATE SET backing = excluded.backing, last_backing_poll = NULL, updated_at = unixepoch()`
+    `INSERT INTO user_settings
+       (user_did, backing, last_backing_poll, last_successful_backing_poll, updated_at)
+     VALUES (?, ?, NULL, NULL, unixepoch())
+     ON CONFLICT(user_did) DO UPDATE SET
+       backing = excluded.backing,
+       last_backing_poll = NULL,
+       last_successful_backing_poll = NULL,
+       updated_at = unixepoch()`
   )
     .bind(session.did, serializeBacking(backing))
     .run();
@@ -117,7 +122,9 @@ export async function enableBacking(
 export async function disableBacking(env: Env, session: Session): Promise<void> {
   await env.DB.batch([
     env.DB.prepare(
-      `UPDATE user_settings SET backing = 'skyreader', last_backing_poll = NULL, updated_at = unixepoch()
+      `UPDATE user_settings
+       SET backing = 'skyreader', last_backing_poll = NULL,
+           last_successful_backing_poll = NULL, updated_at = unixepoch()
        WHERE user_did = ?`
     ).bind(session.did),
     env.DB.prepare(`DELETE FROM backed_collection_members WHERE user_did = ?`).bind(session.did),

--- a/backend/src/services/backing/sync.ts
+++ b/backend/src/services/backing/sync.ts
@@ -179,12 +179,15 @@ export async function pollBackedMembership(
     }
   }
 
-  // (4) Stamp the poll time.
+  // (4) Stamp both the attempt time (the retry gate) and the successful-snapshot
+  // marker. The latter lets the read route distinguish a valid empty snapshot
+  // from an account whose first complete snapshot has never landed.
   batch.push(
-    env.DB.prepare(`UPDATE user_settings SET last_backing_poll = ? WHERE user_did = ?`).bind(
-      now,
-      userDid
-    )
+    env.DB.prepare(
+      `UPDATE user_settings
+       SET last_backing_poll = ?, last_successful_backing_poll = ?
+       WHERE user_did = ?`
+    ).bind(now, now, userDid)
   );
 
   await env.DB.batch(batch);
@@ -384,10 +387,13 @@ export async function listBackedSaved(
 ): Promise<SavedArticleView[]> {
   const collectionUri = backing.collectionUri;
 
-  // (A) Every current member, joined to its enrichment row (body/word count/labels).
+  // (A) Every current member, joined to its enrichment row. Deliberately NOT
+  // s.content: the only caller (GET /api/saved) strips the body before
+  // responding — clients hydrate bodies via /api/saved/bodies — and selecting
+  // it made D1 read every row's article-body blob just to discard it.
   const membersQ = env.DB.prepare(
     `SELECT m.url AS m_url, m.metadata AS m_metadata, m.external_item_uri,
-            s.rkey, s.record_uri, s.url, s.title, s.author, s.description, s.content,
+            s.rkey, s.record_uri, s.url, s.title, s.author, s.description, NULL AS content,
             s.content_type, s.domain, s.image, s.word_count, s.published_at, s.saved_at,
             s.source, s.item_guid
      FROM backed_collection_members m
@@ -400,7 +406,7 @@ export async function listBackedSaved(
   //     (uploads, legacy saves yet to be exported). url_normalized NULL = legacy.
   const nativeQ = env.DB.prepare(
     `SELECT NULL AS m_url, NULL AS m_metadata, NULL AS external_item_uri,
-            s.rkey, s.record_uri, s.url, s.title, s.author, s.description, s.content,
+            s.rkey, s.record_uri, s.url, s.title, s.author, s.description, NULL AS content,
             s.content_type, s.domain, s.image, s.word_count, s.published_at, s.saved_at,
             s.source, s.item_guid
      FROM saved_articles s

--- a/backend/test/backing-enable.spec.ts
+++ b/backend/test/backing-enable.spec.ts
@@ -74,6 +74,12 @@ describe('enableBacking', () => {
     expect(createCol).not.toHaveBeenCalled(); // reused, not created
     expect(result.backing).toEqual({ provider: 'semble', collectionUri: COLLECTION });
     expect(await backingOf()).toBe(`semble:${COLLECTION}`);
+    const state = await env.DB.prepare(
+      'SELECT last_successful_backing_poll FROM user_settings WHERE user_did = ?'
+    )
+      .bind(DID)
+      .first<{ last_successful_backing_poll: number | null }>();
+    expect(state?.last_successful_backing_poll).toBeTypeOf('number');
   });
 
   it('creates a default "Skyreader Saves" collection when none is given', async () => {
@@ -305,7 +311,11 @@ describe('disableBacking', () => {
   beforeEach(reset);
 
   it('reverts to skyreader and clears the local snapshot, leaving enrichment rows', async () => {
-    await env.DB.prepare(`INSERT INTO user_settings (user_did, backing) VALUES (?, ?)`)
+    await env.DB.prepare(
+      `INSERT INTO user_settings
+         (user_did, backing, last_backing_poll, last_successful_backing_poll)
+       VALUES (?, ?, 123, 123)`
+    )
       .bind(DID, `semble:${COLLECTION}`)
       .run();
     await env.DB.prepare(
@@ -325,6 +335,19 @@ describe('disableBacking', () => {
     await disableBacking(env, fakeSession);
 
     expect(await backingOf()).toBe('skyreader');
+    const state = await env.DB.prepare(
+      `SELECT last_backing_poll, last_successful_backing_poll
+       FROM user_settings WHERE user_did = ?`
+    )
+      .bind(DID)
+      .first<{
+        last_backing_poll: number | null;
+        last_successful_backing_poll: number | null;
+      }>();
+    expect(state).toMatchObject({
+      last_backing_poll: null,
+      last_successful_backing_poll: null,
+    });
     const mem = await env.DB.prepare(
       'SELECT COUNT(*) AS n FROM backed_collection_members WHERE user_did = ?'
     )

--- a/backend/test/backing-sync.spec.ts
+++ b/backend/test/backing-sync.spec.ts
@@ -25,7 +25,7 @@ async function reset() {
   await env.DB.prepare('DELETE FROM backed_unsave_tombstones WHERE user_did = ?').bind(DID).run();
   await env.DB.prepare('DELETE FROM user_settings WHERE user_did = ?').bind(DID).run();
   // A backed user always has a user_settings row (backing is stored there) — the
-  // poll's last_backing_poll stamp updates it. user_settings FKs to users.
+  // poll's attempt/success stamps update it. user_settings FKs to users.
   await env.DB.prepare(
     `INSERT INTO users (did, handle, pds_url, last_synced_at) VALUES (?, 'backing.test', 'https://pds.test', 0)
      ON CONFLICT(did) DO NOTHING`
@@ -79,6 +79,44 @@ describe('pollBackedMembership — wholesale replace + safety', () => {
       .bind(DID)
       .first<{ n: number }>();
     expect(enr?.n).toBe(2);
+  });
+
+  it('marks a complete empty snapshot as successful', async () => {
+    mockSnapshot([]);
+
+    const res = await pollBackedMembership(env, DID, BACKING, { force: true });
+
+    expect(res).toMatchObject({ polled: true, complete: true, memberCount: 0 });
+    const settings = await env.DB.prepare(
+      `SELECT last_backing_poll, last_successful_backing_poll
+       FROM user_settings WHERE user_did = ?`
+    )
+      .bind(DID)
+      .first<{
+        last_backing_poll: number | null;
+        last_successful_backing_poll: number | null;
+      }>();
+    expect(settings?.last_backing_poll).toBeTypeOf('number');
+    expect(settings?.last_successful_backing_poll).toBe(settings?.last_backing_poll);
+  });
+
+  it('does not mark an incomplete snapshot as successful', async () => {
+    mockSnapshot([], false);
+
+    const res = await pollBackedMembership(env, DID, BACKING, { force: true });
+
+    expect(res).toMatchObject({ polled: true, complete: false, memberCount: 0 });
+    const settings = await env.DB.prepare(
+      `SELECT last_backing_poll, last_successful_backing_poll
+       FROM user_settings WHERE user_did = ?`
+    )
+      .bind(DID)
+      .first<{
+        last_backing_poll: number | null;
+        last_successful_backing_poll: number | null;
+      }>();
+    expect(settings?.last_backing_poll).toBeTypeOf('number');
+    expect(settings?.last_successful_backing_poll).toBeNull();
   });
 
   it('a removed-upstream member drops on the next complete poll', async () => {
@@ -461,10 +499,12 @@ describe('listBackedSaved — membership ⋈ enrichment ∪ native-only', () => 
     const byUrl = Object.fromEntries(list.map((v) => [v.url, v]));
 
     expect(list).toHaveLength(3);
-    // enriched member keeps its extracted body + real title
+    // enriched member keeps its real title/word count — but never the body:
+    // the list deliberately skips reading content blobs (clients hydrate via
+    // /api/saved/bodies, and GET /api/saved strips the field anyway)
     expect(byUrl['https://a.test/x']).toMatchObject({
       title: 'Article A',
-      content: 'BODY',
+      content: null,
       wordCount: 1200,
     });
     // member without enrichment falls back to membership metadata title + foreign uri

--- a/backend/test/saved-backing-routes.spec.ts
+++ b/backend/test/saved-backing-routes.spec.ts
@@ -367,5 +367,142 @@ describe('GET /api/saved — backed list path', () => {
     // /api/saved/bodies, so it must NOT ride along in the snapshot.
     expect(body.articles[0]).toMatchObject({ title: 'A' });
     expect('content' in body.articles[0]).toBe(false);
+    // Nothing has ever snapshotted successfully, so this membership is unverified:
+    // `full` would tell the client to replace its cache with it.
+    expect(body.full).toBe(false);
+  });
+
+  it('forces past the poll gate — and withholds `full` — until a snapshot lands', async () => {
+    await setBackingRow(`semble:${COLLECTION}`);
+    // An enable-time poll just failed: the gate timestamp is fresh, but no
+    // snapshot has ever completed. An unforced poll here would no-op.
+    await env.DB.prepare(
+      `UPDATE user_settings SET last_backing_poll = ?, last_successful_backing_poll = NULL WHERE user_did = ?`
+    )
+      .bind(Date.now(), DID)
+      .run();
+    const snapshot = vi.spyOn(read, 'snapshotBackedCollection').mockResolvedValue({
+      complete: false,
+      members: [],
+      skipped: [],
+      typeMix: {},
+    });
+    vi.spyOn(sync, 'extractMissingBackedContent').mockResolvedValue(0);
+
+    const get = () =>
+      new IncomingRequest('http://localhost/api/saved', {
+        method: 'GET',
+        headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+      });
+
+    const failed = await call(get());
+    expect(failed.status).toBe(200);
+    // Forced: the gate did not swallow the poll.
+    expect(snapshot).toHaveBeenCalledTimes(1);
+    // Still unverified, so the empty list must not be applied as a replace.
+    expect(failed.body).toMatchObject({ articles: [], full: false });
+
+    // Next open, the provider answers: the snapshot lands and `full` is honest.
+    snapshot.mockResolvedValue({
+      complete: true,
+      members: [
+        {
+          url: 'https://a.test/x',
+          urlNormalized: 'https://a.test/x',
+          itemUri: 'at://card/1',
+          linkUri: 'at://link/1',
+          itemType: 'network.cosmik.card',
+          title: 'A',
+        },
+      ],
+      skipped: [],
+      typeMix: {},
+    });
+    const landed = await call(get());
+    expect(landed.status).toBe(200);
+    expect(landed.body.full).toBe(true);
+    expect(landed.body.articles).toHaveLength(1);
+  });
+});
+
+describe('PUT /api/settings — backing change tears down the old snapshot', () => {
+  beforeEach(() => reset());
+  afterEach(() => vi.restoreAllMocks());
+
+  async function seedSnapshot(collection: string) {
+    await env.DB.prepare(
+      `INSERT INTO backed_collection_members
+         (user_did, external_collection, url_normalized, url, external_provider, external_item_uri, external_link_uri)
+       VALUES (?, ?, 'https://a.test/x', 'https://a.test/x', 'semble', 'at://card/1', 'at://link/1')`
+    )
+      .bind(DID, collection)
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO backed_unsave_tombstones (user_did, external_collection, url_normalized, created_at)
+       VALUES (?, ?, 'https://a.test/y', ?)`
+    )
+      .bind(DID, collection, Date.now())
+      .run();
+    await env.DB.prepare(
+      `UPDATE user_settings SET last_successful_backing_poll = ?, last_backing_poll = ? WHERE user_did = ?`
+    )
+      .bind(Date.now(), Date.now(), DID)
+      .run();
+  }
+
+  const counts = async () => ({
+    members: (
+      await env.DB.prepare(`SELECT COUNT(*) AS n FROM backed_collection_members WHERE user_did = ?`)
+        .bind(DID)
+        .first<{ n: number }>()
+    )?.n,
+    tombstones: (
+      await env.DB.prepare(`SELECT COUNT(*) AS n FROM backed_unsave_tombstones WHERE user_did = ?`)
+        .bind(DID)
+        .first<{ n: number }>()
+    )?.n,
+  });
+
+  it('clears membership + tombstones (and the poll markers) when backing changes', async () => {
+    await setBackingRow(`semble:${COLLECTION}`);
+    await seedSnapshot(COLLECTION);
+
+    const { status } = await call(
+      post('/api/settings', { backing: { provider: 'skyreader' } }, 'PUT')
+    );
+    expect(status).toBe(200);
+    // Otherwise the old collection's rows would be served as the Saved list as
+    // soon as a poll under the NEW backing marked the snapshot verified.
+    expect(await counts()).toEqual({ members: 0, tombstones: 0 });
+    const row = await env.DB.prepare(
+      `SELECT last_backing_poll, last_successful_backing_poll FROM user_settings WHERE user_did = ?`
+    )
+      .bind(DID)
+      .first<{ last_backing_poll: number | null; last_successful_backing_poll: number | null }>();
+    expect(row?.last_backing_poll).toBeNull();
+    expect(row?.last_successful_backing_poll).toBeNull();
+  });
+
+  it('leaves a verified snapshot alone when the write does not change backing', async () => {
+    await setBackingRow(`semble:${COLLECTION}`);
+    await seedSnapshot(COLLECTION);
+
+    // Same backing re-sent, and an unrelated field changed: neither may drop the
+    // snapshot, which is still the user's Saved list.
+    expect(
+      (
+        await call(
+          post(
+            '/api/settings',
+            { backing: { provider: 'semble', collectionUri: COLLECTION } },
+            'PUT'
+          )
+        )
+      ).status
+    ).toBe(200);
+    expect(await counts()).toEqual({ members: 1, tombstones: 1 });
+
+    expect((await call(post('/api/settings', { pdsSyncEnabled: true }, 'PUT'))).status).toBe(200);
+    expect(await counts()).toEqual({ members: 1, tombstones: 1 });
   });
 });

--- a/frontend/src/lib/stores/app.svelte.ts
+++ b/frontend/src/lib/stores/app.svelte.ts
@@ -140,22 +140,38 @@ function createAppManager() {
       }
 
       await migrateGuestSubscriptions();
-      // Sync subscriptions and reload every server-backed user collection in parallel.
-      // Saves must participate here (not only during initialize): another device can
-      // add one while this tab stays open, and an explicit refresh is the user's way
-      // to pull that new server row into this device's IndexedDB cache.
-      const [syncResult] = await Promise.all([
-        syncSubscriptions(),
-        itemLabelsStore.load(),
-        savesStore.load(),
-        magazineStore.load(),
-        socialStore.loadFeed(true),
-        filteredViewsStore.syncWithBackend(),
+      // Reload every server-backed user collection in the background. Saves must
+      // participate here (not only during initialize): another device can add one
+      // while this tab stays open, and an explicit refresh is the user's way to
+      // pull that new server row into this device's IndexedDB cache. The timeline
+      // fetch below must NOT wait on these — its only real dependency is the
+      // subscription list, and the saves load in particular can take seconds
+      // (external backing serves a full snapshot), which used to hold every new
+      // article hostage.
+      //
+      // `allSettled`, not `all`: these are independent collections, so one of
+      // them failing is not a failed refresh. A rejection used to abort the try
+      // block before the last-refresh marker below, leaving "last updated" (and
+      // the service worker's copy of it) stale even though the timeline had
+      // already merged — and it settled the refresh at the FIRST failure while
+      // its siblings were still in flight.
+      const loads: Array<[string, Promise<unknown>]> = [
+        ['saves', savesStore.load()],
+        ['magazine', magazineStore.load()],
+        ['social', socialStore.loadFeed(true)],
+        ['filteredViews', filteredViewsStore.syncWithBackend()],
         // Pull the user's own linkblog so share-state reconciles across devices.
         // Forced each refresh so a share made elsewhere lights up the button here;
         // then reconcile prunes any local share the (complete) pull says is gone.
-        myLinkblogStore.load(true).then(() => linkblogStore.reconcile()),
-      ]);
+        ['linkblog', myLinkblogStore.load(true).then(() => linkblogStore.reconcile())],
+      ];
+      const storeLoads = Promise.allSettled(loads.map(([, p]) => p));
+
+      // Labels stay on the critical path (they're one fast delta): the fetch
+      // below reads articlesStore.savedGuids — derived from itemLabelsStore —
+      // to keep starred articles out of merge cleanup, so it must see a label
+      // starred on another device since this tab's last pull.
+      await Promise.all([syncSubscriptions(), itemLabelsStore.load()]);
 
       // One-time migration: push existing local custom fields to backend
       await migrateCustomFieldsToBackend();
@@ -169,6 +185,15 @@ function createAppManager() {
         ]);
         newArticles = result.newArticles;
       }
+
+      // The refresh isn't done (and phase doesn't reach 'ready') until the
+      // store loads settle too. Failures are reported, not thrown: the timeline
+      // has already merged by here, so the refresh did happen.
+      (await storeLoads).forEach((r, i) => {
+        if (r.status === 'rejected') {
+          console.error(`Background refresh: ${loads[i][0]} store failed to load:`, r.reason);
+        }
+      });
 
       lastRefreshAt = Date.now();
       // Persist to IndexedDB for service worker and cross-session access


### PR DESCRIPTION
…meline

A refresh took ~12s to show new articles, ~8.5s of it one request: with external backing on, GET /api/saved re-polled the whole foreign collection (a listRecords walk plus a getRecord per member) before responding, and the client refresh serialized the timeline fetch behind it.

- GET /api/saved now serves the last good membership immediately and runs pollBackedMembership in ctx.waitUntil (it is auth-free and session-less); only an empty membership still polls inline so the list can't render empty.
- listBackedSaved selects NULL AS content: the route strips the body anyway (clients hydrate via /api/saved/bodies), so reading every row's article blob out of D1 was pure waste.
- refreshFromBackend fires fetchAllFeeds/fetchAllDocuments as soon as subscriptions and labels have synced, backgrounding the heavy store loads. Labels stay on the critical path: the fetch reads savedGuids (derived from labels) to keep starred articles out of merge cleanup.
- Access-Control-Max-Age: 86400 so browsers stop paying a preflight per call.