### PR TITLE
Cut refresh latency: parallel unread counts, digest prechecks for doc…

### DIFF
--- a/backend/src/routes/feeds-v2.ts
+++ b/backend/src/routes/feeds-v2.ts
@@ -13,6 +13,7 @@ import {
   serveDocumentScope,
   serveSingleDocument,
 } from '../services/document-store';
+import { digestScope, isValidDid } from '../services/standard-site';
 import { log, serializeError } from '../utils/logger';
 import { chunkArray, getReadKeys } from './reading';
 import { clearFeedHealth, ingestProxyFeed } from './ingest';
@@ -699,6 +700,72 @@ export async function handleV2BatchDocumentFetch(
   }
 }
 
+// D1 caps bound parameters per statement; a batch is ≤50 scopes so one chunk
+// normally covers it, but dedup keeps the IN list minimal either way.
+const DIGEST_PRECHECK_DID_CHUNK = 50;
+
+/**
+ * Answer every scope whose `since_digest` still matches without loading anything
+ * per-scope. The digest is a hash over the scope's sorted `(recordUri, recordCid)`
+ * pairs — both raw columns on `documents_v2` — so one batch-wide query of those
+ * two columns reproduces it exactly as `serveDocumentScope` would compute it from
+ * the fully-built documents. On a steady-state poll nearly every scope is
+ * unchanged, and the per-scope path spends ~4 D1 queries (author row, documents
+ * with `record_json`, site metas, count) discovering that.
+ *
+ * Returns the scope keys (`did\nsiteUri`) that are unchanged. Deliberately
+ * conservative: a scope with zero stored rows is left to the slow path (its
+ * answer depends on `document_authors.last_listed_at` — never-ingested must serve
+ * `error`, not `unchanged`), and a scope whose rows fail record parsing at serve
+ * time simply never matches (the served digest was computed over the parsed
+ * subset), so it also falls through. A false "unchanged" would require a SHA-256
+ * collision.
+ */
+async function findUnchangedScopes(
+  env: Env,
+  requests: Array<{ did: string; siteUri?: string; since_digest?: string }>
+): Promise<Set<string>> {
+  const candidates = requests.filter((r) => r.since_digest && isValidDid(r.did));
+  if (candidates.length === 0) return new Set();
+
+  const dids = [...new Set(candidates.map((r) => r.did))];
+  const pairsByAuthor = new Map<string, Array<{ recordUri: string; recordCid: string }>>();
+  for (let i = 0; i < dids.length; i += DIGEST_PRECHECK_DID_CHUNK) {
+    const chunk = dids.slice(i, i + DIGEST_PRECHECK_DID_CHUNK);
+    const rows = await env.DB.prepare(
+      `SELECT author_did, site_uri, record_uri, record_cid FROM documents_v2
+        WHERE author_did IN (${chunk.map(() => '?').join(',')})`
+    )
+      .bind(...chunk)
+      .all<{ author_did: string; site_uri: string; record_uri: string; record_cid: string }>();
+    for (const row of rows.results ?? []) {
+      let list = pairsByAuthor.get(`${row.author_did}\n${row.site_uri}`);
+      if (!list) {
+        list = [];
+        pairsByAuthor.set(`${row.author_did}\n${row.site_uri}`, list);
+      }
+      list.push({ recordUri: row.record_uri, recordCid: row.record_cid });
+    }
+  }
+
+  const unchanged = new Set<string>();
+  await Promise.all(
+    candidates.map(async (entry) => {
+      // An unscoped request covers every publication of the author's.
+      const pairs = entry.siteUri
+        ? (pairsByAuthor.get(`${entry.did}\n${entry.siteUri}`) ?? [])
+        : [...pairsByAuthor.entries()]
+            .filter(([key]) => key.startsWith(`${entry.did}\n`))
+            .flatMap(([, list]) => list);
+      if (pairs.length === 0) return;
+      if ((await digestScope(pairs)) === entry.since_digest) {
+        unchanged.add(`${entry.did}\n${entry.siteUri ?? ''}`);
+      }
+    })
+  );
+  return unchanged;
+}
+
 /**
  * Serve every requested scope from D1. One curated-edition resolve budget is shared
  * across the whole batch: each edition costs up to 50 cross-PDS getRecords, and a
@@ -711,8 +778,21 @@ async function serveDocumentsFromD1(
   requests: Array<{ did: string; siteUri?: string; since_digest?: string }>
 ): Promise<ProxyDocumentEntry[]> {
   const collectionBudget = { remaining: MAX_COLLECTION_RESOLVES_PER_REQUEST };
+
+  // Best-effort: a failed precheck just means every scope takes the per-scope
+  // path, exactly as before the fast path existed.
+  let unchanged = new Set<string>();
+  try {
+    unchanged = await findUnchangedScopes(env, requests);
+  } catch (error) {
+    console.error('Document digest precheck failed; serving per-scope:', error);
+  }
+
   return Promise.all(
     requests.map(async (entry): Promise<ProxyDocumentEntry> => {
+      if (unchanged.has(`${entry.did}\n${entry.siteUri ?? ''}`)) {
+        return { did: entry.did, siteUri: entry.siteUri, status: 'unchanged' };
+      }
       try {
         return await serveDocumentScope(env, entry, collectionBudget);
       } catch (error) {

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -740,13 +740,42 @@ export async function handleGetSaved(
       const articles = (await listBackedSaved(env, session.did, settings.backing)).map(
         ({ content: _content, ...rest }) => rest
       );
-      // Fill in bodies for imported stubs after responding (bounded, self-healing
-      // across opens). Titles are already seeded from the foreign record metadata.
+
+      // The snapshot is served whole on every refresh (membership can shrink, so
+      // it can't page), which for a large collection is >1MB per poll — almost
+      // always byte-identical to what the client already holds. The digest is
+      // over the serialized articles themselves (not membership keys), so an
+      // enrichment update (a title or description landing after extraction)
+      // moves it too; the client echoes the digest of the last snapshot it kept
+      // and an unchanged one costs a couple hundred bytes. Only a verified
+      // snapshot may short-circuit: `unchanged` tells the client to keep its
+      // cache, which is exactly the wholesale trust an unverified one hasn't earned.
+      const serialized = JSON.stringify(articles);
+      const digestBytes = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode(serialized)
+      );
+      const digest = [...new Uint8Array(digestBytes)]
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+
+      // Keep enrichment self-healing even when the metadata snapshot is
+      // unchanged. In particular, a failed extraction leaves `content` NULL
+      // without changing this digest; scheduling the retry after the early
+      // return would strand that stub forever.
       ctx.waitUntil(
         extractMissingBackedContent(env, session.did).catch((err) => {
           console.error('Backed content extraction failed:', err);
         })
       );
+
+      const sinceDigest = new URL(request.url).searchParams.get('since_digest');
+      if (verified && sinceDigest && sinceDigest === digest) {
+        return new Response(
+          JSON.stringify({ articles: [], cursor: null, full: true, unchanged: true, digest }),
+          { headers: { 'Content-Type': 'application/json' } }
+        );
+      }
       // Backing is a snapshot of foreign membership (items can be *removed*
       // elsewhere), so it can't be merged incrementally — `full: true` tells the
       // client to replace its cache wholesale. `cursor: null` → single page.
@@ -754,7 +783,7 @@ export async function handleGetSaved(
       // replace from an unverified (possibly empty) membership table wipes the
       // user's Saved list. Unverified degrades to the merge path, which keeps
       // the client's cache and is a no-op when we have no rows to offer.
-      return new Response(JSON.stringify({ articles, cursor: null, full: verified }), {
+      return new Response(JSON.stringify({ articles, cursor: null, full: verified, digest }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }

--- a/backend/src/routes/timeline.ts
+++ b/backend/src/routes/timeline.ts
@@ -356,12 +356,21 @@ async function subscribedUnreadCounts(
     );
   }
 
-  const counts: Record<string, number> = {};
+  // The chunks are independent read batches, so they run concurrently: awaited
+  // one at a time, a ~100-feed library serialized 4-5 D1 round trips and the
+  // counts dominated the whole timeline response (~1.2s of it).
+  const chunks: string[][] = [];
   for (let i = 0; i < feedUrls.length; i += COUNTS_CHUNK) {
-    const chunk = feedUrls.slice(i, i + COUNTS_CHUNK);
-    const statements = chunk.map((feedUrl) =>
-      env.DB.prepare(
-        `SELECT ?2 AS feed_url, COUNT(*) AS unread FROM (
+    chunks.push(feedUrls.slice(i, i + COUNTS_CHUNK));
+  }
+  const chunkResults = await Promise.all(
+    chunks.map((chunk) =>
+      timedBatch<{ feed_url: string; unread: number }>(
+        'unread_counts',
+        env.DB,
+        chunk.map((feedUrl) =>
+          env.DB.prepare(
+            `SELECT ?2 AS feed_url, COUNT(*) AS unread FROM (
                 SELECT fi.guid FROM feed_items fi
                  WHERE fi.feed_url = ?2
                  ORDER BY fi.published_at DESC, fi.seq DESC
@@ -371,13 +380,13 @@ async function subscribedUnreadCounts(
                    WHERE il.user_did = ?1 AND il.item_key = w.guid
                      AND il.item_type = 'article' AND il.label = 'read'
                      AND il.deleted_at IS NULL)`
-      ).bind(userDid, feedUrl, ARTICLE_WINDOW_PER_FEED)
-    );
-    const results = await timedBatch<{ feed_url: string; unread: number }>(
-      'unread_counts',
-      env.DB,
-      statements
-    );
+          ).bind(userDid, feedUrl, ARTICLE_WINDOW_PER_FEED)
+        )
+      )
+    )
+  );
+  const counts: Record<string, number> = {};
+  for (const results of chunkResults) {
     for (const result of results) {
       for (const row of result.results ?? []) counts[row.feed_url] = row.unread;
     }

--- a/backend/src/services/standard-site.ts
+++ b/backend/src/services/standard-site.ts
@@ -413,7 +413,9 @@ export function filterByPublication(documents: ProxyDocument[], siteUri?: string
  * Byte-for-byte the proxy's algorithm, so the digests a client already holds keep
  * matching across the cutover. The client treats it as opaque either way.
  */
