### PR TITLE
Rescue a stuck poller alarm, and stop paging on a stale firehose

### DIFF
--- a/backend/src/durable-objects/jetstream-poller.ts
+++ b/backend/src/durable-objects/jetstream-poller.ts
@@ -108,6 +108,46 @@ const MAX_PENDING_BACKFILLS = 200;
 // enough that a genuinely dead poller is caught within a couple of minutes.
 export const ALARM_ACTIVE_WINDOW_MS = 2 * ALARM_INTERVAL_MS;
 
+// How far past its scheduled time an alarm has to sit before `/start` stops
+// believing it and re-arms. A pending alarm whose time is in the past means
+// Cloudflare hasn't delivered it — either the invocation was terminated out from
+// under us (an object reset skips the `finally` that would have rescheduled) or
+// delivery stalled. Either way the poller is wedged and nothing else will notice:
+// `getAlarm()` is non-null, so the every-minute `/start` ping used to read it as
+// healthy and leave the firehose stopped until Cloudflare got around to it (a
+// 16-minute stall on 2026-09-10). Two intervals of slack keeps normal scheduling
+// jitter from re-arming a healthy alarm.
+export const STUCK_ALARM_GRACE_MS = 2 * ALARM_INTERVAL_MS;
+
+/** What the every-minute `/start` ping should do with the alarm state it found. */
+export type StartAction = 'started' | 'rearmed' | 'scheduled' | 'recently_active';
+
+/**
+ * The `/start` verdict, kept pure so the cases that matter can be tested without
+ * a Durable Object. Three of the four states were already here; `rearmed` is the
+ * one that was missing, and its absence is what let a stalled alarm sit for 16
+ * minutes on 2026-09-10 while the cron pinged past it every minute reading
+ * `scheduled`.
+ */
+export function decideStartAction(
+  alarmTime: number | null,
+  lastAlarmStart: number | null | undefined,
+  now: number
+): StartAction {
+  const recentlyActive =
+    typeof lastAlarmStart === 'number' && now - lastAlarmStart < ALARM_ACTIVE_WINDOW_MS;
+
+  // Nothing scheduled and nothing running: the original cold-start case.
+  if (alarmTime === null) return recentlyActive ? 'recently_active' : 'started';
+
+  // A scheduled alarm is evidence of life only while its time is still ahead of
+  // us, or a handler is plausibly mid-flight holding it. Past that, Cloudflare has
+  // not delivered it and nothing but this ping will.
+  if (now - alarmTime > STUCK_ALARM_GRACE_MS && !recentlyActive) return 'rearmed';
+
+  return 'scheduled';
+}
+
 // Two streams: `app.skyreader.feed.subscription`, and the standard.site document
 // pair (`site.standard.document` + its `app.standard-reader.collection` sidecar),
 // which lived here before it moved to the proxy and has now come back. Everything
@@ -245,21 +285,41 @@ class JetstreamPollerBase implements DurableObject {
         this.state.storage.get<number>('last_alarm_start'),
       ]);
 
-      const recentlyActive = lastAlarmStart && Date.now() - lastAlarmStart < ALARM_ACTIVE_WINDOW_MS;
+      const now = Date.now();
+      const action = decideStartAction(alarmTime, lastAlarmStart, now);
 
