### PR TITLE
Add saved item provenance labels

### DIFF
--- a/backend/migrations/0079_saved_provenance.sql
+++ b/backend/migrations/0079_saved_provenance.sql
@@ -1,0 +1,3 @@
+ALTER TABLE saved_articles ADD COLUMN saved_via TEXT;
+ALTER TABLE saved_articles ADD COLUMN saved_from_title TEXT;
+ALTER TABLE saved_articles ADD COLUMN saved_from_url TEXT;

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -26,6 +26,8 @@ const COLLECTION = 'app.skyreader.feed.saved';
 
 // Conservative cap on bound parameters per D1 statement (see reading.ts).
 const BODIES_SQL_PARAMS = 90;
+type SavedVia = 'web' | 'extension' | 'share-target' | 'reader';
+const CLIENT_SAVED_VIA = new Set<SavedVia>(['web', 'extension', 'share-target', 'reader']);
 
 interface SavedRow {
   id: number;
@@ -46,6 +48,9 @@ interface SavedRow {
   created_at: number;
   source: string;
   item_guid: string | null;
+  saved_via: string | null;
+  saved_from_title: string | null;
+  saved_from_url: string | null;
 }
 
 interface CreateSavedBody {
@@ -67,6 +72,9 @@ interface CreateSavedBody {
   // extension, whose live-DOM extraction can see paywalled/JS-rendered content
   // the server-side extractor can't.
   updateContent?: boolean;
+  savedVia?: SavedVia;
+  savedFromTitle?: string;
+  savedFromUrl?: string;
 }
 
 // POST /api/saved — save an item from a URL or feed article
@@ -121,6 +129,32 @@ export async function handleCreateSaved(
 
   if (!body.rkey || !isValidRkey(body.rkey)) {
     return invalidRkeyResponse();
+  }
+
+  // Provenance is optional and intentionally tolerant of older/modified clients:
+  // unknown channels are discarded, while malformed supplied referrers are rejected.
+  if (!CLIENT_SAVED_VIA.has(body.savedVia as SavedVia)) body.savedVia = undefined;
+  if (typeof body.savedFromTitle === 'string') {
+    body.savedFromTitle = body.savedFromTitle.trim().slice(0, 300) || undefined;
+  } else {
+    body.savedFromTitle = undefined;
+  }
+  if (body.savedFromUrl !== undefined) {
+    if (typeof body.savedFromUrl !== 'string' || body.savedFromUrl.length > 2048) {
+      return new Response(JSON.stringify({ error: 'Invalid savedFromUrl' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    try {
+      const referrer = new URL(body.savedFromUrl);
+      if (!['http:', 'https:', 'at:'].includes(referrer.protocol)) throw new Error();
+    } catch {
+      return new Response(JSON.stringify({ error: 'Invalid savedFromUrl' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
   }
 
   // Validate URL only for url/feed sources
@@ -257,8 +291,8 @@ async function handleMetadataSave(
   // save) is stored here, not in the PDS record — same split as URL saves — so
   // the saved item stays readable after the source article ages out of the feed.
   await env.DB.prepare(
-    `INSERT INTO saved_articles (user_did, rkey, record_uri, url, title, author, description, content, content_type, domain, image, word_count, published_at, saved_at, created_at, source, item_guid)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO saved_articles (user_did, rkey, record_uri, url, title, author, description, content, content_type, domain, image, word_count, published_at, saved_at, created_at, source, item_guid, saved_via, saved_from_title, saved_from_url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       session.did,
@@ -277,7 +311,10 @@ async function handleMetadataSave(
       now,
       now,
       source,
-      body.itemGuid || null
+      body.itemGuid || null,
+      body.savedVia || null,
+      body.savedFromTitle || null,
+      body.savedFromUrl || null
     )
     .run();
 
@@ -298,6 +335,9 @@ async function handleMetadataSave(
       savedAt,
       source,
       itemGuid: body.itemGuid || null,
+      savedVia: body.savedVia || null,
+      savedFromTitle: body.savedFromTitle || null,
+      savedFromUrl: body.savedFromUrl || null,
     }),
     { headers: { 'Content-Type': 'application/json' } }
   );
@@ -370,8 +410,8 @@ async function handleUrlSave(
 
   // Cache in D1 (content is stored here, not in PDS)
   await env.DB.prepare(
-    `INSERT INTO saved_articles (user_did, rkey, record_uri, url, title, author, description, content, content_type, domain, image, word_count, published_at, saved_at, created_at, source)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO saved_articles (user_did, rkey, record_uri, url, title, author, description, content, content_type, domain, image, word_count, published_at, saved_at, created_at, source, saved_via, saved_from_title, saved_from_url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       session.did,
@@ -389,7 +429,10 @@ async function handleUrlSave(
       publishedAt ? new Date(publishedAt).getTime() : null,
       now,
       now,
-      'url'
+      'url',
+      body.savedVia || null,
+      body.savedFromTitle || null,
+      body.savedFromUrl || null
     )
     .run();
 
@@ -397,6 +440,9 @@ async function handleUrlSave(
     JSON.stringify({
       uri: recordUri,
       savedAt,
+      savedVia: body.savedVia || null,
+      savedFromTitle: body.savedFromTitle || null,
+      savedFromUrl: body.savedFromUrl || null,
     }),
     { headers: { 'Content-Type': 'application/json' } }
   );
@@ -467,8 +513,9 @@ async function handleBackedSave(
     env.DB.prepare(
       `INSERT INTO saved_articles
          (user_did, rkey, record_uri, url, url_normalized, title, author, description, content,
-          content_type, domain, image, word_count, published_at, saved_at, created_at, source, item_guid)
-       VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          content_type, domain, image, word_count, published_at, saved_at, created_at, source, item_guid,
+          saved_via, saved_from_title, saved_from_url)
+       VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(user_did, url_normalized) DO UPDATE SET
          rkey = excluded.rkey,
          title = COALESCE(excluded.title, title),
@@ -482,6 +529,9 @@ async function handleBackedSave(
          published_at = COALESCE(excluded.published_at, published_at),
          source = excluded.source,
          item_guid = COALESCE(excluded.item_guid, item_guid),
+         saved_via = COALESCE(saved_via, excluded.saved_via),
+         saved_from_title = COALESCE(saved_from_title, excluded.saved_from_title),
+         saved_from_url = COALESCE(saved_from_url, excluded.saved_from_url),
          saved_at = excluded.saved_at`
     ).bind(
       session.did,
@@ -500,7 +550,10 @@ async function handleBackedSave(
       now,
       now,
       source,
-      body.itemGuid || canonicalAtUri || null
+      body.itemGuid || canonicalAtUri || null,
+      body.savedVia || null,
+      body.savedFromTitle || null,
+      body.savedFromUrl || null
     ),
     env.DB.prepare(
       `INSERT INTO backed_collection_members
@@ -538,6 +591,9 @@ async function handleBackedSave(
       content: body.content || null,
       contentType,
       domain: body.domain || null,
+      savedVia: body.savedVia || null,
+      savedFromTitle: body.savedFromTitle || null,
+      savedFromUrl: body.savedFromUrl || null,
       image: body.image || null,
       wordCount: body.wordCount || null,
       publishedAt,
@@ -833,7 +889,8 @@ export async function handleGetSaved(
     // already has bodies cached. Fresh rkeys are hydrated via /api/saved/bodies.
     const result = await env.DB.prepare(
       `SELECT id, rkey, record_uri, url, title, author, description, content_type, domain, image,
-              word_count, published_at, saved_at, created_at, source, item_guid
+              word_count, published_at, saved_at, created_at, source, item_guid,
+              saved_via, saved_from_title, saved_from_url
        FROM saved_articles WHERE ${where} ORDER BY saved_at DESC, id DESC LIMIT ?`
     )
       .bind(...bindings)
@@ -854,6 +911,9 @@ export async function handleGetSaved(
       savedAt: new Date(row.saved_at).toISOString(),
       source: row.source || 'url',
       itemGuid: row.item_guid,
+      savedVia: row.saved_via,
+      savedFromTitle: row.saved_from_title,
+      savedFromUrl: row.saved_from_url,
     }));
 
     // A full page means there may be more — hand back a cursor pointing past the

--- a/backend/src/routes/saved.ts
+++ b/backend/src/routes/saved.ts
@@ -26,8 +26,51 @@ const COLLECTION = 'app.skyreader.feed.saved';
 
 // Conservative cap on bound parameters per D1 statement (see reading.ts).
 const BODIES_SQL_PARAMS = 90;
-type SavedVia = 'web' | 'extension' | 'share-target' | 'reader';
-const CLIENT_SAVED_VIA = new Set<SavedVia>(['web', 'extension', 'share-target', 'reader']);
+// The provenance channels a client may claim. 'semble'/'margin' also live in the
+// column but are written by the backing poll, never accepted from a request.
+type SavedVia = 'web' | 'extension' | 'share-target' | 'bookmarklet' | 'reader';
+const CLIENT_SAVED_VIA = new Set<SavedVia>([
+  'web',
+  'extension',
+  'share-target',
+  'bookmarklet',
+  'reader',
+]);
+const MAX_SAVED_FROM_TITLE = 300;
+const MAX_SAVED_FROM_URL = 2048;
+
+// Provenance is a label, not the save. Every field is dropped when it's unusable
+// rather than failing the request: the reader hosts pass the article they're
+// rendering unconditionally, and an item with no web URL of its own (a saved
+// standard.site document, a relative `doc.path`) sends a blank or relative
+// referrer — which must still save, exactly as it did before provenance existed.
+function sanitizeProvenance(body: CreateSavedBody): void {
+  if (!CLIENT_SAVED_VIA.has(body.savedVia as SavedVia)) body.savedVia = undefined;
+  body.savedFromTitle =
+    typeof body.savedFromTitle === 'string'
+      ? body.savedFromTitle.trim().slice(0, MAX_SAVED_FROM_TITLE) || undefined
+      : undefined;
+  body.savedFromUrl = sanitizeReferrerUrl(body.savedFromUrl);
+}
+
+// `at://did:plc:…/…` does not survive `new URL()`: the DID authority's colons
+// read as an invalid port, so the parse throws. Match the shape instead.
+const AT_URI_RE = /^at:\/\/[a-zA-Z0-9._:%-]+(\/[^\s]*)?$/;
+
+// An absolute http(s)/at:// referrer, or nothing at all.
+function sanitizeReferrerUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_SAVED_FROM_URL) return undefined;
+  if (trimmed.startsWith('at://')) return AT_URI_RE.test(trimmed) ? trimmed : undefined;
+  try {
+    const { protocol } = new URL(trimmed);
+    if (protocol !== 'http:' && protocol !== 'https:') return undefined;
+  } catch {
+    return undefined;
+  }
+  return trimmed;
+}
 
 interface SavedRow {
   id: number;
@@ -131,31 +174,9 @@ export async function handleCreateSaved(
     return invalidRkeyResponse();
   }
 
-  // Provenance is optional and intentionally tolerant of older/modified clients:
-  // unknown channels are discarded, while malformed supplied referrers are rejected.
-  if (!CLIENT_SAVED_VIA.has(body.savedVia as SavedVia)) body.savedVia = undefined;
-  if (typeof body.savedFromTitle === 'string') {
-    body.savedFromTitle = body.savedFromTitle.trim().slice(0, 300) || undefined;
-  } else {
-    body.savedFromTitle = undefined;
-  }
-  if (body.savedFromUrl !== undefined) {
-    if (typeof body.savedFromUrl !== 'string' || body.savedFromUrl.length > 2048) {
-      return new Response(JSON.stringify({ error: 'Invalid savedFromUrl' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-    try {
-      const referrer = new URL(body.savedFromUrl);
-      if (!['http:', 'https:', 'at:'].includes(referrer.protocol)) throw new Error();
-    } catch {
-      return new Response(JSON.stringify({ error: 'Invalid savedFromUrl' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-  }
+  // Optional, tolerant of older/modified clients, and never fatal — see
+  // sanitizeProvenance.
+  sanitizeProvenance(body);
 
   // Validate URL only for url/feed sources
   if (source !== 'share' && source !== 'document') {

--- a/backend/src/services/backing/sync.ts
+++ b/backend/src/services/backing/sync.ts
@@ -146,8 +146,8 @@ export async function pollBackedMembership(
       env.DB.prepare(
         `INSERT INTO saved_articles
            (user_did, rkey, record_uri, url, url_normalized, title, author, description, image,
-            content_type, source, item_guid, saved_at, created_at)
-         VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, 'webpage', 'url', ?, ?, ?)
+            content_type, source, item_guid, saved_at, created_at, saved_via)
+         VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, 'webpage', 'url', ?, ?, ?, ?)
          ON CONFLICT(user_did, url_normalized) DO NOTHING`
       ).bind(
         userDid,
@@ -160,7 +160,8 @@ export async function pollBackedMembership(
         m.image ?? null,
         m.canonicalAtUri ?? null,
         now,
-        now
+        now,
+        backing.provider
       )
     );
   }
@@ -321,6 +322,9 @@ export interface SavedArticleView {
   savedAt: string;
   source: string;
   itemGuid: string | null;
+  savedVia: string | null;
+  savedFromTitle: string | null;
+  savedFromUrl: string | null;
 }
 
 interface JoinedRow {
@@ -342,6 +346,9 @@ interface JoinedRow {
   saved_at: number | null;
   source: string | null;
   item_guid: string | null;
+  saved_via: string | null;
+  saved_from_title: string | null;
+  saved_from_url: string | null;
 }
 
 function rowToView(row: JoinedRow): SavedArticleView {
@@ -372,6 +379,9 @@ function rowToView(row: JoinedRow): SavedArticleView {
     savedAt: new Date(row.saved_at ?? Date.now()).toISOString(),
     source: row.source || 'url',
     itemGuid: row.item_guid ?? meta.canonicalAtUri ?? null,
+    savedVia: row.saved_via,
+    savedFromTitle: row.saved_from_title,
+    savedFromUrl: row.saved_from_url,
   };
 }
 
@@ -395,7 +405,7 @@ export async function listBackedSaved(
     `SELECT m.url AS m_url, m.metadata AS m_metadata, m.external_item_uri,
             s.rkey, s.record_uri, s.url, s.title, s.author, s.description, NULL AS content,
             s.content_type, s.domain, s.image, s.word_count, s.published_at, s.saved_at,
-            s.source, s.item_guid
+            s.source, s.item_guid, s.saved_via, s.saved_from_title, s.saved_from_url
      FROM backed_collection_members m
      LEFT JOIN saved_articles s
        ON s.user_did = m.user_did AND s.url_normalized = m.url_normalized
@@ -408,7 +418,7 @@ export async function listBackedSaved(
     `SELECT NULL AS m_url, NULL AS m_metadata, NULL AS external_item_uri,
             s.rkey, s.record_uri, s.url, s.title, s.author, s.description, NULL AS content,
             s.content_type, s.domain, s.image, s.word_count, s.published_at, s.saved_at,
-            s.source, s.item_guid
+            s.source, s.item_guid, s.saved_via, s.saved_from_title, s.saved_from_url
      FROM saved_articles s
      WHERE s.user_did = ?
        AND (s.url_normalized IS NULL OR NOT EXISTS (

--- a/backend/test/backing-sync.spec.ts
+++ b/backend/test/backing-sync.spec.ts
@@ -79,6 +79,12 @@ describe('pollBackedMembership — wholesale replace + safety', () => {
       .bind(DID)
       .first<{ n: number }>();
     expect(enr?.n).toBe(2);
+    const provenance = await env.DB.prepare(
+      'SELECT saved_via FROM saved_articles WHERE user_did = ? LIMIT 1'
+    )
+      .bind(DID)
+      .first<{ saved_via: string | null }>();
+    expect(provenance?.saved_via).toBe('semble');
   });
 
   it('marks a complete empty snapshot as successful', async () => {

--- a/backend/test/saved-content-update.spec.ts
+++ b/backend/test/saved-content-update.spec.ts
@@ -148,23 +148,55 @@ describe('POST /api/saved — updateContent upgrade of an existing save', () => 
     expect(row.saved_from_url).toBe('https://source.example/post');
   });
 
-  it('drops unknown channels and rejects invalid referrer URLs', async () => {
+  it('drops unusable provenance without ever failing the save', async () => {
     const unknown = await call(
       post({ url: URL, rkey: 'aaaaaaaaaaaaa', savedVia: 'modified-client' })
     );
     expect(unknown.status).toBe(200);
     expect((await getRow()).saved_via).toBeNull();
 
-    await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ?').bind(DID).run();
-    const invalid = await call(
+    // A reader host passes the article it is rendering unconditionally, and an
+    // item with no web URL of its own sends a blank or relative referrer. The
+    // save must still land — the label is what's optional, not the save.
+    for (const savedFromUrl of [
+      '',
+      '   ',
+      '/relative/path',
+      'javascript:alert(1)',
+      'x'.repeat(3000),
+    ]) {
+      await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ?').bind(DID).run();
+      const res = await call(
+        post({
+          url: URL,
+          rkey: 'bbbbbbbbbbbbb',
+          savedVia: 'reader',
+          savedFromTitle: 'Source article',
+          savedFromUrl,
+        })
+      );
+      expect(res.status, `savedFromUrl=${JSON.stringify(savedFromUrl)}`).toBe(200);
+      const row = await getRow();
+      expect(row.saved_from_url).toBeNull();
+      // The rest of the provenance still lands.
+      expect(row.saved_via).toBe('reader');
+      expect(row.saved_from_title).toBe('Source article');
+    }
+  });
+
+  it('accepts the bookmarklet channel and an at:// referrer', async () => {
+    const res = await call(
       post({
         url: URL,
-        rkey: 'bbbbbbbbbbbbb',
-        savedVia: 'reader',
-        savedFromUrl: 'javascript:alert(1)',
+        rkey: 'aaaaaaaaaaaaa',
+        savedVia: 'bookmarklet',
+        savedFromUrl: 'at://did:plc:abc/site.standard.document/xyz',
       })
     );
-    expect(invalid.status).toBe(400);
+    expect(res.status).toBe(200);
+    const row = await getRow();
+    expect(row.saved_via).toBe('bookmarklet');
+    expect(row.saved_from_url).toBe('at://did:plc:abc/site.standard.document/xyz');
   });
 
   it('never blanks existing metadata with missing fields (COALESCE new-wins)', async () => {

--- a/backend/test/saved-content-update.spec.ts
+++ b/backend/test/saved-content-update.spec.ts
@@ -118,6 +118,55 @@ describe('POST /api/saved — updateContent upgrade of an existing save', () => 
     expect(count!.cnt).toBe(1);
   });
 
+  it('records validated provenance and keeps it through content upgrades', async () => {
+    const first = await call(
+      post({
+        url: URL,
+        rkey: 'aaaaaaaaaaaaa',
+        content: '<p>Stub</p>',
+        savedVia: 'reader',
+        savedFromTitle: 'Source article',
+        savedFromUrl: 'https://source.example/post',
+      })
+    );
+    expect(first.status).toBe(200);
+
+    const upgrade = await call(
+      post({
+        url: URL,
+        rkey: 'bbbbbbbbbbbbb',
+        updateContent: true,
+        content: '<p>Full text</p>',
+        savedVia: 'extension',
+      })
+    );
+    expect(upgrade.status).toBe(200);
+
+    const row = await getRow();
+    expect(row.saved_via).toBe('reader');
+    expect(row.saved_from_title).toBe('Source article');
+    expect(row.saved_from_url).toBe('https://source.example/post');
+  });
+
+  it('drops unknown channels and rejects invalid referrer URLs', async () => {
+    const unknown = await call(
+      post({ url: URL, rkey: 'aaaaaaaaaaaaa', savedVia: 'modified-client' })
+    );
+    expect(unknown.status).toBe(200);
+    expect((await getRow()).saved_via).toBeNull();
+
+    await env.DB.prepare('DELETE FROM saved_articles WHERE user_did = ?').bind(DID).run();
+    const invalid = await call(
+      post({
+        url: URL,
+        rkey: 'bbbbbbbbbbbbb',
+        savedVia: 'reader',
+        savedFromUrl: 'javascript:alert(1)',
+      })
+    );
+    expect(invalid.status).toBe(400);
+  });
+
   it('never blanks existing metadata with missing fields (COALESCE new-wins)', async () => {
     await call(
       post({

--- a/docs-site/src/content/docs/guide/saving-and-highlights.md
+++ b/docs-site/src/content/docs/guide/saving-and-highlights.md
@@ -5,7 +5,7 @@ description: Save articles from anywhere, highlight passages, and review what yo
 
 ## Saving
 
-Save an article from its card or from the reader, or from outside Skyreader entirely: the [Chrome extension](https://chromewebstore.google.com/detail/skyreader/kdefpnnpmajcclfepekgdkcdiklfooed), the bookmarklet, the iOS shortcut, or the Android share sheet (see [Adding sources](/guide/adding-sources/#save-and-subscribe-from-anywhere)). Saves keep the full article text, so they read fine offline.
+Save an article from its card or from the reader, or from outside Skyreader entirely: the [Chrome extension](https://chromewebstore.google.com/detail/skyreader/kdefpnnpmajcclfepekgdkcdiklfooed), the bookmarklet, the iOS shortcut, or the Android share sheet (see [Adding sources](/guide/adding-sources/#save-and-subscribe-from-anywhere)). Saves keep the full article text, so they read fine offline. Each save remembers where it came from, such as the extension, a share, or the article you were reading.
 
 ![The Saved list: articles kept with their full text, newest first](../../../assets/screenshots/saved.png)
 

--- a/docs-site/src/content/docs/guide/saving-and-highlights.md
+++ b/docs-site/src/content/docs/guide/saving-and-highlights.md
@@ -5,7 +5,7 @@ description: Save articles from anywhere, highlight passages, and review what yo
 
 ## Saving
 
-Save an article from its card or from the reader, or from outside Skyreader entirely: the [Chrome extension](https://chromewebstore.google.com/detail/skyreader/kdefpnnpmajcclfepekgdkcdiklfooed), the bookmarklet, the iOS shortcut, or the Android share sheet (see [Adding sources](/guide/adding-sources/#save-and-subscribe-from-anywhere)). Saves keep the full article text, so they read fine offline. Each save remembers where it came from, such as the extension, a share, or the article you were reading.
+Save an article from its card or from the reader, or from outside Skyreader entirely: the [Chrome extension](https://chromewebstore.google.com/detail/skyreader/kdefpnnpmajcclfepekgdkcdiklfooed), the bookmarklet, the iOS shortcut, or the Android share sheet (see [Adding sources](/guide/adding-sources/#save-and-subscribe-from-anywhere)). Saves keep the full article text, so they read fine offline. Each save quietly remembers where it came from — the extension, the bookmarklet, a shared link, or the article you were reading.
 
 ![The Saved list: articles kept with their full text, newest first](../../../assets/screenshots/saved.png)
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -253,6 +253,7 @@ async function performSave(url, { fallbackTitle, extractTabId } = {}) {
     // If this URL is already saved, upgrade the stored content with this
     // (likely richer) extraction instead of getting a 409 back.
     updateContent: true,
+    savedVia: 'extension',
     title: extracted?.title || fallbackTitle || undefined,
     author: extracted?.author || undefined,
     description: extracted?.description || undefined,

--- a/frontend/src/lib/components/ArticleCard.svelte
+++ b/frontend/src/lib/components/ArticleCard.svelte
@@ -1002,7 +1002,9 @@
   onComposeShare={composeShare}
   onEditShare={editShare}
   onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
-  onSaveConnection={auth.user ? toggleSavedLink : undefined}
+  onSaveConnection={auth.user
+    ? (url) => toggleSavedLink(url, { title: itemTitle, url: itemUrl })
+    : undefined}
   onCreateConnection={auth.user && itemUrl ? createConnection : undefined}
   isConnectionSaved={(url) => savesStore.isSaved(url)}
   onMentionClick={(did) => sidebarStore.openAddFeedModalForDid(did)}
@@ -1029,6 +1031,8 @@
       <LinkContextMenu
         url={linkInterception.menuState.url}
         linkText={linkInterception.menuState.linkText}
+        fromTitle={itemTitle}
+        fromUrl={itemUrl}
         anchorRect={linkInterception.menuState.anchorRect}
         onClose={linkInterception.closeMenu}
       />

--- a/frontend/src/lib/components/SaveArticleModal.svelte
+++ b/frontend/src/lib/components/SaveArticleModal.svelte
@@ -46,7 +46,7 @@
     error = null;
     limitInfo = null;
     try {
-      const saved = await savesStore.saveFromUrl(url);
+      const saved = await savesStore.saveFromUrl(url, { savedVia: 'web' });
       urlValue = '';
       onclose();
       // Take the user to the saved article. Navigate first, THEN signal which

--- a/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
+++ b/frontend/src/lib/components/feed/DailyMagazineArticle.svelte
@@ -243,6 +243,8 @@
     <LinkContextMenu
       url={linkInterception.menuState.url}
       linkText={linkInterception.menuState.linkText}
+      fromTitle={title}
+      fromUrl={item.url}
       anchorRect={linkInterception.menuState.anchorRect}
       onClose={linkInterception.closeMenu}
     />

--- a/frontend/src/lib/components/feed/LinkContextMenu.svelte
+++ b/frontend/src/lib/components/feed/LinkContextMenu.svelte
@@ -12,9 +12,11 @@
     linkText: string;
     anchorRect: DOMRect;
     onClose: () => void;
+    fromTitle?: string;
+    fromUrl?: string;
   }
 
-  let { url, linkText, anchorRect, onClose }: Props = $props();
+  let { url, linkText, anchorRect, onClose, fromTitle, fromUrl }: Props = $props();
 
   let menuEl = $state<HTMLDivElement | null>(null);
   let copyState = $state<'idle' | 'copied'>('idle');
@@ -29,7 +31,11 @@
     const toastId = toastStore.add('Saving article...');
     onClose();
     savesStore
-      .saveFromUrl(saveUrl)
+      .saveFromUrl(saveUrl, {
+        savedVia: 'reader',
+        savedFromTitle: fromTitle,
+        savedFromUrl: fromUrl,
+      })
       .then(() => toastStore.update(toastId, 'success', 'Article saved'))
       .catch((err) => {
         // The monthly save cap has a reason and a way out, so it says so

--- a/frontend/src/lib/components/feed/LinkContextMenu.svelte
+++ b/frontend/src/lib/components/feed/LinkContextMenu.svelte
@@ -6,6 +6,7 @@
   import { toastStore } from '$lib/stores/toast.svelte';
   import { UrlSaveLimitError } from '$lib/services/api';
   import { saveLimitLine } from '$lib/utils/limitCopy';
+  import { readerProvenance } from '$lib/utils/saveProvenance';
 
   interface Props {
     url: string;
@@ -31,11 +32,7 @@
     const toastId = toastStore.add('Saving article...');
     onClose();
     savesStore
-      .saveFromUrl(saveUrl, {
-        savedVia: 'reader',
-        savedFromTitle: fromTitle,
-        savedFromUrl: fromUrl,
-      })
+      .saveFromUrl(saveUrl, readerProvenance({ title: fromTitle, url: fromUrl }))
       .then(() => toastStore.update(toastId, 'success', 'Article saved'))
       .catch((err) => {
         // The monthly save cap has a reason and a way out, so it says so

--- a/frontend/src/lib/components/feed/ReaderDiscussion.svelte
+++ b/frontend/src/lib/components/feed/ReaderDiscussion.svelte
@@ -196,7 +196,9 @@
     onRetry={atmosphere.retry}
     onCreateInLane={createInLane}
     onOpenAuthor={(did) => sidebarStore.openAddFeedModalForDid(did)}
-    onSaveConnection={auth.user ? toggleSavedLink : undefined}
+    onSaveConnection={auth.user
+      ? (url) => toggleSavedLink(url, { title, url: itemUrl })
+      : undefined}
     onCreateConnection={auth.user && itemUrl ? createConnection : undefined}
     isConnectionSaved={(url) => savesStore.isSaved(url)}
     composeLead={canShareLinkblog ? shareControl : undefined}

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -7,7 +7,7 @@
   import { feedViewStore, searchHaystack } from '$lib/stores/feedView.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
-  import { savedFromLabel } from '$lib/utils/savedFromLabel';
+  import { savedFromDetail, savedFromLabel } from '$lib/utils/savedFromLabel';
   import {
     makeSnippet,
     matchesTerms,
@@ -74,6 +74,12 @@
   });
   let provenanceLabel = $derived(
     displayItem.type === 'saved' ? savedFromLabel(displayItem.item) : null
+  );
+  // The label is truncated and deliberately not a link (it's information, not an
+  // interaction), so the untruncated referrer and its URL ride along as the
+  // native tooltip.
+  let provenanceDetail = $derived(
+    displayItem.type === 'saved' ? savedFromDetail(displayItem.item) : null
   );
 
   // Feed info (for articles only)
@@ -622,7 +628,9 @@
             </span>
           {/if}
           <span class="meta-date">{formatRelativeDate(publishedAt)}</span>
-          {#if provenanceLabel}<span class="meta-provenance">{provenanceLabel}</span>{/if}
+          {#if provenanceLabel}<span class="meta-provenance" title={provenanceDetail ?? undefined}
+              >{provenanceLabel}</span
+            >{/if}
           {#each tags as tag, i}
             {#if i === 0}<span class="meta-dot" aria-hidden="true">·</span>{/if}
             <span class="tag-chip">{tag}</span>

--- a/frontend/src/lib/components/feed/SavedCard.svelte
+++ b/frontend/src/lib/components/feed/SavedCard.svelte
@@ -7,6 +7,7 @@
   import { feedViewStore, searchHaystack } from '$lib/stores/feedView.svelte';
   import { savesStore } from '$lib/stores/saves.svelte';
   import { savedSearchStore } from '$lib/stores/savedSearch.svelte';
+  import { savedFromLabel } from '$lib/utils/savedFromLabel';
   import {
     makeSnippet,
     matchesTerms,
@@ -71,6 +72,9 @@
     if (displayItem.type === 'saved') return displayItem.item.savedAt;
     return '';
   });
+  let provenanceLabel = $derived(
+    displayItem.type === 'saved' ? savedFromLabel(displayItem.item) : null
+  );
 
   // Feed info (for articles only)
   let sub = $derived(
@@ -618,6 +622,7 @@
             </span>
           {/if}
           <span class="meta-date">{formatRelativeDate(publishedAt)}</span>
+          {#if provenanceLabel}<span class="meta-provenance">{provenanceLabel}</span>{/if}
           {#each tags as tag, i}
             {#if i === 0}<span class="meta-dot" aria-hidden="true">·</span>{/if}
             <span class="tag-chip">{tag}</span>
@@ -790,6 +795,15 @@
 
   .meta-feed {
     font-weight: var(--weight-medium);
+  }
+
+  .meta-provenance {
+    min-width: 0;
+    max-width: 16rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-style: italic;
   }
 
   .meta-type-badge {

--- a/frontend/src/lib/components/feed/SavedReader.svelte
+++ b/frontend/src/lib/components/feed/SavedReader.svelte
@@ -1155,6 +1155,8 @@
         <LinkContextMenu
           url={linkInterception.menuState.url}
           linkText={linkInterception.menuState.linkText}
+          fromTitle={title}
+          fromUrl={itemUrl}
           anchorRect={linkInterception.menuState.anchorRect}
           onClose={linkInterception.closeMenu}
         />

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -24,6 +24,7 @@ import type {
   CommunityHighlightNote,
   SembleContext,
   SocialDocument,
+  SavedItem,
   User,
 } from '$lib/types';
 import { getLinkPostTitle, isLinkPost } from '$lib/utils/linkPost';
@@ -1651,6 +1652,9 @@ class ApiClient {
       publishedAt?: string;
       domain?: string;
       wordCount?: number;
+      savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
+      savedFromTitle?: string;
+      savedFromUrl?: string;
     }
   ): Promise<{
     rkey: string;
@@ -1668,6 +1672,9 @@ class ApiClient {
     savedAt: string;
     source?: 'url' | 'feed' | 'document';
     itemGuid?: string;
+    savedVia?: SavedItem['savedVia'];
+    savedFromTitle?: string | null;
+    savedFromUrl?: string | null;
   }> {
     return this.fetch('/api/saved', {
       method: 'POST',
@@ -1695,6 +1702,9 @@ class ApiClient {
       savedAt: string;
       source?: 'url' | 'feed' | 'document';
       itemGuid?: string;
+      savedVia?: SavedItem['savedVia'];
+      savedFromTitle?: string | null;
+      savedFromUrl?: string | null;
     }>;
     // Keyset cursor for the next (older) page; null at the end of the list.
     cursor: string | null;

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -24,6 +24,7 @@ import type {
   CommunityHighlightNote,
   SembleContext,
   SocialDocument,
+  SaveProvenance,
   SavedItem,
   User,
 } from '$lib/types';
@@ -1652,10 +1653,7 @@ class ApiClient {
       publishedAt?: string;
       domain?: string;
       wordCount?: number;
-      savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
-      savedFromTitle?: string;
-      savedFromUrl?: string;
-    }
+    } & SaveProvenance
   ): Promise<{
     rkey: string;
     uri: string;

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -49,6 +49,9 @@ export interface SavedPayload {
   image?: string;
   publishedAt?: string;
   domain?: string;
+  savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
+  savedFromTitle?: string;
+  savedFromUrl?: string;
 }
 
 export interface IntegrationPayload {
@@ -581,6 +584,9 @@ class SyncQueue {
           image: payload.image,
           publishedAt: payload.publishedAt,
           domain: payload.domain,
+          savedVia: payload.savedVia,
+          savedFromTitle: payload.savedFromTitle,
+          savedFromUrl: payload.savedFromUrl,
         });
         break;
       case 'delete':

--- a/frontend/src/lib/services/sync-queue.ts
+++ b/frontend/src/lib/services/sync-queue.ts
@@ -1,7 +1,12 @@
 import { db, type SyncQueueEntry } from './db';
 import { api } from './api';
 import { toUnifiedReadItem } from './readSync';
-import type { MagazineItemSnapshot, MagazineParams, MagazinePosition } from '$lib/types';
+import type {
+  MagazineItemSnapshot,
+  MagazineParams,
+  MagazinePosition,
+  SaveProvenance,
+} from '$lib/types';
 
 const MAX_RETRIES = 5;
 
@@ -35,7 +40,7 @@ export interface LabelPayload {
   mode?: 'replace' | 'merge';
 }
 
-export interface SavedPayload {
+export interface SavedPayload extends SaveProvenance {
   rkey: string;
   url: string;
   fromFeed?: boolean;
@@ -49,9 +54,6 @@ export interface SavedPayload {
   image?: string;
   publishedAt?: string;
   domain?: string;
-  savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
-  savedFromTitle?: string;
-  savedFromUrl?: string;
 }
 
 export interface IntegrationPayload {

--- a/frontend/src/lib/stores/saves.component.test.ts
+++ b/frontend/src/lib/stores/saves.component.test.ts
@@ -88,6 +88,14 @@ vi.mock('./savedSearch.svelte', () => ({
   savedSearchStore: { invalidate: vi.fn(), upsert: vi.fn(), remove: vi.fn() },
 }));
 
+// The provenance of a feed save is the feed's own name, looked up by the
+// subscription id the caller already passes.
+vi.mock('./subscriptions.svelte', () => ({
+  subscriptionsStore: {
+    getById: (id: number) => (id === 7 ? { id: 7, title: 'Feed Y', customTitle: null } : undefined),
+  },
+}));
+
 const authState = { isGuest: true };
 vi.mock('./auth.svelte', () => ({
   auth: {
@@ -221,6 +229,66 @@ describe('savesStore in guest mode', () => {
       'saved',
       'guid-1',
       expect.objectContaining({ itemGuid: 'guid-1' })
+    );
+  });
+
+  it('stamps a feed save with the feed it came from — row, Dexie and queue alike', async () => {
+    articleRows.push({ guid: 'guid-1', subscriptionId: 7, content: '<p>the rss body text</p>' });
+
+    const saved = await savesStore.saveArticle({
+      url: 'https://example.com/piece',
+      guid: 'guid-1',
+      subscriptionId: 7,
+      title: 'A Piece',
+    });
+
+    expect(saved.savedFromTitle).toBe('Feed Y');
+    expect(savedRows.get(saved.rkey)?.savedFromTitle).toBe('Feed Y');
+    // The queue IS the migration on sign-in, so the label has to ride along.
+    expect(enqueue).toHaveBeenCalledWith(
+      'create',
+      'saved',
+      'guid-1',
+      expect.objectContaining({ savedFromTitle: 'Feed Y' })
+    );
+  });
+
+  it('saves an article whose subscription is gone, just without a label', async () => {
+    const saved = await savesStore.saveArticle({
+      url: 'https://example.com/orphan',
+      guid: 'guid-9',
+      subscriptionId: 404,
+      title: 'An Orphan',
+    });
+
+    expect(saved.savedFromTitle).toBeNull();
+    expect(savesStore.isSaved('guid-9')).toBe(true);
+  });
+
+  it('keeps provenance through a re-save of the same item', async () => {
+    // Undoing an Unsave brings the same save back: it keeps saying where it came
+    // from rather than being relabeled by the way it came back.
+    const first = await savesStore.saveArticle({
+      url: 'https://example.com/piece',
+      guid: 'guid-1',
+      subscriptionId: 7,
+    });
+    await savesStore.unsaveByGuid('guid-1');
+    enqueue.mockClear();
+
+    const again = await savesStore.saveArticle({
+      url: first.url,
+      guid: 'guid-1',
+      provenance: { savedVia: 'reader', savedFromTitle: 'Feed Y' },
+    });
+
+    expect(again.savedVia).toBe('reader');
+    expect(again.savedFromTitle).toBe('Feed Y');
+    expect(enqueue).toHaveBeenCalledWith(
+      'create',
+      'saved',
+      'guid-1',
+      expect.objectContaining({ savedVia: 'reader', savedFromTitle: 'Feed Y' })
     );
   });
 

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -9,6 +9,7 @@ import { auth } from './auth.svelte';
 import { extractArticle } from '$lib/services/extract';
 import { computeContentStats } from '$lib/services/articleMerge';
 import { savedSearchStore } from './savedSearch.svelte';
+import { subscriptionsStore } from './subscriptions.svelte';
 import { compareSavedNewestFirst } from '$lib/utils/savedPile';
 import type { SavedItem } from '$lib/types';
 
@@ -300,7 +301,14 @@ function createSavesStore() {
     }
   }
 
-  async function saveFromUrl(url: string): Promise<SavedItem> {
+  async function saveFromUrl(
+    url: string,
+    provenance: {
+      savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
+      savedFromTitle?: string;
+      savedFromUrl?: string;
+    } = {}
+  ): Promise<SavedItem> {
     saving = true;
     error = null;
     try {
@@ -323,6 +331,7 @@ function createSavesStore() {
         image: extracted.image || undefined,
         publishedAt: extracted.published || undefined,
         wordCount: wordCount || undefined,
+        ...provenance,
       });
 
       const savedItem: SavedItem = {
@@ -340,6 +349,7 @@ function createSavesStore() {
         publishedAt: extracted.published,
         savedAt: result.savedAt,
         source: 'url',
+        ...provenance,
       };
 
       // Insert a light copy into memory immediately, then persist the full row
@@ -374,6 +384,13 @@ function createSavesStore() {
     try {
       const rkey = generateTid();
       const now = new Date().toISOString();
+      const savedFromTitle =
+        article.subscriptionId == null
+          ? undefined
+          : (() => {
+              const sub = subscriptionsStore.getById(article.subscriptionId);
+              return sub?.customTitle || sub?.title;
+            })();
 
       // Instant/offline fallback body: pull the RSS body back from IndexedDB.
       // The in-memory feed list is kept "light" (content stripped — see
@@ -417,6 +434,7 @@ function createSavesStore() {
         savedAt: now,
         source: 'feed',
         itemGuid: article.guid,
+        savedFromTitle: savedFromTitle ?? null,
       };
 
       articles = [toLightSaved(savedItem), ...articles];
@@ -459,6 +477,7 @@ function createSavesStore() {
             publishedAt: article.publishedAt,
             domain: domain ?? undefined,
             wordCount: wordCount ?? undefined,
+            savedFromTitle,
           });
 
           // Update with extracted content + server response
@@ -494,6 +513,7 @@ function createSavesStore() {
             wordCount: wordCountFrom(rssBody) ?? undefined,
             image: article.imageUrl,
             publishedAt: article.publishedAt,
+            savedFromTitle,
           } as SavedPayload);
           return savedItem;
         }
@@ -514,6 +534,7 @@ function createSavesStore() {
           wordCount: wordCountFrom(rssBody) ?? undefined,
           image: article.imageUrl,
           publishedAt: article.publishedAt,
+          savedFromTitle,
         } as SavedPayload);
         return savedItem;
       }

--- a/frontend/src/lib/stores/saves.svelte.ts
+++ b/frontend/src/lib/stores/saves.svelte.ts
@@ -11,7 +11,7 @@ import { computeContentStats } from '$lib/services/articleMerge';
 import { savedSearchStore } from './savedSearch.svelte';
 import { subscriptionsStore } from './subscriptions.svelte';
 import { compareSavedNewestFirst } from '$lib/utils/savedPile';
-import type { SavedItem } from '$lib/types';
+import type { SaveProvenance, SavedItem } from '$lib/types';
 
 /**
  * Whether save writes/reads can reach the backend at all.
@@ -45,6 +45,15 @@ function toLightSaved(item: SavedItem): SavedItem {
   if (item.content == null) return item;
   const { content: _content, ...rest } = item;
   return { ...rest, content: null };
+}
+
+// The provenance of a feed save is the feed it came from. A subscription that was
+// just deleted (or a save with no subscription behind it) resolves to nothing —
+// a save is never blocked or delayed on its label.
+function feedTitleFor(subscriptionId: number | undefined): string | undefined {
+  if (subscriptionId == null) return undefined;
+  const sub = subscriptionsStore.getById(subscriptionId);
+  return sub?.customTitle || sub?.title || undefined;
 }
 
 function createSavesStore() {
@@ -301,14 +310,7 @@ function createSavesStore() {
     }
   }
 
-  async function saveFromUrl(
-    url: string,
-    provenance: {
-      savedVia?: 'web' | 'extension' | 'share-target' | 'reader';
-      savedFromTitle?: string;
-      savedFromUrl?: string;
-    } = {}
-  ): Promise<SavedItem> {
+  async function saveFromUrl(url: string, provenance: SaveProvenance = {}): Promise<SavedItem> {
     saving = true;
     error = null;
     try {
@@ -378,19 +380,19 @@ function createSavesStore() {
     summary?: string;
     imageUrl?: string;
     publishedAt?: string;
+    // Provenance carried over from a save that already existed (undoing an
+    // Unsave is the same save coming back, so it keeps where it came from).
+    // Absent for a first save, where the feed's own name is the provenance.
+    provenance?: SaveProvenance;
   }): Promise<SavedItem> {
     saving = true;
     error = null;
     try {
       const rkey = generateTid();
       const now = new Date().toISOString();
-      const savedFromTitle =
-        article.subscriptionId == null
-          ? undefined
-          : (() => {
-              const sub = subscriptionsStore.getById(article.subscriptionId);
-              return sub?.customTitle || sub?.title;
-            })();
+      const provenance: SaveProvenance = article.provenance ?? {
+        savedFromTitle: feedTitleFor(article.subscriptionId),
+      };
 
       // Instant/offline fallback body: pull the RSS body back from IndexedDB.
       // The in-memory feed list is kept "light" (content stripped — see
@@ -434,7 +436,9 @@ function createSavesStore() {
         savedAt: now,
         source: 'feed',
         itemGuid: article.guid,
-        savedFromTitle: savedFromTitle ?? null,
+        savedVia: provenance.savedVia ?? null,
+        savedFromTitle: provenance.savedFromTitle ?? null,
+        savedFromUrl: provenance.savedFromUrl ?? null,
       };
 
       articles = [toLightSaved(savedItem), ...articles];
@@ -477,7 +481,7 @@ function createSavesStore() {
             publishedAt: article.publishedAt,
             domain: domain ?? undefined,
             wordCount: wordCount ?? undefined,
-            savedFromTitle,
+            ...provenance,
           });
 
           // Update with extracted content + server response
@@ -513,7 +517,7 @@ function createSavesStore() {
             wordCount: wordCountFrom(rssBody) ?? undefined,
             image: article.imageUrl,
             publishedAt: article.publishedAt,
-            savedFromTitle,
+            ...provenance,
           } as SavedPayload);
           return savedItem;
         }
@@ -534,7 +538,7 @@ function createSavesStore() {
           wordCount: wordCountFrom(rssBody) ?? undefined,
           image: article.imageUrl,
           publishedAt: article.publishedAt,
-          savedFromTitle,
+          ...provenance,
         } as SavedPayload);
         return savedItem;
       }
@@ -558,12 +562,18 @@ function createSavesStore() {
     // and we persist it as the saved copy's content (otherwise the saved reader
     // has nothing to show — see the collection-piece save path).
     content?: string;
+    // Provenance carried over from a save that already existed — undoing an
+    // Unsave brings the same save back, label and all. A first document save
+    // has no referrer the call sites can name, so it stays unlabeled (a
+    // `source: 'document'` row on its own renders no label).
+    provenance?: SaveProvenance;
   }): Promise<SavedItem> {
     saving = true;
     error = null;
     try {
       const rkey = generateTid();
       const now = new Date().toISOString();
+      const provenance: SaveProvenance = doc.provenance ?? {};
 
       const savedItem: SavedItem = {
         rkey,
@@ -581,6 +591,9 @@ function createSavesStore() {
         savedAt: now,
         source: 'document',
         itemGuid: doc.recordUri,
+        savedVia: provenance.savedVia ?? null,
+        savedFromTitle: provenance.savedFromTitle ?? null,
+        savedFromUrl: provenance.savedFromUrl ?? null,
       };
 
       articles = [savedItem, ...articles];
@@ -602,6 +615,7 @@ function createSavesStore() {
             // extracting from the URL).
             content: doc.content,
             wordCount: savedItem.wordCount ?? undefined,
+            ...provenance,
           });
 
           const updated: SavedItem = {
@@ -627,6 +641,7 @@ function createSavesStore() {
             publishedAt: doc.publishedAt,
             content: doc.content,
             wordCount: savedItem.wordCount ?? undefined,
+            ...provenance,
           } as SavedPayload);
           return savedItem;
         }
@@ -641,6 +656,7 @@ function createSavesStore() {
           publishedAt: doc.publishedAt,
           content: doc.content,
           wordCount: savedItem.wordCount ?? undefined,
+          ...provenance,
         } as SavedPayload);
         return savedItem;
       }

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1116,6 +1116,9 @@ export interface SavedItem {
   savedAt: string;
   source?: 'url' | 'feed' | 'document';
   itemGuid?: string;
+  savedVia?: 'web' | 'extension' | 'share-target' | 'reader' | 'semble' | 'margin' | null;
+  savedFromTitle?: string | null;
+  savedFromUrl?: string | null;
 }
 
 export interface ItemLabel {

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -1100,6 +1100,32 @@ export interface ItemTags {
 
 export type ItemLabelType = 'article' | 'document' | 'saved';
 
+/**
+ * Where a save came from — the channel axis, orthogonal to `source` (its shape).
+ * `share-target` is the `/save` route, which is the Android share sheet *and* an
+ * Apple Shortcut, so its copy stays generic; only the bookmarklet, which
+ * Settings builds itself, can name its own entry point.
+ */
+export type SavedVia = ClientSavedVia | 'semble' | 'margin';
+
+/** The channels a client may claim; `semble`/`margin` are server-written only. */
+export const CLIENT_SAVED_VIA = [
+  'web',
+  'extension',
+  'share-target',
+  'bookmarklet',
+  'reader',
+] as const;
+
+export type ClientSavedVia = (typeof CLIENT_SAVED_VIA)[number];
+
+/** Provenance a client supplies when a save is born. */
+export interface SaveProvenance {
+  savedVia?: ClientSavedVia;
+  savedFromTitle?: string;
+  savedFromUrl?: string;
+}
+
 export interface SavedItem {
   rkey: string;
   uri: string;
@@ -1116,7 +1142,7 @@ export interface SavedItem {
   savedAt: string;
   source?: 'url' | 'feed' | 'document';
   itemGuid?: string;
-  savedVia?: 'web' | 'extension' | 'share-target' | 'reader' | 'semble' | 'margin' | null;
+  savedVia?: SavedVia | null;
   savedFromTitle?: string | null;
   savedFromUrl?: string | null;
 }

--- a/frontend/src/lib/utils/readerSave.ts
+++ b/frontend/src/lib/utils/readerSave.ts
@@ -13,7 +13,12 @@
 // lookup maps don't index — asking `savesStore.isSaved` about it answers "not
 // saved" for an item that plainly is.
 import { savesStore } from '$lib/stores/saves.svelte';
-import type { SavedItem } from '$lib/types';
+import {
+  CLIENT_SAVED_VIA,
+  type ClientSavedVia,
+  type SaveProvenance,
+  type SavedItem,
+} from '$lib/types';
 
 /**
  * The live row for `save`, or undefined once it's been unsaved. Reactive: it
@@ -34,6 +39,24 @@ export function isSavedItemSaved(save: SavedItem): boolean {
 // Unsave would otherwise bring the item back empty. One slot: only the undo of
 // the thing you just did needs it.
 let lastUnsavedBody: { guid: string; content: string | null } | null = null;
+
+/**
+ * The provenance of a re-save is the provenance it already had: undoing a
+ * mis-tapped Unsave brings the same save back, so it keeps saying where it came
+ * from rather than being relabeled by the way it came back. `semble`/`margin`
+ * are server-written channels a client may not claim, so those rows carry only
+ * their referrer across — the backing poll re-stamps the channel itself.
+ */
+function carriedProvenance(save: SavedItem): SaveProvenance {
+  const via = CLIENT_SAVED_VIA.includes(save.savedVia as ClientSavedVia)
+    ? (save.savedVia as ClientSavedVia)
+    : undefined;
+  return {
+    savedVia: via,
+    savedFromTitle: save.savedFromTitle ?? undefined,
+    savedFromUrl: save.savedFromUrl ?? undefined,
+  };
+}
 
 /**
  * Toggle the save behind a `'saved'` reader item. Unsaves the *live* row rather
@@ -64,6 +87,7 @@ export async function toggleSavedItemSave(save: SavedItem): Promise<void> {
       content:
         save.content ??
         (lastUnsavedBody?.guid === guid ? (lastUnsavedBody.content ?? undefined) : undefined),
+      provenance: carriedProvenance(save),
     });
     return;
   }
@@ -78,5 +102,6 @@ export async function toggleSavedItemSave(save: SavedItem): Promise<void> {
     summary: save.description ?? undefined,
     imageUrl: save.image ?? undefined,
     publishedAt: save.publishedAt ?? undefined,
+    provenance: carriedProvenance(save),
   });
 }

--- a/frontend/src/lib/utils/saveLink.ts
+++ b/frontend/src/lib/utils/saveLink.ts
@@ -11,11 +11,19 @@ import { UrlSaveLimitError } from '$lib/services/api';
 import { saveLimitLine } from '$lib/utils/limitCopy';
 
 /** Toggle `url` in and out of Saved. Resolves once the list reflects the change. */
-export async function toggleSavedLink(url: string): Promise<void> {
+export async function toggleSavedLink(
+  url: string,
+  from?: { title?: string; url?: string }
+): Promise<void> {
   const existing = savesStore.getByUrl(url);
   try {
     if (existing) await savesStore.remove(existing.rkey);
-    else await savesStore.saveFromUrl(url);
+    else
+      await savesStore.saveFromUrl(url, {
+        savedVia: 'reader',
+        savedFromTitle: from?.title,
+        savedFromUrl: from?.url,
+      });
   } catch (err) {
     // The monthly save cap is a different kind of failure from "that didn't
     // work": it has a reason, a reset date, and something the reader can do

--- a/frontend/src/lib/utils/saveLink.ts
+++ b/frontend/src/lib/utils/saveLink.ts
@@ -9,21 +9,17 @@ import { savesStore } from '$lib/stores/saves.svelte';
 import { toastStore } from '$lib/stores/toast.svelte';
 import { UrlSaveLimitError } from '$lib/services/api';
 import { saveLimitLine } from '$lib/utils/limitCopy';
+import { readerProvenance } from '$lib/utils/saveProvenance';
 
 /** Toggle `url` in and out of Saved. Resolves once the list reflects the change. */
 export async function toggleSavedLink(
   url: string,
-  from?: { title?: string; url?: string }
+  from?: { title?: string | null; url?: string | null }
 ): Promise<void> {
   const existing = savesStore.getByUrl(url);
   try {
     if (existing) await savesStore.remove(existing.rkey);
-    else
-      await savesStore.saveFromUrl(url, {
-        savedVia: 'reader',
-        savedFromTitle: from?.title,
-        savedFromUrl: from?.url,
-      });
+    else await savesStore.saveFromUrl(url, readerProvenance(from));
   } catch (err) {
     // The monthly save cap is a different kind of failure from "that didn't
     // work": it has a reason, a reset date, and something the reader can do

--- a/frontend/src/lib/utils/saveProvenance.test.ts
+++ b/frontend/src/lib/utils/saveProvenance.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readerProvenance } from './saveProvenance';
+
+describe('readerProvenance', () => {
+  it('carries an absolute http(s) or at:// referrer', () => {
+    expect(readerProvenance({ title: 'The article', url: 'https://example.com/post' })).toEqual({
+      savedVia: 'reader',
+      savedFromTitle: 'The article',
+      savedFromUrl: 'https://example.com/post',
+    });
+    expect(
+      readerProvenance({ title: 'A document', url: 'at://did:plc:abc/site.standard.document/xyz' })
+        .savedFromUrl
+    ).toBe('at://did:plc:abc/site.standard.document/xyz');
+  });
+
+  // The reading surfaces pass the hosting item unconditionally, and an item with
+  // no web URL of its own sends '' (or a bare relative document path).
+  it.each(['', '   ', '/relative/path', 'javascript:alert(1)', 'at://'])(
+    'drops the unusable referrer %o and still names the channel',
+    (url) => {
+      expect(readerProvenance({ title: 'The article', url })).toEqual({
+        savedVia: 'reader',
+        savedFromTitle: 'The article',
+        savedFromUrl: undefined,
+      });
+    }
+  );
+
+  it('survives a host with nothing to offer', () => {
+    expect(readerProvenance()).toEqual({
+      savedVia: 'reader',
+      savedFromTitle: undefined,
+      savedFromUrl: undefined,
+    });
+    expect(readerProvenance({ title: '  ', url: null })).toEqual({
+      savedVia: 'reader',
+      savedFromTitle: undefined,
+      savedFromUrl: undefined,
+    });
+  });
+});

--- a/frontend/src/lib/utils/saveProvenance.ts
+++ b/frontend/src/lib/utils/saveProvenance.ts
@@ -1,0 +1,40 @@
+import type { SaveProvenance } from '$lib/types';
+
+// `at://did:plc:…/…` does not survive `new URL()` — the DID authority's colons
+// read as an invalid port — so it is matched on shape, as the backend does.
+const AT_URI_RE = /^at:\/\/[a-zA-Z0-9._:%-]+(\/[^\s]*)?$/;
+
+/** An absolute http(s)/at:// referrer, or nothing — mirrors the backend's rule. */
+function referrerUrl(url: string | null | undefined): string | undefined {
+  const trimmed = url?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('at://')) return AT_URI_RE.test(trimmed) ? trimmed : undefined;
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === 'http:' || protocol === 'https:' ? trimmed : undefined;
+  } catch {
+    // Not absolute (a standard.site document's relative `path`, say) — no referrer.
+    return undefined;
+  }
+}
+
+/**
+ * Provenance for a link saved from inside something you were reading.
+ *
+ * The reading surfaces pass whatever the hosting item has, and that is often
+ * partial: a saved standard.site document with no canonical URL carries `url:
+ * ''`, `getDocumentEffectiveUrl` can yield a bare relative `path`, and an
+ * untitled item has no title. Every unusable field is left off the request
+ * rather than sent — the backend drops it too, and a save must never fail, or
+ * carry junk, over its label.
+ */
+export function readerProvenance(from?: {
+  title?: string | null;
+  url?: string | null;
+}): SaveProvenance {
+  return {
+    savedVia: 'reader',
+    savedFromTitle: from?.title?.trim() || undefined,
+    savedFromUrl: referrerUrl(from?.url),
+  };
+}

--- a/frontend/src/lib/utils/savedFromLabel.test.ts
+++ b/frontend/src/lib/utils/savedFromLabel.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { savedFromLabel } from './savedFromLabel';
+import { savedFromDetail, savedFromLabel } from './savedFromLabel';
 
 describe('savedFromLabel', () => {
   it.each([
     [{}, null],
     [{ savedVia: 'web' }, null],
     [{ savedVia: 'extension' }, 'from extension'],
-    [{ savedVia: 'share-target' }, 'from share sheet'],
+    [{ savedVia: 'share-target' }, 'from a shared link'],
+    [{ savedVia: 'bookmarklet' }, 'from bookmarklet'],
     [{ savedVia: 'semble' }, 'from Semble'],
     [{ savedVia: 'margin' }, 'from Margin'],
   ] as const)('maps %o to %s', (item, label) => expect(savedFromLabel(item)).toBe(label));
@@ -16,5 +17,27 @@ describe('savedFromLabel', () => {
       'from The article'
     );
     expect(savedFromLabel({ savedFromTitle: 'x'.repeat(50) })).toBe(`from ${'x'.repeat(39)}…`);
+  });
+});
+
+describe('savedFromDetail', () => {
+  it('carries the source URL behind the label', () => {
+    expect(
+      savedFromDetail({
+        savedVia: 'reader',
+        savedFromTitle: 'The article',
+        savedFromUrl: 'https://source.example/post',
+      })
+    ).toBe('from The article\nhttps://source.example/post');
+  });
+
+  it('spells out a title the label had to truncate', () => {
+    expect(savedFromDetail({ savedFromTitle: 'x'.repeat(50) })).toBe(`from ${'x'.repeat(50)}`);
+  });
+
+  it('stays silent when the label already says everything', () => {
+    expect(savedFromDetail({ savedFromTitle: 'The article' })).toBeNull();
+    expect(savedFromDetail({ savedVia: 'extension' })).toBeNull();
+    expect(savedFromDetail({})).toBeNull();
   });
 });

--- a/frontend/src/lib/utils/savedFromLabel.test.ts
+++ b/frontend/src/lib/utils/savedFromLabel.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { savedFromLabel } from './savedFromLabel';
+
+describe('savedFromLabel', () => {
+  it.each([
+    [{}, null],
+    [{ savedVia: 'web' }, null],
+    [{ savedVia: 'extension' }, 'from extension'],
+    [{ savedVia: 'share-target' }, 'from share sheet'],
+    [{ savedVia: 'semble' }, 'from Semble'],
+    [{ savedVia: 'margin' }, 'from Margin'],
+  ] as const)('maps %o to %s', (item, label) => expect(savedFromLabel(item)).toBe(label));
+
+  it('prefers and truncates the referrer title', () => {
+    expect(savedFromLabel({ savedVia: 'extension', savedFromTitle: 'The article' })).toBe(
+      'from The article'
+    );
+    expect(savedFromLabel({ savedFromTitle: 'x'.repeat(50) })).toBe(`from ${'x'.repeat(39)}…`);
+  });
+});

--- a/frontend/src/lib/utils/savedFromLabel.ts
+++ b/frontend/src/lib/utils/savedFromLabel.ts
@@ -1,0 +1,30 @@
+import type { SavedItem } from '$lib/types';
+
+const MAX_TITLE_LENGTH = 40;
+
+function truncateTitle(title: string): string {
+  const clean = title.trim();
+  return clean.length > MAX_TITLE_LENGTH
+    ? `${clean.slice(0, MAX_TITLE_LENGTH - 1).trimEnd()}…`
+    : clean;
+}
+
+/** Quiet provenance copy for a saved item's metadata line. */
+export function savedFromLabel(
+  item: Pick<SavedItem, 'savedVia' | 'savedFromTitle'>
+): string | null {
+  if (item.savedFromTitle?.trim()) return `from ${truncateTitle(item.savedFromTitle)}`;
+
+  switch (item.savedVia) {
+    case 'extension':
+      return 'from extension';
+    case 'share-target':
+      return 'from share sheet';
+    case 'semble':
+      return 'from Semble';
+    case 'margin':
+      return 'from Margin';
+    default:
+      return null;
+  }
+}

--- a/frontend/src/lib/utils/savedFromLabel.ts
+++ b/frontend/src/lib/utils/savedFromLabel.ts
@@ -2,6 +2,8 @@ import type { SavedItem } from '$lib/types';
 
 const MAX_TITLE_LENGTH = 40;
 
+type Provenance = Pick<SavedItem, 'savedVia' | 'savedFromTitle' | 'savedFromUrl'>;
+
 function truncateTitle(title: string): string {
   const clean = title.trim();
   return clean.length > MAX_TITLE_LENGTH
@@ -9,17 +11,27 @@ function truncateTitle(title: string): string {
     : clean;
 }
 
-/** Quiet provenance copy for a saved item's metadata line. */
-export function savedFromLabel(
-  item: Pick<SavedItem, 'savedVia' | 'savedFromTitle'>
-): string | null {
+/**
+ * Quiet provenance copy for a saved item's metadata line. Total over legacy rows
+ * (no provenance → no label), and deliberately silent for the channels that have
+ * nothing to say on their own: the in-app save modal ('web'), and a link saved
+ * from an untitled reading surface ('reader' with no referrer). "From the save
+ * modal" is noise, not information.
+ */
+export function savedFromLabel(item: Provenance): string | null {
   if (item.savedFromTitle?.trim()) return `from ${truncateTitle(item.savedFromTitle)}`;
 
   switch (item.savedVia) {
     case 'extension':
       return 'from extension';
+    // `/save` serves the Android share sheet, an Apple Shortcut and (when it
+    // isn't self-identified below) a bookmarklet, so the copy names none of
+    // them — a desktop bookmarklet save claiming a share sheet would simply be
+    // untrue.
     case 'share-target':
-      return 'from share sheet';
+      return 'from a shared link';
+    case 'bookmarklet':
+      return 'from bookmarklet';
     case 'semble':
       return 'from Semble';
     case 'margin':
@@ -27,4 +39,17 @@ export function savedFromLabel(
     default:
       return null;
   }
+}
+
+/**
+ * The untruncated referrer behind a label, for its native tooltip: the full
+ * title, and the source URL when the save kept one. `null` when the label
+ * already says everything there is to say.
+ */
+export function savedFromDetail(item: Provenance): string | null {
+  const title = item.savedFromTitle?.trim();
+  if (!title) return null;
+  const url = item.savedFromUrl?.trim();
+  if (url) return `from ${title}\n${url}`;
+  return title.length > MAX_TITLE_LENGTH ? `from ${title}` : null;
 }

--- a/frontend/src/routes/save/+page.svelte
+++ b/frontend/src/routes/save/+page.svelte
@@ -8,7 +8,7 @@
   import Logo from '$lib/assets/logo.svg';
   import LimitNotice from '$lib/components/LimitNotice.svelte';
   import { saveLimitLine } from '$lib/utils/limitCopy';
-  import type { SavedItem } from '$lib/types';
+  import type { ClientSavedVia, SavedItem } from '$lib/types';
 
   // Lightweight share-target / bookmarklet endpoint. An Apple Shortcut (or a
   // bookmarklet, or a future PWA share_target) opens
@@ -48,6 +48,16 @@
     return null;
   }
 
+  // Which entry point opened this page. The Shortcut and the Android share sheet
+  // are indistinguishable here (both just hand over a URL), so they share the
+  // generic `share-target` channel — whose label names neither. The bookmarklet
+  // is the one caller Skyreader builds itself (Settings), so it says so; a
+  // bookmarklet dragged to the bar before this shipped carries no marker and
+  // falls back to the generic channel.
+  function readVia(): ClientSavedVia {
+    return $page.url.searchParams.get('via') === 'bookmarklet' ? 'bookmarklet' : 'share-target';
+  }
+
   // The article URL from the query string. Accepts the `url` param (Shortcut /
   // bookmarklet) or the `text` param (PWA share_target / Android share sheet).
   function readUrl(): string | null {
@@ -60,25 +70,33 @@
     return null;
   }
 
+  // The path back here after a login, keeping the entry point so the finished
+  // save still records where it came from.
+  function saveReturnPath(url: string): string {
+    const via = readVia();
+    return `/save?url=${encodeURIComponent(url)}${via === 'share-target' ? '' : `&via=${via}`}`;
+  }
+
   async function run() {
     const url = readUrl();
     if (!url) {
       status = 'invalid';
       return;
     }
+    const savedVia = readVia();
 
     // Not logged in → send to login, then come back here and finish the save.
     // Re-encode the URL into the returnUrl so the path carries no literal "//"
     // (the backend's open-redirect guard rejects relative returnUrls with "//",
     // so an unencoded https:// would be silently dropped to "/").
     if (!auth.isAuthenticated) {
-      const returnUrl = `/save?url=${encodeURIComponent(url)}`;
+      const returnUrl = saveReturnPath(url);
       await goto(`/auth/login?returnUrl=${encodeURIComponent(returnUrl)}`);
       return;
     }
 
     try {
-      saved = await savesStore.saveFromUrl(url, { savedVia: 'share-target' });
+      saved = await savesStore.saveFromUrl(url, { savedVia });
       status = 'success';
     } catch (err) {
       if (err instanceof ScopeUpgradeError) {
@@ -109,9 +127,7 @@
 
   const loginReturnUrl = $derived.by(() => {
     const url = readUrl();
-    return url
-      ? `/auth/login?returnUrl=${encodeURIComponent(`/save?url=${encodeURIComponent(url)}`)}`
-      : '/auth/login';
+    return url ? `/auth/login?returnUrl=${encodeURIComponent(saveReturnPath(url))}` : '/auth/login';
   });
 
   onMount(run);

--- a/frontend/src/routes/save/+page.svelte
+++ b/frontend/src/routes/save/+page.svelte
@@ -78,7 +78,7 @@
     }
 
     try {
-      saved = await savesStore.saveFromUrl(url);
+      saved = await savesStore.saveFromUrl(url, { savedVia: 'share-target' });
       status = 'success';
     } catch (err) {
       if (err instanceof ScopeUpgradeError) {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -70,7 +70,10 @@
 
   // Build links against the current origin so they also work on staging/local.
   const appOrigin = browser ? window.location.origin : 'https://skyreader.app';
-  const saveBookmarklet = `javascript:void(window.open('${appOrigin}/save?url='+encodeURIComponent(location.href)))`;
+  // `via=bookmarklet` names the entry point for the save's provenance label —
+  // /save also serves the share sheet and the Apple Shortcut, which can't
+  // identify themselves (see readVia in routes/save/+page.svelte).
+  const saveBookmarklet = `javascript:void(window.open('${appOrigin}/save?via=bookmarklet&url='+encodeURIComponent(location.href)))`;
   const subscribeBookmarklet = `javascript:void(window.open('${appOrigin}/subscribe?url='+encodeURIComponent(location.href)))`;
 
   let copiedKey = $state<string | null>(null);


### PR DESCRIPTION
Adds first-write provenance to saved items across the backend, frontend, browser extension, offline queue, and external-backed snapshots.

Saved cards now show a quiet “from …” label for reader links, the extension, shared links, the bookmarklet, feeds, Semble, and Margin. Includes validation, migration, tests, and docs.

## Review follow-up (second pass)

- **A bad referrer no longer fails the save.** `POST /api/saved` sanitizes the provenance triple instead of rejecting it: a blank, relative, non-`http(s)`/`at://` or over-long `savedFromUrl` is dropped and the save lands. The reader hosts pass the item they're rendering unconditionally, and an item with no web URL of its own sends `''` — which used to 400 the whole request. Clients drop such referrers before they go out (`utils/saveProvenance.ts`), and `at://` URIs are matched on shape, since a DID authority's colons make `new URL()` throw (so the previous `at:` support never actually worked).
- **Honest copy for `/save`.** That route is the Android share sheet, an Apple Shortcut *and* the bookmarklet, so “from share sheet” was a claim it couldn't back. The generic channel now reads **“from a shared link”**, and the bookmarklet Settings builds carries `via=bookmarklet` (a new `bookmarklet` channel) so the one entry point we control names itself; the marker survives a login round trip.
- **`saved_from_url` has a consumer.** The label's native tooltip spells out the untruncated referrer and its source URL (`savedFromDetail`). The label itself stays plain meta text — information, not an interaction — per the approved plan's step 7, so it is deliberately not a link.
- **Provenance survives a re-save.** Undoing a mis-tapped Unsave in the reader carries the row's own provenance back (`readerSave.ts`), instead of the save returning unlabeled; server-written `semble`/`margin` channels carry only their referrer across.
- **Backend suite verified green** (was unverified in the first pass): 72 files / 994 tests.

Intentionally left as-is: a first-time document save stays unlabeled (no referrer the call sites carry — the plan permits this for v1), and the Home lane keeps its single meta slot for read-time/progress.

[Radial artifact](at://did:plc:n6ku5xddiuguwze3f356evla/com.disnetdev.radial.artifact/impl-b6l2d7yfyiiclqxllyrsv2i6)

[Radial artifact (first pass)](at://did:plc:hbonvqr5ysrscg5wdyb5klie/com.disnetdev.radial.artifact/impl-qtp76uwm27lgsjwnqb5fn6i3)