-export async function digestScope(documents: ProxyDocument[]): Promise<string> {
+export async function digestScope(
+  documents: Array<Pick<ProxyDocument, 'recordUri' | 'recordCid'>>
+): Promise<string> {
   const pairs = documents.map((d) => `${d.recordUri}\t${d.recordCid}`).sort();
   const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(pairs.join('\n')));
   return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, '0')).join('');

--- a/backend/test/documents-store.spec.ts
+++ b/backend/test/documents-store.spec.ts
@@ -1605,6 +1605,72 @@ describe('the read rollout gate', () => {
     expect(body.authors[0].documents?.[0].read).toBe(false);
   });
 
+  // The batch precheck answers unchanged scopes from one query of raw
+  // (record_uri, record_cid) pairs instead of ~4 per-scope loads. It must
+  // reproduce serveDocumentScope's digest exactly: a served digest echoed back
+  // is unchanged, an edit misses again, and a scoped request hashes only its
+  // publication's rows.
+  it('round-trips the digest through the batch fast path', async () => {
+    const allowed = new Set([AUTHOR]);
+    await seedPublication(OTHER_PUBLICATION, 'https://other.example');
+    await applyDocumentEvent(env, docEvent('a'), allowed);
+    await applyDocumentEvent(env, docEvent('b', { site: OTHER_PUBLICATION }), allowed);
+    await env.DB.prepare(
+      `INSERT INTO document_authors (author_did, last_listed_at, complete) VALUES (?, ?, 1)
+       ON CONFLICT(author_did) DO UPDATE SET last_listed_at = excluded.last_listed_at, complete = 1`
+    )
+      .bind(AUTHOR, Date.now())
+      .run();
+    await setDocumentFlag(env, DOCUMENTS_V2_ENABLED_KEY, '1');
+
+    type Entry = { status: string; digest?: string; siteUri?: string };
+    const serve = async (documents: unknown[]): Promise<Entry[]> => {
+      const res = await handleV2BatchDocumentFetch(
+        batchRequest({ documents }),
+        env as Env,
+        SESSION
+      );
+      return ((await res.json()) as { authors: Entry[] }).authors;
+    };
+
+    const [unscoped, scoped] = await serve([
+      { did: AUTHOR },
+      { did: AUTHOR, siteUri: PUBLICATION },
+    ]);
+    expect(unscoped.status).toBe('ready');
+    expect(scoped.status).toBe('ready');
+    expect(scoped.digest).not.toBe(unscoped.digest);
+
+    const repeat = await serve([
+      { did: AUTHOR, since_digest: unscoped.digest },
+      { did: AUTHOR, siteUri: PUBLICATION, since_digest: scoped.digest },
+    ]);
+    expect(repeat.map((e) => e.status)).toEqual(['unchanged', 'unchanged']);
+
+    // An edit moves the digest: the edited scope re-serves, the other stays put.
+    await applyDocumentEvent(env, docEvent('a', { operation: 'update', cid: 'cid-a2' }), allowed);
+    const afterEdit = await serve([
+      { did: AUTHOR, since_digest: unscoped.digest },
+      { did: AUTHOR, siteUri: OTHER_PUBLICATION, since_digest: scoped.digest },
+    ]);
+    expect(afterEdit[0].status).toBe('ready');
+    expect(afterEdit[1].status).toBe('ready'); // different scope than its digest → miss
+  });
+
+  // A never-ingested author must keep serving `error` even when the client sends
+  // a digest — the precheck skips zero-row scopes precisely so it can't claim
+  // `unchanged` over an answer that depends on document_authors bookkeeping.
+  it('leaves a zero-row scope to the slow path, digest or not', async () => {
+    await setDocumentFlag(env, DOCUMENTS_V2_ENABLED_KEY, '1');
+    const res = await handleV2BatchDocumentFetch(
+      batchRequest({ documents: [{ did: OTHER, since_digest: 'stale' }] }),
+      env as Env,
+      SESSION
+    );
+    const { authors } = (await res.json()) as { authors: Array<{ status: string }> };
+    expect(authors[0].status).toBe('error');
+  });
+
   it('serves a single document from D1 when the gate is on', async () => {
     await applyDocumentEvent(env, docEvent('single'), new Set([AUTHOR]));
     await setDocumentFlag(env, DOCUMENTS_V2_ENABLED_KEY, '1');

--- a/backend/test/saved-backing-routes.spec.ts
+++ b/backend/test/saved-backing-routes.spec.ts
@@ -423,6 +423,104 @@ describe('GET /api/saved — backed list path', () => {
     expect(landed.body.full).toBe(true);
     expect(landed.body.articles).toHaveLength(1);
   });
+
+  // The snapshot can't page (membership can shrink), so it re-ships whole on
+  // every refresh — for a large collection >1MB of almost-always-identical
+  // bytes. The digest short-circuit answers a matching echo with `unchanged`
+  // instead; membership changes land on the open AFTER the background poll that
+  // observed them, exactly as the snapshot itself always has.
+  it('short-circuits an unchanged verified snapshot on the digest', async () => {
+    await setBackingRow(`semble:${COLLECTION}`);
+    await env.DB.prepare(
+      `UPDATE user_settings SET last_backing_poll = ?, last_successful_backing_poll = ? WHERE user_did = ?`
+    )
+      .bind(Date.now(), Date.now(), DID)
+      .run();
+    const memberA = {
+      url: 'https://a.test/x',
+      urlNormalized: 'https://a.test/x',
+      itemUri: 'at://card/1',
+      linkUri: 'at://link/1',
+      itemType: 'network.cosmik.card',
+      title: 'A',
+    };
+    const snapshot = vi.spyOn(read, 'snapshotBackedCollection').mockResolvedValue({
+      complete: true,
+      members: [memberA],
+      skipped: [],
+      typeMix: {},
+    });
+    const extractMissing = vi.spyOn(sync, 'extractMissingBackedContent').mockResolvedValue(0);
+    await env.DB.prepare(
+      `INSERT INTO saved_articles (user_did, rkey, url, url_normalized, title, source, saved_at, created_at)
+       VALUES (?, '3klist0000001', 'https://a.test/x', 'https://a.test/x', 'A', 'url', 200, 200)`
+    )
+      .bind(DID)
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO backed_collection_members
+         (user_did, external_collection, url_normalized, url, external_provider, external_item_uri, external_link_uri)
+       VALUES (?, ?, 'https://a.test/x', 'https://a.test/x', 'semble', 'at://card/1', 'at://link/1')`
+    )
+      .bind(DID, COLLECTION)
+      .run();
+
+    const get = (qs = '') =>
+      new IncomingRequest(`http://localhost/api/saved${qs}`, {
+        method: 'GET',
+        headers: { Cookie: `session_id=${SESSION}`, Origin: env.FRONTEND_URL },
+      });
+
+    const first = await call(get());
+    expect(first.body.full).toBe(true);
+    expect(first.body.articles).toHaveLength(1);
+    expect(first.body.digest).toBeTruthy();
+
+    const repeat = await call(get(`?since_digest=${first.body.digest}`));
+    expect(repeat.body).toMatchObject({
+      unchanged: true,
+      full: true,
+      articles: [],
+      digest: first.body.digest,
+    });
+    // A matching metadata digest must not suppress retries for enrichment rows
+    // whose earlier extraction failed and therefore left the digest unchanged.
+    expect(extractMissing).toHaveBeenCalledTimes(2);
+
+    // Membership grows externally. The serve still answers from the last-good
+    // snapshot (the poll that sees the growth runs in the background), so this
+    // open is still `unchanged` — and the next one re-ships the grown list.
+    snapshot.mockResolvedValue({
+      complete: true,
+      members: [
+        memberA,
+        {
+          url: 'https://b.test/y',
+          urlNormalized: 'https://b.test/y',
+          itemUri: 'at://card/2',
+          linkUri: 'at://link/2',
+          itemType: 'network.cosmik.card',
+          title: 'B',
+        },
+      ],
+      skipped: [],
+      typeMix: {},
+    });
+    // Expire the poll gate so this open's background poll actually runs (the
+    // earlier opens' polls no-op'd inside the gate window, which is fine — the
+    // serve never depended on them).
+    await env.DB.prepare(`UPDATE user_settings SET last_backing_poll = 0 WHERE user_did = ?`)
+      .bind(DID)
+      .run();
+    const stillOld = await call(get(`?since_digest=${first.body.digest}`));
+    expect(stillOld.body.unchanged).toBe(true);
+
+    const grown = await call(get(`?since_digest=${first.body.digest}`));
+    expect(grown.body.unchanged).toBeUndefined();
+    expect(grown.body.full).toBe(true);
+    expect(grown.body.articles).toHaveLength(2);
+    expect(grown.body.digest).not.toBe(first.body.digest);
+  });
 });
 
 describe('PUT /api/settings — backing change tears down the old snapshot', () => {

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -1498,7 +1498,7 @@ class ApiClient {
     });
   }
 