-      if (!alarmTime && !recentlyActive) {
-        // No alarm scheduled and none ran recently - start fresh
-        await this.state.storage.setAlarm(Date.now() + 100);
-        return new Response(JSON.stringify({ status: 'started' }), {
+      if (action === 'started' || action === 'rearmed') {
+        // setAlarm overwrites any pending alarm, so the same call both cold-starts
+        // a fresh object and replaces one Cloudflare never delivered.
+        await this.state.storage.setAlarm(now + 100);
+      }
+
+      if (action === 'rearmed') {
+        // The cycle that stalled left no trace of its own: it died before the
+        // `finally` in runPollCycle, and an object reset raises nothing our
+        // try/catch can see. This is the only place that knows it happened, so
+        // say so — a silent wedge is what made the 2026-09-10 stall an uptime
+        // page with no matching Sentry event to explain it.
+        const overdueMs = now - (alarmTime ?? now);
+        log.error('jetstream_alarm_stuck', {
+          overdueMs,
+          alarmTime,
+          lastAlarmStart: lastAlarmStart ?? null,
+        });
+        reportError(
+          new Error(`JetstreamPoller alarm overdue by ${Math.round(overdueMs / 1000)}s; re-armed`),
+          { tags: { source: 'jetstream-poller', phase: 'alarm-stuck' } }
+        );
+        return new Response(JSON.stringify({ status: action, overdueMs, alarmTime }), {
           headers: { 'Content-Type': 'application/json' },
         });
       }
 
       return new Response(
         JSON.stringify({
-          status: alarmTime ? 'scheduled' : 'recently_active',
+          status: action,
           nextPoll: alarmTime,
-          lastAlarmStart,
+          lastAlarmStart: lastAlarmStart ?? null,
         }),
         {
           headers: { 'Content-Type': 'application/json' },
@@ -274,6 +334,7 @@ class JetstreamPollerBase implements DurableObject {
         lastStats,
         alarmTime,
         lastAlarmStart,
+        lastAlarmEnd,
         subscriptionsLagMs,
         documentsLagMs,
       ] = await Promise.all([
@@ -282,6 +343,7 @@ class JetstreamPollerBase implements DurableObject {
         this.state.storage.get<PollStats>('last_stats'),
         this.state.storage.getAlarm(),
         this.state.storage.get<number>('last_alarm_start'),
+        this.state.storage.get<number>('last_alarm_end'),
         this.streamLag('subscriptions'),
         this.streamLag('documents'),
       ]);
@@ -309,6 +371,11 @@ class JetstreamPollerBase implements DurableObject {
           // routes/health.ts.
           isRunning: !!alarmTime,
           lastAlarmStart: lastAlarmStart ?? null,
+          // Paired with `lastAlarmStart`, this is what separates "mid-cycle" from
+          // "the cycle that started here never finished". An end older than the
+          // start means the alarm handler was terminated before its `finally` —
+          // the shape of the 2026-09-10 wedge.
+          lastAlarmEnd: lastAlarmEnd ?? null,
         }),
         {
           headers: { 'Content-Type': 'application/json' },
@@ -428,6 +495,17 @@ class JetstreamPollerBase implements DurableObject {
         // this one is worth a page rather than a log line.
         console.error('[JetstreamPoller] CRITICAL: Error scheduling next alarm:', error);
         reportError(error, { tags: { source: 'jetstream-poller', phase: 'alarm-scheduling' } });
+      }
+
+      // `last_alarm_end` is the completion half of `last_alarm_start`: with only
+      // the start, "a cycle is running right now" and "a cycle started and was
+      // killed before it could reschedule" are the same two numbers. Purely
+      // diagnostic, and in its own try after the reschedule so it can never be
+      // what costs the firehose its next cycle.
+      try {
+        await this.state.storage.put('last_alarm_end', Date.now());
+      } catch (error) {
+        log.error('jetstream_alarm_end_write_failed', { ...serializeError(error) });
       }
     }
   }

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -9,12 +9,14 @@ import { ALARM_ACTIVE_WINDOW_MS } from '../durable-objects/jetstream-poller';
 //   costing anything or becoming an amplification vector. It answers exactly one
 //   question: is this Worker serving, and which build is it serving?
 // - `/api/health/deep` does the real dependency checks and is therefore gated by
-//   a shared secret and rate-limited.
+//   a shared secret and rate-limited. It reports on all three dependencies but
+//   only 503s on the two a reader is served through.
 
 const DEEP_HEALTH_PATH = '/api/health/deep';
 
 // The poller's alarm re-arms every 60s. Anything past 5 minutes without a
-// completed poll means it's wedged, not merely between cycles.
+// completed poll means it's wedged, not merely between cycles. This grades
+// `checks.poller.ok` in the body; it is not a 503 condition (see `healthy` below).
 const POLLER_STALE_MS = 5 * 60 * 1000;
 
 // Dependency checks are for a monitor with a timeout of its own; fail fast rather
@@ -111,6 +113,7 @@ async function checkPoller(env: Env): Promise<CheckResult> {
       nextPoll?: number | null;
       isRunning?: boolean;
       lastAlarmStart?: number | null;
+      lastAlarmEnd?: number | null;
     };
 
     const lastPollAt = status.lastStats?.lastPollAt;
@@ -128,11 +131,26 @@ async function checkPoller(env: Env): Promise<CheckResult> {
     const recentlyActive = alarmStart !== null && Date.now() - alarmStart < ALARM_ACTIVE_WINDOW_MS;
     const running = Boolean(status.isRunning) || recentlyActive;
 
+    // A cycle that started and never wrote its end marker was terminated before
+    // its `finally` — the poller is wedged rather than merely mid-poll. Reported
+    // so the body says which of the two a stale `lastPollAgeMs` is.
+    //
+    // The `recentlyActive` gate is what makes that distinction true: a missing end
+    // marker is the *normal* state for the 5–16s a cycle is in flight, and a probe
+    // lands in that window often enough that reporting it as unfinished would be a
+    // false positive on a healthy poller several times an hour. Only once the
+    // start marker is older than a plausible cycle does an absent end mean killed.
+    const alarmEnd = typeof status.lastAlarmEnd === 'number' ? status.lastAlarmEnd : null;
+    const cycleUnfinished =
+      alarmStart !== null && !recentlyActive && (alarmEnd === null || alarmEnd < alarmStart);
+
     return {
       ok: running && fresh,
       isRunning: running,
       alarmScheduled: Boolean(status.isRunning),
       lastAlarmAgeMs: alarmStart === null ? null : Date.now() - alarmStart,
+      lastAlarmEndAgeMs: alarmEnd === null ? null : Date.now() - alarmEnd,
+      cycleUnfinished,
       lastPollAgeMs,
       nextPoll: status.nextPoll ?? null,
     };
@@ -167,8 +185,10 @@ async function checkFeedProxy(env: Env): Promise<CheckResult> {
 }
 
 /**
- * Deep health: one URL that answers "is everything up". Returns 503 when any
- * dependency is unhealthy so an uptime monitor alerts on it directly.
+ * Deep health: one URL that answers "is everything up". Returns 503 when a
+ * dependency users are reading through is unhealthy, so an uptime monitor alerts
+ * on it directly. `checks.poller` is reported but does not affect the status code
+ * — see the note at the `healthy` line below.
  */
 export async function handleDeepHealth(request: Request, env: Env): Promise<Response> {
   const expected = env.HEALTH_CHECK_SECRET;
@@ -200,15 +220,30 @@ export async function handleDeepHealth(request: Request, env: Env): Promise<Resp
     checkFeedProxy(env),
   ]);
 
-  const healthy = database.ok && poller.ok && feedProxy.ok;
+  // Two verdicts on purpose, because they answer different questions.
+  //
+  // `status` stays honest about every dependency, so a human reading the body
+  // during triage sees "degraded" whenever anything is off.
+  //
+  // The status **code** is the paging decision, and the poller deliberately isn't
+  // part of it. A wedged firehose delays PDS-mirrored subscriptions and new
+  // standard.site documents; feeds, the timeline and every read path come from D1
+  // and the Fly crawler, so nobody's reading breaks and there is nothing to do at
+  // 3am. Per RUNBOOK §8 that makes it warning-class, which is what
+  // `firehose_lag_high` already is — folding it into the 503 paged the whole team
+  // for it anyway, and at a tighter threshold (5 min) than the Sentry alert it was
+  // kept quieter than (15 min). So a stale poller reads `200 degraded`: reported,
+  // visible on the admin ops tiles, not a phone call.
+  const allOk = database.ok && poller.ok && feedProxy.ok;
+  const serving = database.ok && feedProxy.ok;
 
   return json(
     {
-      status: healthy ? 'ok' : 'degraded',
+      status: allOk ? 'ok' : 'degraded',
       version: getVersion(env),
       timestamp: Date.now(),
       checks: { database, poller, feedProxy },
     },
-    healthy ? 200 : 503
+    serving ? 200 : 503
   );
 }

--- a/backend/test/health.spec.ts
+++ b/backend/test/health.spec.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { handleDeepHealth } from '../src/routes/health';
 
 const SECRET = 'correct-horse-battery-staple';
@@ -112,9 +112,12 @@ describe('health endpoints', () => {
       expect(body.checks!.database.ok).toBe(true);
       expect(body.checks!.poller).toBeDefined();
       expect(body.checks!.feedProxy).toBeDefined();
+      // `status` grades every dependency; the status code grades only the two a
+      // reader is served through — see the paging tests below.
       const allOk = body.checks!.database.ok && body.checks!.poller.ok && body.checks!.feedProxy.ok;
+      const serving = body.checks!.database.ok && body.checks!.feedProxy.ok;
       expect(body.status).toBe(allOk ? 'ok' : 'degraded');
-      expect(response.status).toBe(allOk ? 200 : 503);
+      expect(response.status).toBe(serving ? 200 : 503);
     });
 
     // The DO reports `isRunning: !!getAlarm()`, and getAlarm() is null for the
@@ -167,6 +170,116 @@ describe('health endpoints', () => {
 
         expect(poller.ok).toBe(true);
         expect(poller.lastPollAgeMs).toBeNull();
+      });
+
+      // A cycle that started and never wrote its end marker was killed before its
+      // `finally` — the wedge shape. Both halves are surfaced so the body says
+      // which kind of staleness this is instead of leaving it to be guessed.
+      it('flags a cycle that started and never finished', async () => {
+        const start = Date.now() - 9 * 60_000;
+        const poller = await pollerCheck({
+          isRunning: true,
+          nextPoll: start,
+          lastAlarmStart: start,
+          lastAlarmEnd: start - 60_000,
+          lastStats: { lastPollAt: start - 68_000 },
+        });
+
+        expect(poller.cycleUnfinished).toBe(true);
+        expect(poller.ok).toBe(false);
+      });
+
+      it('does not flag a cycle that completed', async () => {
+        const poller = await pollerCheck({
+          isRunning: true,
+          nextPoll: Date.now() + 30_000,
+          lastAlarmStart: Date.now() - 30_000,
+          lastAlarmEnd: Date.now() - 25_000,
+          lastStats: { lastPollAt: Date.now() - 30_000 },
+        });
+
+        expect(poller.cycleUnfinished).toBe(false);
+        expect(poller.ok).toBe(true);
+      });
+
+      // The end marker is absent for the whole time a cycle is in flight, which is
+      // several seconds of every minute. Flagging that would make `cycleUnfinished`
+      // fire on a healthy poller far more often than on a wedged one.
+      it('does not flag a cycle that is still in flight', async () => {
+        const poller = await pollerCheck({
+          isRunning: false,
+          nextPoll: null,
+          lastAlarmStart: Date.now() - 3000,
+          lastAlarmEnd: Date.now() - 63_000,
+          lastStats: { lastPollAt: Date.now() - 60_000 },
+        });
+
+        expect(poller.cycleUnfinished).toBe(false);
+        expect(poller.ok).toBe(true);
+      });
+
+      // A brand-new storage key: on the first probe after the deploy that added
+      // `last_alarm_end`, a perfectly healthy poller has a start and no end.
+      it('does not flag a healthy poller that has never written an end marker', async () => {
+        const poller = await pollerCheck({
+          isRunning: true,
+          nextPoll: Date.now() + 30_000,
+          lastAlarmStart: Date.now() - 30_000,
+          lastStats: { lastPollAt: Date.now() - 30_000 },
+        });
+
+        expect(poller.cycleUnfinished).toBe(false);
+        expect(poller.ok).toBe(true);
+      });
+    });
+
+    // Per RUNBOOK §8 a wedged firehose is warning-class: reads are served from D1
+    // and the Fly crawler, so nothing a user is doing breaks and there is nothing
+    // to do at 3am. It stays in the body; it must not page.
+    describe('poller staleness does not page', () => {
+      it('keeps a 200 when the poller is stale but D1 and the proxy are fine', async () => {
+        const stale = Date.now() - 10 * 60_000;
+        const wedgedEnv = envWithPollerStatus({
+          isRunning: true,
+          nextPoll: Date.now() - 9 * 60_000,
+          lastAlarmStart: Date.now() - 9 * 60_000,
+          lastStats: { lastPollAt: stale },
+        });
+
+        // The proxy isn't reachable from the test worker, so stub its /health.
+        // Without a green proxy the 503 could come from either dependency and the
+        // assertion would prove nothing.
+        const realFetch = globalThis.fetch;
+        const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+          const href = typeof input === 'string' ? input : (input as Request).url;
+          if (href.endsWith('/health')) {
+            return new Response(JSON.stringify({ cachedFeeds: 1, version: 'test' }), {
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return realFetch(input as RequestInfo, init);
+        });
+
+        try {
+          const response = await handleDeepHealth(
+            new Request('http://localhost/api/health/deep', {
+              headers: { 'X-Health-Secret': SECRET },
+            }),
+            wedgedEnv
+          );
+          const body = (await response.json()) as HealthBody;
+
+          expect(body.checks!.poller.ok).toBe(false);
+          expect(body.checks!.poller.lastPollAgeMs).toBeGreaterThan(5 * 60_000);
+          expect(body.checks!.database.ok).toBe(true);
+          expect(body.checks!.feedProxy.ok).toBe(true);
+          // The whole point: a wedged firehose is reported, not paged. The body
+          // stays honest for whoever reads it; only the status code goes quiet.
+          expect(response.status).toBe(200);
+          expect(body.status).toBe('degraded');
+        } finally {
+          spy.mockRestore();
+        }
       });
     });
   });

