### PR TITLE
Make Home and Saved share save-pile behavior

### DIFF
--- a/frontend/src/lib/components/feed/HomePage.svelte
+++ b/frontend/src/lib/components/feed/HomePage.svelte
@@ -34,7 +34,12 @@
   import { useScrollDirection } from '$lib/hooks/useScrollDirection.svelte';
   import { getFaviconUrl } from '$lib/utils/favicon';
   import { decodeEntities } from '$lib/utils/entities';
-  import { savedItemLabelKeys } from '$lib/utils/dailyMagazine';
+  import {
+    compareSavedNewestFirst,
+    isSavedItemArchived,
+    savedAtMs,
+    savedItemLabelKeys,
+  } from '$lib/utils/savedPile';
   import { preferences, type CardDensity, type DefaultView } from '$lib/stores/preferences.svelte';
   import {
     datePresetToMs,
@@ -154,9 +159,8 @@
   let enriched = $derived.by((): Enriched[] => {
     const out: Enriched[] = [];
     for (const s of savesStore.articles) {
-      const keys = keysFor(s);
-      if (keys.some((k) => itemLabelsStore.isArchived(k))) continue;
-      out.push({ s, activity: itemLabelsStore.getReadActivity(keys) });
+      if (isSavedItemArchived(s, itemLabelsStore.isArchived)) continue;
+      out.push({ s, activity: itemLabelsStore.getReadActivity(keysFor(s)) });
     }
     return out;
   });
@@ -184,8 +188,17 @@
   let continueSet = $derived(new Set(continueEnriched.map((e) => e.s.rkey)));
   let continueItems = $derived(continueEnriched.map((e) => toVM(e.s, e.activity)));
 
-  // Recently saved: savesStore is newest-first already.
-  let recentItems = $derived(enriched.slice(0, RECENT_CAP).map((e) => toVM(e.s, null)));
+  // Recently saved: the same rule the Saved list's default sort applies —
+  // newest by savedAt, not whatever order the store's last load left behind
+  // (the cache path reads an rkey index, and rkeys minted on another device or
+  // by a backed collection don't line up with save time). Sorted here as well
+  // as in the store so "View all" lands on a list that opens with these tiles.
+  let recentItems = $derived(
+    [...enriched]
+      .sort((a, b) => compareSavedNewestFirst(a.s, b.s))
+      .slice(0, RECENT_CAP)
+      .map((e) => toVM(e.s, null))
+  );
 
   // From your saved: a rotating random sample. Held in state so it only re-rolls on
   // demand (shuffle) or when first seeded — not on every reactive tick. Prefers
@@ -249,9 +262,6 @@
     return true;
   }
 
-  function savedAtMs(s: SavedItem): number {
-    return new Date(s.savedAt).getTime();
-  }
   function publishedMs(s: SavedItem): number {
     return s.publishedAt ? new Date(s.publishedAt).getTime() : 0;
   }
@@ -277,7 +287,7 @@
       case 'domain-desc':
         return arr.sort((a, b) => domainOf(b.s).localeCompare(domainOf(a.s)));
       default:
-        return arr.sort((a, b) => savedAtMs(b.s) - savedAtMs(a.s));
+        return arr.sort((a, b) => compareSavedNewestFirst(a.s, b.s));
     }
   }
 

--- a/frontend/src/lib/components/feed/HomePage.svelte
+++ b/frontend/src/lib/components/feed/HomePage.svelte
@@ -43,7 +43,9 @@
   import { preferences, type CardDensity, type DefaultView } from '$lib/stores/preferences.svelte';
   import {
     datePresetToMs,
+    isSavedRowArchived,
     matchesReadingLength,
+    setSavedRowArchived,
     type FeedDisplayItem,
   } from '$lib/stores/feedView.svelte';
   import type { FilteredView, SavedItem, SortOrder } from '$lib/types';
@@ -321,10 +323,7 @@
   let readerItem = $derived(reader.readerItem);
 
   function handleArchive(item: FeedDisplayItem) {
-    itemLabelsStore.toggleArchive(item.key, item.type);
-    if (item.type === 'saved' && item.item.itemGuid && item.item.itemGuid !== item.key) {
-      itemLabelsStore.toggleArchive(item.item.itemGuid, 'saved');
-    }
+    void setSavedRowArchived(item, !isSavedRowArchived(item));
     if (readerItem?.key === item.key) reader.closeReader();
   }
 

--- a/frontend/src/lib/components/feed/SavedListView.svelte
+++ b/frontend/src/lib/components/feed/SavedListView.svelte
@@ -4,13 +4,17 @@
   import SavedReader from './SavedReader.svelte';
   import InfiniteScrollSentinel from '$lib/components/common/InfiniteScrollSentinel.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
-  import { feedViewStore, type FeedDisplayItem } from '$lib/stores/feedView.svelte';
+  import {
+    feedViewStore,
+    isSavedRowArchived,
+    setSavedRowArchived,
+    type FeedDisplayItem,
+  } from '$lib/stores/feedView.svelte';
   import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
   import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
   import { useReaderStack } from '$lib/hooks/useReaderStack.svelte';
-  import type { ItemLabelType } from '$lib/types';
 
   interface Props {
     onReaderChange?: (open: boolean) => void;
@@ -58,17 +62,8 @@
   let otherViewCount = $derived(feedViewStore.savedSearchOtherViewCount);
   let otherViewLabel = $derived(feedViewStore.savedView === 'inbox' ? 'Archive' : 'Inbox');
 
-  function getItemType(item: FeedDisplayItem): ItemLabelType {
-    return item.type;
-  }
-
   function handleArchive(item: FeedDisplayItem) {
-    itemLabelsStore.toggleArchive(item.key, getItemType(item));
-    // For saved items where itemGuid differs from key, also toggle archive by itemGuid
-    // to ensure consistent archive state regardless of which key is used for lookup
-    if (item.type === 'saved' && item.item.itemGuid && item.item.itemGuid !== item.key) {
-      itemLabelsStore.toggleArchive(item.item.itemGuid, 'saved');
-    }
+    void setSavedRowArchived(item, !isSavedRowArchived(item));
     if (readerItem?.key === item.key) {
       closeReader();
     }

--- a/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
+++ b/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
@@ -339,6 +339,13 @@ export function useFeedKeyboardShortcuts(params: KeyboardShortcutsParams) {
         const item = getSelectedItem();
         if (!item) return;
         itemLabelsStore.toggleArchive(item.key, item.type);
+        // Mirror the row's own archive button: a save whose display key is its
+        // record uri also carries the label under its itemGuid. Toggling one of
+        // the pair would leave them out of step, and the next toggle would set
+        // the other one instead of clearing it.
+        if (item.type === 'saved' && item.item.itemGuid && item.item.itemGuid !== item.key) {
+          itemLabelsStore.toggleArchive(item.item.itemGuid, 'saved');
+        }
       },
       condition: () => hasSelected() && !!feedViewStore.savedFilter,
     });

--- a/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
+++ b/frontend/src/lib/hooks/useFeedKeyboardShortcuts.svelte.ts
@@ -2,7 +2,12 @@ import { onDestroy } from 'svelte';
 import { tick } from 'svelte';
 import { keyboardStore } from '$lib/stores/keyboard.svelte';
 import { auth } from '$lib/stores/auth.svelte';
