### PR TITLE
docs: fix formatting and add PR-time docs CI

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,65 @@
+name: Docs CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+    # The workflow file is in the filter on purpose: a PR that only edits this
+    # file still has to run it.
+    paths: ['docs-site/**', '.github/workflows/docs-ci.yml']
+
+concurrency:
+  group: docs-ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: docs-site
+
+jobs:
+  typecheck:
+    name: Typecheck & Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # astro check + `prettier --check .`. docs-site/ is in the root
+      # .prettierignore because it owns its own Prettier config, so repo-ci's
+      # Format job never reaches these files. Until this job existed the only
+      # thing running the check was the deploy workflow, so a formatting miss
+      # got discovered on main by a failed production deploy.
+      - name: Run type check
+        run: npm run check
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -9,7 +9,7 @@ On [skyreader.app](https://skyreader.app), **Start Reading** opens a guest libra
 
 ![The Skyreader start page, with a Start Reading button that opens a guest library, no account needed](../../assets/screenshots/welcome.png)
 
-Logging in with an account allows you to add your own feeds, sync across devices, share to your linkblog, and save articles to Semble or Margin. 
+Logging in with an account allows you to add your own feeds, sync across devices, share to your linkblog, and save articles to Semble or Margin.
 
 ## Signing in
 

--- a/docs-site/src/content/docs/guide/reading.md
+++ b/docs-site/src/content/docs/guide/reading.md
@@ -15,19 +15,19 @@ Items you scroll past can be marked read automatically (a toggle in **Settings â
 
 ## The reader
 
-Opening an article gives you a clean, full-screen reading surface. 
+Opening an article gives you a clean, full-screen reading surface.
 
 ![The reader: a full-screen article with quiet chrome and a Discussion section at the end](../../../assets/screenshots/reader.png)
 
 - **Style customization** : change the font style and size.
-- **Paged mode**: a toggle in the reader switches from scrolling to page turns, one page at a time, or two columns side by side on a wide screen. 
+- **Paged mode**: a toggle in the reader switches from scrolling to page turns, one page at a time, or two columns side by side on a wide screen.
 - **Highlighting**: double-click a paragraph or select text. See [Saving and highlights](/guide/saving-and-highlights/).
 
 ![Paged mode: the same article flowed into two side-by-side columns, turned a page at a time](../../../assets/screenshots/paged-reader.png)
 
 ## Discussion
 
-Articles carry a **Discussion** section at the end that gathers what people across the Atmosphere have written about that link: linkblog notes, Leaflet comments, Bluesky posts, Margin annotations, Semble connections, merged into one stream. 
+Articles carry a **Discussion** section at the end that gathers what people across the Atmosphere have written about that link: linkblog notes, Leaflet comments, Bluesky posts, Margin annotations, Semble connections, merged into one stream.
 
 ## The daily magazine
 

--- a/docs-site/src/content/docs/guide/sharing-and-your-linkblog.md
+++ b/docs-site/src/content/docs/guide/sharing-and-your-linkblog.md
@@ -3,7 +3,7 @@ title: Sharing and your linkblog
 description: Post links with commentary to a public linkblog that's portable across the Atmosphere.
 ---
 
-Sharing in Skyreader means posting a link, with your commentary, to your **linkblog**: a public publication that anyone can read, follow, or subscribe to by RSS. 
+Sharing in Skyreader means posting a link, with your commentary, to your **linkblog**: a public publication that anyone can read, follow, or subscribe to by RSS.
 
 ## The composer
 
@@ -34,7 +34,7 @@ Your link posts are Atmosphere records, so other apps can render them too. On a 
 
 Changing either applies to new posts; posts you already published keep the shape they were written in.
 
-If you'd like your posts to say where they came from, turn on **Offer a "Posted from Skyreader" line when sharing**. That adds a checkbox to the composer. 
+If you'd like your posts to say where they came from, turn on **Offer a "Posted from Skyreader" line when sharing**. That adds a checkbox to the composer.
 
 ## What's public
 

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -3,7 +3,7 @@ title: What is Skyreader?
 description: A reading app that helps you make sense of what you read.
 ---
 
-Skyreader is a reading app. It gathers everything you want to read – blogs and news sites via RSS,  Atmospheric publications via standard.site, articles you find on the web – into one calm place.
+Skyreader is a reading app. It gathers everything you want to read – blogs and news sites via RSS, Atmospheric publications via standard.site, articles you find on the web – into one calm place.
 
 It runs on the AT Protocol, the open network behind Bluesky. That matters for one reason: your reading life is yours. You sign in with an account you own, and the parts of your data you choose to make portable work in any Atmospheric app, not just this one. See [Your data](/your-data/) for exactly what lives where.
 

--- a/docs-site/src/content/docs/your-data.md
+++ b/docs-site/src/content/docs/your-data.md
@@ -3,7 +3,7 @@ title: Your data
 description: What Skyreader stores, where it lives, and exactly what is public.
 ---
 
-The short version: **your reading is private to you by default.** A few things are public, or can be made public, so they're portable across the Atmosphere. 
+The short version: **your reading is private to you by default.** A few things are public, or can be made public, so they're portable across the Atmosphere.
 
 ## At a glance
 
@@ -30,11 +30,11 @@ Either way, you can walk away with your list at any time: **Settings → Import 
 
 Saves live on Skyreader, private to you. They are **not** stored on your PDS.
 
-The one way a save becomes public is choosing it: backing your Saved list with **Semble or Margin** (**Settings → Saved articles**) turns the list into a public collection in that app. 
+The one way a save becomes public is choosing it: backing your Saved list with **Semble or Margin** (**Settings → Saved articles**) turns the list into a public collection in that app.
 
 ## Highlights and notes
 
-Highlights are private to Skyreader and sync across your devices through Skyreader, not through your PDS. 
+Highlights are private to Skyreader and sync across your devices through Skyreader, not through your PDS.
 
 If you'd like to share a highlight publicly, you can share an individual highlight to **Margin**, which publishes that one highlight to your public PDS.
 


### PR DESCRIPTION
The Deploy Docs Site run on main failed its Type Check job: trailing whitespace on seven lines plus a double space in index.md, all landed by #454. Fixed with prettier --write.

It reached main because docs-site/ was the one package with no pull_request workflow. Its check ran only inside docs-deploy.yml (push to main), and repo-ci.yml's Format job can't cover it because docs-site/ is in the root .prettierignore, owning its own Prettier config. Adds docs-ci.yml, mirroring linkblog-ci.yml: astro check + prettier --check and an astro build on PRs touching docs-site/.