--- a/backend/test/jetstream-start.spec.ts
+++ b/backend/test/jetstream-start.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideStartAction,
+  ALARM_ACTIVE_WINDOW_MS,
+  STUCK_ALARM_GRACE_MS,
+} from '../src/durable-objects/jetstream-poller';
+
+// The every-minute cron pings /start to keep the firehose alive. What it does
+// with the alarm state it finds is the whole liveness story, and it had a hole:
+// on 2026-09-10 an alarm fired, its invocation was terminated before the
+// `finally` that reschedules, and Cloudflare then sat on the undelivered alarm
+// for 16 minutes. `getAlarm()` stayed non-null the whole time, so every ping read
+// it as "scheduled" and left the poller stopped. A pending alarm whose time is in
+// the past is not evidence of life.
+
+const NOW = 1_700_000_000_000;
+
+describe('decideStartAction', () => {
+  it('cold-starts an object with no alarm and no recent cycle', () => {
+    expect(decideStartAction(null, null, NOW)).toBe('started');
+    expect(decideStartAction(null, undefined, NOW)).toBe('started');
+    expect(decideStartAction(null, NOW - 10 * 60_000, NOW)).toBe('started');
+  });
+
+  it('leaves a mid-flight cycle alone', () => {
+    // getAlarm() is null for the several seconds a handler runs. Re-arming here
+    // would start a second cycle on top of the one already working.
+    expect(decideStartAction(null, NOW - 3_000, NOW)).toBe('recently_active');
+    expect(decideStartAction(null, NOW - (ALARM_ACTIVE_WINDOW_MS - 1), NOW)).toBe(
+      'recently_active'
+    );
+  });
+
+  it('leaves an alarm scheduled in the future alone', () => {
+    expect(decideStartAction(NOW + 30_000, NOW - 30_000, NOW)).toBe('scheduled');
+  });
+
+  it('tolerates an alarm slightly past its time', () => {
+    // Normal delivery jitter and a slow cycle both land here; re-arming on this
+    // would fight the poller instead of rescuing it.
+    expect(decideStartAction(NOW - 1_000, NOW - 61_000, NOW)).toBe('scheduled');
+    expect(decideStartAction(NOW - STUCK_ALARM_GRACE_MS, NOW - 10 * 60_000, NOW)).toBe('scheduled');
+  });
+
+  it('re-arms an alarm that is long overdue', () => {
+    // The 2026-09-10 shape: the alarm fired at its scheduled time, the cycle died
+    // before rescheduling, and nine minutes later the same alarm was still
+    // pending with the same last_alarm_start.
+    const alarmTime = NOW - 9 * 60_000;
+    expect(decideStartAction(alarmTime, alarmTime, NOW)).toBe('rearmed');
+  });
+
+  it('waits out the active window before re-arming an overdue alarm', () => {
+    // A cycle that started recently may still be running and holding the alarm.
+    // Staleness has to outlast that window before it means "wedged".
+    const alarmTime = NOW - 9 * 60_000;
+    expect(decideStartAction(alarmTime, NOW - 5_000, NOW)).toBe('scheduled');
+  });
+
+  it('recovers within one cron tick once the poller is wedged', () => {
+    // The property that matters: from the moment staleness is unambiguous, the
+    // next ping re-arms. That caps a wedge at a cron interval instead of leaving
+    // it to Cloudflare's own delivery.
+    const alarmTime = NOW;
+    const firstUnambiguousPing = alarmTime + STUCK_ALARM_GRACE_MS + 1;
+    expect(decideStartAction(alarmTime, alarmTime, firstUnambiguousPing)).toBe('rearmed');
+  });
+});

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -15,23 +15,23 @@ it rather than learning to ignore it.
 
 ## 1. What's instrumented
 