-import { feedViewStore, type FeedDisplayItem } from '$lib/stores/feedView.svelte';
+import {
+  feedViewStore,
+  isSavedRowArchived,
+  setSavedRowArchived,
+  type FeedDisplayItem,
+} from '$lib/stores/feedView.svelte';
 import { subscriptionsStore } from '$lib/stores/subscriptions.svelte';
 import { itemLabelsStore } from '$lib/stores/itemLabels.svelte';
 import { linkblogStore } from '$lib/stores/linkblog.svelte';
@@ -338,14 +343,7 @@ export function useFeedKeyboardShortcuts(params: KeyboardShortcutsParams) {
       action: () => {
         const item = getSelectedItem();
         if (!item) return;
-        itemLabelsStore.toggleArchive(item.key, item.type);
-        // Mirror the row's own archive button: a save whose display key is its
-        // record uri also carries the label under its itemGuid. Toggling one of
-        // the pair would leave them out of step, and the next toggle would set
-        // the other one instead of clearing it.
-        if (item.type === 'saved' && item.item.itemGuid && item.item.itemGuid !== item.key) {
-          itemLabelsStore.toggleArchive(item.item.itemGuid, 'saved');
-        }
+        void setSavedRowArchived(item, !isSavedRowArchived(item));
       },
       condition: () => hasSelected() && !!feedViewStore.savedFilter,
     });

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -21,7 +21,7 @@ import type {
 } from '$lib/types';
 import { htmlToText, normalize, searchRank } from '$lib/services/savedSearch';
 import { sameUrlFilters, type UrlFilters } from '$lib/utils/urlFilters';