-  async getSaved(opts?: { limit?: number; cursor?: string | null }): Promise<{
+  async getSaved(opts?: { limit?: number; cursor?: string | null; sinceDigest?: string }): Promise<{
     // Metadata only — `content` (the article body) is omitted; hydrate it for
     // unseen rkeys via getSavedBodies. The body is ~20-50× the rest of a row and
     // the client already caches it, so re-sending it every refresh is the bulk
@@ -1524,10 +1524,16 @@ class ApiClient {
     // True when the response is a full snapshot that must replace the cache
     // wholesale (external-backed saves) rather than being merged incrementally.
     full: boolean;
+    // External-backed only: digest of the snapshot's serialized articles. Echo
+    // it back as `sinceDigest`; a matching snapshot answers `unchanged: true`
+    // with no articles instead of re-shipping the whole (large) list.
+    digest?: string;
+    unchanged?: boolean;
   }> {
     const params = new URLSearchParams();
     if (opts?.limit != null) params.set('limit', String(opts.limit));
     if (opts?.cursor) params.set('cursor', opts.cursor);
+    if (opts?.sinceDigest) params.set('since_digest', opts.sinceDigest);
     const qs = params.toString();
     return this.fetch(`/api/saved${qs ? `?${qs}` : ''}`);
   }

--- a/frontend/src/lib/services/documentSync.ts
+++ b/frontend/src/lib/services/documentSync.ts
@@ -101,8 +101,11 @@ export function buildDocumentRequests(
 
 /**
  * Run `requests` through `fetchBatch` in chunks of `batchSize`, accumulating every
- * batch's author entries. A failing batch is logged via `onError` and skipped —
- * it must not abort the others or the overall refresh.
+ * batch's author entries. Batches are independent scope sets, so they run
+ * concurrently (awaited one at a time, the overflow batch of a >50-scope library
+ * waited out the full batch ahead of it); results keep request order. A failing
+ * batch is logged via `onError` and skipped — it must not abort the others or
+ * the overall refresh.
  */
 export async function collectDocumentBatches<A>(
   requests: DocumentRequest[],
@@ -110,15 +113,19 @@ export async function collectDocumentBatches<A>(
   fetchBatch: (batch: DocumentRequest[]) => Promise<{ authors: A[] }>,
   onError: (e: unknown) => void = (e) => console.error('Document batch fetch failed:', e)
 ): Promise<A[]> {
-  const all: A[] = [];
+  const batches: DocumentRequest[][] = [];
   for (let offset = 0; offset < requests.length; offset += batchSize) {
-    const batch = requests.slice(offset, offset + batchSize);
-    try {
-      const { authors } = await fetchBatch(batch);
-      all.push(...authors);
-    } catch (e) {
-      onError(e);
-    }
+    batches.push(requests.slice(offset, offset + batchSize));
   }
-  return all;
+  const settled = await Promise.all(
+    batches.map(async (batch): Promise<A[]> => {
+      try {
+        return (await fetchBatch(batch)).authors;
+      } catch (e) {
+        onError(e);
+        return [];
+      }
+    })
+  );
+  return settled.flat();
 }

--- a/frontend/src/lib/services/feedFetcher.ts
+++ b/frontend/src/lib/services/feedFetcher.ts
@@ -744,7 +744,12 @@ export async function fetchAllDocuments(subscriptions: Subscription[]): Promise<
   let readCursor: number | undefined;
   const allAuthors = await collectDocumentBatches(requests, DOCUMENT_BATCH_SIZE, async (batch) => {
     const res = await api.fetchDocumentsBatchV2(batch);
-    if (readCursor === undefined && res.readCursor) readCursor = res.readCursor;
+    // Batches run concurrently: keep the EARLIEST server timestamp, so the
+    // seeded read-delta cursor can never skip past a read recorded between one
+    // batch's serve and another's.
+    if (res.readCursor && (readCursor === undefined || res.readCursor < readCursor)) {
+      readCursor = res.readCursor;
+    }
     return res;
   });
 

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -1,4 +1,4 @@
-import { db } from '$lib/services/db';
+import { db, getMetadata, setMetadata } from '$lib/services/db';
 import { safePut, safeBulkPut } from '$lib/services/safeDb.svelte';
 import { api } from '$lib/services/api';
 import { generateTid } from '$lib/utils/tid';
@@ -114,13 +114,20 @@ function createSavesStore() {
 
   const PAGE_SIZE = 50;
   const BODY_BATCH = 200;
+  // Digest of the last external-backed snapshot applied to the cache (Dexie
+  // metadata key); echoed to /api/saved so an unchanged snapshot isn't re-shipped.
+  const SNAPSHOT_DIGEST_KEY = 'savedSnapshotDigest';
 
   // The list endpoint returns metadata only (the body is the bulk of a row and
   // we already cache it). Fill each item's `content` in place: reuse the cached
   // body when we still have it, otherwise fetch bodies for the unseen rkeys.
   // Offline, items keep whatever body the cache had (null for genuinely new ones).
-  async function hydrateBodies(items: SavedItem[], cachedByRkey: Map<string, SavedItem>) {
+  async function hydrateBodies(
+    items: SavedItem[],
+    cachedByRkey: Map<string, SavedItem>
+  ): Promise<SavedItem[]> {
     const needFetch: string[] = [];
+    const hydrated: SavedItem[] = [];
     for (const it of items) {
       if (it.content != null) continue;
       const cachedBody = cachedByRkey.get(it.rkey)?.content;
@@ -130,7 +137,7 @@ function createSavesStore() {
         needFetch.push(it.rkey);
       }
     }
-    if (needFetch.length === 0 || !syncStore.isOnline) return;
+    if (needFetch.length === 0 || !syncStore.isOnline) return hydrated;
 
     const byRkey = new Map(items.map((it) => [it.rkey, it]));
     for (let i = 0; i < needFetch.length; i += BODY_BATCH) {
@@ -139,12 +146,16 @@ function createSavesStore() {
         const { bodies } = await api.getSavedBodies(chunk);
         for (const [rkey, body] of Object.entries(bodies)) {
           const it = byRkey.get(rkey);
-          if (it && body != null) it.content = body;
+          if (it && body != null) {
+            it.content = body;
+            hydrated.push(it);
+          }
         }
       } catch (err) {
         console.warn('Failed to hydrate saved bodies:', err);
       }
     }
+    return hydrated;
   }
 
   async function load() {
@@ -169,7 +180,26 @@ function createSavesStore() {
       // cursor; `full` means an external-backed snapshot that must replace the
       // cache wholesale (membership can be *removed* elsewhere, so it can't be
       // merged incrementally).
-      const first = await api.getSaved({ limit: PAGE_SIZE });
+      //
+      // Echo the digest of the last snapshot we applied so an unchanged one
+      // costs bytes, not the whole list — but only while a cache exists to keep:
+      // with an empty cache an `unchanged` answer would leave the list empty.
+      const sinceDigest = firstLoad
+        ? undefined
+        : ((await getMetadata<string>(SNAPSHOT_DIGEST_KEY)) ?? undefined);
+      const first = await api.getSaved({ limit: PAGE_SIZE, sinceDigest });
+
+      // Membership and metadata are unchanged, but a previous body request may
+      // have failed after the snapshot digest was stored. Retry only those
+      // missing cached bodies before keeping the snapshot.
+      if (first.unchanged) {
+        const hydrated = await hydrateBodies(cached, cachedByRkey);
+        if (hydrated.length > 0) {
+          await safeBulkPut(db.saved, hydrated);
+          savedSearchStore.invalidate();
+        }
+        return;
+      }
 
       if (first.full) {
         const snapshot = first.articles as SavedItem[];
@@ -206,6 +236,9 @@ function createSavesStore() {
         // than patching it row by row.
         savedSearchStore.invalidate();
         pushWordCountBackfills(backfilled);
+        // Only after the snapshot is fully applied: a digest stored before the
+        // cache write would claim "unchanged" over a cache we never built.
+        if (first.digest) await setMetadata(SNAPSHOT_DIGEST_KEY, first.digest);
         return;
       }
 

--- a/frontend/src/lib/stores/savesSnapshot.component.test.ts
+++ b/frontend/src/lib/stores/savesSnapshot.component.test.ts
@@ -11,8 +11,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SavedItem } from '$lib/types';
 
 const savedRows = new Map<string, SavedItem>();
+const metadataRows = new Map<string, unknown>();
 
 vi.mock('$lib/services/db', () => ({
+  getMetadata: async (key: string) => metadataRows.get(key) ?? null,
+  setMetadata: async (key: string, value: unknown) => void metadataRows.set(key, value),
   db: {
     saved: {
       orderBy: () => ({ reverse: () => ({ toArray: async () => [...savedRows.values()] }) }),
@@ -40,6 +43,7 @@ vi.mock('$lib/services/safeDb.svelte', () => ({
 const api = {
   getSaved: vi.fn(),
   getSavedBodies: vi.fn(async () => ({ bodies: {} })),
+  updateSaved: vi.fn(async () => ({ success: true })),
 };
 vi.mock('$lib/services/api', () => ({ api }));
 
@@ -74,7 +78,9 @@ describe('external-backed snapshot replace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     savedRows.clear();
+    metadataRows.clear();
     pendingSavedRkeys.mockResolvedValue(new Set<string>());
+    api.getSavedBodies.mockResolvedValue({ bodies: {} });
   });
 
   it('keeps a save whose create has not been sent yet', async () => {
@@ -91,6 +97,61 @@ describe('external-backed snapshot replace', () => {
     expect(savesStore.articles.map((a) => a.rkey).sort()).toEqual(['remote', 'unsent']);
     // And it survives in Dexie, not just in the list.
     expect([...savedRows.keys()].sort()).toEqual(['remote', 'unsent']);
+  });
+
+  it('echoes the stored digest and keeps the cache on an unchanged answer', async () => {
+    savedRows.set('remote', save('remote', '2026-01-01T00:00:00Z'));
+    metadataRows.set('savedSnapshotDigest', 'digest-1');
+    api.getSaved.mockResolvedValue({
+      full: true,
+      unchanged: true,
+      digest: 'digest-1',
+      articles: [],
+      cursor: null,
+    });
+
+    await savesStore.load();
+
+    expect(api.getSaved).toHaveBeenCalledWith({ limit: 50, sinceDigest: 'digest-1' });
+    // `unchanged` means the server snapshot is what this cache was built from:
+    // nothing is replaced, nothing hydrated.
+    expect(savesStore.articles.map((a) => a.rkey)).toEqual(['remote']);
+    expect([...savedRows.keys()]).toEqual(['remote']);
+    expect(api.getSavedBodies).not.toHaveBeenCalled();
+  });
+
+  it('retries a missing cached body when the snapshot is unchanged', async () => {
+    savedRows.set('remote', { ...save('remote', '2026-01-01T00:00:00Z'), content: null });
+    metadataRows.set('savedSnapshotDigest', 'digest-1');
+    api.getSaved.mockResolvedValue({
+      full: true,
+      unchanged: true,
+      digest: 'digest-1',
+      articles: [],
+      cursor: null,
+    });
+    api.getSavedBodies.mockResolvedValue({ bodies: { remote: 'recovered body' } });
+
+    await savesStore.load();
+
+    expect(api.getSavedBodies).toHaveBeenCalledWith(['remote']);
+    expect(savedRows.get('remote')?.content).toBe('recovered body');
+  });
+
+  it('stores the snapshot digest only after the replace lands', async () => {
+    api.getSaved.mockResolvedValue({
+      full: true,
+      digest: 'digest-2',
+      articles: [save('remote', '2026-01-01T00:00:00Z')],
+      cursor: null,
+    });
+
+    await savesStore.load();
+
+    expect(metadataRows.get('savedSnapshotDigest')).toBe('digest-2');
+    // An empty cache must never claim a digest: an `unchanged` answer over one
+    // would leave the list empty.
+    expect(api.getSaved).toHaveBeenCalledWith({ limit: 50, sinceDigest: undefined });
   });
 
   it('still drops a synced row the collection no longer holds', async () => {


### PR DESCRIPTION
…uments and backed saves

Three steady-state costs measured from a production refresh HAR (~3.4s total):

- /api/v2/timeline spent ~1.2s of its 1.4s on per-feed unread COUNTs run in sequential D1 batches; the chunks are independent reads and now run concurrently.
- /api/v2/documents/batch spent ~4 D1 queries per scope discovering "unchanged" (the digest was only computable after the full load). A batch-wide precheck now hashes the raw (record_uri, record_cid) pairs in one query and answers matching scopes immediately; zero-row scopes still take the slow path so a never-ingested author keeps serving error. The client also fetches its batches in parallel (the overflow batch used to wait out the full one) and seeds the earliest readCursor across them.
- The external-backed /api/saved snapshot re-shipped ~1.4MB of almost-always-identical articles every refresh. The server now returns a digest of the serialized snapshot and answers a matching since_digest echo with a bodyless unchanged response; the client stores the digest after a replace lands and only echoes it while a cache exists to keep.