-| Surface                     | Signal                                | Where it lives                                    |
-| --------------------------- | ------------------------------------- | ------------------------------------------------- |
-| Backend Worker              | `GET /api/health`                     | Shallow: status, version, timestamp. No deps.     |
-| Backend Worker              | `GET /api/health/deep`                | D1 + poller lag + feed proxy. Secret-gated.       |
-| Backend Worker              | Sentry (`@sentry/cloudflare`)         | Exceptions from `fetch`, `scheduled`, DO alarm.   |
-| Backend Worker              | Structured logs (Workers Logs)        | One JSON object per event, keyed by `requestId`.  |
-| Backend cron (every minute) | Heartbeat ping (`HEARTBEAT_URL`)      | Dead-man's switch; also guards the firehose.      |
-| Feed proxy                  | `GET /health`                         | Status, version, cached feed count. No auth.      |
-| Feed proxy                  | `GET /stats`                          | Cache freshness, per-feed errors, ingest backlog. |
-| Feed proxy                  | Sentry (`@sentry/bun`)                | Route escapes, warmer failures.                   |
-| Feed proxy warmer           | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.              |
-| Backend cron (every minute) | `system_status` rows (D1)             | Cron liveness, poller lag, proxy cache stats.     |
-| Backend cron (hourly)       | `metrics_snapshots` rows (D1)         | One trend point per hour, pruned at 90 days.      |
-| Admin dashboard             | Ops tiles + 30-day sparklines         | The same rows, rendered. No token, works locally. |
-| Frontend PWA                | `POST /api/telemetry/error`           | Sampled client errors, forwarded to Sentry.       |
-| Frontend PWA                | Settings → Diagnostics                | On-device state. Sent nowhere; read by a human.   |
-| All deploys                 | `scripts/smoke-check.mjs`             | Post-deploy assertion against production.         |
+| Surface                     | Signal                                | Where it lives                                      |
+| --------------------------- | ------------------------------------- | --------------------------------------------------- |
+| Backend Worker              | `GET /api/health`                     | Shallow: status, version, timestamp. No deps.       |
+| Backend Worker              | `GET /api/health/deep`                | D1 + feed proxy 503; poller reported. Secret-gated. |
+| Backend Worker              | Sentry (`@sentry/cloudflare`)         | Exceptions from `fetch`, `scheduled`, DO alarm.     |
+| Backend Worker              | Structured logs (Workers Logs)        | One JSON object per event, keyed by `requestId`.    |
+| Backend cron (every minute) | Heartbeat ping (`HEARTBEAT_URL`)      | Dead-man's switch; also guards the firehose.        |
+| Feed proxy                  | `GET /health`                         | Status, version, cached feed count. No auth.        |
+| Feed proxy                  | `GET /stats`                          | Cache freshness, per-feed errors, ingest backlog.   |
+| Feed proxy                  | Sentry (`@sentry/bun`)                | Route escapes, warmer failures.                     |
+| Feed proxy warmer           | Heartbeat ping (`WARM_HEARTBEAT_URL`) | Dead-man's switch for the warm loop.                |
+| Backend cron (every minute) | `system_status` rows (D1)             | Cron liveness, poller lag, proxy cache stats.       |
+| Backend cron (hourly)       | `metrics_snapshots` rows (D1)         | One trend point per hour, pruned at 90 days.        |
+| Admin dashboard             | Ops tiles + 30-day sparklines         | The same rows, rendered. No token, works locally.   |
+| Frontend PWA                | `POST /api/telemetry/error`           | Sampled client errors, forwarded to Sentry.         |
+| Frontend PWA                | Settings → Diagnostics                | On-device state. Sent nowhere; read by a human.     |
+| All deploys                 | `scripts/smoke-check.mjs`             | Post-deploy assertion against production.           |
 
 Deliberately absent: per-user client telemetry (no page views, no session replay,
 no third-party SDK in the browser bundle), distributed tracing, and log shipping.