-import { isSavedItemArchived, savedAtMs } from '$lib/utils/savedPile';
+import { isSavedItemArchived, savedAtMs, setSavedItemArchived } from '$lib/utils/savedPile';
 import { urlKey } from '$lib/utils/urlKey';
 import {
   isRssSource,
@@ -134,6 +134,21 @@ export function isSavedRowArchived(item: FeedDisplayItem): boolean {
   if (itemLabelsStore.isArchived(item.key)) return true;
   const save = saveBehind(item);
   return save ? isSavedItemArchived(save, itemLabelsStore.isArchived) : false;
+}
+
+/** Set one saved-pile row's complete alias set to the requested archive state. */
+export async function setSavedRowArchived(item: FeedDisplayItem, archived: boolean): Promise<void> {
+  const save = saveBehind(item);
+  if (!save) {
+    const mutate = archived ? itemLabelsStore.archiveItem : itemLabelsStore.unarchiveItem;
+    await mutate(item.key, item.type);
+    return;
+  }
+
+  await setSavedItemArchived(save, archived, (key, desired) => {
+    const mutate = desired ? itemLabelsStore.archiveItem : itemLabelsStore.unarchiveItem;
+    return mutate(key, 'saved');
+  });
 }
 
 /** Same test for an article row, without building the wrapper first. */

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -21,6 +21,8 @@ import type {
 } from '$lib/types';
 import { htmlToText, normalize, searchRank } from '$lib/services/savedSearch';
 import { sameUrlFilters, type UrlFilters } from '$lib/utils/urlFilters';
+import { isSavedItemArchived, savedAtMs } from '$lib/utils/savedPile';
+import { urlKey } from '$lib/utils/urlKey';
 import {
   isRssSource,
   isDocumentsSource,
@@ -90,15 +92,53 @@ function getItemDate(item: FeedDisplayItem): number {
   }
 }
 
+/** The item's own link, for the url-keyed lookups a save can be found under. */
+function itemUrl(item: FeedDisplayItem): string | null {
+  if (item.type === 'saved') return item.item.url || null;
+  if (item.type === 'article') return item.item.url || null;
+  return item.item.canonicalUrl || item.item.path || null;
+}
+
+/**
+ * The save behind a row of the saved pile, or undefined for a row that isn't in
+ * it. An article or document lands in the Saved list because `isSaved()` said
+ * so — and that answers yes on a url match too, which is how a save made from a
+ * bare link claims the feed article for the same page. Resolving only by guid
+ * left those rows with no save to read from, so they fell back to the publish
+ * date and sorted into the middle of a list that claims to be newest-saved.
+ */
+function saveBehind(item: FeedDisplayItem): SavedItem | undefined {
+  if (item.type === 'saved') return item.item;
+  const byKey = savesStore.find(item.key);
+  if (byKey) return byKey;
+  const url = itemUrl(item);
+  return url ? savesStore.find(url) : undefined;
+}
+
 export function getSavedDate(item: FeedDisplayItem): number {
-  if (item.type === 'saved') {
-    return new Date(item.item.savedAt).getTime();
-  }
-  const savedItem = savesStore.getByGuid(item.key);
-  if (savedItem) {
-    return new Date(savedItem.savedAt).getTime();
-  }
+  const savedItem = saveBehind(item);
+  if (savedItem) return savedAtMs(savedItem);
   return getItemDate(item);
+}
+
+/**
+ * The archived test for a row of the saved pile, keyed on the save rather than
+ * on the row. An `archived` label lands under whichever alias the surface that
+ * wrote it held (see `savedItemLabelKeys`), so testing the row's own key alone
+ * made the Saved list and Home's lanes disagree about the same item. Rows with
+ * no save behind them fall back to their own key.
+ */
+export function isSavedRowArchived(item: FeedDisplayItem): boolean {
+  // The row's own key first: it's a map hit, and it's the alias most archives
+  // land under, so the common case never pays for resolving the save.
+  if (itemLabelsStore.isArchived(item.key)) return true;
+  const save = saveBehind(item);
+  return save ? isSavedItemArchived(save, itemLabelsStore.isArchived) : false;
+}
+
+/** Same test for an article row, without building the wrapper first. */
+function isSavedArticleArchived(article: Article): boolean {
+  return isSavedRowArchived({ type: 'article', item: article, key: article.guid });
 }
 
 function getItemPublishedDate(item: FeedDisplayItem): number {
@@ -494,11 +534,11 @@ function createFeedViewStore() {
       // Saved view with inbox/archive sub-filter
       if (savedView === 'inbox') {
         articles = allArticles.filter((a) => {
-          return itemLabelsStore.isSaved(a.guid) && !itemLabelsStore.isArchived(a.guid);
+          return itemLabelsStore.isSaved(a.guid) && !isSavedArticleArchived(a);
         });
       } else {
         articles = allArticles.filter((a) => {
-          return itemLabelsStore.isSaved(a.guid) && itemLabelsStore.isArchived(a.guid);
+          return itemLabelsStore.isSaved(a.guid) && isSavedArticleArchived(a);
         });
       }
     } else {
@@ -730,7 +770,7 @@ function createFeedViewStore() {
       const seen = new Set<string>();
       return articlesStore.allArticles.filter((a) => {
         if (!itemLabelsStore.isSaved(a.guid)) return false;
-        if (itemLabelsStore.isArchived(a.guid) !== isArchiveView) return false;
+        if (isSavedArticleArchived(a) !== isArchiveView) return false;
         if (seen.has(a.guid)) return false;
         seen.add(a.guid);
         return true;
@@ -753,8 +793,12 @@ function createFeedViewStore() {
         : socialStore.documents
             .filter((d) => {
               if (!itemLabelsStore.isSaved(d.recordUri)) return false;
-              if (isArchiveView) return itemLabelsStore.isArchived(d.recordUri);
-              return !itemLabelsStore.isArchived(d.recordUri);
+              const archived = isSavedRowArchived({
+                type: 'document',
+                item: d,
+                key: d.recordUri,
+              });
+              return archived === isArchiveView;
             })
             .map((d) => ({
               type: 'document' as const,
@@ -767,23 +811,36 @@ function createFeedViewStore() {
     // otherwise an article that's filtered out (e.g. by reading length) would
     // silently kill its matching bookmark, and the sidebar count would not
     // agree with the displayed list.
-    const allSavedArticleGuids = new Set(
-      articlesStore.allArticles
-        .filter(
-          (a) =>
-            itemLabelsStore.isSaved(a.guid) &&
-            matchesSavedChannelFilters({
-              type: 'article',
-              item: a,
-              key: a.guid,
-            })
-        )
-        .map((a) => a.guid)
-    );
+    // Gated on the source filter as well, because a channel showing only url
+    // saves renders no article rows at all — deduping against rows that aren't
+    // there would drop the bookmark and leave the channel short an item.
+    const dedupableArticles =
+      sourceFilter && !sourceFilter.has('feed')
+        ? []
+        : articlesStore.allArticles.filter(
+            (a) =>
+              itemLabelsStore.isSaved(a.guid) &&
+              matchesSavedChannelFilters({
+                type: 'article',
+                item: a,
+                key: a.guid,
+              })
+          );
+    const allSavedArticleGuids = new Set(dedupableArticles.map((a) => a.guid));
     // Only dedup bookmarks against documents that will actually pass
     // the channel filters — same reasoning as allSavedArticleGuids above.
-    const documentRecordUris = new Set(
-      starredDocumentItems.filter((d) => matchesSavedChannelFilters(d)).map((d) => d.key)
+    const dedupableDocuments = starredDocumentItems.filter((d) => matchesSavedChannelFilters(d));
+    const documentRecordUris = new Set(dedupableDocuments.map((d) => d.key));
+    // A save made from a bare url carries no itemGuid, so the guid check below
+    // can't see that the very same page is already in this list as a feed
+    // article — `isSaved()` matched that article by url, which is exactly how
+    // it got here. The page then rendered twice in the Saved list while Home,
+    // which draws the save alone, showed it once. Canonical url keys, so a
+    // trailing slash or a utm param doesn't reopen the gap.
+    const displayedUrlKeys = new Set(
+      [...dedupableArticles.map((a) => a.url), ...dedupableDocuments.map((d) => itemUrl(d))]
+        .map((url) => (url ? urlKey(url) : null))
+        .filter((key): key is string => key !== null)
     );
     const bookmarkItems: FeedDisplayItem[] = savesStore.articles
       .filter((bm) => {
@@ -799,11 +856,12 @@ function createFeedViewStore() {
           if (allSavedArticleGuids.has(bm.itemGuid)) return false;
           if (documentRecordUris.has(bm.itemGuid)) return false;
         }
-        // Use itemGuid (article guid) for archive checks when available, since archive
-        // labels are stored against the article guid, not the AT Protocol URI
-        const archiveKey = bm.itemGuid || bm.uri || '';
-        if (isArchiveView) return itemLabelsStore.isArchived(archiveKey);
-        return !itemLabelsStore.isArchived(archiveKey);
+        const bmUrlKey = bm.url ? urlKey(bm.url) : null;
+        if (bmUrlKey && displayedUrlKeys.has(bmUrlKey)) return false;
+        // Archive state belongs to the save, not to one of its keys: the label
+        // may sit under the guid, the record uri, the url or the rkey depending
+        // on which surface wrote it (see savedItemLabelKeys).
+        return isSavedItemArchived(bm, itemLabelsStore.isArchived) === isArchiveView;
       })
       .map((bm) => ({
         type: 'saved' as const,
@@ -815,6 +873,18 @@ function createFeedViewStore() {
 
     // Sort saved items
     const sort = isSavedChannel ? (toolbarSortOrder ?? 'newest') : sortOrder;
+    // Memoized per row: resolving the save behind an article or document row
+    // can cost a url canonicalization, and a comparator is called O(n log n)
+    // times. Lazy, so the other sort orders pay nothing for it.
+    const savedDates = new Map<FeedDisplayItem, number>();
+    const savedDateOf = (item: FeedDisplayItem): number => {
+      let value = savedDates.get(item);
+      if (value === undefined) {
+        value = getSavedDate(item);
+        savedDates.set(item, value);
+      }
+      return value;
+    };
     items.sort((a, b) => {
       switch (sort) {
         case 'published-newest':
@@ -838,8 +908,8 @@ function createFeedViewStore() {
         }
         default: {
           // newest / oldest — sort by savedAt
-          const dateA = getSavedDate(a);
-          const dateB = getSavedDate(b);
+          const dateA = savedDateOf(a);
+          const dateB = savedDateOf(b);
           return sort === 'oldest' ? dateA - dateB : dateB - dateA;
         }
       }
@@ -854,7 +924,7 @@ function createFeedViewStore() {
     // Apply date added filter
     if (toolbarDateFilter) {
       const cutoff = datePresetToMs(toolbarDateFilter);
-      items = items.filter((item) => getSavedDate(item) >= cutoff);
+      items = items.filter((item) => savedDateOf(item) >= cutoff);
     }
 
     // Apply reading length filter. Items with unknown word count are

--- a/frontend/src/lib/stores/feedView.svelte.ts
+++ b/frontend/src/lib/stores/feedView.svelte.ts
@@ -145,10 +145,15 @@ export async function setSavedRowArchived(item: FeedDisplayItem, archived: boole
     return;
   }
 
-  await setSavedItemArchived(save, archived, (key, desired) => {
-    const mutate = desired ? itemLabelsStore.archiveItem : itemLabelsStore.unarchiveItem;
-    return mutate(key, 'saved');
-  });
+  await setSavedItemArchived(
+    save,
+    archived,
+    (key, desired) => {
+      const mutate = desired ? itemLabelsStore.archiveItem : itemLabelsStore.unarchiveItem;
+      return mutate(key, 'saved');
+    },
+    [item.key]
+  );
 }
 
 /** Same test for an article row, without building the wrapper first. */

--- a/frontend/src/lib/stores/savedPileConsistency.component.test.ts
+++ b/frontend/src/lib/stores/savedPileConsistency.component.test.ts
@@ -44,6 +44,12 @@ vi.mock('./itemLabels.svelte', () => ({
     // a feed article whose page was saved from a bare link gets into the list.
     isSaved: (key: string) => findSave(key) !== undefined,
     isArchived: (key: string) => isArchivedKey(key),
+    archiveItem: async (key: string) => {
+      if (!fixtures.archived.includes(key)) fixtures.archived = [...fixtures.archived, key];
+    },
+    unarchiveItem: async (key: string) => {
+      fixtures.archived = fixtures.archived.filter((archivedKey) => archivedKey !== key);
+    },
     isRead: () => false,
     isSocialRead: () => false,
     itemHasAnyTag: () => true,
@@ -102,7 +108,8 @@ vi.mock('$lib/services/liveDb.svelte', () => ({
   liveDb: { articlesVersion: 0, getArticleBodies: async () => new Map() },
 }));
 
-const { feedViewStore } = await import('./feedView.svelte');
+const { feedViewStore, isSavedRowArchived, setSavedRowArchived } =
+  await import('./feedView.svelte');
 
 function save(overrides: Partial<SavedItem> = {}): SavedItem {
   return {
@@ -183,6 +190,27 @@ describe('the Saved list and Home draw the same pile', () => {
     fixtures.articles = [article()];
 
     expect(feedViewStore.currentItems).toHaveLength(1);
+  });
+
+  it('moves a canonically matched article from Archive to Inbox in one operation', async () => {
+    const item = save({ itemGuid: undefined, url: 'https://example.com/piece' });
+    const row = article({
+      guid: 'https://example.com/piece?utm_source=rss',
+      url: 'https://example.com/piece?utm_source=rss',
+    });
+    fixtures.saves = [item];
+    fixtures.articles = [row];
+    // This is the key the old row action wrote, but it is not one of the
+    // resolved save record's own aliases.
+    fixtures.archived = [row.guid];
+
+    const displayRow = { type: 'article' as const, item: row, key: row.guid };
+    expect(isSavedRowArchived(displayRow)).toBe(true);
+
+    await setSavedRowArchived(displayRow, false);
+
+    expect(fixtures.archived).toEqual([]);
+    expect(isSavedRowArchived(displayRow)).toBe(false);
   });
 
   it('keeps the bookmark in a url-only channel, which renders no article rows', () => {

--- a/frontend/src/lib/stores/savedPileConsistency.component.test.ts
+++ b/frontend/src/lib/stores/savedPileConsistency.component.test.ts
@@ -1,0 +1,283 @@
+// Named `.component.test.ts` so it runs in the project that compiles runes —
+// feedView is a `.svelte.ts` module and its derivations need the Svelte plugin.
+//
+// Home's "Recently saved" lane and the Saved list render the same pile through
+// two different pipelines, and they used to answer three questions
+// independently: is this item archived, is it the same page as one already in
+// the list, and when was it saved. Each disagreement was visible as the lane
+// and the list showing different items in a different order. These tests pin
+// the Saved list to the shared rules in `utils/savedPile` — the ones the lane
+// now imports — so the two can't drift apart again.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Article, FilteredView, SavedItem, SocialDocument } from '$lib/types';
+import { urlKey } from '$lib/utils/urlKey';
+import { compareSavedNewestFirst, isSavedItemArchived } from '$lib/utils/savedPile';
+// Reactive, so feedView's `$derived` chain re-runs between cases.
+import { fixtures, resetFixtures } from '../../../test/stubs/saved-pile-fixtures.svelte';
+
+function findSave(key: string): SavedItem | undefined {
+  if (!key) return undefined;
+  const direct = fixtures.saves.find((s) => s.itemGuid === key || s.url === key);
+  if (direct) return direct;
+  const canonical = urlKey(key);
+  return canonical ? fixtures.saves.find((s) => urlKey(s.url) === canonical) : undefined;
+}
+
+function isArchivedKey(key: string): boolean {
+  return fixtures.archived.includes(key);
+}
+
+vi.mock('./saves.svelte', () => ({
+  savesStore: {
+    get articles() {
+      return fixtures.saves;
+    },
+    find: (key: string) => findSave(key),
+    getByGuid: (guid: string) => fixtures.saves.find((s) => s.itemGuid === guid),
+    getByUrl: (url: string) => fixtures.saves.find((s) => s.url === url),
+  },
+}));
+
+vi.mock('./itemLabels.svelte', () => ({
+  itemLabelsStore: {
+    // The real one delegates to savesStore, url ladder and all — which is how
+    // a feed article whose page was saved from a bare link gets into the list.
+    isSaved: (key: string) => findSave(key) !== undefined,
+    isArchived: (key: string) => isArchivedKey(key),
+    isRead: () => false,
+    isSocialRead: () => false,
+    itemHasAnyTag: () => true,
+    get tagsByItem() {
+      return {};
+    },
+    markAsRead: () => {},
+    markSocialAsRead: () => {},
+  },
+}));
+
+vi.mock('./articles.svelte', () => ({
+  articlesStore: {
+    get allArticles() {
+      return fixtures.articles;
+    },
+  },
+}));
+
+vi.mock('./social.svelte', () => ({
+  socialStore: {
+    get documents() {
+      return fixtures.documents;
+    },
+    isLoading: false,
+  },
+}));
+
+vi.mock('./myLinkblog.svelte', () => ({ myLinkblogStore: { documents: [] } }));
+vi.mock('./subscriptions.svelte', () => ({
+  subscriptionsStore: { subscriptions: [], getById: () => undefined, getByRkey: () => undefined },
+}));
+vi.mock('./filteredViews.svelte', () => ({
+  filteredViewsStore: {
+    get views() {
+      return fixtures.channel ? [fixtures.channel] : [];
+    },
+    getById: () => undefined,
+    getByUuid: (uuid: string) => (fixtures.channel?.uuid === uuid ? fixtures.channel : undefined),
+    update: () => {},
+  },
+}));
+vi.mock('./savedSearch.svelte', () => ({
+  savedSearchStore: {
+    terms: [],
+    bodyMatchTerms: [],
+    active: false,
+    reset: () => {},
+    setSurfaceActive: () => {},
+  },
+}));
+vi.mock('./preferences.svelte', () => ({
+  preferences: { sortOrder: 'newest', toggleSortOrder: () => {} },
+}));
+vi.mock('$lib/services/liveDb.svelte', () => ({
+  liveDb: { articlesVersion: 0, getArticleBodies: async () => new Map() },
+}));
+
+const { feedViewStore } = await import('./feedView.svelte');
+
+function save(overrides: Partial<SavedItem> = {}): SavedItem {
+  return {
+    rkey: '3ksaveaaaaaaa',
+    uri: 'at://did:plc:test/app.skyreader.feed.saved/3ksaveaaaaaaa',
+    url: 'https://example.com/piece',
+    title: 'A Piece',
+    author: null,
+    description: null,
+    content: null,
+    contentType: 'article',
+    domain: 'example.com',
+    image: null,
+    wordCount: 400,
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    savedAt: '2026-08-09T00:00:00.000Z',
+    source: 'url',
+    ...overrides,
+  };
+}
+
+function article(overrides: Partial<Article> = {}): Article {
+  return {
+    guid: 'https://example.com/piece',
+    subscriptionId: 1,
+    title: 'A Piece',
+    url: 'https://example.com/piece',
+    content: null,
+    summary: null,
+    author: null,
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    imageUrl: null,
+    wordCount: 400,
+    ...overrides,
+  } as Article;
+}
+
+/** The pile as Home's lanes build it: every unarchived save, newest first. */
+function homeLane(): SavedItem[] {
+  return fixtures.saves
+    .filter((s) => !isSavedItemArchived(s, isArchivedKey))
+    .sort(compareSavedNewestFirst);
+}
+
+function savedListKeys(): string[] {
+  return feedViewStore.currentItems.map((item) => item.key);
+}
+
+describe('the Saved list and Home draw the same pile', () => {
+  beforeEach(() => {
+    resetFixtures();
+    feedViewStore.setSavedView('inbox');
+    feedViewStore.setFilters({
+      feed: null,
+      saved: 'true',
+      sharer: null,
+      following: null,
+      feeds: null,
+    });
+  });
+
+  it('lists a url save once when a feed article covers the same page', () => {
+    // The save carries no itemGuid (it was made from a bare link), but the feed
+    // article's guid IS that url, so `isSaved()` matches it and the article
+    // joins the list. The guid-keyed dedup couldn't see the pair, so the page
+    // rendered twice here while Home, drawing the save alone, showed it once.
+    fixtures.saves = [save({ itemGuid: undefined })];
+    fixtures.articles = [article()];
+
+    expect(savedListKeys()).toEqual(['https://example.com/piece']);
+    expect(feedViewStore.currentItems).toHaveLength(homeLane().length);
+  });
+
+  it('dedups across a trailing slash or a tracking param', () => {
+    fixtures.saves = [
+      save({ itemGuid: undefined, url: 'https://example.com/piece/?utm_source=news' }),
+    ];
+    fixtures.articles = [article()];
+
+    expect(feedViewStore.currentItems).toHaveLength(1);
+  });
+
+  it('keeps the bookmark in a url-only channel, which renders no article rows', () => {
+    // Dedup has to follow what the channel actually shows: a "url saves only"
+    // channel drops every article row, so deduping against one would leave the
+    // channel a row short instead of merely un-duplicated.
+    fixtures.saves = [save({ itemGuid: undefined, source: 'url' })];
+    fixtures.articles = [article()];
+    fixtures.channel = {
+      id: 1,
+      uuid: 'chan-1',
+      name: 'Links',
+      mode: 'saved',
+      savedSourceFilter: ['url'],
+    } as FilteredView;
+
+    feedViewStore.setFilters({
+      feed: null,
+      saved: null,
+      sharer: null,
+      following: null,
+      feeds: null,
+      view: 'chan-1',
+    });
+
+    expect(savedListKeys()).toEqual(['at://did:plc:test/app.skyreader.feed.saved/3ksaveaaaaaaa']);
+  });
+
+  it('sorts a url save by when it was saved, not when it was published', () => {
+    // An old article saved today belongs at the top of both surfaces. Resolving
+    // the save by guid alone found nothing for this row, so it fell through to
+    // the publish date and sank into the middle of the list.
+    fixtures.saves = [
+      save({ itemGuid: undefined, rkey: '3kold', url: 'https://example.com/older' }),
+      save({
+        itemGuid: undefined,
+        rkey: '3knew',
+        url: 'https://example.com/piece',
+        savedAt: '2026-08-20T00:00:00.000Z',
+        publishedAt: '2011-01-01T00:00:00.000Z',
+      }),
+    ];
+    fixtures.articles = [
+      article({ guid: 'https://example.com/older', url: 'https://example.com/older' }),
+      article({ publishedAt: '2011-01-01T00:00:00.000Z' }),
+    ];
+
+    expect(savedListKeys()).toEqual(['https://example.com/piece', 'https://example.com/older']);
+    expect(homeLane().map((s) => s.url)).toEqual([
+      'https://example.com/piece',
+      'https://example.com/older',
+    ]);
+  });
+
+  it('hides an item archived under its record uri, the key the `e` shortcut writes', () => {
+    const item = save({ itemGuid: 'guid-1' });
+    fixtures.saves = [item];
+    fixtures.archived = [item.uri];
+
+    expect(savedListKeys()).toEqual([]);
+    expect(homeLane()).toEqual([]);
+  });
+
+  it('hides a saved feed article archived under any of the save’s aliases', () => {
+    const item = save({ itemGuid: 'guid-1', source: 'feed' });
+    fixtures.saves = [item];
+    fixtures.articles = [article({ guid: 'guid-1' })];
+    fixtures.archived = [item.uri];
+
+    expect(savedListKeys()).toEqual([]);
+    expect(homeLane()).toEqual([]);
+  });
+
+  it('hides a saved document archived under its save’s record uri', () => {
+    const item = save({ itemGuid: 'at://did:plc:author/site.standard.document/doc1' });
+    fixtures.saves = [item];
+    fixtures.documents = [
+      {
+        recordUri: 'at://did:plc:author/site.standard.document/doc1',
+        title: 'A Document',
+        publishedAt: '2026-01-01T00:00:00.000Z',
+      } as SocialDocument,
+    ];
+    fixtures.archived = [item.uri];
+
+    expect(savedListKeys()).toEqual([]);
+    expect(homeLane()).toEqual([]);
+  });
+
+  it('shows the archived item in the Archive tab, keyed the same way', () => {
+    const item = save({ itemGuid: 'guid-1' });
+    fixtures.saves = [item];
+    fixtures.archived = [item.uri];
+
+    feedViewStore.setSavedView('archive');
+    expect(savedListKeys()).toEqual([item.uri]);
+  });
+});

--- a/frontend/src/lib/stores/saves.component.test.ts
+++ b/frontend/src/lib/stores/saves.component.test.ts
@@ -145,6 +145,42 @@ describe('savesStore in guest mode', () => {
     expect(api.getSavedBodies).not.toHaveBeenCalled();
   });
 
+  it('load() leaves the cache in savedAt order, not the rkey order it reads in', async () => {
+    // The list is Home's "Recently saved" lane and the Saved list's default
+    // sort, and this path returns early (a guest, or an unchanged backed
+    // snapshot) — so it has to sort like the other two. rkey order only
+    // proxies save time: the extension, another device and a backed collection
+    // all mint rkeys that don't line up.
+    const row = (rkey: string, savedAt: string): SavedItem =>
+      ({
+        rkey,
+        uri: '',
+        url: `https://example.com/${rkey}`,
+        title: rkey,
+        author: null,
+        description: null,
+        content: null,
+        contentType: 'article',
+        domain: null,
+        image: null,
+        wordCount: 1,
+        publishedAt: null,
+        savedAt,
+      }) as SavedItem;
+
+    savedRows.set('3kzzzzzzzzzzz', row('3kzzzzzzzzzzz', '2026-08-01T00:00:00.000Z'));
+    savedRows.set('3kaaaaaaaaaaa', row('3kaaaaaaaaaaa', '2026-08-09T00:00:00.000Z'));
+    savedRows.set('3kmmmmmmmmmmm', row('3kmmmmmmmmmmm', '2026-08-05T00:00:00.000Z'));
+
+    await savesStore.load();
+
+    expect(savesStore.articles.map((a) => a.rkey)).toEqual([
+      '3kaaaaaaaaaaa',
+      '3kmmmmmmmmmmm',
+      '3kzzzzzzzzzzz',
+    ]);
+  });
+
   it('saveArticle writes locally with the RSS body and queues the create for sign-in', async () => {
     articleRows.push({ guid: 'guid-1', subscriptionId: 7, content: '<p>the rss body text</p>' });
 

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -9,6 +9,7 @@ import { auth } from './auth.svelte';
 import { extractArticle } from '$lib/services/extract';
 import { computeContentStats } from '$lib/services/articleMerge';
 import { savedSearchStore } from './savedSearch.svelte';
+import { compareSavedNewestFirst } from '$lib/utils/savedPile';
 import type { SavedItem } from '$lib/types';
 
 /**
@@ -164,7 +165,17 @@ function createSavesStore() {
     try {
       // Load from local cache first. The in-memory list is kept "light" (no
       // body); IndexedDB retains the full rows.
-      const cached = await db.saved.orderBy('rkey').reverse().toArray();
+      //
+      // Sorted by savedAt, not by the rkey the index reads in: rkey order is
+      // only a proxy for save time (rkeys minted on another device, by the
+      // extension, or by a backed collection don't line up), and this is the
+      // order Home's "Recently saved" lane shows. The two paths below already
+      // sort this way; the cache path returns early for a guest and for an
+      // unchanged backed snapshot, so it has to as well or those two cases
+      // render a "recent" lane that isn't.
+      const cached = (await db.saved.orderBy('rkey').reverse().toArray()).sort(
+        compareSavedNewestFirst
+      );
       const cachedByRkey = new Map(cached.map((c) => [c.rkey, c]));
       const firstLoad = cached.length === 0;
       if (!firstLoad) {
@@ -223,9 +234,7 @@ function createSavesStore() {
         // before the clear()+replace below drops the old cache (and its bodies).
         await hydrateBodies(snapshot, cachedByRkey);
         const backfilled = backfillWordCounts(snapshot);
-        const kept = [...unsent, ...snapshot].sort((a, b) =>
-          a.savedAt < b.savedAt ? 1 : a.savedAt > b.savedAt ? -1 : 0
-        );
+        const kept = [...unsent, ...snapshot].sort(compareSavedNewestFirst);
         articles = kept.map(toLightSaved);
         rebuildMaps();
         await db.saved.clear();
@@ -271,7 +280,7 @@ function createSavesStore() {
       const merged = [
         ...fresh.map(toLightSaved),
         ...cached.filter((c) => !freshKeys.has(c.rkey)).map(toLightSaved),
-      ].sort((a, b) => (a.savedAt < b.savedAt ? 1 : a.savedAt > b.savedAt ? -1 : 0));
+      ].sort(compareSavedNewestFirst);
       articles = merged;
       rebuildMaps();
 
@@ -681,10 +690,24 @@ function createSavesStore() {
     }
   }
 
-  function isSaved(guidOrUrl: string): boolean {
-    if (savedByGuid.has(guidOrUrl) || savedByUrl.has(guidOrUrl)) return true;
+  // The save behind an arbitrary item key — a feed guid, a document record uri,
+  // or a url — resolved down the same guid → url → canonical-url ladder that
+  // isSaved() answers yes on. Callers that only ask "is this saved?" and
+  // callers that need the row itself have to agree, or the Saved list can list
+  // an article as saved (url match) and then find no save to read its savedAt
+  // and archive state from.
+  function find(guidOrUrl: string): SavedItem | undefined {
+    if (!guidOrUrl) return undefined;
+    const byGuid = savedByGuid.get(guidOrUrl);
+    if (byGuid) return byGuid;
+    const byUrl = savedByUrl.get(guidOrUrl);
+    if (byUrl) return byUrl;
     const key = urlKey(guidOrUrl);
-    return key !== null && savedByUrlKey.has(key);
+    return key ? savedByUrlKey.get(key) : undefined;
+  }
+
+  function isSaved(guidOrUrl: string): boolean {
+    return find(guidOrUrl) !== undefined;
   }
 
   function getByUri(uri: string): SavedItem | undefined {
@@ -780,6 +803,7 @@ function createSavesStore() {
     unsaveByGuid,
     remove,
     isSaved,
+    find,
     getByUri,
     getByUrl,
     getByGuid,

--- a/frontend/src/lib/stores/unreadCounts.svelte.ts
+++ b/frontend/src/lib/stores/unreadCounts.svelte.ts
@@ -11,6 +11,7 @@ import {
   getSavedDate,
   datePresetToMs,
   matchesReadingLength,
+  isSavedRowArchived,
 } from './feedView.svelte';
 import { liveDb } from '$lib/services/liveDb.svelte';
 import { reportClientError } from '$lib/services/telemetry';
@@ -201,15 +202,15 @@ function createUnreadCountsStore() {
         if (!sourceFilter || sourceFilter.has('feed')) {
           for (const article of articlesStore.allArticles) {
             if (seen.has(article.guid)) continue;
-            if (
-              itemLabelsStore.isSaved(article.guid) &&
-              !itemLabelsStore.isArchived(article.guid)
-            ) {
+            if (itemLabelsStore.isSaved(article.guid)) {
               const displayItem: FeedDisplayItem = {
                 type: 'article',
                 item: article,
                 key: article.guid,
               };
+              // Same archived test the Saved list and Home apply, so a channel's
+              // badge can't promise items the lane below it has already dropped.
+              if (isSavedRowArchived(displayItem)) continue;
               if (!matchesChannelFilters(displayItem)) continue;
               seen.add(article.guid);
             }
@@ -220,15 +221,13 @@ function createUnreadCountsStore() {
         if (!sourceFilter || sourceFilter.has('document')) {
           for (const doc of socialStore.documents) {
             if (seen.has(doc.recordUri)) continue;
-            if (
-              itemLabelsStore.isSaved(doc.recordUri) &&
-              !itemLabelsStore.isArchived(doc.recordUri)
-            ) {
+            if (itemLabelsStore.isSaved(doc.recordUri)) {
               const displayItem: FeedDisplayItem = {
                 type: 'document',
                 item: doc,
                 key: doc.recordUri,
               };
+              if (isSavedRowArchived(displayItem)) continue;
               if (!matchesChannelFilters(displayItem)) continue;
               seen.add(doc.recordUri);
             }
@@ -242,13 +241,12 @@ function createUnreadCountsStore() {
           if (sourceFilter && !sourceFilter.has(src)) continue;
           const key = bm.itemGuid || bm.uri || bm.rkey;
           if (seen.has(key)) continue;
-          const archiveKey = bm.itemGuid || bm.uri || '';
-          if (itemLabelsStore.isArchived(archiveKey)) continue;
           const displayItem: FeedDisplayItem = {
             type: 'saved',
             item: bm,
             key: bm.uri || bm.itemGuid || bm.rkey,
           };
+          if (isSavedRowArchived(displayItem)) continue;
           if (!matchesChannelFilters(displayItem)) continue;
           seen.add(key);
         }

--- a/frontend/src/lib/utils/dailyMagazine.ts
+++ b/frontend/src/lib/utils/dailyMagazine.ts
@@ -61,12 +61,14 @@ export function savedItemDisplayKey(item: SavedItem): string {
   return item.uri || item.itemGuid || item.rkey || item.url;
 }
 
-/** The label keys under which a save can be read or archived. */
-export function savedItemLabelKeys(item: SavedItem): string[] {
-  return [item.itemGuid, item.uri, item.url].filter(
-    (key): key is string => typeof key === 'string' && key.length > 0
-  );
-}
+/**
+ * The label keys under which a save can be read or archived.
+ *
+ * Re-exported from `savedPile` — the magazine, the Saved list and Home's lanes
+ * all have to agree on a save's aliases or the same item is archived on one
+ * surface and live on another.
+ */
+export { savedItemLabelKeys } from './savedPile';
 
 // FNV-1a gives each stable key a repeatable daily sort score. It is not used
 // for security or randomness; it simply rotates the pile without persisting an

--- a/frontend/src/lib/utils/savedPile.test.ts
+++ b/frontend/src/lib/utils/savedPile.test.ts
@@ -9,6 +9,7 @@ import {
   isSavedItemArchived,
   savedAtMs,
   savedItemLabelKeys,
+  setSavedItemArchived,
 } from './savedPile';
 
 function save(overrides: Partial<SavedItem> = {}): SavedItem {
@@ -72,6 +73,39 @@ describe('isSavedItemArchived', () => {
     const item = save({ itemGuid: 'guid-1' });
     const archived = new Set([item.uri]);
     expect(isSavedItemArchived(item, (k) => archived.has(k))).toBe(true);
+  });
+});
+
+describe('setSavedItemArchived', () => {
+  it.each([
+    ['URL', (item: SavedItem) => item.url],
+    ['rkey', (item: SavedItem) => item.rkey],
+  ])('clears a sole %s archive label when moving the save to Inbox', async (_name, alias) => {
+    const item = save({ itemGuid: 'guid-1' });
+    const archived = new Set([alias(item)]);
+
+    await setSavedItemArchived(item, false, (key, desired) => {
+      if (desired) archived.add(key);
+      else archived.delete(key);
+    });
+
+    expect(archived).toEqual(new Set());
+    expect(isSavedItemArchived(item, (key) => archived.has(key))).toBe(false);
+  });
+
+  it('sets every unique alias to the desired state', async () => {
+    const item = save({ itemGuid: 'https://example.com/a' });
+    const writes: Array<[string, boolean]> = [];
+
+    await setSavedItemArchived(item, true, (key, archived) => {
+      writes.push([key, archived]);
+    });
+
+    expect(writes).toEqual([
+      ['https://example.com/a', true],
+      ['at://did:plc:test/app.skyreader.feed.saved/3kabcdefghijk', true],
+      ['3kabcdefghijk', true],
+    ]);
   });
 });
 

--- a/frontend/src/lib/utils/savedPile.test.ts
+++ b/frontend/src/lib/utils/savedPile.test.ts
@@ -1,0 +1,123 @@
+// The Saved list and Home's "Recently saved" lane render the same pile from
+// two different pipelines. Every rule they used to decide independently showed
+// up as the same item present on one surface and missing from the other, so
+// these are the rules both now import.
+import { describe, expect, it } from 'vitest';
+import type { SavedItem } from '$lib/types';
+import {
+  compareSavedNewestFirst,
+  isSavedItemArchived,
+  savedAtMs,
+  savedItemLabelKeys,
+} from './savedPile';
+
+function save(overrides: Partial<SavedItem> = {}): SavedItem {
+  return {
+    rkey: '3kabcdefghijk',
+    uri: 'at://did:plc:test/app.skyreader.feed.saved/3kabcdefghijk',
+    url: 'https://example.com/a',
+    title: 'A',
+    author: null,
+    description: null,
+    content: null,
+    contentType: 'article',
+    domain: 'example.com',
+    image: null,
+    wordCount: 400,
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    savedAt: '2026-02-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('savedItemLabelKeys', () => {
+  it('covers every key a surface can use as a display key', () => {
+    const item = save({ itemGuid: 'guid-1' });
+    expect(savedItemLabelKeys(item)).toEqual([
+      'guid-1',
+      'at://did:plc:test/app.skyreader.feed.saved/3kabcdefghijk',
+      'https://example.com/a',
+      '3kabcdefghijk',
+    ]);
+  });
+
+  it('drops empty aliases so an optimistic save (no uri yet) still resolves', () => {
+    expect(savedItemLabelKeys(save({ uri: '', itemGuid: undefined }))).toEqual([
+      'https://example.com/a',
+      '3kabcdefghijk',
+    ]);
+  });
+
+  it('keeps the guid first — callers take [0] as the primary key', () => {
+    expect(savedItemLabelKeys(save({ itemGuid: 'guid-1' }))[0]).toBe('guid-1');
+  });
+});
+
+describe('isSavedItemArchived', () => {
+  it('is true whichever alias the label landed under', () => {
+    const item = save({ itemGuid: 'guid-1' });
+    for (const key of savedItemLabelKeys(item)) {
+      expect(isSavedItemArchived(item, (k) => k === key)).toBe(true);
+    }
+  });
+
+  it('is false when nothing about the save is archived', () => {
+    expect(isSavedItemArchived(save({ itemGuid: 'guid-1' }), () => false)).toBe(false);
+  });
+
+  it('sees an archive written against the record uri by the `e` shortcut', () => {
+    // The list rows dual-write guid + uri; the keyboard path used to write the
+    // display key alone, and the list's guid-only test then kept showing an
+    // item Home had already dropped.
+    const item = save({ itemGuid: 'guid-1' });
+    const archived = new Set([item.uri]);
+    expect(isSavedItemArchived(item, (k) => archived.has(k))).toBe(true);
+  });
+});
+
+describe('savedAtMs', () => {
+  it('parses savedAt', () => {
+    expect(savedAtMs(save({ savedAt: '2026-02-01T00:00:00.000Z' }))).toBe(
+      Date.parse('2026-02-01T00:00:00.000Z')
+    );
+  });
+
+  it('sorts a missing or unparseable savedAt last rather than throwing NaN around', () => {
+    expect(savedAtMs(save({ savedAt: '' }))).toBe(0);
+    expect(savedAtMs(save({ savedAt: 'not a date' }))).toBe(0);
+  });
+});
+
+describe('compareSavedNewestFirst', () => {
+  it('orders by savedAt, newest first', () => {
+    const older = save({ rkey: 'a', savedAt: '2026-01-01T00:00:00.000Z' });
+    const newer = save({ rkey: 'b', savedAt: '2026-03-01T00:00:00.000Z' });
+    expect([older, newer].sort(compareSavedNewestFirst).map((s) => s.rkey)).toEqual(['b', 'a']);
+  });
+
+  it('does not fall back to rkey order, which only proxies save time', () => {
+    // An extension save, another device's clock, or a backed collection mints
+    // rkeys that do not line up with savedAt — the order the cache path used to
+    // hand Home.
+    const rows = [
+      save({ rkey: '3zzz', savedAt: '2026-01-01T00:00:00.000Z' }),
+      save({ rkey: '3aaa', savedAt: '2026-05-01T00:00:00.000Z' }),
+    ];
+    expect(rows.sort(compareSavedNewestFirst).map((s) => s.rkey)).toEqual(['3aaa', '3zzz']);
+  });
+
+  it('breaks savedAt ties on rkey so a bulk import lands in one stable order', () => {
+    const rows = [
+      save({ rkey: 'b', savedAt: '2026-01-01T00:00:00.000Z' }),
+      save({ rkey: 'c', savedAt: '2026-01-01T00:00:00.000Z' }),
+      save({ rkey: 'a', savedAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    expect(rows.sort(compareSavedNewestFirst).map((s) => s.rkey)).toEqual(['c', 'b', 'a']);
+    expect(
+      [...rows]
+        .reverse()
+        .sort(compareSavedNewestFirst)
+        .map((s) => s.rkey)
+    ).toEqual(['c', 'b', 'a']);
+  });
+});

--- a/frontend/src/lib/utils/savedPile.ts
+++ b/frontend/src/lib/utils/savedPile.ts
@@ -1,0 +1,62 @@
+import type { SavedItem } from '$lib/types';
+
+/**
+ * The saved pile's shared rules.
+ *
+ * Two surfaces render the same pile — the Saved list (`feedView`'s
+ * `computeSavedItems`) and Home's "Recently saved" lane — and they used to
+ * decide membership and order independently. Every rule they disagreed on was
+ * visible as the same item sitting in one surface and missing from the other,
+ * or the two showing different "newest" items. These helpers are the single
+ * definition both consume.
+ */
+
+/**
+ * Every key a save can carry a label under.
+ *
+ * One save is reachable by several identities: the feed item's guid, its
+ * atproto record uri, the article url, and the record rkey. Whichever one the
+ * surface writing an `archived` label happened to hold is the one the label
+ * landed on — the `e` shortcut writes the display key alone, while the list
+ * rows write the display key *and* the itemGuid. `rkey` belongs in the set
+ * because an optimistic save has no `uri` yet (`saveArticle` leaves it empty)
+ * and every display-key helper falls back to the rkey.
+ *
+ * Order matters: callers take `[0]` as the item's primary key.
+ */
+export function savedItemLabelKeys(item: SavedItem): string[] {
+  return [item.itemGuid, item.uri, item.url, item.rkey].filter(
+    (key): key is string => typeof key === 'string' && key.length > 0
+  );
+}
+
+/**
+ * The one archived test for a save. Testing a single key is what let the Home
+ * lane and the Saved list disagree about the same item: archive it with `e` in
+ * the list (which labels the record uri) and the list kept showing it while
+ * Home dropped it.
+ */
+export function isSavedItemArchived(
+  item: SavedItem,
+  isArchived: (key: string) => boolean
+): boolean {
+  return savedItemLabelKeys(item).some((key) => isArchived(key));
+}
+
+/** `savedAt` in epoch ms; 0 when missing or unparseable, so it sorts last. */
+export function savedAtMs(item: Pick<SavedItem, 'savedAt'>): number {
+  const ms = item.savedAt ? Date.parse(item.savedAt) : NaN;
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Newest-first by `savedAt` — what the Saved list's default sort means and what
+ * "Recently saved" claims to show. The rkey tie-break keeps a bulk import (a
+ * backed collection can stamp many rows with the same second) in one stable
+ * order instead of whatever order each surface happened to build its array in.
+ */
+export function compareSavedNewestFirst(a: SavedItem, b: SavedItem): number {
+  const diff = savedAtMs(b) - savedAtMs(a);
+  if (diff !== 0) return diff;
+  return (b.rkey || '').localeCompare(a.rkey || '');
+}

--- a/frontend/src/lib/utils/savedPile.ts
+++ b/frontend/src/lib/utils/savedPile.ts
@@ -55,11 +55,11 @@ export function isSavedItemArchived(
 export async function setSavedItemArchived(
   item: SavedItem,
   archived: boolean,
-  setArchived: (key: string, archived: boolean) => void | Promise<void>
+  setArchived: (key: string, archived: boolean) => void | Promise<void>,
+  additionalKeys: Iterable<string> = []
 ): Promise<void> {
-  for (const key of new Set(savedItemLabelKeys(item))) {
-    await setArchived(key, archived);
-  }
+  const keys = new Set([...savedItemLabelKeys(item), ...additionalKeys]);
+  await Promise.all([...keys].map((key) => setArchived(key, archived)));
 }
 
 /** `savedAt` in epoch ms; 0 when missing or unparseable, so it sorts last. */

--- a/frontend/src/lib/utils/savedPile.ts
+++ b/frontend/src/lib/utils/savedPile.ts
@@ -43,6 +43,25 @@ export function isSavedItemArchived(
   return savedItemLabelKeys(item).some((key) => isArchived(key));
 }
 
+/**
+ * Put every identity for a save into one archive state.
+ *
+ * Archive membership is true when any alias is archived, so toggling just the
+ * key a row happens to display cannot reliably undo it. In particular, an old
+ * URL- or rkey-backed label would keep the item in Archive after the row's
+ * guid/uri was unarchived. Callers provide the store mutation so this rule
+ * stays independently testable and every UI path uses the same alias set.
+ */
+export async function setSavedItemArchived(
+  item: SavedItem,
+  archived: boolean,
+  setArchived: (key: string, archived: boolean) => void | Promise<void>
+): Promise<void> {
+  for (const key of new Set(savedItemLabelKeys(item))) {
+    await setArchived(key, archived);
+  }
+}
+
 /** `savedAt` in epoch ms; 0 when missing or unparseable, so it sorts last. */
 export function savedAtMs(item: Pick<SavedItem, 'savedAt'>): number {
   const ms = item.savedAt ? Date.parse(item.savedAt) : NaN;

--- a/frontend/test/stubs/saved-pile-fixtures.svelte.ts
+++ b/frontend/test/stubs/saved-pile-fixtures.svelte.ts
@@ -1,0 +1,25 @@
+// Reactive fixtures for `savedPileConsistency.component.test.ts`.
+//
+// feedView's saved-list pipeline is a chain of `$derived` values, so a plain
+// module-level array behind a stand-in store is read once and cached forever —
+// every case after the first would assert against the previous case's list.
+// `$state` lives in a `.svelte.ts` module, which is why this sits here rather
+// than in the test file.
+import type { Article, FilteredView, SavedItem, SocialDocument } from '$lib/types';
+
+export const fixtures = $state({
+  saves: [] as SavedItem[],
+  articles: [] as Article[],
+  documents: [] as SocialDocument[],
+  archived: [] as string[],
+  /** The saved channel `?view=` resolves to, when a case needs one. */
+  channel: null as FilteredView | null,
+});
+
+export function resetFixtures() {
+  fixtures.saves = [];
+  fixtures.articles = [];
+  fixtures.documents = [];
+  fixtures.archived = [];
+  fixtures.channel = null;
+}


### PR DESCRIPTION
Home's "Recently saved" lane and the Saved list now share one definition of archive membership, save ordering, and canonical-URL identity.

This revision also resolves the review finding around alias-backed archive labels: archive/inbox actions now set one desired state across the resolved save's complete guid, record URI, URL, and rkey alias set. Saved-list controls, Home's reader, and the `e` shortcut all use the same operation, so URL-only or rkey-only archive labels can always be cleared when moving an item back to Inbox.

Additional regression coverage exercises URL-only and rkey-only unarchive state and de-duplicates aliases before mutation.

### Checks

- `npm run test` (frontend): 731 passing, 62 files
- `npm run check`: 0 errors, 18 pre-existing warnings; Prettier clean
- `npm run build`: passed with existing warnings

The Playwright suites were not run; the change is confined to frontend store/component logic and unit/component coverage.

[Radial artifact](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-kzmfszbcsoa7ooq3abeatfs7)