@@ -67,8 +67,24 @@ app itself is broken. It catches Cloudflare being down and nothing else. Give th
 prober an Access service token if you want it to mean more.
 
 The deep check needs the header `X-Health-Secret: <HEALTH_CHECK_SECRET>`. It
-returns **503 with a per-dependency breakdown** when anything is down, so it
-alerts on its own status code — no response-body assertion needed.
+returns **503 with a per-dependency breakdown** when a dependency users read
+through is down, so it alerts on its own status code — no response-body assertion
+needed.
+
+`checks.poller` is reported in that breakdown but **deliberately does not affect
+the status code**. A wedged firehose delays PDS-mirrored subscriptions and new
+standard.site documents; feeds, the timeline and every read path are served from
+D1 and the Fly crawler, so no reader is affected and there is nothing to do about
+it at 3am. Per §8 that makes it warning-class, which is what `firehose_lag_high`
+already is — folding it into the 503 paged the whole team for it anyway, and at a
+tighter threshold (5 min) than the Sentry alert it was deliberately kept quieter
+than (15 min).
+
+So the body and the status code answer different questions, and a stale poller
+reads **`200` with `"status": "degraded"`**: `status` still grades all three
+dependencies for whoever is reading the body, while only D1 and the feed proxy
+decide the code. Keep the uptime check asserting on the **code**; a body assertion
+on `status` would put the page straight back.
 
 "2 consecutive failures" everywhere: a single failed probe is usually the prober,
 not us.
@@ -177,11 +193,11 @@ Sentry for a spike.
 ```
 
 - `database.ok = false` → D1 is unavailable or slow (>3s). Check Cloudflare status.
-- `poller.ok = false` → the JetstreamPoller DO is stopped, or its last completed
-  poll is >5 min old. The every-minute cron re-pings `/start` automatically, so
-  first confirm the cron heartbeat is alive; if the cron is healthy and the poller
-  still isn't, redeploy the backend to recycle the DO.
 - `feedProxy.ok = false` → see below.
+
+Only those two decide the status code, so `poller.ok = false` is never why this
+is 503ing — a stale poller alone returns `200 degraded`. For that one see
+`jetstream_alarm_stuck` below.
 
 ### `backend-cron` heartbeat missed
 
@@ -214,6 +230,38 @@ restart fast, not to prevent the outage.
 **Check:** the Pages dashboard for the project's latest deployment.
 **Fix:** roll back to the previous deployment in the dashboard, or re-run the
 deploy workflow.
+
+### `jetstream_alarm_stuck` (Sentry exception, `phase: alarm-stuck`)
+
+**Means:** the every-minute `/start` ping found the poller's alarm scheduled for a
+time more than **2 minutes in the past** and re-armed it. The poller had stopped;
+it is running again by the time you read this.
+
+**Why it happens:** the alarm handler writes `last_alarm_start`, runs the cycle,
+and reschedules in a `finally`. If the invocation is terminated out from under us
+— an object reset, an eviction — that `finally` never runs and nothing our
+try/catch can see is raised. The alarm stays pending in Cloudflare's scheduler
+with a time in the past, and until this check existed `/start` read any non-null
+`getAlarm()` as healthy and pinged past it every minute. Recovery then waited on
+Cloudflare's own delivery: on 2026-09-10 that took **16 minutes**.
+
+**Check:** the event's `overdueMs` says how long the stall ran. In `/status` (and
+in the deep-health body) `cycleUnfinished: true` is the fingerprint of a cycle
+killed mid-flight: a start marker older than two alarm intervals with no matching
+end. A cycle simply running right now does not set it. Note it only holds while
+the poller is still wedged — once the re-arm lands, the next completed cycle
+writes an end marker and the flag clears, so an absent flag after recovery says
+nothing. Read it live during a stall, not after the fact; `overdueMs` on the event
+is the durable record.
+
+**Fix:** none needed for a single event; the re-arm _is_ the fix and it caps a
+stall at one cron tick. What warrants action is **frequency**: several a day means
+cycles are dying rather than Cloudflare being slow. Look for what the cycle was
+doing — `event = jetstream_poll` durations trending up, D1 `object to be reset`
+errors, or a subrequest budget being exhausted — rather than at the alarm.
+
+**Does not page.** It is a Sentry issue, not a phone call: by the time it fires
+the poller is already running again.
 
 ### `firehose_lag_high` (Sentry message, not an exception)
 
@@ -1043,7 +1091,8 @@ regression. The steady state to protect is a quiet phone that you still trust.
 
 ### Pruning log
 
-| Date        | Change                                                                                                  | Why                                                                                                                                                                                    |
-| ----------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-03  | `proxy-document-cache-frozen`: threshold `frozen > 0` → 3 authors or 25% of active; re-alert 30m → 24h. | One stuck author fired 93 events over two days with no action available. Root cause fixed in the proxy the same day (the re-list floor was only checked on the firehose-covered path). |
-| _(pending)_ | First pass due 2–4 weeks after the §2 checks are configured.                                            | —                                                                                                                                                                                      |
+| Date        | Change                                                                                                                                               | Why                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-09-03  | `proxy-document-cache-frozen`: threshold `frozen > 0` → 3 authors or 25% of active; re-alert 30m → 24h.                                              | One stuck author fired 93 events over two days with no action available. Root cause fixed in the proxy the same day (the re-list floor was only checked on the firehose-covered path).                                                                                                                                                                                                                                     |
+| 2026-09-10  | `API (deep)`: `checks.poller` no longer affects the status code. Firehose staleness is reported in the body and alerted by `firehose_lag_high` only. | Recurring 10–15 min pages that resolved themselves, all from a wedged poller while D1, the proxy and every read path were fine. Nothing was broken for a reader and there was nothing to do at 3am, so by §8 it never qualified to page — and it was paging at 5 min against a Sentry alert deliberately set at 15. Root cause fixed the same day: `/start` now re-arms an overdue alarm instead of reading it as healthy. |
+| _(pending)_ | First pass due 2–4 weeks after the §2 checks are configured.                                                                                         | —                                                                                                                                                                                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
Recurring 10-15 minute uptime pages that resolved themselves, all traced to the same shape. On 2026-09-10 the alarm scheduled for 18:54:36.323 fired, wrote last_alarm_start, and its invocation was terminated before the finally that reschedules. Nine minutes later getAlarm() still returned that same past time, so the every-minute cron ping read it as "scheduled" and did nothing. Recovery waited on Cloudflare's own delivery: 16 minutes. No Sentry event, because an object reset raises nothing runPollCycle's try/catch can see.

/start now re-arms an alarm more than two intervals past its scheduled time, which caps a wedge at one cron tick, and reports it as phase: alarm-stuck so the next one leaves a trace. The decision moves into a pure decideStartAction() alongside streamLagMs and decideLagAlert. A last_alarm_end marker separates "mid-cycle" from "the cycle that started here never finished"; it is written after the reschedule so a diagnostic put can never cost the firehose its next cycle.

Deep health drops the poller from the status code. A wedged firehose delays PDS-mirrored subscriptions and new standard.site documents, while feeds, the timeline and every read path come from D1 and the Fly crawler, so no reader is affected and there is nothing to do at 3am. Per RUNBOOK section 8 that is warning-class, which is what firehose_lag_high already is, and folding it into the 503 paged the whole team anyway at a tighter threshold (5 min) than the Sentry alert it was kept quieter than (15 min). The body stays honest: status still grades all three checks, so a stale poller reads 200 with "degraded".